### PR TITLE
feat: MCP server registry — built-in MCP definitions with install/sync/uninstall lifecycle

### DIFF
--- a/.vault/adr/2026-04-11-mcp-registry-adr.md
+++ b/.vault/adr/2026-04-11-mcp-registry-adr.md
@@ -1,0 +1,196 @@
+---
+tags:
+  - '#adr'
+  - '#mcp-registry'
+date: '2026-04-11'
+related:
+  - '[[2026-04-11-mcp-registry-research]]'
+  - '[[2026-03-28-mcp-installation-patterns-research]]'
+  - '[[2026-02-22-mcp-consolidation-adr]]'
+---
+
+# `mcp-registry` adr: built-in MCP definitions with install/sync/uninstall lifecycle | (**status:** `accepted`)
+
+## Problem Statement
+
+`.mcp.json` management is currently hardcoded to a single `vaultspec-core`
+server entry via `_scaffold_mcp_json()`. There is no mechanism for:
+
+- Registering additional MCP servers programmatically
+- Consumer projects (e.g., vaultspec-rag) enrolling their servers through
+  Core's CLI
+- Listing, adding, or removing MCP definitions from the command line
+- Detecting drift between intended and deployed MCP configuration
+
+The rule/skill/agent resources all have a registry pattern (source
+definitions in `.vaultspec/rules/{type}/`, CLI CRUD, sync to destinations).
+MCP servers lack this entirely, forcing consumers to hand-roll JSON
+manipulation.
+
+## Considerations
+
+- MCP definitions are JSON structures, not Markdown with YAML frontmatter
+  like rules/skills/agents. The existing `collect_md_resources()` and
+  `sync_to_all_tools()` abstractions do not fit.
+- `.mcp.json` is a single shared file (provider-agnostic), not a per-tool
+  directory tree. Sync is a JSON key-level merge, not a file copy.
+- The existing `_scaffold_mcp_json()` already implements correct merge
+  semantics (read, merge, preserve user entries, atomic write). This logic
+  needs to be generalized, not discarded.
+- `seed_builtins()` recursively copies `.vaultspec/rules/` contents, so
+  placing MCP definitions in `.vaultspec/rules/mcps/` gets free seeding
+  on install.
+- The `pyproject.toml` `force-include` already bundles `.vaultspec/rules`
+  into the wheel, so new subdirectories are automatically included.
+- MCP definitions are not provider-scoped. They are workspace-level: all
+  providers share the same `.mcp.json`. The provider manifest does not
+  need MCP-specific fields.
+- The `--skip mcp` opt-out pattern must be preserved across install, sync,
+  and uninstall.
+
+## Constraints
+
+- Must not break the existing `_scaffold_mcp_json()` contract during the
+  transition - the hardcoded `vaultspec-core` entry must continue to work.
+- Must not touch `_scaffold_precommit()` or `resolver.py` (PR #36 merge
+  surface).
+- Must not add MCP server runtime management (starting/stopping servers).
+- Must not modify how providers consume `.mcp.json`.
+- `WorkspaceContext` is a frozen dataclass - adding `mcps_src_dir` requires
+  updating its field list and all construction sites.
+
+## Implementation
+
+### Storage format
+
+One JSON file per MCP server in `.vaultspec/rules/mcps/`:
+
+- `{server-name}.builtin.json` for built-in definitions (bundled in wheel)
+- `{server-name}.json` for custom/user definitions
+
+File content is the server configuration object matching the `.mcp.json`
+`mcpServers` value schema:
+
+```json
+{
+  "command": "uv",
+  "args": ["run", "python", "-m", "vaultspec_core.mcp_server.app"]
+}
+```
+
+The filename stem (minus `.builtin.json` or `.json` suffix) becomes the
+key in `mcpServers`.
+
+### New module: `core/mcps.py`
+
+Mirrors the `core/rules.py` pattern with JSON-specific collection:
+
+- `collect_mcp_servers(warnings)` - reads `.json` files from
+  `mcps_src_dir`, returns `dict[str, tuple[Path, dict]]` mapping server
+  name to (source path, parsed config)
+- `mcp_list()` - returns metadata dicts with `name` and `source` fields
+- `mcp_add(name, config, force)` - writes a new custom `.json` definition
+- `mcp_remove(name)` - deletes a definition file
+- `mcp_sync(dry_run, force)` - collects definitions, merges into
+  `.mcp.json`, returns `SyncResult`
+
+### Sync algorithm
+
+`mcp_sync()` replaces `_scaffold_mcp_json()` as the single code path
+for all `.mcp.json` management:
+
+- Collect all definitions from `mcps_src_dir`
+- Read existing `.mcp.json` (or initialize empty `{"mcpServers": {}}`)
+- For each definition file:
+  - If server name absent in `.mcp.json`: add (count as `added`)
+  - If present and content matches: skip (count as `skipped`)
+  - If present and content differs:
+    - Without `--force`: skip, emit warning (count as `skipped`)
+    - With `--force`: overwrite (count as `updated`)
+- Write merged result via `atomic_write()`
+- User-added entries (not matching any definition file) are always
+  preserved
+
+### Lifecycle integration
+
+**Install** (`init_run()`):
+Replace `_scaffold_mcp_json(target)` with `mcp_sync()`. The builtins
+are already seeded by `seed_builtins()` before this runs, so the
+registry source directory will contain the built-in definition.
+
+**Sync** (`sync_provider()`):
+Add `mcp_sync` to `_run_all_syncs()` alongside rules/skills/agents/
+system/config. Remove the standalone `_scaffold_mcp_json()` repair
+call that currently runs after syncs.
+
+**Upgrade** (`install_upgrade()`):
+Add `"mcps": len(collect_mcp_servers())` to `source_counts`.
+
+**Uninstall** (`uninstall_run()`):
+Replace hardcoded `vaultspec-core` key removal with registry-aware
+cleanup: collect managed server names from registry, remove each from
+`.mcp.json`, delete file if empty.
+
+### CLI subcommands
+
+Add `mcps_app` Typer sub-group to `spec_cmd.py`:
+
+```
+vaultspec-core spec mcps list [--json]
+vaultspec-core spec mcps add --name <name> [--config <json>] [--force]
+vaultspec-core spec mcps remove <name> [--force]
+vaultspec-core spec mcps sync [--dry-run] [--force] [--json]
+```
+
+### Diagnostics
+
+Extend `collect_mcp_config_state()` to compare deployed `.mcp.json`
+entries against registry definitions. Add `REGISTRY_DRIFT` signal for
+when managed entries are missing or have stale configuration.
+
+### Public API
+
+Re-export from `core/__init__.py`:
+`collect_mcp_servers`, `mcp_list`, `mcp_add`, `mcp_remove`, `mcp_sync`
+
+### Enum and type changes
+
+- `Resource` enum: add `MCPS = "mcps"`
+- `WorkspaceContext`: add `mcps_src_dir: Path` field
+- `init_paths()`: construct `mcps_src_dir` from layout
+
+## Rationale
+
+**Option A (standalone MCP sync)** was chosen over adapting
+`sync_to_all_tools()` because:
+
+- MCP definitions are JSON, not Markdown - forcing them through the MD
+  pipeline would require artificial format conversion
+- `.mcp.json` is a single file, not a per-tool directory tree - the
+  `sync_to_all_tools()` abstraction of iterating over tool configs and
+  writing to per-tool directories does not apply
+- The conceptual pattern (collect -> merge -> write) is preserved while
+  the implementation is adapted to JSON merge semantics
+- The CLI surface (`spec mcps list|add|remove|sync`) mirrors rules/skills
+  exactly, maintaining UX consistency
+
+The `_scaffold_mcp_json()` function is superseded rather than wrapped
+because its hardcoded single-entry logic cannot support multiple
+definitions. The merge semantics it pioneered (read, merge, preserve
+user entries, atomic write) are preserved in `mcp_sync()`.
+
+## Consequences
+
+- `_scaffold_mcp_json()` becomes dead code and should be removed
+- All three lifecycle touchpoints (install, sync, uninstall) gain
+  data-driven MCP management instead of hardcoded single-entry handling
+- Consumer projects can ship `.builtin.json` files that get seeded
+  alongside their rules, enabling `vaultspec-core sync` to propagate
+  MCP entries without manual JSON editing
+- The `--skip mcp` opt-out continues to work unchanged
+- The `SyncResult` returned by `sync_provider()` will now include MCP
+  sync statistics
+- Doctor diagnostics can detect configuration drift for MCP entries,
+  not just presence/absence of the `vaultspec-core` key
+- The provider manifest does not require MCP-specific fields; MCP
+  definitions remain workspace-scoped, not provider-scoped

--- a/.vault/audit/2026-04-11-mcp-registry-audit.md
+++ b/.vault/audit/2026-04-11-mcp-registry-audit.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - '#audit'
+  - '#mcp-registry'
+date: '2026-04-11'
+related:
+  - '[[2026-04-11-mcp-registry-adr]]'
+  - '[[2026-04-11-mcp-registry-phase1-plan]]'
+---
+
+# `mcp-registry` Code Review
+
+## CORRECT-001 | HIGH | `--skip mcp` not respected in `_run_all_syncs()`
+
+`_run_all_syncs()` unconditionally calls `_mcp_sync`. The `skip` set is
+not consulted for `"mcp"` because it only filters `Tool` enum members.
+Must gate the `_mcp_sync` call on `"mcp" not in skip`.
+
+**Status:** FIXED
+
+## DIAG-002 / CORRECT-002 | MEDIUM | Hardcoded `vaultspec-core` guard in `collect_mcp_config_state()`
+
+The collector returns `PARTIAL_MCP` if `"vaultspec-core"` is not in
+servers before checking registry drift. This gates the registry check
+and misclassifies workspaces that use only custom servers. Fix: replace
+hardcoded check with registry-aware presence check.
+
+**Status:** FIXED
+
+## DIAG-001 | MEDIUM | `REGISTRY_DRIFT` silently no-op in resolver
+
+`_resolve_config()` groups `REGISTRY_DRIFT` with `OK`/`PARTIAL_MCP`/
+`USER_MCP` in a no-op return. Intent is advisory-only (doctor surfaces
+it, sync repairs it via `_run_all_syncs`). This is correct behavior:
+sync already repairs drift by re-merging definitions. No fix needed.
+
+**Status:** BY DESIGN
+
+## DIAG-003 | LOW | Absolute import in `collectors.py`
+
+`from vaultspec_core.core.mcps import collect_mcp_servers` should use
+relative import. Fixed for consistency.
+
+**Status:** FIXED
+
+## SAFETY-001 | LOW | `mcp_uninstall` silently swallows parse errors
+
+Returns empty list on corrupt `.mcp.json` with no logging. Acceptable
+since uninstall is best-effort cleanup; corrupt files require manual
+intervention regardless.
+
+**Status:** WONTFIX
+
+## QUAL-001 | LOW | No dict validation in `mcp_add()`
+
+`mcp_add()` does not validate config is a dict. `collect_mcp_servers()`
+catches non-dicts on read. Acceptable layering.
+
+**Status:** WONTFIX
+
+## ARCH-003 | LOW | Module docstring not updated
+
+`spec_cmd.py` docstring doesn't mention `mcps_app`. Fixed.
+
+**Status:** FIXED
+
+## TEST-001 | MEDIUM | No test for missing context error path
+
+`mcp_sync()` LookupError guard not tested. Test added.
+
+**Status:** FIXED
+
+## COMPLETE-002 | LOW | Missing CLI integration tests (Step 6.4)
+
+Typer runner CLI tests deferred to follow-up. Core logic is covered
+by unit and lifecycle tests.
+
+**Status:** DEFERRED

--- a/.vault/plan/2026-04-11-mcp-registry-phase1-plan.md
+++ b/.vault/plan/2026-04-11-mcp-registry-phase1-plan.md
@@ -1,0 +1,95 @@
+---
+tags:
+  - '#plan'
+  - '#mcp-registry'
+date: '2026-04-11'
+related:
+  - '[[2026-04-11-mcp-registry-adr]]'
+  - '[[2026-04-11-mcp-registry-research]]'
+---
+
+# `mcp-registry` `phase-1` plan
+
+Implement the MCP server registry: built-in MCP definitions stored in
+`.vaultspec/rules/mcps/`, a new `core/mcps.py` module with collect/list/
+add/remove/sync functions, CLI subcommands (`spec mcps`), lifecycle
+integration with install/sync/uninstall, and doctor diagnostics for
+registry drift detection. Replaces the hardcoded `_scaffold_mcp_json()`
+with a data-driven pipeline.
+
+## Proposed Changes
+
+Per the accepted ADR, the implementation uses a standalone MCP sync
+pipeline (Option A) that operates on JSON definition files rather than
+adapting the Markdown-based `sync_to_all_tools()` abstraction. The
+`_scaffold_mcp_json()` function is superseded by `mcp_sync()`.
+
+## Tasks
+
+- Phase 1: Foundation (enums, types, built-in definition)
+
+  - [ ] Step 1.1: Add `MCPS = "mcps"` to `Resource` enum in `core/enums.py`
+  - [ ] Step 1.2: Add `mcps_src_dir: Path` field to `WorkspaceContext` in `core/types.py`; update ALL construction sites: `init_paths()` (types.py:334), `uninstall_run()` bootstrap (commands.py:787), `install_upgrade()` bootstrap (commands.py:538), `_target.py` fallback context (cli/\_target.py:166), and any test fixtures that construct `WorkspaceContext` directly (tests/cli/conftest.py, tests/cli/test_sync_manifest.py). Consider giving the field a default value to ease construction.
+  - [ ] Step 1.3: Create the built-in definition file `.vaultspec/rules/mcps/vaultspec-core.builtin.json` containing the server config currently hardcoded in `_scaffold_mcp_json()`
+
+- Phase 2: Core module (`core/mcps.py`)
+
+  - [ ] Step 2.1: Implement `collect_mcp_servers(warnings)` - reads `.json` files from `mcps_src_dir`, parses each, returns `dict[str, tuple[Path, dict]]` mapping server name (derived from filename) to (source path, parsed config); filename stem extraction must strip `.builtin.json` as a unit first, then fall back to `.json` (handles `foo.bar.builtin.json` -> `foo.bar`); must return empty dict gracefully when `mcps_src_dir` does not exist (fresh workspace before seeding)
+  - [ ] Step 2.2: Implement `mcp_list()` - returns `list[dict[str, str]]` with `name` and `source` ("Built-in" or "Custom") fields, mirroring `rules_list()` pattern
+  - [ ] Step 2.3: Implement `mcp_add(name, config, force)` - writes a new `.json` file to `mcps_src_dir`; validates JSON structure; raises `ResourceExistsError` if exists and not `force`
+  - [ ] Step 2.4: Implement `mcp_remove(name)` - finds and deletes the definition file; raises `ResourceNotFoundError` if not found
+  - [ ] Step 2.5: Implement `mcp_sync(dry_run, force)` - the core merge pipeline: collect definitions, read/initialize `.mcp.json`, merge entries (add missing, skip matching, warn on diff without force / overwrite with force), atomic write, return `SyncResult` (imported from `core/types.py`); must also call `ensure_dir(mcps_src_dir)` to handle missing directory gracefully
+
+- Phase 3: Lifecycle integration (`core/commands.py`)
+
+  - [ ] Step 3.1: Replace `_scaffold_mcp_json(target)` call in `init_run()` (line ~428) with `mcp_sync()` call, gated by `"mcp" not in skip`
+  - [ ] Step 3.2: Add `mcp_sync` to `_run_all_syncs()` list in `sync_provider()` alongside rules/skills/agents/system/config; the `--skip mcp` gating is handled by the caller (sync_provider checks skip before calling \_run_all_syncs for the "all" path, and mcp_sync runs unconditionally within \_run_all_syncs since it targets a provider-agnostic file)
+  - [ ] Step 3.3: Remove the standalone `_scaffold_mcp_json()` repair call in `sync_provider()` (line ~1270) - now handled by `_run_all_syncs()`
+  - [ ] Step 3.4: Replace `_scaffold_mcp_json()` calls in `install_upgrade()`: (a) the dry-run manifest path at line ~584 should call `mcp_sync(dry_run=True)` or equivalent, (b) the upgrade repair call at line ~623 is removed (now handled via `sync_provider()` which calls `_run_all_syncs()`), (c) add `"mcps": len(collect_mcp_servers())` to `source_counts`
+  - [ ] Step 3.5: Replace hardcoded `vaultspec-core` key removal in `uninstall_run()` (line ~901) with registry-aware cleanup: collect managed server names, remove each from `.mcp.json`, delete file if empty; this applies only to full uninstall (`effective_provider == "all"`); per-provider uninstall leaves MCP untouched
+  - [ ] Step 3.6: Search for ALL remaining `_scaffold_mcp_json` references; once all callsites are migrated, remove the function entirely
+
+- Phase 4: Public API and CLI
+
+  - [ ] Step 4.1: Add re-exports to `core/__init__.py`: `collect_mcp_servers`, `mcp_list`, `mcp_add`, `mcp_remove`, `mcp_sync`
+  - [ ] Step 4.2: Add `mcps_app` Typer sub-group to `cli/spec_cmd.py` with commands: `list`, `add`, `remove`, `sync` - mirroring the `rules_app` pattern (including `--json`, `--force`, `--dry-run`, `--target` options)
+
+- Phase 5: Doctor diagnostics
+
+  - [ ] Step 5.1: Add `REGISTRY_DRIFT` value to `ConfigSignal` enum in `diagnosis/signals.py`; update the signal display dict in `cli/root.py` (line ~867-875) to include a human-readable label; update the if-elif chain in `diagnosis/resolver.py` (line ~539-552) to handle the new signal
+  - [ ] Step 5.2: Extend `collect_mcp_config_state()` in `diagnosis/collectors.py` to compare deployed `.mcp.json` entries against registry definitions; return `REGISTRY_DRIFT` when managed entries are missing or have stale configuration
+
+- Phase 6: Tests
+
+  - [ ] Step 6.1: Unit tests for `collect_mcp_servers()` - empty dir, missing dir, single builtin, custom, mixed, parse errors, multi-dot filename stems (`foo.bar.builtin.json`)
+  - [ ] Step 6.2: Unit tests for `mcp_list()`, `mcp_add()`, `mcp_remove()` - CRUD operations, error cases
+  - [ ] Step 6.3: Unit tests for `mcp_sync()` - idempotent merge, non-destructive preserve, warn on diff without force, force overwrite, dry-run, empty state, missing `.mcp.json`
+  - [ ] Step 6.4: Integration tests for CLI subcommands via Typer test runner
+  - [ ] Step 6.5: Integration tests for lifecycle: install seeds MCPs, sync repairs drift, uninstall cleans managed entries
+  - [ ] Step 6.6: Test for doctor diagnostics: REGISTRY_DRIFT detection
+
+- Phase 7: Finalization
+
+  - [ ] Step 7.1: Run `uv run ruff check` and `uv run ty check` on all modified files; fix any issues
+  - [ ] Step 7.2: Run full test suite `uv run pytest` and verify all tests pass
+  - [ ] Step 7.3: Commit changes and open/update draft PR
+
+## Parallelization
+
+- Phase 1 steps are sequential (each depends on prior)
+- Phase 2 steps 2.1-2.4 are independent; 2.5 depends on 2.1
+- Phase 3 steps are mostly independent but should be applied sequentially to avoid merge conflicts within `commands.py`
+- Phase 4 depends on Phase 2
+- Phase 5 is independent of Phases 3-4
+- Phase 6 depends on all prior phases
+- Phase 7 depends on all prior phases
+
+## Verification
+
+- All existing tests continue to pass (no regressions)
+- New unit tests cover: collection from empty/populated dirs, builtin vs custom classification, filename stem extraction for both suffixes, JSON parse error handling, idempotent sync, non-destructive merge preserving user entries, force overwrite, dry-run mode
+- Integration tests verify the full lifecycle: `install` seeds the builtin definition and merges to `.mcp.json`; `sync` repairs missing/drifted entries; `uninstall` removes managed entries cleanly
+- CLI subcommands produce correct output for `--json` and table modes
+- `ruff check` and `ty check` report zero errors on modified files
+- Pre-commit hooks pass on all staged files
+- The existing `test_mcp_config.py` tests continue to pass (`.mcp.json` at repo root still valid)

--- a/.vault/research/2026-04-11-mcp-registry-research.md
+++ b/.vault/research/2026-04-11-mcp-registry-research.md
@@ -1,0 +1,290 @@
+---
+tags:
+  - '#research'
+  - '#mcp-registry'
+date: '2026-04-11'
+related:
+  - '[[2026-03-28-mcp-installation-patterns-research]]'
+  - '[[2026-02-22-mcp-consolidation-research]]'
+  - '[[2026-02-22-mcp-consolidation-adr]]'
+---
+
+# `mcp-registry` research: built-in MCP definitions with install/sync/uninstall lifecycle
+
+Researched the internal architecture of vaultspec-core's resource management
+pipeline to determine the optimal design for an MCP server registry that
+mirrors the existing rule/skill/agent registry pattern. This registry will
+allow built-in and custom MCP server definitions to be programmatically
+managed and synced to `.mcp.json`.
+
+## Findings
+
+### 1. Existing resource registry architecture
+
+All resource types (rules, skills, agents) follow the same pipeline:
+
+- **Source directory**: `.vaultspec/rules/{resource}/` stores canonical
+  definitions
+- **Collection**: `collect_{resource}()` gathers source files via
+  `collect_md_resources()` (Markdown with YAML frontmatter)
+- **Transform**: `transform_{resource}()` adapts content for each tool
+  destination
+- **Sync**: `{resource}_sync()` calls `sync_to_all_tools()` to distribute
+  to per-tool directories
+- **CLI**: `spec {resource} list|add|remove|sync` via Typer sub-groups
+- **Public API**: re-exported from `core/__init__.py`
+- **Built-in naming**: `*.builtin.md` suffix distinguishes bundled from
+  custom definitions
+
+The `sync_to_all_tools()` function iterates over `installed_tool_configs()`
+and writes transformed content to per-tool destination directories
+(`.claude/rules/`, `.gemini/rules/`, etc.).
+
+### 2. MCP definitions diverge from the MD pattern
+
+MCP server definitions are inherently JSON structures matching the
+`.mcp.json` schema:
+
+```json
+{
+  "command": "uv",
+  "args": ["run", "python", "-m", "vaultspec_core.mcp_server.app"]
+}
+```
+
+Key differences from rules/skills/agents:
+
+- **Format**: JSON, not Markdown with frontmatter
+- **Destination**: Single `.mcp.json` file, not per-tool directories
+- **Transform**: No per-tool adaptation needed - `.mcp.json` is
+  provider-agnostic
+- **Merge semantics**: JSON key-level merge into `mcpServers` dict, not
+  file-level copy
+
+This means `sync_to_all_tools()` is NOT the right abstraction. MCP sync
+needs its own pipeline: collect JSON definitions from source, merge into
+the single `.mcp.json` destination.
+
+### 3. Source storage convention
+
+MCP definitions should live in `.vaultspec/rules/mcps/` as individual JSON
+files. Each file defines one MCP server:
+
+- Filename (minus extension) = server name in `.mcp.json`
+- `.builtin.json` suffix for built-in definitions
+- `.json` suffix for custom definitions
+- File content = the server configuration object
+
+Example: `.vaultspec/rules/mcps/vaultspec-core.builtin.json` contains the
+server entry that gets merged as `mcpServers["vaultspec-core"]`.
+
+This is consistent with the existing directory structure under
+`.vaultspec/rules/` and will be automatically bundled by the existing
+`force-include` in `pyproject.toml`:
+`".vaultspec/rules" = "vaultspec_core/builtins"`.
+
+### 4. Current MCP handling across the install/sync/uninstall lifecycle
+
+MCP management currently uses three hardcoded touchpoints, all operating
+on a single `vaultspec-core` server entry:
+
+**Install (`init_run()`, line 427)**:
+After core scaffolding and builtin seeding, calls `_scaffold_mcp_json()`
+as a standalone step gated by `"mcp" not in skip`. This is provider-
+agnostic - it runs regardless of which provider is being installed.
+The MCP entry is not tracked in the provider manifest; it has no
+provider ownership.
+
+**Sync (`sync_provider()`, line 1269)**:
+After running all resource syncs (rules, skills, agents, system, config),
+calls `_scaffold_mcp_json()` as a "repair" step - it re-ensures the
+hardcoded entry exists. Again gated by `"mcp" not in skip`. This means
+`vaultspec-core sync` silently repairs a missing `.mcp.json` entry
+every time.
+
+**Upgrade (`install_upgrade()`, line 664)**:
+Calls `sync_provider()` which triggers the repair step above.
+Source counts are gathered for rules/skills/agents but not for MCPs.
+
+**Uninstall (`uninstall_run()`, line 901)**:
+Surgical cleanup removes only `mcpServers["vaultspec-core"]` from
+`.mcp.json`. If no servers remain, deletes the file entirely.
+Gated by `"mcp" not in skip`.
+
+**Key implication**: The registry replaces all three hardcoded
+`_scaffold_mcp_json()` calls with data-driven `mcp_sync()`. The
+`_scaffold_mcp_json()` function becomes obsolete - its merge logic
+moves into `mcp_sync()` which operates on the full set of registry
+definitions rather than a single hardcoded entry.
+
+The `--skip mcp` opt-out continues to work because the gating pattern
+(`"mcp" not in skip`) stays the same - it just gates `mcp_sync()`
+instead of `_scaffold_mcp_json()`.
+
+### 5. Provider manifest implications
+
+The provider manifest (`ManifestData` in `manifest.py`) tracks installed
+providers and their state but has no MCP-specific fields. MCP definitions
+are not provider-scoped - they are workspace-level (`.mcp.json` is shared
+by all providers).
+
+This means:
+
+- MCP registry state does not belong in the provider manifest
+- MCP sync runs for all providers, not per-provider
+- Uninstalling a single provider should NOT remove MCP entries (unless
+  the provider contributed them and no other provider needs them)
+- The `source_counts` dict in install_upgrade should include `"mcps"`
+
+However, consumer projects (e.g., vaultspec-rag) will ship their own
+MCP definitions. When multiple packages contribute definitions to the
+same `.vaultspec/rules/mcps/` directory, the registry should track which
+definitions are built-in vs custom, but ownership tracking beyond
+`.builtin.json` naming is out of scope for this PR.
+
+### 6. Integration points requiring modification (updated)
+
+**`core/enums.py`**:
+
+- Add `MCPS = "mcps"` to `Resource` enum
+
+**`core/types.py`**:
+
+- Add `mcps_src_dir: Path` to `WorkspaceContext`
+- Construct it in `init_paths()` as
+  `vaultspec / Resource.RULES.value / Resource.MCPS.value`
+
+**`core/mcps.py`** (new module):
+
+- `collect_mcp_servers()` - reads `.json` files from `mcps_src_dir`
+- `mcp_list()` - returns metadata dicts
+- `mcp_add()` - scaffolds a new custom definition
+- `mcp_remove()` - deletes a definition
+- `mcp_sync()` - merges definitions into `.mcp.json`
+
+**`core/__init__.py`**:
+
+- Re-export public API from `mcps.py`
+
+**`core/commands.py`**:
+
+- `_scaffold_mcp_json()` becomes obsolete - replaced by `mcp_sync()`
+- `init_run()` line 427: replace `_scaffold_mcp_json(target)` with
+  `mcp_sync(target)` (or equivalent call)
+- `sync_provider()` `_run_all_syncs()`: add `mcp_sync` to the sync
+  list alongside rules/skills/agents/system/config
+- `sync_provider()` line 1269: remove the standalone
+  `_scaffold_mcp_json()` repair call (now part of `_run_all_syncs`)
+- `install_upgrade()` line 674: add `"mcps"` to `source_counts`
+- `uninstall_run()` line 901: replace hardcoded `vaultspec-core` key
+  removal with registry-aware cleanup (remove all managed entries)
+
+**`cli/spec_cmd.py`**:
+
+- Add `mcps_app` Typer sub-group mirroring `rules_app`
+
+**`builtins/__init__.py`**:
+
+- `seed_builtins()` already handles this - it copies all files from
+  `.vaultspec/rules/` recursively, so `mcps/` will be seeded
+  automatically
+
+**`diagnosis/collectors.py`**:
+
+- Extend `collect_mcp_config_state()` to detect drift between registry
+  definitions and deployed `.mcp.json` entries
+
+### 7. Sync semantics for `.mcp.json`
+
+The merge must be:
+
+- **Idempotent**: re-running produces the same result
+- **Non-destructive**: user-added servers are preserved
+- **Registry-aware**: only entries whose names match definition files are
+  considered "managed"
+- **Force mode**: `--force` overwrites managed entries even if user has
+  modified them
+
+Algorithm:
+
+- Collect all JSON definitions from `mcps_src_dir`
+- Read existing `.mcp.json` (or start with empty structure)
+- For each definition: if server name absent or `--force`, write/overwrite
+  the entry
+- Write back the merged result via `atomic_write()`
+- Return `SyncResult` with added/updated/skipped counts
+
+### 8. Uninstall cleanup
+
+Currently `uninstall_run()` hardcodes removal of the `vaultspec-core` key.
+With the registry, uninstall should:
+
+- Collect all managed server names from the registry
+- Remove each from `.mcp.json`
+- If no servers remain, delete `.mcp.json`
+- The `.vaultspec/rules/mcps/` directory is already cleaned up when
+  `.vaultspec/` is removed during full uninstall
+
+For per-provider uninstall, the question is whether to remove MCP entries
+that "belong" to that provider. Since MCP definitions are workspace-level
+(not provider-scoped), the simplest approach is: full uninstall removes
+all managed entries; per-provider uninstall leaves MCP untouched.
+
+### 9. Doctor diagnostics extension
+
+Current signals: `PARTIAL_MCP` (missing/malformed), `USER_MCP` (extra
+servers), `OK` (only vaultspec-core).
+
+New signal needed: `REGISTRY_DRIFT` - when managed entries in `.mcp.json`
+differ from their registry definitions (stale command, wrong args, missing
+entry that should be present).
+
+### 10. Parallel PR #36 merge surface
+
+PR #36 handles pre-commit hook standardization. The merge surface is
+minimal:
+
+- Both touch `commands.py` but in different functions
+- #36 touches `_scaffold_precommit()` and pre-commit resolver logic
+- This PR touches `_scaffold_mcp_json()` and MCP sync logic
+- No overlap in `spec_cmd.py` (no `spec precommit` group in #36)
+
+Risk: low. Avoid modifying `_scaffold_precommit()` or `resolver.py`.
+
+## Design options
+
+### Option A: Standalone MCP sync (recommended)
+
+MCP sync operates independently from `sync_to_all_tools()`. Has its own
+collect/merge pipeline targeting `.mcp.json` directly. Called alongside
+other syncs in `sync_provider()`.
+
+Pros: Clean separation, JSON-native, no awkward adaptation of the MD
+pipeline. Cons: Small amount of pattern divergence from rules/skills.
+
+### Option B: Adapt sync_to_all_tools for JSON
+
+Extend `sync_to_all_tools()` to handle non-MD resources and single-file
+destinations.
+
+Pros: Unified sync surface. Cons: Significant complexity to generalize
+a function designed for per-tool directory distribution. The abstraction
+would leak - MCP has no per-tool variants.
+
+### Option C: Wrapper around existing \_scaffold_mcp_json
+
+Keep `_scaffold_mcp_json()` as the write layer, add collection and CLI
+on top.
+
+Pros: Minimal change. Cons: The scaffold function is hardcoded to the
+`vaultspec-core` entry - it would need refactoring anyway to support
+multiple definitions.
+
+## Recommendation
+
+**Option A** is the clear winner. It mirrors the rule registry's conceptual
+pattern (collect -> transform -> sync) while respecting the fundamental
+difference in destination format (JSON merge vs file copy). The CLI surface
+mirrors rules exactly. The `_scaffold_mcp_json()` function is refactored
+into the new `mcp_sync()` so there's one code path for all MCP config
+management.

--- a/.vaultspec/rules/mcps/vaultspec-core.builtin.json
+++ b/.vaultspec/rules/mcps/vaultspec-core.builtin.json
@@ -1,0 +1,4 @@
+{
+  "command": "uv",
+  "args": ["run", "python", "-m", "vaultspec_core.mcp_server.app"]
+}

--- a/src/vaultspec_core/cli/root.py
+++ b/src/vaultspec_core/cli/root.py
@@ -867,12 +867,14 @@ def cmd_doctor(
             ConfigSignal.OK: ("ok", "green"),
             ConfigSignal.MISSING: ("warn", "yellow"),
             ConfigSignal.FOREIGN: ("info", "dim"),
+            ConfigSignal.REGISTRY_DRIFT: ("warn", "yellow"),
         },
     )
     mcp_detail = {
         ConfigSignal.OK: ".mcp.json present",
         ConfigSignal.MISSING: ".mcp.json not found",
         ConfigSignal.FOREIGN: ".mcp.json present (no vaultspec entry)",
+        ConfigSignal.REGISTRY_DRIFT: ".mcp.json entries differ from registry",
     }.get(diag.mcp, str(diag.mcp))
     table.add_row(
         "mcp",
@@ -968,7 +970,11 @@ def _doctor_exit_code(diag: WorkspaceDiagnosis) -> int:
             has_warn = True
         if prov.dir_state in (ProviderDirSignal.EMPTY, ProviderDirSignal.PARTIAL):
             has_warn = True
-        if prov.config in (ConfigSignal.MISSING, ConfigSignal.FOREIGN):
+        if prov.config in (
+            ConfigSignal.MISSING,
+            ConfigSignal.FOREIGN,
+            ConfigSignal.REGISTRY_DRIFT,
+        ):
             has_warn = True
         for s in prov.content.values():
             if s in (ContentSignal.STALE, ContentSignal.DIVERGED):

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -973,3 +973,147 @@ def cmd_hooks_run(
                 console.print(f"    {line}")
         if r["error"]:
             console.print(f"    [red]error:[/red] {r['error']}")
+
+
+# =============================================================================
+# MCPs
+# =============================================================================
+
+mcps_app = typer.Typer(
+    help="Manage MCP server definitions and synced .mcp.json entries.",
+    no_args_is_help=True,
+)
+spec_app.add_typer(mcps_app, name="mcps")
+
+
+@mcps_app.command("list")
+def cmd_mcps_list(
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """List all registered MCP server definitions."""
+    apply_target(target)
+    from rich import box
+    from rich.table import Table
+
+    from vaultspec_core.console import get_console
+    from vaultspec_core.core import mcp_list
+
+    items = mcp_list()
+
+    if json_output:
+        import json
+
+        typer.echo(json.dumps(items, indent=2, default=str))
+        raise typer.Exit(0)
+
+    console = get_console()
+    if not items:
+        console.print("No MCP server definitions found.")
+        return
+
+    table = Table(box=box.SIMPLE_HEAD, highlight=False, show_edge=False)
+    table.add_column("Name", no_wrap=True)
+    table.add_column("Source")
+
+    for item in items:
+        table.add_row(item["name"], item["source"])
+
+    console.print(table)
+
+
+@mcps_app.command("add")
+def cmd_mcps_add(
+    name: Annotated[str, typer.Option("--name", help="MCP server name")],
+    config: Annotated[
+        str | None, typer.Option("--config", help="Server config as JSON string")
+    ] = None,
+    force: Annotated[bool, typer.Option("--force", help="Overwrite existing")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Add a new custom MCP server definition."""
+    apply_target(target)
+    import json as json_mod
+
+    from vaultspec_core.core import mcp_add
+    from vaultspec_core.core.exceptions import VaultSpecError
+
+    parsed_config = None
+    if config is not None:
+        try:
+            parsed_config = json_mod.loads(config)
+        except json_mod.JSONDecodeError as exc:
+            typer.echo(f"Error: Invalid JSON config: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
+
+    try:
+        file_path = mcp_add(name=name, config=parsed_config, force=force)
+    except VaultSpecError as exc:
+        _handle_error(exc)
+        return
+
+    if json_output:
+        import json
+
+        typer.echo(json.dumps({"path": str(file_path)}, indent=2))
+        raise typer.Exit(0)
+
+
+@mcps_app.command("remove")
+def cmd_mcps_remove(
+    name: Annotated[str, typer.Argument(help="MCP server name")],
+    force: Annotated[bool, typer.Option("--force", help="Skip confirmation")] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Remove an MCP server definition."""
+    apply_target(target)
+    from vaultspec_core.core import mcp_remove
+    from vaultspec_core.core.exceptions import VaultSpecError
+
+    if not force and not typer.confirm(f"Remove MCP definition '{name}'?"):
+        raise typer.Abort()
+
+    try:
+        mcp_remove(name=name)
+    except VaultSpecError as exc:
+        _handle_error(exc)
+        return
+
+    if json_output:
+        import json
+
+        typer.echo(json.dumps({"removed": name}, indent=2))
+        raise typer.Exit(0)
+
+
+@mcps_app.command("sync")
+def cmd_mcps_sync(
+    dry_run: Annotated[bool, typer.Option("--dry-run", help="Preview changes")] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Overwrite modified entries"),
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Sync MCP definitions to .mcp.json."""
+    apply_target(target)
+    from vaultspec_core.console import get_console
+    from vaultspec_core.core import mcp_sync
+    from vaultspec_core.core.sync import format_summary
+
+    result = mcp_sync(force=force, dry_run=dry_run)
+
+    if json_output:
+        import dataclasses
+        import json
+
+        typer.echo(json.dumps(dataclasses.asdict(result), indent=2, default=str))
+        raise typer.Exit(0)
+
+    console = get_console()
+    console.print(f"  [bold]{format_summary('MCPs', result)}[/bold]")
+    for warning in result.warnings:
+        console.print(f"  [yellow]•[/yellow] {warning}")

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -2,7 +2,8 @@
 
 Sub-groups: ``spec rules`` (:data:`rules_app`), ``spec skills`` (:data:`skills_app`),
 ``spec agents`` (:data:`agents_app`), ``spec system`` (:data:`system_app`),
-``spec hooks`` (:data:`hooks_app`). Delegates to :mod:`vaultspec_core.core`
+``spec hooks`` (:data:`hooks_app`), ``spec mcps`` (:data:`mcps_app`).
+Delegates to :mod:`vaultspec_core.core`
 CRUD functions via lazy imports to avoid circular-import issues. Mounted onto
 :data:`.root.app` as the ``spec`` sub-group.
 """

--- a/src/vaultspec_core/core/__init__.py
+++ b/src/vaultspec_core/core/__init__.py
@@ -26,6 +26,11 @@ from .exceptions import WorkspaceNotInitializedError as WorkspaceNotInitializedE
 from .helpers import atomic_write as atomic_write
 from .helpers import build_file as build_file
 from .helpers import ensure_dir as ensure_dir
+from .mcps import collect_mcp_servers as collect_mcp_servers
+from .mcps import mcp_add as mcp_add
+from .mcps import mcp_list as mcp_list
+from .mcps import mcp_remove as mcp_remove
+from .mcps import mcp_sync as mcp_sync
 from .resources import resource_edit as resource_edit
 from .resources import resource_remove as resource_remove
 from .resources import resource_rename as resource_rename

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -190,54 +190,6 @@ def _scaffold_provider(
     return created
 
 
-def _scaffold_mcp_json(target: Path, *, dry_run: bool = False) -> list[tuple[str, str]]:
-    """Scaffold or merge ``vaultspec-core`` into ``.mcp.json``.
-
-    If ``.mcp.json`` already exists the function merges the ``vaultspec-core``
-    server entry into the existing ``mcpServers`` dict, preserving user entries.
-    When the entry already exists the file is left untouched.
-
-    Args:
-        target: Workspace root directory.
-        dry_run: When ``True``, returns the manifest without writing anything.
-
-    Returns:
-        List with a single ``(".mcp.json", "mcp")`` tuple when a write
-        occurred (or would occur), otherwise empty.
-    """
-    import json
-
-    from .helpers import atomic_write
-
-    mcp_json = target / ".mcp.json"
-    server_entry = {
-        "command": "uv",
-        "args": ["run", "python", "-m", "vaultspec_core.mcp_server.app"],
-    }
-
-    if mcp_json.exists():
-        try:
-            raw = json.loads(mcp_json.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            return []
-        if not isinstance(raw, dict):
-            return []
-        servers = raw.setdefault("mcpServers", {})
-        if not isinstance(servers, dict):
-            return []
-        if "vaultspec-core" in servers:
-            return []
-        servers["vaultspec-core"] = server_entry
-        if not dry_run:
-            atomic_write(mcp_json, json.dumps(raw, indent=2) + "\n")
-        return [(".mcp.json", "mcp")]
-
-    if not dry_run:
-        mcp_config = {"mcpServers": {"vaultspec-core": server_entry}}
-        atomic_write(mcp_json, json.dumps(mcp_config, indent=2) + "\n")
-    return [(".mcp.json", "mcp")]
-
-
 def _scaffold_precommit(
     target: Path, *, dry_run: bool = False
 ) -> list[tuple[str, str]]:
@@ -425,7 +377,11 @@ def init_run(
         created.extend(_scaffold_provider(target, tool))
 
     if "mcp" not in skip:
-        created.extend(_scaffold_mcp_json(target))
+        from .mcps import mcp_sync
+
+        mcp_result = mcp_sync()
+        if mcp_result.items:
+            created.append((".mcp.json", "mcp"))
     if "precommit" not in skip:
         created.extend(_scaffold_precommit(target))
 
@@ -581,7 +537,11 @@ def install_run(
         for tool in tools:
             manifest.extend(_scaffold_provider(path, tool, dry_run=True))
         if "mcp" not in skip:
-            manifest.extend(_scaffold_mcp_json(path, dry_run=True))
+            from .mcps import mcp_sync
+
+            mcp_result = mcp_sync(dry_run=True)
+            if mcp_result.items:
+                manifest.append((".mcp.json", "mcp"))
         if "precommit" not in skip:
             manifest.extend(_scaffold_precommit(path, dry_run=True))
 
@@ -618,9 +578,6 @@ def install_run(
         sync_target = provider if provider not in ("all", "core") else "all"
         sync_provider(sync_target, force=True, skip=skip)
 
-        # Re-scaffold MCP entry if missing (repair)
-        if "mcp" not in skip:
-            _scaffold_mcp_json(path)
         if "precommit" not in skip:
             _scaffold_precommit(path)
 
@@ -668,6 +625,7 @@ def install_run(
 
     # Count actual source resources (what the user authored)
     from .agents import collect_agents
+    from .mcps import collect_mcp_servers
     from .rules import collect_rules
     from .skills import collect_skills
 
@@ -675,6 +633,7 @@ def install_run(
         "rules": len(collect_rules()),
         "skills": len(collect_skills()),
         "agents": len(collect_agents()),
+        "mcps": len(collect_mcp_servers()),
     }
 
     tools = _filter_tools(_PROVIDER_TO_TOOLS.get(provider, []), skip)
@@ -845,8 +804,6 @@ def uninstall_run(
         mdata_before = ManifestData()
 
     if effective_provider == "all":
-        import json
-
         from .helpers import atomic_write
 
         # Remove everything (respecting skip).
@@ -898,24 +855,13 @@ def uninstall_run(
                 label = file_labels.get(f.name, "")
                 removed.append((str(f).replace("\\", "/"), label))
 
-        # Surgical .mcp.json cleanup: remove only the vaultspec-core key
+        # Surgical .mcp.json cleanup: remove registry-managed entries
         mcp_path = path / ".mcp.json"
         if "mcp" not in skip:
-            if mcp_path.exists() and not dry_run:
-                try:
-                    raw = json.loads(mcp_path.read_text(encoding="utf-8"))
-                    if isinstance(raw, dict):
-                        servers = raw.get("mcpServers", {})
-                        if isinstance(servers, dict) and "vaultspec-core" in servers:
-                            del servers["vaultspec-core"]
-                            if servers:
-                                atomic_write(mcp_path, json.dumps(raw, indent=2) + "\n")
-                            else:
-                                mcp_path.unlink()
-                            removed.append((_rel(path, mcp_path), "mcp"))
-                except (json.JSONDecodeError, OSError):
-                    pass
-            elif mcp_path.exists() and dry_run:
+            from .mcps import mcp_uninstall
+
+            uninstalled = mcp_uninstall(path, dry_run=dry_run)
+            if uninstalled:
                 removed.append((_rel(path, mcp_path), "mcp"))
 
         # Surgical .pre-commit-config.yaml cleanup: remove vaultspec-core hooks
@@ -1197,6 +1143,7 @@ def sync_provider(
     from .agents import agents_sync
     from .config_gen import config_sync
     from .guards import guard_dev_repo
+    from .mcps import mcp_sync as _mcp_sync
     from .rules import rules_sync
     from .skills import skills_sync
     from .system import system_sync
@@ -1212,6 +1159,7 @@ def sync_provider(
             (lambda: agents_sync(prune=force, dry_run=dry_run), "agents"),
             (lambda: system_sync(dry_run=dry_run, force=force), "system"),
             (lambda: config_sync(dry_run=dry_run, force=force), "config"),
+            (lambda: _mcp_sync(dry_run=dry_run, force=force), "mcps"),
         ]:
             try:
                 results.append(sync_fn())
@@ -1265,9 +1213,6 @@ def sync_provider(
 
             from .gitignore import ensure_gitignore_block
 
-            # Repair MCP entry if missing (unless mcp is skipped)
-            if "mcp" not in skip:
-                _scaffold_mcp_json(ctx.target_dir)
             if "precommit" not in skip:
                 _scaffold_precommit(ctx.target_dir)
 

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import contextvars
 import logging
 import shutil
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
@@ -1153,14 +1154,18 @@ def sync_provider(
 
     def _run_all_syncs() -> list[_t.SyncResult]:
         results: list[_t.SyncResult] = []
-        for sync_fn, label in [
+        sync_passes: list[tuple[Callable[[], _t.SyncResult], str]] = [
             (lambda: rules_sync(prune=force, dry_run=dry_run), "rules"),
             (lambda: skills_sync(prune=force, dry_run=dry_run), "skills"),
             (lambda: agents_sync(prune=force, dry_run=dry_run), "agents"),
             (lambda: system_sync(dry_run=dry_run, force=force), "system"),
             (lambda: config_sync(dry_run=dry_run, force=force), "config"),
-            (lambda: _mcp_sync(dry_run=dry_run, force=force), "mcps"),
-        ]:
+        ]
+        if "mcp" not in skip:
+            sync_passes.append(
+                (lambda: _mcp_sync(dry_run=dry_run, force=force), "mcps")
+            )
+        for sync_fn, label in sync_passes:
             try:
                 results.append(sync_fn())
             except Exception as exc:

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -825,6 +825,16 @@ def uninstall_run(
             path / "AGENTS.md",
         ]
 
+        # Surgical .mcp.json cleanup BEFORE directory removal so the
+        # registry in .vaultspec/rules/mcps/ is still readable.
+        mcp_path = path / ".mcp.json"
+        if "mcp" not in skip:
+            from .mcps import mcp_uninstall
+
+            uninstalled = mcp_uninstall(path, dry_run=dry_run)
+            if uninstalled:
+                removed.append((_rel(path, mcp_path), "mcp"))
+
         for d in managed_dirs:
             owners = _dir_owners.get(d.name, [])
             if owners and any(o in skip for o in owners):
@@ -855,15 +865,6 @@ def uninstall_run(
                         continue
                 label = file_labels.get(f.name, "")
                 removed.append((str(f).replace("\\", "/"), label))
-
-        # Surgical .mcp.json cleanup: remove registry-managed entries
-        mcp_path = path / ".mcp.json"
-        if "mcp" not in skip:
-            from .mcps import mcp_uninstall
-
-            uninstalled = mcp_uninstall(path, dry_run=dry_run)
-            if uninstalled:
-                removed.append((_rel(path, mcp_path), "mcp"))
 
         # Surgical .pre-commit-config.yaml cleanup: remove vaultspec-core hooks
         precommit_path = path / ".pre-commit-config.yaml"

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -345,19 +345,26 @@ def collect_mcp_config_state(target: Path) -> ConfigSignal:
     if not isinstance(servers, dict):
         return ConfigSignal.PARTIAL_MCP
 
-    if "vaultspec-core" not in servers:
-        return ConfigSignal.PARTIAL_MCP
-
-    # Check for registry drift: compare deployed entries against definitions
-    from vaultspec_core.core.mcps import collect_mcp_servers
+    # Check registry drift: compare deployed entries against definitions
+    from ..mcps import collect_mcp_servers
 
     registry = collect_mcp_servers()
     if registry:
+        managed_names = set(registry.keys())
         for name, (_path, expected_config) in registry.items():
             if name not in servers:
                 return ConfigSignal.REGISTRY_DRIFT
             if servers[name] != expected_config:
                 return ConfigSignal.REGISTRY_DRIFT
+
+        has_user_entries = bool(set(servers.keys()) - managed_names)
+        if has_user_entries:
+            return ConfigSignal.USER_MCP
+        return ConfigSignal.OK
+
+    # Fallback when no registry is available (pre-registry workspace)
+    if "vaultspec-core" not in servers:
+        return ConfigSignal.PARTIAL_MCP
 
     if len(servers) > 1:
         return ConfigSignal.USER_MCP

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -348,6 +348,17 @@ def collect_mcp_config_state(target: Path) -> ConfigSignal:
     if "vaultspec-core" not in servers:
         return ConfigSignal.PARTIAL_MCP
 
+    # Check for registry drift: compare deployed entries against definitions
+    from vaultspec_core.core.mcps import collect_mcp_servers
+
+    registry = collect_mcp_servers()
+    if registry:
+        for name, (_path, expected_config) in registry.items():
+            if name not in servers:
+                return ConfigSignal.REGISTRY_DRIFT
+            if servers[name] != expected_config:
+                return ConfigSignal.REGISTRY_DRIFT
+
     if len(servers) > 1:
         return ConfigSignal.USER_MCP
 

--- a/src/vaultspec_core/core/diagnosis/signals.py
+++ b/src/vaultspec_core/core/diagnosis/signals.py
@@ -62,6 +62,7 @@ class ConfigSignal(StrEnum):
     FOREIGN = "foreign"
     PARTIAL_MCP = "partial_mcp"
     USER_MCP = "user_mcp"
+    REGISTRY_DRIFT = "registry_drift"
 
 
 class GitignoreSignal(StrEnum):

--- a/src/vaultspec_core/core/enums.py
+++ b/src/vaultspec_core/core/enums.py
@@ -106,6 +106,7 @@ class Resource(StrEnum):
     TEMPLATES = "templates"
     HOOKS = "hooks"
     WORKFLOWS = "workflows"
+    MCPS = "mcps"
 
 
 class FileName(StrEnum):

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from . import types as _t
-from .exceptions import ResourceExistsError, ResourceNotFoundError
+from .exceptions import ResourceExistsError, ResourceNotFoundError, VaultSpecError
 from .helpers import atomic_write, ensure_dir
 from .types import SyncResult
 
@@ -96,11 +96,19 @@ def mcp_list() -> list[dict[str, str]]:
     if mcps_dir is None or not mcps_dir.exists():
         return []
 
-    items: list[dict[str, str]] = []
+    items: dict[str, dict[str, str]] = {}
     for f in sorted(mcps_dir.glob("*.json")):
-        source = "Built-in" if f.name.endswith(".builtin.json") else "Custom"
-        items.append({"name": _server_name(f.name), "source": source})
-    return items
+        name = _server_name(f.name)
+        is_builtin = f.name.endswith(".builtin.json")
+        if name in items:
+            if not is_builtin:
+                items[name]["source"] = "Custom (shadows Built-in)"
+        else:
+            items[name] = {
+                "name": name,
+                "source": "Built-in" if is_builtin else "Custom",
+            }
+    return list(items.values())
 
 
 def mcp_add(
@@ -130,6 +138,17 @@ def mcp_add(
         )
     ensure_dir(mcps_dir)
 
+    if "/" in name or "\\" in name or name == "..":
+        raise VaultSpecError(f"Invalid MCP server name: {name}")
+    if name.endswith(".builtin.json") or name.endswith(".builtin"):
+        raise VaultSpecError(
+            "Cannot add a definition with '.builtin' suffix "
+            "(reserved for package-bundled definitions)."
+        )
+
+    if config is not None and not isinstance(config, dict):
+        raise VaultSpecError("MCP configuration must be a JSON object (dict).")
+
     file_name = name if name.endswith(".json") else f"{name}.json"
     file_path = mcps_dir / file_name
 
@@ -147,7 +166,9 @@ def mcp_add(
 def mcp_remove(name: str) -> Path:
     """Delete an MCP server definition.
 
-    Searches for both ``{name}.json`` and ``{name}.builtin.json``.
+    Searches for ``{name}.json`` first (custom), then ``{name}.builtin.json``.
+    This prioritizes removing custom overrides so users can revert to the
+    built-in definition.
 
     Args:
         name: Server name.
@@ -165,7 +186,7 @@ def mcp_remove(name: str) -> Path:
             hint="No MCP definitions directory exists.",
         )
 
-    for suffix in (".builtin.json", ".json"):
+    for suffix in (".json", ".builtin.json"):
         candidate = mcps_dir / f"{name}{suffix}"
         if candidate.exists():
             candidate.unlink()

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -1,0 +1,301 @@
+"""Manage MCP server definitions for the vaultspec framework.
+
+This module handles MCP server definition collection, custom definition
+scaffolding, and the merge pipeline that syncs definitions into ``.mcp.json``.
+Unlike rules/skills/agents (which use Markdown sources and per-tool directory
+sync), MCP definitions are JSON files merged into a single provider-agnostic
+``.mcp.json`` file.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from . import types as _t
+from .exceptions import ResourceExistsError, ResourceNotFoundError
+from .helpers import atomic_write, ensure_dir
+from .types import SyncResult
+
+logger = logging.getLogger(__name__)
+
+
+def _server_name(filename: str) -> str:
+    """Derive the MCP server name from a definition filename.
+
+    Strips ``.builtin.json`` as a unit first, then falls back to ``.json``.
+
+    Args:
+        filename: The definition filename (e.g. ``vaultspec-core.builtin.json``).
+
+    Returns:
+        The server name (e.g. ``vaultspec-core``).
+    """
+    if filename.endswith(".builtin.json"):
+        return filename[: -len(".builtin.json")]
+    if filename.endswith(".json"):
+        return filename[: -len(".json")]
+    return filename
+
+
+def _get_mcps_src_dir() -> Path | None:
+    """Return the MCP source directory from the active context, or ``None``."""
+    try:
+        return _t.get_context().mcps_src_dir
+    except LookupError:
+        return None
+
+
+def collect_mcp_servers(
+    warnings: list[str] | None = None,
+) -> dict[str, tuple[Path, dict[str, Any]]]:
+    """Collect MCP server definitions from ``.vaultspec/rules/mcps/``.
+
+    Reads and parses every ``.json`` file in the MCP source directory,
+    returning a mapping of server name to (source path, parsed config).
+
+    Args:
+        warnings: Optional list to append parse-error messages to.
+
+    Returns:
+        Mapping of server name to ``(source_path, config_dict)``.
+    """
+    mcps_dir = _get_mcps_src_dir()
+    if mcps_dir is None or not mcps_dir.exists():
+        return {}
+
+    sources: dict[str, tuple[Path, dict[str, Any]]] = {}
+    for f in sorted(mcps_dir.glob("*.json")):
+        try:
+            raw = json.loads(f.read_text(encoding="utf-8"))
+            if not isinstance(raw, dict):
+                msg = f"MCP definition {f.name} is not a JSON object"
+                logger.error(msg)
+                if warnings is not None:
+                    warnings.append(msg)
+                continue
+            name = _server_name(f.name)
+            sources[name] = (f, raw)
+        except (json.JSONDecodeError, OSError) as e:
+            msg = f"Failed to read/parse MCP definition {f}: {e}"
+            logger.error(msg)
+            if warnings is not None:
+                warnings.append(msg)
+    return sources
+
+
+def mcp_list() -> list[dict[str, str]]:
+    """Return a list of MCP server metadata dicts.
+
+    Each dict contains ``"name"`` and ``"source"`` (``"Built-in"`` or
+    ``"Custom"``).
+    """
+    mcps_dir = _get_mcps_src_dir()
+    if mcps_dir is None or not mcps_dir.exists():
+        return []
+
+    items: list[dict[str, str]] = []
+    for f in sorted(mcps_dir.glob("*.json")):
+        source = "Built-in" if f.name.endswith(".builtin.json") else "Custom"
+        items.append({"name": _server_name(f.name), "source": source})
+    return items
+
+
+def mcp_add(
+    name: str,
+    config: dict[str, Any] | None = None,
+    force: bool = False,
+) -> Path:
+    """Scaffold a new custom MCP server definition.
+
+    Args:
+        name: Server name.
+        config: Server configuration dict.  Uses an empty scaffold when
+            ``None``.
+        force: Whether to overwrite an existing definition.
+
+    Returns:
+        Path to the created definition file.
+
+    Raises:
+        ResourceExistsError: If the definition exists and *force* is ``False``.
+    """
+    mcps_dir = _get_mcps_src_dir()
+    if mcps_dir is None:
+        raise ResourceNotFoundError(
+            "MCP source directory not configured.",
+            hint="Run 'vaultspec-core install' first.",
+        )
+    ensure_dir(mcps_dir)
+
+    file_name = name if name.endswith(".json") else f"{name}.json"
+    file_path = mcps_dir / file_name
+
+    if file_path.exists() and not force:
+        raise ResourceExistsError(
+            f"MCP definition '{file_name}' exists. Use --force to overwrite."
+        )
+
+    server_config = config if config is not None else {"command": "", "args": []}
+    atomic_write(file_path, json.dumps(server_config, indent=2) + "\n")
+    logger.info("Created MCP definition: %s", file_path)
+    return file_path
+
+
+def mcp_remove(name: str) -> Path:
+    """Delete an MCP server definition.
+
+    Searches for both ``{name}.json`` and ``{name}.builtin.json``.
+
+    Args:
+        name: Server name.
+
+    Returns:
+        Path to the removed definition file.
+
+    Raises:
+        ResourceNotFoundError: If no definition file matches *name*.
+    """
+    mcps_dir = _get_mcps_src_dir()
+    if mcps_dir is None or not mcps_dir.exists():
+        raise ResourceNotFoundError(
+            f"MCP definition '{name}' not found.",
+            hint="No MCP definitions directory exists.",
+        )
+
+    for suffix in (".builtin.json", ".json"):
+        candidate = mcps_dir / f"{name}{suffix}"
+        if candidate.exists():
+            candidate.unlink()
+            logger.info("Removed MCP definition: %s", candidate)
+            return candidate
+
+    raise ResourceNotFoundError(f"MCP definition '{name}' not found.")
+
+
+def mcp_sync(
+    dry_run: bool = False,
+    force: bool = False,
+) -> SyncResult:
+    """Sync MCP server definitions into ``.mcp.json``.
+
+    Collects all definitions from the MCP source directory, merges them
+    into the workspace ``.mcp.json`` file.  User-added entries (not
+    matching any definition file) are always preserved.
+
+    Args:
+        dry_run: If ``True``, compute changes without writing.
+        force: Overwrite entries that differ from their definitions.
+
+    Returns:
+        :class:`~vaultspec_core.core.types.SyncResult` with sync statistics.
+    """
+    result = SyncResult()
+    parse_warnings: list[str] = []
+    sources = collect_mcp_servers(warnings=parse_warnings)
+    result.warnings.extend(parse_warnings)
+
+    try:
+        target_dir = _t.get_context().target_dir
+    except LookupError:
+        result.errors.append("No workspace context available for MCP sync.")
+        return result
+
+    mcp_json = target_dir / ".mcp.json"
+
+    # Read existing config
+    existing: dict[str, Any] = {}
+    if mcp_json.exists():
+        try:
+            raw = json.loads(mcp_json.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                existing = raw
+        except (json.JSONDecodeError, OSError) as exc:
+            result.warnings.append(f"Cannot parse existing .mcp.json: {exc}")
+
+    servers = existing.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        servers = {}
+        existing["mcpServers"] = servers
+
+    changed = False
+    for name, (_path, config) in sources.items():
+        if name not in servers:
+            servers[name] = config
+            result.added += 1
+            result.items.append((name, "added"))
+            changed = True
+        elif servers[name] == config:
+            result.skipped += 1
+        else:
+            if force:
+                servers[name] = config
+                result.updated += 1
+                result.items.append((name, "updated"))
+                changed = True
+            else:
+                result.skipped += 1
+                result.warnings.append(
+                    f"MCP server '{name}' differs from definition "
+                    f"(use --force to overwrite)"
+                )
+
+    if changed and not dry_run:
+        atomic_write(mcp_json, json.dumps(existing, indent=2) + "\n")
+
+    return result
+
+
+def mcp_uninstall(target_dir: Path, *, dry_run: bool = False) -> list[str]:
+    """Remove all registry-managed MCP entries from ``.mcp.json``.
+
+    Collects managed server names from the registry source directory and
+    removes each from ``.mcp.json``.  User-added entries are preserved.
+    If no servers remain, the file is deleted.
+
+    Args:
+        target_dir: Workspace root directory.
+        dry_run: When ``True``, returns names without modifying files.
+
+    Returns:
+        List of server names that were (or would be) removed.
+    """
+    sources = collect_mcp_servers()
+    managed_names = set(sources.keys())
+
+    # If no registry is available, fall back to removing known built-in names
+    if not managed_names:
+        managed_names = {"vaultspec-core"}
+
+    mcp_json = target_dir / ".mcp.json"
+    if not mcp_json.exists():
+        return []
+
+    try:
+        raw = json.loads(mcp_json.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+
+    if not isinstance(raw, dict):
+        return []
+
+    servers = raw.get("mcpServers", {})
+    if not isinstance(servers, dict):
+        return []
+
+    removed: list[str] = []
+    for name in managed_names:
+        if name in servers:
+            removed.append(name)
+            if not dry_run:
+                del servers[name]
+
+    if not dry_run and removed:
+        if servers:
+            atomic_write(mcp_json, json.dumps(raw, indent=2) + "\n")
+        else:
+            mcp_json.unlink()
+
+    return removed

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -40,6 +40,22 @@ def _server_name(filename: str) -> str:
     return filename
 
 
+def _validate_server_name(name: str) -> None:
+    """Raise :class:`VaultSpecError` if *name* is unsafe for use as a filename.
+
+    Guards against path traversal, empty names, reserved suffixes, and
+    OS-unsafe characters.
+    """
+    if not name or not name.strip():
+        raise VaultSpecError("MCP server name must not be empty.")
+    if "/" in name or "\\" in name or ".." in name:
+        raise VaultSpecError(f"Invalid MCP server name: {name}")
+    if name.endswith(".builtin.json") or name.endswith(".builtin"):
+        raise VaultSpecError(
+            "Cannot use '.builtin' suffix (reserved for package-bundled definitions)."
+        )
+
+
 def _get_mcps_src_dir() -> Path | None:
     """Return the MCP source directory from the active context, or ``None``."""
     try:
@@ -77,6 +93,8 @@ def collect_mcp_servers(
                     warnings.append(msg)
                 continue
             name = _server_name(f.name)
+            if not name:
+                continue
             sources[name] = (f, raw)
         except (json.JSONDecodeError, OSError) as e:
             msg = f"Failed to read/parse MCP definition {f}: {e}"
@@ -99,6 +117,8 @@ def mcp_list() -> list[dict[str, str]]:
     items: dict[str, dict[str, str]] = {}
     for f in sorted(mcps_dir.glob("*.json")):
         name = _server_name(f.name)
+        if not name:
+            continue
         is_builtin = f.name.endswith(".builtin.json")
         if name in items:
             if not is_builtin:
@@ -138,13 +158,7 @@ def mcp_add(
         )
     ensure_dir(mcps_dir)
 
-    if "/" in name or "\\" in name or name == "..":
-        raise VaultSpecError(f"Invalid MCP server name: {name}")
-    if name.endswith(".builtin.json") or name.endswith(".builtin"):
-        raise VaultSpecError(
-            "Cannot add a definition with '.builtin' suffix "
-            "(reserved for package-bundled definitions)."
-        )
+    _validate_server_name(name)
 
     if config is not None and not isinstance(config, dict):
         raise VaultSpecError("MCP configuration must be a JSON object (dict).")
@@ -179,6 +193,8 @@ def mcp_remove(name: str) -> Path:
     Raises:
         ResourceNotFoundError: If no definition file matches *name*.
     """
+    _validate_server_name(name)
+
     mcps_dir = _get_mcps_src_dir()
     if mcps_dir is None or not mcps_dir.exists():
         raise ResourceNotFoundError(

--- a/src/vaultspec_core/core/resolver.py
+++ b/src/vaultspec_core/core/resolver.py
@@ -536,7 +536,12 @@ def _resolve_config(
     if action != "sync":
         return
 
-    if signal in (ConfigSignal.OK, ConfigSignal.PARTIAL_MCP, ConfigSignal.USER_MCP):
+    if signal in (
+        ConfigSignal.OK,
+        ConfigSignal.PARTIAL_MCP,
+        ConfigSignal.USER_MCP,
+        ConfigSignal.REGISTRY_DRIFT,
+    ):
         return
 
     if signal == ConfigSignal.MISSING:

--- a/src/vaultspec_core/core/types.py
+++ b/src/vaultspec_core/core/types.py
@@ -141,6 +141,7 @@ class WorkspaceContext:
     system_src_dir: Path
     templates_dir: Path
     hooks_dir: Path
+    mcps_src_dir: Path | None = None
     tool_configs: dict[Tool, ToolConfig] = field(default_factory=dict)
 
 
@@ -242,6 +243,7 @@ def init_paths(layout: Any) -> WorkspaceContext:
     system_src_dir = vaultspec / Resource.RULES.value / Resource.SYSTEM.value
     templates_dir = vaultspec / Resource.RULES.value / Resource.TEMPLATES.value
     hooks_dir = vaultspec / Resource.RULES.value / Resource.HOOKS.value
+    mcps_src_dir = vaultspec / Resource.RULES.value / Resource.MCPS.value
     shared_agents_root = target / DirName.ANTIGRAVITY.value
 
     gemini_dir = target / cfg.gemini_dir
@@ -340,6 +342,7 @@ def init_paths(layout: Any) -> WorkspaceContext:
         system_src_dir=system_src_dir,
         templates_dir=templates_dir,
         hooks_dir=hooks_dir,
+        mcps_src_dir=mcps_src_dir,
         tool_configs=tool_configs,
     )
     _workspace_ctx.set(ctx)

--- a/src/vaultspec_core/tests/cli/test_signals.py
+++ b/src/vaultspec_core/tests/cli/test_signals.py
@@ -49,7 +49,7 @@ pytestmark = [pytest.mark.unit]
         ),
         (
             ConfigSignal,
-            {"OK", "MISSING", "FOREIGN", "PARTIAL_MCP", "USER_MCP"},
+            {"OK", "MISSING", "FOREIGN", "PARTIAL_MCP", "USER_MCP", "REGISTRY_DRIFT"},
         ),
         (
             GitignoreSignal,

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -1,0 +1,495 @@
+"""Tests for MCP server registry: collection, CRUD, sync, and lifecycle."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from uuid import uuid4
+
+import pytest
+
+from tests.constants import PROJECT_ROOT
+from vaultspec_core.config import reset_config
+
+
+def _make_workspace(tmp: object = None):
+    """Create a minimal workspace with .vaultspec/rules/mcps/ directory."""
+    path = PROJECT_ROOT / ".pytest-tmp" / f"mcps-{uuid4().hex}"
+    path.mkdir(parents=True, exist_ok=True)
+    mcps_dir = path / ".vaultspec" / "rules" / "mcps"
+    mcps_dir.mkdir(parents=True, exist_ok=True)
+    return path, mcps_dir
+
+
+def _init_context(path):
+    """Bootstrap a WorkspaceContext pointing at the given path."""
+    from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.types import init_paths
+
+    reset_config()
+    # Create minimal .vaultspec structure for workspace resolution
+    fw_dir = path / ".vaultspec"
+    fw_dir.mkdir(parents=True, exist_ok=True)
+    layout = resolve_workspace(target_override=path)
+    return init_paths(layout)
+
+
+@pytest.mark.unit
+class TestServerName:
+    def test_builtin_suffix(self):
+        from vaultspec_core.core.mcps import _server_name
+
+        assert _server_name("vaultspec-core.builtin.json") == "vaultspec-core"
+
+    def test_json_suffix(self):
+        from vaultspec_core.core.mcps import _server_name
+
+        assert _server_name("my-server.json") == "my-server"
+
+    def test_multi_dot_builtin(self):
+        from vaultspec_core.core.mcps import _server_name
+
+        assert _server_name("foo.bar.builtin.json") == "foo.bar"
+
+    def test_multi_dot_json(self):
+        from vaultspec_core.core.mcps import _server_name
+
+        assert _server_name("foo.bar.json") == "foo.bar"
+
+    def test_no_json_suffix(self):
+        from vaultspec_core.core.mcps import _server_name
+
+        assert _server_name("something") == "something"
+
+
+@pytest.mark.unit
+class TestCollectMcpServers:
+    def test_empty_directory(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            result = collect_mcp_servers()
+            assert result == {}
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_missing_directory(self):
+        path = PROJECT_ROOT / ".pytest-tmp" / f"mcps-missing-{uuid4().hex}"
+        path.mkdir(parents=True, exist_ok=True)
+        try:
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            result = collect_mcp_servers()
+            assert result == {}
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_single_builtin(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            config = {"command": "uv", "args": ["run", "test"]}
+            (mcps_dir / "test-server.builtin.json").write_text(
+                json.dumps(config), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            result = collect_mcp_servers()
+            assert "test-server" in result
+            assert result["test-server"][1] == config
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_custom_definition(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            config = {"command": "node", "args": ["server.js"]}
+            (mcps_dir / "custom-mcp.json").write_text(
+                json.dumps(config), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            result = collect_mcp_servers()
+            assert "custom-mcp" in result
+            assert result["custom-mcp"][1] == config
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_parse_error_captured_in_warnings(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "bad.json").write_text("not valid json", encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            warnings: list[str] = []
+            result = collect_mcp_servers(warnings=warnings)
+            assert result == {}
+            assert len(warnings) == 1
+            assert "bad.json" in warnings[0]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_non_object_json_rejected(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "array.json").write_text("[1, 2, 3]", encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            warnings: list[str] = []
+            result = collect_mcp_servers(warnings=warnings)
+            assert result == {}
+            assert len(warnings) == 1
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_mixed_builtin_and_custom(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "core.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            (mcps_dir / "custom.json").write_text(
+                json.dumps({"command": "node"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            result = collect_mcp_servers()
+            assert len(result) == 2
+            assert "core" in result
+            assert "custom" in result
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
+class TestMcpList:
+    def test_lists_with_source_classification(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "builtin-srv.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            (mcps_dir / "custom-srv.json").write_text(
+                json.dumps({"command": "node"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_list
+
+            items = mcp_list()
+            names = {i["name"]: i["source"] for i in items}
+            assert names["builtin-srv"] == "Built-in"
+            assert names["custom-srv"] == "Custom"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
+class TestMcpAdd:
+    def test_creates_definition_file(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_add
+
+            result = mcp_add("my-server", config={"command": "test"})
+            assert result.exists()
+            content = json.loads(result.read_text(encoding="utf-8"))
+            assert content["command"] == "test"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_raises_on_existing_without_force(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "exists.json").write_text("{}", encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.exceptions import ResourceExistsError
+            from vaultspec_core.core.mcps import mcp_add
+
+            with pytest.raises(ResourceExistsError):
+                mcp_add("exists")
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_overwrites_with_force(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "exists.json").write_text("{}", encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_add
+
+            result = mcp_add("exists", config={"command": "new"}, force=True)
+            content = json.loads(result.read_text(encoding="utf-8"))
+            assert content["command"] == "new"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
+class TestMcpRemove:
+    def test_removes_json_file(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            target_file = mcps_dir / "removable.json"
+            target_file.write_text("{}", encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_remove
+
+            result = mcp_remove("removable")
+            assert result == target_file
+            assert not target_file.exists()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_removes_builtin_file(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            target_file = mcps_dir / "removable.builtin.json"
+            target_file.write_text("{}", encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_remove
+
+            mcp_remove("removable")
+            assert not target_file.exists()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_raises_when_not_found(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.exceptions import ResourceNotFoundError
+            from vaultspec_core.core.mcps import mcp_remove
+
+            with pytest.raises(ResourceNotFoundError):
+                mcp_remove("nonexistent")
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
+class TestMcpSync:
+    def test_creates_mcp_json_from_scratch(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            config = {"command": "uv", "args": ["run", "test"]}
+            (mcps_dir / "test-srv.builtin.json").write_text(
+                json.dumps(config), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync()
+            assert result.added == 1
+            assert result.skipped == 0
+
+            mcp_json = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert mcp_json["mcpServers"]["test-srv"] == config
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_idempotent_sync(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            config = {"command": "uv", "args": ["run", "test"]}
+            (mcps_dir / "test-srv.builtin.json").write_text(
+                json.dumps(config), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            mcp_sync()
+            result = mcp_sync()
+            assert result.added == 0
+            assert result.skipped == 1
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_preserves_user_entries(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "managed.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            # Pre-populate .mcp.json with a user entry
+            user_config = {
+                "mcpServers": {"user-server": {"command": "custom", "args": []}}
+            }
+            (path / ".mcp.json").write_text(json.dumps(user_config), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync()
+            assert result.added == 1
+
+            mcp_json = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "user-server" in mcp_json["mcpServers"]
+            assert "managed" in mcp_json["mcpServers"]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_warns_on_diff_without_force(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "srv.builtin.json").write_text(
+                json.dumps({"command": "new"}), encoding="utf-8"
+            )
+            existing = {"mcpServers": {"srv": {"command": "old"}}}
+            (path / ".mcp.json").write_text(json.dumps(existing), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync(force=False)
+            assert result.skipped == 1
+            assert result.updated == 0
+            assert any("--force" in w for w in result.warnings)
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_force_overwrites_diff(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            new_config = {"command": "new"}
+            (mcps_dir / "srv.builtin.json").write_text(
+                json.dumps(new_config), encoding="utf-8"
+            )
+            existing = {"mcpServers": {"srv": {"command": "old"}}}
+            (path / ".mcp.json").write_text(json.dumps(existing), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync(force=True)
+            assert result.updated == 1
+
+            mcp_json = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert mcp_json["mcpServers"]["srv"] == new_config
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_dry_run_does_not_write(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "srv.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync(dry_run=True)
+            assert result.added == 1
+            assert not (path / ".mcp.json").exists()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
+class TestMcpUninstall:
+    def test_removes_managed_entries(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "managed.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            mcp_data = {
+                "mcpServers": {
+                    "managed": {"command": "uv"},
+                    "user": {"command": "custom"},
+                }
+            }
+            (path / ".mcp.json").write_text(json.dumps(mcp_data), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_uninstall
+
+            removed = mcp_uninstall(path)
+            assert "managed" in removed
+
+            remaining = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "managed" not in remaining["mcpServers"]
+            assert "user" in remaining["mcpServers"]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_deletes_file_when_empty(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "only.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            mcp_data = {"mcpServers": {"only": {"command": "uv"}}}
+            (path / ".mcp.json").write_text(json.dumps(mcp_data), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_uninstall
+
+            mcp_uninstall(path)
+            assert not (path / ".mcp.json").exists()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_fallback_to_vaultspec_core_when_no_registry(self):
+        path = PROJECT_ROOT / ".pytest-tmp" / f"mcps-uninstall-{uuid4().hex}"
+        path.mkdir(parents=True, exist_ok=True)
+        try:
+            mcp_data = {"mcpServers": {"vaultspec-core": {"command": "uv"}}}
+            (path / ".mcp.json").write_text(json.dumps(mcp_data), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_uninstall
+
+            removed = mcp_uninstall(path)
+            assert "vaultspec-core" in removed
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
+class TestInstallSeedsMcps:
+    def test_install_creates_mcp_json_from_registry(self):
+        path = PROJECT_ROOT / ".pytest-tmp" / f"mcps-install-{uuid4().hex}"
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            reset_config()
+
+            from vaultspec_core.core.commands import install_run
+
+            install_run(
+                path=path, provider="all", upgrade=False, dry_run=False, force=False
+            )
+
+            mcp_json = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "vaultspec-core" in mcp_json["mcpServers"]
+            server = mcp_json["mcpServers"]["vaultspec-core"]
+            assert server["command"] == "uv"
+            expected_args = ["run", "python", "-m", "vaultspec_core.mcp_server.app"]
+            assert server["args"] == expected_args
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -177,6 +177,26 @@ class TestCollectMcpServers:
 
 @pytest.mark.unit
 class TestMcpList:
+    def test_shadowed_definition_shows_custom(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "srv.builtin.json").write_text(
+                json.dumps({"command": "old"}), encoding="utf-8"
+            )
+            (mcps_dir / "srv.json").write_text(
+                json.dumps({"command": "new"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_list
+
+            items = mcp_list()
+            assert len(items) == 1
+            assert items[0]["name"] == "srv"
+            assert "shadows" in items[0]["source"].lower()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
     def test_lists_with_source_classification(self):
         path, mcps_dir = _make_workspace()
         try:
@@ -238,6 +258,45 @@ class TestMcpAdd:
             result = mcp_add("exists", config={"command": "new"}, force=True)
             content = json.loads(result.read_text(encoding="utf-8"))
             assert content["command"] == "new"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_rejects_path_traversal(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.exceptions import VaultSpecError
+            from vaultspec_core.core.mcps import mcp_add
+
+            with pytest.raises(VaultSpecError, match="Invalid"):
+                mcp_add("../evil")
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_rejects_builtin_suffix(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.exceptions import VaultSpecError
+            from vaultspec_core.core.mcps import mcp_add
+
+            with pytest.raises(VaultSpecError, match="builtin"):
+                mcp_add("fake.builtin")
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_rejects_non_dict_config(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.exceptions import VaultSpecError
+            from vaultspec_core.core.mcps import mcp_add
+
+            with pytest.raises(VaultSpecError, match="dict"):
+                mcp_add("srv", config=[1, 2, 3])  # type: ignore[arg-type]
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -174,6 +174,49 @@ class TestCollectMcpServers:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
 
+    def test_custom_shadows_builtin_in_collect(self):
+        """When both foo.builtin.json and foo.json exist, custom config wins."""
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "srv.builtin.json").write_text(
+                json.dumps({"command": "old-builtin"}), encoding="utf-8"
+            )
+            (mcps_dir / "srv.json").write_text(
+                json.dumps({"command": "new-custom"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            result = collect_mcp_servers()
+            assert len(result) == 1
+            assert result["srv"][1]["command"] == "new-custom"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_empty_stem_filenames_skipped(self):
+        """Files named '.json' or '.builtin.json' (no server name) are ignored."""
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / ".json").write_text(
+                json.dumps({"command": "bad"}), encoding="utf-8"
+            )
+            (mcps_dir / ".builtin.json").write_text(
+                json.dumps({"command": "also-bad"}), encoding="utf-8"
+            )
+            (mcps_dir / "valid.json").write_text(
+                json.dumps({"command": "good"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import collect_mcp_servers
+
+            result = collect_mcp_servers()
+            assert len(result) == 1
+            assert "valid" in result
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
 
 @pytest.mark.unit
 class TestMcpList:
@@ -230,6 +273,19 @@ class TestMcpAdd:
             assert result.exists()
             content = json.loads(result.read_text(encoding="utf-8"))
             assert content["command"] == "test"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_created_file_stays_within_mcps_dir(self):
+        """Security invariant: the written file must be inside mcps_dir."""
+        path, mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_add
+
+            result = mcp_add("legit-server", config={"command": "test"})
+            assert result.resolve().is_relative_to(mcps_dir.resolve())
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
@@ -346,6 +402,39 @@ class TestMcpRemove:
 
             mcp_remove("removable")
             assert not target_file.exists()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_custom_removed_before_builtin(self):
+        """When both exist, custom .json is removed first (revert semantics)."""
+        path, mcps_dir = _make_workspace()
+        try:
+            builtin = mcps_dir / "srv.builtin.json"
+            custom = mcps_dir / "srv.json"
+            builtin.write_text(json.dumps({"command": "old"}), encoding="utf-8")
+            custom.write_text(json.dumps({"command": "new"}), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_remove
+
+            mcp_remove("srv")
+            assert not custom.exists(), "Custom .json should be removed first"
+            assert builtin.exists(), "Builtin should survive first removal"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_removed_file_was_within_mcps_dir(self):
+        """Security invariant: only files inside mcps_dir can be removed."""
+        path, mcps_dir = _make_workspace()
+        try:
+            target = mcps_dir / "safe.json"
+            target.write_text("{}", encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_remove
+
+            result = mcp_remove("safe")
+            assert result.resolve().is_relative_to(mcps_dir.resolve())
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
@@ -567,6 +656,60 @@ class TestMcpUninstall:
 
             removed = mcp_uninstall(path)
             assert "vaultspec-core" in removed
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
+class TestUninstallRemovesCustomMcps:
+    def test_full_uninstall_removes_custom_mcp_entries(self):
+        """Regression: uninstall must read registry BEFORE deleting .vaultspec/.
+
+        If .vaultspec/ is deleted first, collect_mcp_servers() returns empty
+        and only the hardcoded 'vaultspec-core' fallback is cleaned up,
+        leaving custom entries behind.
+        """
+        path = PROJECT_ROOT / ".pytest-tmp" / f"mcps-uninstall-full-{uuid4().hex}"
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            reset_config()
+
+            from vaultspec_core.core.commands import install_run
+
+            install_run(
+                path=path, provider="all", upgrade=False, dry_run=False, force=False
+            )
+
+            # Add a custom MCP definition post-install
+            mcps_dir = path / ".vaultspec" / "rules" / "mcps"
+            (mcps_dir / "custom-rag.json").write_text(
+                json.dumps({"command": "uv", "args": ["run", "rag-server"]}),
+                encoding="utf-8",
+            )
+
+            # Sync so the custom entry lands in .mcp.json
+            from vaultspec_core.core.mcps import mcp_sync
+
+            mcp_sync(force=True)
+
+            mcp_before = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "custom-rag" in mcp_before["mcpServers"]
+            assert "vaultspec-core" in mcp_before["mcpServers"]
+
+            # Full uninstall
+            from vaultspec_core.core.commands import uninstall_run
+
+            uninstall_run(path, provider="all", force=True)
+
+            # Both managed entries should be gone
+            if (path / ".mcp.json").exists():
+                mcp_after = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+                servers = mcp_after.get("mcpServers", {})
+                assert "custom-rag" not in servers, (
+                    "Custom MCP entry survived uninstall"
+                )
+                assert "vaultspec-core" not in servers
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -271,6 +271,23 @@ class TestMcpAdd:
 
             with pytest.raises(VaultSpecError, match="Invalid"):
                 mcp_add("../evil")
+            with pytest.raises(VaultSpecError, match="Invalid"):
+                mcp_add("foo/../bar")
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_rejects_empty_name(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.exceptions import VaultSpecError
+            from vaultspec_core.core.mcps import mcp_add
+
+            with pytest.raises(VaultSpecError, match="empty"):
+                mcp_add("")
+            with pytest.raises(VaultSpecError, match="empty"):
+                mcp_add("   ")
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
@@ -329,6 +346,32 @@ class TestMcpRemove:
 
             mcp_remove("removable")
             assert not target_file.exists()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_rejects_traversal_in_remove(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.exceptions import VaultSpecError
+            from vaultspec_core.core.mcps import mcp_remove
+
+            with pytest.raises(VaultSpecError, match="Invalid"):
+                mcp_remove("../escape")
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_rejects_empty_name_in_remove(self):
+        path, _mcps_dir = _make_workspace()
+        try:
+            _init_context(path)
+            from vaultspec_core.core.exceptions import VaultSpecError
+            from vaultspec_core.core.mcps import mcp_remove
+
+            with pytest.raises(VaultSpecError, match="empty"):
+                mcp_remove("")
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)


### PR DESCRIPTION
## Summary

- Adds a programmatic MCP server registry mirroring the existing rule registry pattern (`collect -> merge -> sync`)
- Stores definitions as JSON files in `.vaultspec/rules/mcps/` (`.builtin.json` for built-in, `.json` for custom)
- Replaces hardcoded `_scaffold_mcp_json()` with data-driven `mcp_sync()` across all lifecycle touchpoints
- Provides CLI subcommands: `spec mcps list|add|remove|sync`
- Extends doctor diagnostics with `REGISTRY_DRIFT` signal for configuration drift detection
- 29 new tests covering collection, CRUD, sync semantics, and lifecycle integration

Closes #43

## Test plan

- [x] Unit tests for `_server_name()` filename stem extraction (including multi-dot names)
- [x] Unit tests for `collect_mcp_servers()` (empty dir, missing dir, builtin, custom, mixed, parse errors, non-object JSON)
- [x] Unit tests for `mcp_list()`, `mcp_add()`, `mcp_remove()` CRUD operations
- [x] Unit tests for `mcp_sync()` (idempotent, non-destructive, warn on diff, force overwrite, dry-run)
- [x] Unit tests for `mcp_uninstall()` (managed entry removal, file deletion when empty, fallback)
- [x] Integration test: `install_run()` seeds built-in MCP definition into `.mcp.json`
- [x] Existing `test_mcp_config.py` and `test_commands.py` tests pass (no regressions)
- [x] Full unit test suite passes (58 tests)
- [x] All pre-commit hooks pass (ruff, ty, mdformat, vault doctor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)