### PR TITLE
fix: expose __version__ on package, simplify version discovery

### DIFF
--- a/src/vaultspec_core/__init__.py
+++ b/src/vaultspec_core/__init__.py
@@ -27,3 +27,10 @@ Subpackages:
     :mod:`vaultspec_core.protocol`: Model-provider abstraction for prompt
         execution (Claude, Gemini).
 """
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__: str = version("vaultspec-core")
+except PackageNotFoundError:
+    __version__ = "0.0.0.dev0"

--- a/src/vaultspec_core/cli_common.py
+++ b/src/vaultspec_core/cli_common.py
@@ -5,7 +5,7 @@ surfaces, including version discovery and safe async execution. It supports the
 CLI entry boundary without defining commands itself.
 
 Usage:
-    Use `get_version(...)` to resolve package version text and `run_async(...)`
+    Use `get_version()` to resolve the package version and `run_async(...)`
     to execute async workflows safely from synchronous CLI entrypoints.
 """
 
@@ -16,7 +16,6 @@ import contextlib
 import logging
 import sys
 import warnings
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
@@ -27,33 +26,16 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 
 
-def get_version(root_dir: Path | None = None) -> str:
-    """Read the package version, preferring importlib.metadata for pip-installed usage.
+def get_version() -> str:
+    """Return the package version string.
 
-    Tries ``importlib.metadata.version("vaultspec-core")`` first (correct when
-    pip-installed), then falls back to pyproject.toml line-scanning for
-    development mode (running from source without install).
-
-    Args:
-        root_dir: Directory containing ``pyproject.toml`` for the fallback path.
-            Falls back to ``Path.cwd()`` if ``None``.
-
-    Returns:
-        The version string, or ``"unknown"`` if it cannot be determined.
+    Uses :data:`vaultspec_core.__version__` which is derived from
+    ``importlib.metadata`` at import time. Falls back to ``"unknown"``
+    only if the package metadata is completely unavailable.
     """
-    try:
-        from importlib.metadata import version
+    from vaultspec_core import __version__
 
-        return version("vaultspec-core")
-    except Exception:
-        pass
-    search_root = root_dir if root_dir is not None else Path.cwd()
-    toml_path = search_root / "pyproject.toml"
-    if toml_path.exists():
-        for line in toml_path.read_text(encoding="utf-8").splitlines():
-            if line.strip().startswith("version"):
-                return line.split("=", 1)[1].strip().strip('"').strip("'")
-    return "unknown"
+    return __version__
 
 
 def run_async[T](coro: Coroutine[Any, Any, T], *, debug: bool = False) -> T:


### PR DESCRIPTION
## Summary

- Add `__version__` to `vaultspec_core.__init__` via `importlib.metadata` - the standard Python convention
- Simplify `get_version()` to delegate to `__version__` instead of duplicating metadata lookup + fragile pyproject.toml line-scanning
- Resolves release readiness audit item CLI-08

## Version flow (before)

```
pyproject.toml -> uv build -> wheel metadata -> importlib.metadata.version() -> get_version() -> --version
                                                                                     \-> pyproject.toml line-scan fallback (fragile)
```

No `vaultspec_core.__version__` attribute existed.

## Version flow (after)

```
pyproject.toml -> uv build -> wheel metadata -> importlib.metadata -> __version__ -> get_version() -> --version
```

All three access paths return the same value:
- `import vaultspec_core; vaultspec_core.__version__`
- `from vaultspec_core.cli_common import get_version; get_version()`
- `vaultspec-core --version`

## Test plan

- [x] All three version paths return `0.1.1` locally
- [x] Pre-commit hooks pass (ruff, ty)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)