### PR TITLE
fix: ecosystem CI health - doctor/sync, hooks, contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,5 +210,15 @@ src/vaultspec_core/builtins/*
 !src/vaultspec_core/builtins/__init__.py
 
 # >>> vaultspec-managed (do not edit this block) >>>
+.agents/
+.claude/
+.codex/
+.gemini/
+.mcp.json
+.vault/
+.vaultspec/
 .vaultspec/_snapshots/
+AGENTS.md
+CLAUDE.md
+GEMINI.md
 # <<< vaultspec-managed <<<

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,14 +71,14 @@ repos:
     exclude: ^test-project/
   - id: vault-doctor
     name: Vault Doctor
-    entry: uv run python -m vaultspec_core vault check all
+    entry: uv run --no-sync python -m vaultspec_core vault check all
     language: system
     types:
     - markdown
     pass_filenames: false
   - id: vault-doctor-deep
     name: Vault Doctor (chain + links)
-    entry: uv run python -m vaultspec_core doctor
+    entry: uv run --no-sync python -m vaultspec_core doctor
     language: system
     types:
     - markdown

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -164,11 +164,10 @@ def _scaffold_provider(
             ensure_dir(cfg.agents_dir)
         _add(_rel(target, cfg.agents_dir), "agents")
 
-    if ProviderCapability.WORKFLOWS in caps:
-        wf_dir = target / ".agents" / "workflows"
+    if ProviderCapability.WORKFLOWS in caps and cfg.workflows_dir:
         if not dry_run:
-            ensure_dir(wf_dir)
-        _add(_rel(target, wf_dir), "workflows")
+            ensure_dir(cfg.workflows_dir)
+        _add(_rel(target, cfg.workflows_dir), "workflows")
 
     if cfg.config_file:
         if not dry_run and not cfg.config_file.exists():

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -171,10 +171,18 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
         # Without config we cannot assess completeness beyond non-empty
         return ProviderDirSignal.PARTIAL
 
-    expected_dirs: list[Path] = []
+    # Content directories require markdown files; structural directories
+    # (like workflows) only need to exist.
+    content_dirs: list[Path] = []
     for d in (cfg.rules_dir, cfg.skills_dir, cfg.agents_dir):
         if d is not None:
-            expected_dirs.append(d)
+            content_dirs.append(d)
+
+    structural_dirs: list[Path] = []
+    if cfg.workflows_dir is not None:
+        structural_dirs.append(cfg.workflows_dir)
+
+    expected_dirs = content_dirs + structural_dirs
 
     if not expected_dirs:
         # No subdirectories expected - non-empty is complete enough
@@ -194,7 +202,7 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
         known_paths.add(cfg.system_file)
 
     all_present = True
-    for d in expected_dirs:
+    for d in content_dirs:
         if not d.is_dir():
             all_present = False
             continue
@@ -203,6 +211,9 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
         md_files = list(d.glob("*.md"))
         skill_files = list(d.glob("*/SKILL.md")) if not md_files else []
         if not md_files and not skill_files:
+            all_present = False
+    for d in structural_dirs:
+        if not d.is_dir():
             all_present = False
 
     # Check for files in the provider directory that don't match known patterns

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -184,10 +184,6 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
 
     expected_dirs = content_dirs + structural_dirs
 
-    if not expected_dirs:
-        # No subdirectories expected - non-empty is complete enough
-        return ProviderDirSignal.COMPLETE
-
     # Build a set of known paths to detect foreign content
     known_paths: set[Path] = set()
     for d in expected_dirs:

--- a/src/vaultspec_core/core/types.py
+++ b/src/vaultspec_core/core/types.py
@@ -54,6 +54,8 @@ class ToolConfig:
             tool does not have a dedicated system file.
         emit_system_rule: Whether shared system content should be materialized
             as a rule file when ``system_file`` is absent.
+        workflows_dir: Directory where workflow definitions live, or ``None``
+            if the tool does not support workflows.
         capabilities: Declared provider capabilities.  Used by install, sync,
             and dry-run to reason about what each provider supports.
     """
@@ -68,6 +70,7 @@ class ToolConfig:
     rule_ref_config_file: Path | None = None
     system_file: Path | None = None
     emit_system_rule: bool = True
+    workflows_dir: Path | None = None
     capabilities: frozenset[ProviderCapability] = frozenset()
 
 
@@ -293,6 +296,7 @@ def init_paths(layout: Any) -> WorkspaceContext:
             rule_ref_dir=shared_agents_root / Resource.RULES.value,
             system_file=None,
             emit_system_rule=False,
+            workflows_dir=shared_agents_root / Resource.WORKFLOWS.value,
             capabilities=frozenset(
                 {
                     _pc.RULES,

--- a/src/vaultspec_core/hooks/engine.py
+++ b/src/vaultspec_core/hooks/engine.py
@@ -335,7 +335,7 @@ def _execute_shell(
     try:
         target_dir = get_context().target_dir
         env["VAULTSPEC_TARGET_DIR"] = str(target_dir)
-        cwd: str | None = str(target_dir)
+        cwd: str | None = str(target_dir) if target_dir.is_dir() else None
     except LookupError:
         cwd = None
 

--- a/src/vaultspec_core/hooks/engine.py
+++ b/src/vaultspec_core/hooks/engine.py
@@ -335,7 +335,11 @@ def _execute_shell(
     try:
         target_dir = get_context().target_dir
         env["VAULTSPEC_TARGET_DIR"] = str(target_dir)
-        cwd: str | None = str(target_dir) if target_dir.is_dir() else None
+        if target_dir.is_dir():
+            cwd: str | None = str(target_dir)
+        else:
+            logger.warning("Hook cwd %s does not exist, using process cwd", target_dir)
+            cwd = None
     except LookupError:
         cwd = None
 

--- a/tests/test_automation_contracts.py
+++ b/tests/test_automation_contracts.py
@@ -44,17 +44,17 @@ def test_justfile_exposes_approved_targets() -> None:
     justfile = _read("justfile")
     # Top-level namespace recipes
     assert "prod *args='':" in justfile
-    assert "dev target *args='':" in justfile
-    assert "ci:" in justfile
+    assert "dev target='--help' *args='':" in justfile
+    assert "ci *args='':" in justfile
     # Internal dev recipes with default targets
-    assert "_dev-deps target='sync':" in justfile
-    assert "_dev-lint target='all':" in justfile
-    assert "_dev-fix target='all':" in justfile
-    assert "_dev-audit target:" in justfile
-    assert "_dev-test target='all':" in justfile
-    assert "_dev-build target:" in justfile
-    assert "_dev-publish target tag:" in justfile
-    assert "_dev-precommit target='run':" in justfile
+    assert "_dev-deps target='--help':" in justfile
+    assert "_dev-lint target='--help':" in justfile
+    assert "_dev-fix target='--help':" in justfile
+    assert "_dev-audit target='--help':" in justfile
+    assert "_dev-test target='--help':" in justfile
+    assert "_dev-build target='--help':" in justfile
+    assert "_dev-publish target='--help' tag='':" in justfile
+    assert "_dev-precommit target='--help':" in justfile
     # Dev dispatch covers all verbs
     for verb in (
         "deps",
@@ -78,33 +78,33 @@ def test_justfile_exposes_approved_targets() -> None:
 
 def test_dependency_audit_uses_lockfile_export_without_root_project() -> None:
     justfile = _read("justfile")
-    # Export and audit commands are split across continuation lines
+    # Export and audit commands use platform-conditional logic
     assert "uv export --frozen --group dev" in justfile
     assert "--no-emit-project --output-file" in justfile
-    assert 'uv run pip-audit --strict -r "$tmp"' in justfile
+    assert "uv run pip-audit --strict -r" in justfile
 
 
 def test_lint_all_runs_every_validation_surface() -> None:
     justfile = _read("justfile")
-    assert "just _dev-lint python" in justfile
-    assert "just _dev-lint type" in justfile
-    assert "just _dev-lint links" in justfile
-    assert "just _dev-lint toml" in justfile
-    assert "just _dev-lint markdown" in justfile
-    assert "just _dev-lint workflow" in justfile
+    assert "just _dev-lint-python" in justfile
+    assert "just _dev-lint-type" in justfile
+    assert "just _dev-lint-links" in justfile
+    assert "just _dev-lint-toml" in justfile
+    assert "just _dev-lint-markdown" in justfile
+    assert "just _dev-lint-workflow" in justfile
 
 
 def test_test_all_runs_python_and_docker() -> None:
     justfile = _read("justfile")
-    assert "just _dev-test python" in justfile
-    assert "just _dev-test docker" in justfile
-    assert "just _dev-build docker" in justfile
-    assert "just _dev-build python" in justfile
+    assert "just _dev-test-python" in justfile
+    assert "just _dev-test-docker" in justfile
+    assert "just _dev-build-docker" in justfile
+    assert "just _dev-build-python" in justfile
 
 
 def test_fix_surface_covers_all_autofixable_targets() -> None:
     justfile = _read("justfile")
-    assert "_dev-fix target='all':" in justfile
+    assert "_dev-fix target='--help':" in justfile
     assert "uv run ruff format src tests" in justfile
     assert "uv run ruff check --fix src tests" in justfile
     assert "taplo fmt" in justfile
@@ -175,7 +175,7 @@ def test_prod_delegates_to_cli() -> None:
     justfile = _read("justfile")
     # prod recipe passes all args through to uv run vaultspec-core
     assert "prod *args='':" in justfile
-    assert "uv run vaultspec-core {{args}}" in justfile
+    assert '"uv run vaultspec-core " + args' in justfile
     # install/uninstall available via prod namespace (documented in comments)
     assert "just prod install" in justfile
     assert "uv run vaultspec-core" in justfile
@@ -218,6 +218,10 @@ def test_provider_capability_consistency() -> None:
         if ProviderCapability.ROOT_CONFIG in caps:
             assert cfg.config_file is not None, (
                 f"{tool.value} declares ROOT_CONFIG but has no config_file"
+            )
+        if ProviderCapability.WORKFLOWS in caps:
+            assert cfg.workflows_dir is not None, (
+                f"{tool.value} declares WORKFLOWS but has no workflows_dir"
             )
 
 


### PR DESCRIPTION
## Summary

Resolves three classes of CI health issues found during the ecosystem audit:

- **Doctor/sync false positive**: antigravity provider reported `dir_state: "mixed"` after clean install+sync because doctor didn't recognize the `workflows/` directory that install creates. Added `workflows_dir` to `ToolConfig` and wired it through the collector and install command. Structural directories (like workflows) now only need to exist, not contain markdown files.

- **Hook engine cwd crash on Windows**: when graph tests left a stale context pointing to a non-existent `test-project/` path, subsequent hook tests crashed with `[WinError 267] The directory name is invalid`. The engine now validates `target_dir.is_dir()` before using it as cwd.

- **Stale automation contract tests**: 8 assertions in `test_automation_contracts.py` were out of date with the justfile's refactored recipe signatures. Updated to match current `--help` defaults, hyphenated sub-recipe dispatch, and string concatenation patterns.

- **Pre-commit hook inconsistency**: `vault-doctor` and `vault-doctor-deep` hooks were missing `--no-sync`, inconsistent with all other hooks.

## Canonical hook invocation pattern

The audit identified three invocation patterns across consumer projects:
- `uv run --no-sync` (vaultspec-core) - **canonical for pre-commit hooks**
- `uv run` without --no-sync (vaultspec-a2a) - works but slower
- `python -c` imports (vaultspec-rag) - fragile, avoid

**Canonical**: `uv run --no-sync python -m vaultspec_core <command>` for hooks, `uv run vaultspec-core <command>` for direct CLI use.

## Verification

1. `vaultspec-core install --force && vaultspec-core sync --force` - clean
2. `vaultspec-core doctor --json` - exits 0, all providers "complete", zero false positives
3. Full test suite: **1088 passed, 0 failed** (415s)

## Consumer drift (reference - tracked in downstream issues)

| Project | .gitattributes | Hooks | Doctor |
|---------|---------------|-------|--------|
| vaultspec-core | Complete | Full set | Passes |
| vaultspec-a2a | Complete | Missing 3 hooks | wgergely/vaultspec-a2a#39 |
| vaultspec-rag | Partial | Mixed patterns | wgergely/vaultspec-rag#47, #48 |
| vaultspec-tana | None | None | wgergely/vaultspec-tana#2 |

## Test plan

- [x] `vaultspec-core doctor --json` reports all providers "complete"
- [x] `vaultspec-core sync --force` followed by doctor shows no drift
- [x] All 1088 tests pass including graph+hook ordering
- [x] Pre-commit hooks pass on commit

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)