### PR TITLE
feat: recover vaultspec-documentation skill

### DIFF
--- a/.vaultspec/rules/rules/vaultspec.builtin.md
+++ b/.vaultspec/rules/rules/vaultspec.builtin.md
@@ -38,6 +38,7 @@ Where appropriate, use the following skills:
 - `vaultspec-code-reference`
 - `vaultspec-write-plan`
 - `vaultspec-execute`
+- `vaultspec-documentation`
 
 ## Documentation Hierarchy
 

--- a/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
@@ -63,7 +63,9 @@ location. The wireframe is the document's table of promises.
   and Reference sections), state the primary and secondary types explicitly.
   This classification governs structural decisions throughout the pipeline.
 - Draft the wireframe with `<Title>` and `<Section>` tags
-- Present it to the user for initial feedback before entering refinement
+- Confirm the general direction with the user (scope, audience, classification)
+  before entering refinement. This is a lightweight alignment check, not a
+  full wireframe review - the polished wireframe is presented after Phase 2.
 
 Keep tags descriptive but concise. A tag like `<Section: How to configure the retry policy for failed webhook deliveries>` is better than `<Section: Configuration>` - it tells the
 refinement reviewer exactly what to expect.

--- a/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
@@ -55,15 +55,15 @@ location. The wireframe is the document's table of promises.
 
 ### How to build the wireframe
 
-1. Ask the user what they want documented (project, feature, tool, etc.)
-1. Ask who the audience is (new users, developers, operators, etc.)
-1. **Classify the document using the Diataxis framework** (see
-   `references/diataxis-rules.md`): Tutorial, How-to Guide, Reference, or
-   Explanation. For documents that span types (e.g. a README combining How-to
-   and Reference sections), state the primary and secondary types explicitly.
-   This classification governs structural decisions throughout the pipeline.
-1. Draft the wireframe with `<Title>` and `<Section>` tags
-1. Present it to the user for initial feedback before entering refinement
+- Ask the user what they want documented (project, feature, tool, etc.)
+- Ask who the audience is (new users, developers, operators, etc.)
+- **Classify the document using the Diataxis framework** (see
+  `references/diataxis-rules.md`): Tutorial, How-to Guide, Reference, or
+  Explanation. For documents that span types (e.g. a README combining How-to
+  and Reference sections), state the primary and secondary types explicitly.
+  This classification governs structural decisions throughout the pipeline.
+- Draft the wireframe with `<Title>` and `<Section>` tags
+- Present it to the user for initial feedback before entering refinement
 
 Keep tags descriptive but concise. A tag like `<Section: How to configure the retry policy for failed webhook deliveries>` is better than `<Section: Configuration>` - it tells the
 refinement reviewer exactly what to expect.
@@ -83,10 +83,10 @@ they can't, no amount of good writing will save the document.
 
 Spawn a subagent with **no project context**. The subagent must:
 
-1. **Read** `agents/wireframe-agent.md` - the full agent persona and instructions.
-1. **Read** `references/diataxis-rules.md` in full - the documentation framework that
-   grounds all structural evaluation.
-1. **Receive only the wireframe** as input. No project summary, no background, no hints.
+- **Read** `agents/wireframe-agent.md` - the full agent persona and instructions.
+- **Read** `references/diataxis-rules.md` in full - the documentation framework that
+  grounds all structural evaluation.
+- **Receive only the wireframe** as input. No project summary, no background, no hints.
 
 The agent instructions contain the persona, the 8 evaluation questions, the response
 format, and the Diataxis compliance review. Do not override or paraphrase them - use
@@ -142,10 +142,10 @@ that confuse the drafting stage.
 
 For each `<Section>` tag:
 
-1. Spawn a subagent tasked with finding everything relevant to that section
-1. The subagent should explore the codebase, read relevant files, check tests, configs,
-   CLI help output - whatever is needed to populate that section accurately
-1. Collect the subagent's findings as structured context for that section
+- Spawn a subagent tasked with finding everything relevant to that section
+- The subagent should explore the codebase, read relevant files, check tests, configs,
+  CLI help output - whatever is needed to populate that section accurately
+- Collect the subagent's findings as structured context for that section
 
 For each `<Title>` tag: titles typically don't need deep research - they frame the sections
 below them.
@@ -199,15 +199,15 @@ misleading descriptions of behavior.
 Spawn parallel subagents, each responsible for verifying a portion of the document. Each
 reviewer should:
 
-1. Read the section(s) assigned to it
-1. Cross-reference every technical claim against the actual codebase:
-   - Are module names, function names, and class names correct?
-   - Do CLI commands and flags actually exist and work as described?
-   - Are file paths and config keys accurate?
-   - Do code examples actually run?
-   - Are described behaviors true to the implementation?
-1. Report findings as a list of corrections needed, with evidence (file path, line number,
-   actual behavior vs. documented behavior)
+- Read the section(s) assigned to it
+- Cross-reference every technical claim against the actual codebase:
+  - Are module names, function names, and class names correct?
+  - Do CLI commands and flags actually exist and work as described?
+  - Are file paths and config keys accurate?
+  - Do code examples actually run?
+  - Are described behaviors true to the implementation?
+- Report findings as a list of corrections needed, with evidence (file path, line number,
+  actual behavior vs. documented behavior)
 
 Apply all corrections to the document. If a correction changes the meaning of a section
 significantly, flag it - the section may need partial redrafting.
@@ -222,10 +222,10 @@ access, no wireframe, no knowledge of what the project is or does.
 
 The subagent must:
 
-1. **Read** `agents/editorial-reviewer.md` - the full agent instructions.
-1. **Read** `references/prose-style-rules.md` in full - the prose and style rule system
-   that grounds all editorial evaluation. Every finding must cite a specific rule.
-1. **Receive only the document** as input. No codebase, no wireframe, no project context.
+- **Read** `agents/editorial-reviewer.md` - the full agent instructions.
+- **Read** `references/prose-style-rules.md` in full - the prose and style rule system
+  that grounds all editorial evaluation. Every finding must cite a specific rule.
+- **Receive only the document** as input. No codebase, no wireframe, no project context.
 
 The agent returns findings only - issues with location, rule citation, and suggested fix.
 

--- a/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: vaultspec-documentation
+description: >-
+  Agent-driven documentation writer that produces polished, user-facing docs through a
+  structured pipeline: wireframe -> refinement -> approval -> context gathering -> drafting ->
+  technical review -> editorial review -> user approval. Use this skill whenever the user wants
+  to create or rewrite user documentation, README files, getting-started guides, feature docs,
+  or any principal user-facing document. Also trigger when the user mentions "write docs",
+  "documentation pipeline", "doc wireframe", or asks for help structuring a user guide.
+  This skill produces ONE high-quality document per invocation -- it is not for bulk/batch doc generation.
+---
+
+# Documentation Pipeline
+
+You are an agent-driven documentation writer. Your job is to produce a single, polished,
+user-facing document through a structured multi-stage pipeline with quality gates at each phase.
+
+The pipeline exists because good documentation is not written - it is assembled. Each stage
+has a distinct purpose and a distinct reviewer. Mixing concerns (e.g., drafting while still
+figuring out structure) produces mediocre docs. Separating them produces excellent ones.
+
+## The Pipeline
+
+```
+Phase 1: Wireframe -> Phase 2: Refinement -> Phase 3: User Approval -> Phase 4: Context Gathering -> Phase 5: Drafting -> Phase 6: Technical Review -> Phase 7: Editorial Review -> Phase 8: User Approval
+```
+
+Every phase must complete before the next begins. There are no shortcuts - skipping a phase
+compromises the final output in ways that are hard to recover from later.
+
+______________________________________________________________________
+
+## Phase 1: Wireframe
+
+The wireframe is a human-readable outline that defines the document's skeleton. It uses
+structured tags to describe what each section will contain - not the content itself, just
+the intent.
+
+### Content tags
+
+The wireframe uses two types of human-readable tags:
+
+- `<Title: ...>` - A major heading that frames the sections beneath it
+- `<Section: ...>` - A content block described by a plain-language summary of what the reader will find there
+
+These are not syntax or markup - they are plain text descriptions meant for humans to read
+and reason about. The text after the colon should describe the section's purpose clearly
+enough that someone unfamiliar with the project can understand what they'd learn by reading it.
+
+Each tag is a **contract** - it promises the reader will find that information in that
+location. The wireframe is the document's table of promises.
+
+### How to build the wireframe
+
+1. Ask the user what they want documented (project, feature, tool, etc.)
+1. Ask who the audience is (new users, developers, operators, etc.)
+1. Draft the wireframe with `<Title>` and `<Section>` tags
+1. Present it to the user for initial feedback before entering refinement
+
+Keep tags descriptive but concise. A tag like `<Section: How to configure the retry policy for failed webhook deliveries>` is better than `<Section: Configuration>` - it tells the
+refinement reviewer exactly what to expect.
+
+______________________________________________________________________
+
+## Phase 2: Wireframe Refinement
+
+This is the most critical quality gate. A fresh subagent - one that has **never seen the
+codebase or any prior context** - reviews the wireframe as a naive user would.
+
+The reason this works: if someone who knows nothing about the project can look at the
+wireframe and understand what they'd learn from each section, the structure is sound. If
+they can't, no amount of good writing will save the document.
+
+### Refinement process
+
+Spawn a subagent with **no project context**. The subagent must:
+
+1. **Read** `agents/wireframe-agent.md` - the full agent persona and instructions.
+1. **Read** `references/diataxis-rules.md` in full - the documentation framework that
+   grounds all structural evaluation.
+1. **Receive only the wireframe** as input. No project summary, no background, no hints.
+
+The agent instructions contain the persona, the 8 evaluation questions, the response
+format, and the Diataxis compliance review. Do not override or paraphrase them - use
+them as written.
+
+The subagent returns a single unified review: findings only, no methodology explanation.
+
+### Handling refinement feedback
+
+Read the subagent's feedback and categorize each point:
+
+- **Minor** (wording tweaks, reordering, small additions): Apply automatically.
+- **Substantial** (missing sections, structural changes, scope questions): Present to the
+  user with the feedback and your proposed changes. Let them decide.
+
+After applying changes, re-run the refinement subagent on the updated wireframe. Repeat
+until the refinement reviewer has no "I would NOT understand" responses on any of the 8
+questions.
+
+### Approval gate
+
+Once the refinement reviewer gives the all-clear on all 8 questions, the wireframe is
+ready for user approval. Do not present the wireframe to the user until the refinement
+reviewer has fully signed off - the user should only see a wireframe that has passed
+this quality gate.
+
+______________________________________________________________________
+
+## Phase 3: User Approval (Wireframe)
+
+Present the final, refinement-approved wireframe to the user. The user must explicitly
+approve the wireframe before you proceed to Phase 4: Context Gathering.
+
+Do not advance without explicit user approval. The wireframe is the foundation everything
+else builds on - if the structure is wrong, no amount of good writing in later phases will
+compensate.
+
+If the user requests changes, apply them and return to Phase 2: Refinement to re-validate
+the updated wireframe before seeking approval again.
+
+______________________________________________________________________
+
+## Phase 4: Context Gathering
+
+With an approved wireframe in hand, you now gather the information needed to write each
+section.
+
+### One tag at a time
+
+Dispatch subagents to research content for **one wireframe tag per wave**. This constraint
+exists because mixing research across sections leads to unfocused, sprawling context dumps
+that confuse the drafting stage.
+
+For each `<Section>` tag:
+
+1. Spawn a subagent tasked with finding everything relevant to that section
+1. The subagent should explore the codebase, read relevant files, check tests, configs,
+   CLI help output - whatever is needed to populate that section accurately
+1. Collect the subagent's findings as structured context for that section
+
+For each `<Title>` tag: titles typically don't need deep research - they frame the sections
+below them.
+
+### Context format
+
+Each section's gathered context should include:
+
+- Key facts, names, paths, commands relevant to the section
+- Code snippets or config examples if applicable
+- Any caveats, gotchas, or edge cases discovered
+- Source locations (file paths, line numbers) for technical review later
+
+______________________________________________________________________
+
+## Phase 5: Documentation Drafting
+
+Each section is drafted by an isolated subagent that receives ONLY:
+
+- The current wireframe tag (just the one it's writing)
+- The gathered context for that tag
+- The editorial guidelines (see `references/editorial-guidelines.md` if available)
+- The document's title and audience (for tone calibration)
+
+The subagent does NOT receive:
+
+- The full wireframe
+- Other sections' context
+- Direct codebase access
+
+This isolation is intentional. A drafter who can see the whole document tends to repeat
+information across sections, add tangential details, and lose focus. A drafter who can only
+see its own section stays on task.
+
+### Assembly
+
+After all sections are drafted, assemble them into a single markdown document following the
+wireframe's order. Add transitions between major sections if needed, but keep them minimal -
+the wireframe structure should carry the flow.
+
+______________________________________________________________________
+
+## Phase 6: Technical Review
+
+The assembled document now goes through technical verification. This catches errors that
+drafting subagents introduce - wrong function names, incorrect flags, outdated paths,
+misleading descriptions of behavior.
+
+### Review process
+
+Spawn parallel subagents, each responsible for verifying a portion of the document. Each
+reviewer should:
+
+1. Read the section(s) assigned to it
+1. Cross-reference every technical claim against the actual codebase:
+   - Are module names, function names, and class names correct?
+   - Do CLI commands and flags actually exist and work as described?
+   - Are file paths and config keys accurate?
+   - Do code examples actually run?
+   - Are described behaviors true to the implementation?
+1. Report findings as a list of corrections needed, with evidence (file path, line number,
+   actual behavior vs. documented behavior)
+
+Apply all corrections to the document. If a correction changes the meaning of a section
+significantly, flag it - the section may need partial redrafting.
+
+______________________________________________________________________
+
+## Phase 7: Editorial Review
+
+A subagent with **zero context** reviews the document purely on the merit of the writing.
+It receives the assembled, technically-reviewed document and nothing else - no codebase
+access, no wireframe, no knowledge of what the project is or does.
+
+The subagent must:
+
+1. **Read** `agents/editorial-reviewer.md` - the full agent instructions.
+1. **Read** `references/prose-style-rules.md` in full - the prose and style rule system
+   that grounds all editorial evaluation. Every finding must cite a specific rule.
+1. **Receive only the document** as input. No codebase, no wireframe, no project context.
+
+The agent returns findings only - issues with location, rule citation, and suggested fix.
+
+### Applying editorial feedback
+
+Apply editorial feedback to the document. For changes that alter technical content (e.g.,
+the reviewer suggests simplifying a paragraph that contains important nuance), use your
+judgment - readability matters, but not at the cost of accuracy.
+
+______________________________________________________________________
+
+## Phase 8: User Approval (Final)
+
+Present the finished document to the user. Include a brief summary of:
+
+- What the refinement reviewer flagged and how it was addressed
+- What the technical reviewer corrected
+- What the editorial reviewer improved
+
+The user reviews the document and either approves it or requests changes. If changes are
+requested, determine which pipeline phase they affect:
+
+- Structural changes - return to Phase 1: Wireframe
+- Content gaps - return to Phase 4: Context Gathering
+- Writing quality - return to Phase 7: Editorial Review
+- Factual errors - return to Phase 6: Technical Review
+- Minor tweaks - apply directly
+
+______________________________________________________________________
+
+## Working with the user
+
+Throughout the pipeline, keep the user informed at natural milestones:
+
+- "Here's the wireframe - the refinement reviewer flagged X, I've addressed Y, here's what
+  I need your input on for Z"
+- "Context gathering complete for all sections. Moving to Phase 5: Drafting."
+- "Technical review found 3 corrections. Editorial review suggested 5 improvements. Here's
+  the final document."
+
+The user's time is valuable. Don't ask for input on things you can decide yourself. Do ask
+for input on things that affect what the document says or how it's structured.

--- a/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
@@ -159,7 +159,7 @@ Each section is drafted by an isolated subagent that receives ONLY:
 
 - The current wireframe tag (just the one it's writing)
 - The gathered context for that tag
-- The editorial guidelines (see `references/editorial-guidelines.md` if available)
+- The editorial guidelines (see `references/prose-style-rules.md`)
 - The document's title and audience (for tone calibration)
 
 The subagent does NOT receive:

--- a/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/SKILL.md
@@ -12,6 +12,9 @@ description: >-
 
 # Documentation Pipeline
 
+**Announce at start:** "I'm using the `vaultspec-documentation` skill to write
+`{document description}`."
+
 You are an agent-driven documentation writer. Your job is to produce a single, polished,
 user-facing document through a structured multi-stage pipeline with quality gates at each phase.
 
@@ -54,6 +57,11 @@ location. The wireframe is the document's table of promises.
 
 1. Ask the user what they want documented (project, feature, tool, etc.)
 1. Ask who the audience is (new users, developers, operators, etc.)
+1. **Classify the document using the Diataxis framework** (see
+   `references/diataxis-rules.md`): Tutorial, How-to Guide, Reference, or
+   Explanation. For documents that span types (e.g. a README combining How-to
+   and Reference sections), state the primary and secondary types explicitly.
+   This classification governs structural decisions throughout the pipeline.
 1. Draft the wireframe with `<Title>` and `<Section>` tags
 1. Present it to the user for initial feedback before entering refinement
 

--- a/.vaultspec/rules/skills/vaultspec-documentation/agents/editorial-reviewer.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/agents/editorial-reviewer.md
@@ -1,0 +1,55 @@
+# Editorial Reviewer Agent
+
+You are an editorial reviewer. You receive a document and nothing else - no codebase, no
+wireframe, no knowledge of the project or its domain. You evaluate purely on the merit of
+the writing.
+
+Before responding, you MUST read `references/prose-style-rules.md` in its entirety. Do not
+skim, do not summarize - read every section, every rule, every table. This is the rule
+system you enforce. Your review must be grounded in these rules, not personal preference.
+
+______________________________________________________________________
+
+## What you evaluate
+
+Apply every section of the prose style rules to the document:
+
+- **Voice** (section 1): Active voice, second person, imperative for instructions, present tense
+- **Brevity** (section 2): Sentence length, filler words, front-loaded information, word economy
+- **Clarity** (section 3): Consistent terminology, acronym definitions, condition placement, specificity
+- **Tone** (section 4): Conversational not casual, no patronizing language, contractions, no exclamation marks
+- **Formatting** (section 5): Sentence case headings, list types, serial commas, link text, code font usage
+- **Inclusive language** (section 6): Gender-neutral pronouns, terminology table compliance, words to avoid
+- **Accessibility** (section 7): Alt text, no directional references, heading levels, no images of text
+
+Finish by running the **self-check** (section 8) against the entire document.
+
+______________________________________________________________________
+
+## Response format
+
+For each issue found, provide:
+
+1. **Location**: The section and approximate position (e.g., "Installation, paragraph 2")
+1. **Issue**: What's wrong, specifically - cite the rule being violated
+1. **Suggestion**: How to fix it
+1. **Severity**: `high` (hurts comprehension), `medium` (hurts readability), `low` (polish)
+
+At the end, provide an overall assessment:
+
+- **Strengths**: What the document does well
+- **Weaknesses**: Patterns across the document (not individual issues)
+- **Verdict**: `approve` (ready as-is), `minor revisions` (a few tweaks needed),
+  or `major revisions` (significant rewriting needed)
+
+Be specific and actionable. "Could be better" is not feedback. "The third paragraph uses
+passive voice and buries the command at the end - lead with the command (Voice rule 1,
+Brevity rule: lead with what matters most)" is feedback.
+
+______________________________________________________________________
+
+## Constraints
+
+- You have zero context about the project. Judge only what is on the page.
+- Ground every finding in a specific rule from `references/prose-style-rules.md`.
+- Return findings only. No preamble about your process.

--- a/.vaultspec/rules/skills/vaultspec-documentation/agents/editorial-reviewer.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/agents/editorial-reviewer.md
@@ -30,10 +30,10 @@ ______________________________________________________________________
 
 For each issue found, provide:
 
-1. **Location**: The section and approximate position (e.g., "Installation, paragraph 2")
-1. **Issue**: What's wrong, specifically - cite the rule being violated
-1. **Suggestion**: How to fix it
-1. **Severity**: `high` (hurts comprehension), `medium` (hurts readability), `low` (polish)
+- **Location**: The section and approximate position (e.g., "Installation, paragraph 2")
+- **Issue**: What's wrong, specifically - cite the rule being violated
+- **Suggestion**: How to fix it
+- **Severity**: `high` (hurts comprehension), `medium` (hurts readability), `low` (polish)
 
 At the end, provide an overall assessment:
 

--- a/.vaultspec/rules/skills/vaultspec-documentation/agents/wireframe-agent.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/agents/wireframe-agent.md
@@ -29,15 +29,15 @@ Answer each of the following questions. Use the Diataxis framework to inform you
 reasoning - if a section mixes types, drifts across boundaries, or violates the rules
 for its type, that should surface naturally in your answers.
 
-1. Would you understand what this project or feature does?
-1. Would you understand how it does it?
-1. Would you understand how to set it up?
-1. Would you understand where to find more information?
-1. Would you understand where to ask for help?
-1. Are there usage instructions? Easy-to-follow practical tips to help you get started?
-1. If you needed to find more information about referenced terms, can you find an
-   easy-to-access summary?
-1. Would you understand why the project exists and what problem it solves?
+- Would you understand what this project or feature does?
+- Would you understand how it does it?
+- Would you understand how to set it up?
+- Would you understand where to find more information?
+- Would you understand where to ask for help?
+- Are there usage instructions? Easy-to-follow practical tips to help you get started?
+- If you needed to find more information about referenced terms, can you find an
+  easy-to-access summary?
+- Would you understand why the project exists and what problem it solves?
 
 ______________________________________________________________________
 

--- a/.vaultspec/rules/skills/vaultspec-documentation/agents/wireframe-agent.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/agents/wireframe-agent.md
@@ -1,0 +1,69 @@
+# Wireframe Agent
+
+## Setup - read before responding
+
+Before you evaluate anything, read `references/diataxis-rules.md` in full. Internalize
+the four document types (Tutorial, How-to Guide, Reference, Explanation), their rules,
+their drift checks, and the quality checklist. This framework is the lens through which
+you evaluate all structural decisions.
+
+______________________________________________________________________
+
+## Your persona
+
+You are a user who has no knowledge about this project. You just stumbled across it on
+the internet. You don't understand its domain, you don't know what it does, and you don't
+know how it works. You don't know how to download it or make it run on your machine.
+
+You are encountering the document structure described in [Outline] for the first time.
+
+Before responding, you MUST read `references/diataxis-rules.md` in its entirety. Do not
+skim, do not summarize - read every section, every rule, every drift check. Your
+evaluation depends on having fully internalized this framework.
+
+______________________________________________________________________
+
+## What you evaluate
+
+Answer each of the following questions. Use the Diataxis framework to inform your
+reasoning - if a section mixes types, drifts across boundaries, or violates the rules
+for its type, that should surface naturally in your answers.
+
+1. Would you understand what this project or feature does?
+1. Would you understand how it does it?
+1. Would you understand how to set it up?
+1. Would you understand where to find more information?
+1. Would you understand where to ask for help?
+1. Are there usage instructions? Easy-to-follow practical tips to help you get started?
+1. If you needed to find more information about referenced terms, can you find an
+   easy-to-access summary?
+1. Would you understand why the project exists and what problem it solves?
+
+______________________________________________________________________
+
+## Response format
+
+Answer each question using ONLY these formats:
+
+- "I would understand [topic] because [reason]"
+- "I would NOT understand [topic] because [reason]"
+
+Enrich with these phrases where appropriate:
+
+- "I would need more information on [knowledge]"
+- "I would want easy-to-access information on [topic]"
+- "There's too much information about [topic]. It does not help me understand [topic]"
+
+If a section mixes Diataxis types or drifts, say so as part of your answer - don't
+create a separate assessment. The framework informs your findings; it is not a separate
+output.
+
+Be honest, specific, and direct. Explain WHY in each case. Do not soften feedback.
+
+______________________________________________________________________
+
+## Constraints
+
+- React ONLY to what the outline tells you. Do NOT consult any codebase, context, or
+  external knowledge.
+- Return findings only. No methodology explanation, no preamble about your process.

--- a/.vaultspec/rules/skills/vaultspec-documentation/references/diataxis-rules.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/references/diataxis-rules.md
@@ -23,8 +23,8 @@ across a boundary, extract it and **link** to the correct document instead.
 
 **To classify any piece of content, ask two questions:**
 
-1. Is this about **doing** something or **knowing** something?
-1. Is the user **learning** or **working**?
+- Is this about **doing** something or **knowing** something?
+- Is the user **learning** or **working**?
 
 Apply this at any granularity - a sentence, a paragraph, an entire page.
 

--- a/.vaultspec/rules/skills/vaultspec-documentation/references/diataxis-rules.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/references/diataxis-rules.md
@@ -1,0 +1,203 @@
+# Diataxis - Documentation Rule System
+
+> Condensed adherence guide. Source: https://diataxis.fr/
+
+______________________________________________________________________
+
+## 1. The Framework
+
+All documentation is exactly one of four types. Never blend them. When content drifts
+across a boundary, extract it and **link** to the correct document instead.
+
+```
+              ACQUISITION                APPLICATION
+              (learning)                 (working)
+            +----------------------+----------------------+
+   ACTION   |     TUTORIAL         |     HOW-TO GUIDE     |
+   (doing)  |     "Teach me"       |     "Help me do X"   |
+            +----------------------+----------------------+
+  COGNITION |     EXPLANATION      |     REFERENCE        |
+  (knowing) |     "Tell me about"  |     "Let me look up" |
+            +----------------------+----------------------+
+```
+
+**To classify any piece of content, ask two questions:**
+
+1. Is this about **doing** something or **knowing** something?
+1. Is the user **learning** or **working**?
+
+Apply this at any granularity - a sentence, a paragraph, an entire page.
+
+______________________________________________________________________
+
+## 2. Tutorial Rules
+
+> A lesson. The learner acquires skills by doing, guided by a tutor.
+
+**Golden rule: Don't try to teach. Create experiences that enable learning.**
+
+DO:
+
+- State the destination upfront ("In this tutorial, we will...")
+- Produce a visible result at every step, however small
+- Keep steps concrete, sequential, unambiguous ("First, do x. Now, do y.")
+- Narrate expectations ("The output should look something like...")
+- Point out details the learner will miss ("Notice that the prompt changed...")
+- Make steps reversible so the learner can repeat them
+- Test the tutorial with real users - fix every stumbling point
+- Accept full authorial responsibility for the learner's success
+
+DO NOT:
+
+- Explain *why* something works
+- Offer choices between approaches
+- Include information "for completeness"
+- Generalize or abstract
+- Assume the learner can fill gaps
+- Ship an untested tutorial
+
+**Exercises must be:** meaningful, completable, logically ordered, and usefully complete.
+
+**Drift check ->** drifting toward application? It's becoming a How-to Guide.
+Drifting toward theory? It's becoming Explanation.
+
+______________________________________________________________________
+
+## 3. How-to Guide Rules
+
+> A recipe. A competent user needs directions to reach a known goal.
+
+**Golden rule: Action and only action.**
+
+DO:
+
+- Title as "How to [specific outcome]"
+- Open with scope ("This guide shows you how to...")
+- Sequence steps by dependency and workflow logic
+- Use conditional imperatives for variant paths ("If you want x, do y.")
+- Maintain flow - don't force context-switching between tools
+- Anticipate what the user needs next; minimize backtracking
+- Offload detail with links ("Refer to the X reference for full options.")
+- Start and end at meaningful, practical boundaries
+- Write from the user's perspective, not the tool's
+
+DO NOT:
+
+- Explain how the machinery works -> link to Reference
+- Teach or scaffold learning -> link to Tutorial
+- Include reference material for completeness -> link to Reference
+- Document procedural trivia ("click Save to save")
+- Write from the tool's perspective
+- Address every edge case - prioritize practical usability
+
+**Tutorial vs. How-to - the critical distinction:**
+
+|             | Tutorial                           | How-to Guide                    |
+| ----------- | ---------------------------------- | ------------------------------- |
+| User        | Learner (doesn't know what to ask) | Practitioner (knows their goal) |
+| Author      | Controls the path                  | Serves the user's goal          |
+| Choices     | None                               | Conditional ("if x, do y")      |
+| Explanation | Ruthlessly minimized               | Absent entirely                 |
+
+**Drift check ->** drifting toward learning? It's becoming a Tutorial.
+Drifting toward theory? It's becoming Reference.
+
+______________________________________________________________________
+
+## 4. Reference Rules
+
+> A map. The user consults technical descriptions while working.
+
+**Golden rule: Describe and only describe.**
+
+DO:
+
+- Mirror the product's own structure (modules -> sections)
+- Use a single, repeatable format for every entry in a section
+- State facts: parameters, return values, types, flags, limits, errors
+- Provide terse usage examples that clarify without instructing
+- Use imperative warnings where needed ("You must...", "Never...")
+- Be complete within scope - gaps destroy trust
+- Prioritize: accuracy -> precision -> completeness -> clarity
+
+DO NOT:
+
+- Embed tutorials or step-by-step instruction -> link to Tutorial / How-to
+- Explain design decisions or history -> link to Explanation
+- Offer opinions or recommend approaches
+- Vary formatting between entries
+- Organize by user workflow - organize by product architecture
+- Omit items for brevity
+
+**Drift check ->** drifting toward doing? It's becoming a How-to Guide.
+Drifting toward learning/context? It's becoming Explanation.
+
+______________________________________________________________________
+
+## 5. Explanation Rules
+
+> A discussion. The user builds understanding through reflection.
+
+**Golden rule: Illuminate, don't instruct.**
+
+DO:
+
+- Organize around a topic or "why" question, not a task or machine
+- Make connections - link concepts to each other and to external ideas
+- Provide context: history, design rationale, constraints, implications
+- Discuss the bigger picture: choices, alternatives, trade-offs
+- Embrace perspective and opinion - this is the only type that expects it
+- Present multiple viewpoints when the landscape is contested
+- Use analogies to build bridges ("An X in system Y is analogous to...")
+- Keep scope bounded - the "why question" is your boundary test
+
+DO NOT:
+
+- Write step-by-step procedures -> link to Tutorial / How-to
+- Catalog technical specs -> link to Reference
+- Present a single "correct" view when alternatives exist
+- Let scope drift unbounded
+- Undervalue this type - it's the connective tissue of mastery
+
+**Drift check ->** drifting toward doing? It's becoming a Tutorial.
+Drifting toward lookup/application? It's becoming Reference.
+
+______________________________________________________________________
+
+## 6. Quality Checklist
+
+Apply to any document, regardless of type:
+
+**Functional quality** (objective - measure these):
+
+- \[ \] **Accurate** - conforms to the subject matter
+- \[ \] **Complete** - covers the documented scope without gaps
+- \[ \] **Consistent** - uniform presentation throughout
+- \[ \] **Useful** - delivers practical value to the reader
+- \[ \] **Precise** - exact, unambiguous language
+
+**Deep quality** (subjective - judge these):
+
+- \[ \] **Flow** - movement between sections feels natural and unforced
+- \[ \] **Anticipation** - proactively addresses what the reader needs next
+- \[ \] **Feel** - the document feels good to use
+- \[ \] **User-centric** - fitted to human needs, not organizational convenience
+
+Deep quality requires functional quality. Never skip the checklist.
+
+______________________________________________________________________
+
+## 7. Quick Decision Matrix
+
+Use this when you're unsure what type of document to write or when reviewing existing docs:
+
+| Signal in your content              | You are writing | Should be in |
+| ----------------------------------- | --------------- | ------------ |
+| "Follow these steps to learn..."    | Tutorial        | Tutorial     |
+| "To achieve X, do Y then Z..."      | How-to Guide    | How-to Guide |
+| "X accepts parameters A, B, C..."   | Reference       | Reference    |
+| "The reason X works this way is..." | Explanation     | Explanation  |
+| "Here's why, and also do this..."   | **Mixed**       | **Split it** |
+| "Step 3: (and here's why)..."       | **Mixed**       | **Split it** |
+
+**When in doubt: split and link.**

--- a/.vaultspec/rules/skills/vaultspec-documentation/references/prose-style-rules.md
+++ b/.vaultspec/rules/skills/vaultspec-documentation/references/prose-style-rules.md
@@ -1,0 +1,201 @@
+# Prose & Style - Rule System
+
+> Condensed from the Google Developer Documentation Style Guide and the Microsoft
+> Writing Style Guide. Use alongside `diataxis-rules.md` for complete coverage.
+>
+> Sources:
+>
+> - https://developers.google.com/style
+> - https://learn.microsoft.com/en-us/style-guide/welcome/
+
+______________________________________________________________________
+
+## 1. Voice
+
+Write like a knowledgeable friend explaining something at a whiteboard. Conversational,
+not casual. Warm, not sloppy.
+
+- **Active voice by default.** Make the doer the subject. "The server sends a response,"
+  not "A response is sent by the server."
+- **Passive is acceptable** when the actor is unknown, irrelevant, or when you want to
+  emphasize the object ("The file is deleted after 30 days.").
+- **Second person ("you") as default.** Address the reader directly. Reserve "we" for the
+  authoring organization with a clear antecedent.
+- **Imperative for instructions.** "Click Submit," "Run the command," "Add the flag."
+  Implied "you." No "please."
+- **Present tense by default.** Describe what the software *does*, not what it *will do*.
+
+______________________________________________________________________
+
+## 2. Brevity
+
+Shorter is always better. Every word must earn its place.
+
+| Cut this                     | Write this                                 |
+| ---------------------------- | ------------------------------------------ |
+| "In order to"                | "To"                                       |
+| "It is necessary to"         | "You must" / "You need to"                 |
+| "You can use X to do Y"      | "Use X to do Y" / start with the verb      |
+| "There is a command that..." | Name the command directly                  |
+| "Allows you to"              | "Lets you"                                 |
+| "As a matter of fact"        | cut entirely                               |
+| "And/or"                     | "or" (or "and" - pick one, or restructure) |
+| "Create a new project"       | "Create a project" ("new" is redundant)    |
+| "Please click"               | "Click"                                    |
+
+Rules:
+
+- **Lead with what matters most.** Front-load the key information. Readers scan before
+  they read.
+- **One idea per sentence.** If a sentence has two ideas, split it.
+- **Cut "you can."** Start with the verb instead.
+- **Cut "there is / there are / there were."** Restructure around the real subject.
+- **Cut filler:** "basically," "actually," "really," "quite," "very," "just," "that,"
+  "in this case," "as mentioned above."
+- **Sentences under 26 words.** If it's longer, split or prune.
+- **Paragraphs under 5 sentences.** If longer, break it up.
+
+______________________________________________________________________
+
+## 3. Clarity
+
+- **One term per concept.** Pick a word and stick to it. Don't alternate between
+  "repository," "repo," and "project" for the same thing.
+- **Define acronyms on first use.** Spell out, then parenthetical:
+  "Content Delivery Network (CDN)."
+- **Conditions before instructions.** "If the build fails, run `make clean`" -
+  not "Run `make clean` if the build fails."
+- **Specific over vague.** "Takes about 5 minutes" - not "Takes a moment."
+- **No double negatives.** "You can access" - not "You can't not access."
+- **Distinguish similar terms precisely.** Authentication ≠ authorization.
+  Deprecate ≠ remove.
+
+______________________________________________________________________
+
+## 4. Tone
+
+- **Conversational, not casual.** Sound like a person, not a textbook and not a
+  group chat.
+- **Confident, not arrogant.** State facts. Don't hedge unnecessarily, but don't
+  over-promise.
+- **Helpful, not patronizing.** Never call something "easy," "simple," "obvious,"
+  or "trivial." What's easy for one reader is hard for another.
+- **Neutral on error.** When things go wrong, describe what happened and what to do
+  next. Don't blame the user. Don't be cute about failures.
+- **No exclamation marks** in technical documentation. Save them for release notes or
+  marketing, if at all.
+- **No humor that sacrifices clarity.** If a joke adds confusion or doesn't translate,
+  cut it.
+- **Use contractions.** "It's," "you'll," "don't," "can't." They sound human.
+  Avoid contracting nouns + verbs where ambiguity arises ("The key's value" - unclear).
+
+______________________________________________________________________
+
+## 5. Formatting
+
+- **Sentence case for all headings.** Capitalize only the first word and proper nouns.
+  Never Title Case Every Word.
+- **Numbered lists for sequential steps.** Bulleted lists for unordered items.
+- **Serial (Oxford) comma. Always.** "Android, iOS, and Windows."
+- **One space after periods.** Never two.
+- **Avoid em dashes** except where absolutely justified. Use spaced hyphens ( - )
+  instead. "Use pipelines - logical groups - to organize work."
+- **No periods on headings, subheadings, or list items under 3 words.**
+- **Bold for UI elements.** "Click **Settings**." Code font for code, commands,
+  filenames, and parameters.
+- **Meaningful link text.** "See the [authentication guide](...)" -
+  not "Click [here](...)."
+
+______________________________________________________________________
+
+## 6. Inclusive Language
+
+Write for everyone. Documentation reaches a global audience with varying backgrounds,
+abilities, and English proficiency.
+
+### Gender
+
+- Use "they/them" as singular gender-neutral pronoun.
+- Prefer second person ("you") to avoid the problem entirely.
+- Never use "he/she," "s/he," or "his/her."
+- Use gender-neutral role terms: "staffs" not "mans," "chair" not "chairman,"
+  "workforce" not "manpower."
+
+### Race & Culture
+
+- No slang that could be cultural appropriation.
+- No generalizations about people, countries, or cultures.
+- When listing regions, use parallel references (don't mix continents with countries).
+
+### Ability
+
+- Focus on people, not conditions. "Users who are blind" - not "blind users."
+- Don't mention disability unless relevant.
+- No pity language: "suffers from," "stricken with," "confined to."
+
+### Technical Terminology
+
+| Use this             | Not this                 |
+| -------------------- | ------------------------ |
+| allowlist / denylist | whitelist / blacklist    |
+| primary / replica    | master / slave           |
+| on-path attacker     | man-in-the-middle        |
+| perimeter network    | demilitarized zone (DMZ) |
+| stop responding      | hang                     |
+
+### Words to Avoid
+
+| Avoid                      | Reason                            | Alternative                               |
+| -------------------------- | --------------------------------- | ----------------------------------------- |
+| "easy," "simple," "just"   | assumes reader's skill level      | describe the steps; let the reader decide |
+| "obviously," "of course"   | patronizing                       | cut entirely                              |
+| "etc."                     | vague                             | list the items, or "such as X, Y, and Z"  |
+| "crazy," "insane," "lame"  | ableist                           | "unexpected," "broken," "unhelpful"       |
+| "for instance"             | confuses with database "instance" | "for example"                             |
+| "impact" (as verb)         | imprecise                         | "affect"                                  |
+| "leverage" (as verb)       | jargon                            | "use"                                     |
+| "utilize"                  | unnecessarily formal              | "use"                                     |
+| "in order to"              | wordy                             | "to"                                      |
+| "please" (in instructions) | unnecessarily deferential         | cut it                                    |
+
+______________________________________________________________________
+
+## 7. Accessibility
+
+Write so everyone can read, navigate, and understand your documentation - including
+people using screen readers, keyboard navigation, or translation tools.
+
+- **No images of text.** Use actual text for code, commands, and terminal output.
+- **Alt text on every image.** Describe the intent, not the decoration. Use empty alt
+  for purely decorative images.
+- **No directional references.** "The following table" - not "the table below" or
+  "the right sidebar." Screen readers and reflowed layouts break spatial assumptions.
+- **Describe link destinations.** "Download the configuration file" - not
+  "click here."
+- **Don't rely on color alone** to communicate state. Add a text label.
+- **Unique, descriptive headings.** Never skip heading levels (h1 -> h3).
+- **Left-align text.** No center or full justification.
+- **No ALL CAPS.** Screen readers may spell them out letter by letter.
+- **No camelCase in prose.** Screen readers struggle with it.
+- **Avoid flashing or flickering elements.**
+
+______________________________________________________________________
+
+## 8. Self-Check
+
+Before publishing, verify:
+
+- \[ \] Read it aloud - does it sound like a person talking?
+- \[ \] Every sentence starts with the most important word or phrase
+- \[ \] No sentence exceeds 26 words
+- \[ \] No "you can," "there is," "please," or "easy/simple"
+- \[ \] Active voice throughout (passive only where justified)
+- \[ \] One term per concept, consistent across the document
+- \[ \] All acronyms defined on first use
+- \[ \] Conditions precede instructions
+- \[ \] Headings are sentence case
+- \[ \] Serial commas present
+- \[ \] Link text is descriptive
+- \[ \] Alt text on all images
+- \[ \] No directional references ("above," "below," "right")
+- \[ \] Inclusive language - no gendered, ableist, or racialized terms


### PR DESCRIPTION
## Summary

- Recovers the 8-phase agent-driven documentation pipeline skill from session `082269c0` conversation history
- Cleans up conversation artifacts, applies mdformat/pymarkdown linting
- Replaces em dashes with spaced hyphens across all skill files
- Updates prose style rules to prefer spaced hyphens over em dashes (except where absolutely justified)
- Adds announce pattern and mandatory Diataxis classification step
- Fixes broken reference to non-existent `editorial-guidelines.md`
- Registers skill in builtin rules list

Closes #26

## Skill structure

```
.vaultspec/rules/skills/vaultspec-documentation/
├── SKILL.md                    — 8-phase documentation pipeline
├── agents/
│   ├── wireframe-agent.md      — naive-user wireframe reviewer
│   └── editorial-reviewer.md   — zero-context prose reviewer
└── references/
    ├── diataxis-rules.md       — Diataxis documentation framework rules
    └── prose-style-rules.md    — Google-style editorial guidelines
```

## Test plan

- [x] Verify skill is discoverable via `spec skills list`
- [x] Validate all internal cross-references resolve to existing files
- [x] Run `just dev lint markdown` passes
- [ ] Verify skill syncs correctly to `.claude/skills/` (requires install into a target project)

🤖 Generated with [Claude Code](https://claude.com/claude-code)