### PR TITLE
fix: exclude .vault/ from managed gitignore block

### DIFF
--- a/src/vaultspec_core/core/gitignore.py
+++ b/src/vaultspec_core/core/gitignore.py
@@ -34,7 +34,10 @@ def get_recommended_entries(target: Path) -> list[str]:
             entries.add(".vaultspec/_snapshots/")
             entries.add(".vaultspec/")
         if (target / ".vault").is_dir():
-            entries.add(".vault/")
+            entries.add(".vault/.obsidian/")
+            entries.add(".vault/.trash/")
+            entries.add(".vault/data/")
+            entries.add(".vault/logs/")
 
         mdata = read_manifest_data(target)
 

--- a/src/vaultspec_core/tests/cli/test_gitignore.py
+++ b/src/vaultspec_core/tests/cli/test_gitignore.py
@@ -13,6 +13,7 @@ from vaultspec_core.core.gitignore import (
     MARKER_END,
     _find_markers,
     ensure_gitignore_block,
+    get_recommended_entries,
 )
 
 if TYPE_CHECKING:
@@ -305,3 +306,27 @@ class TestReadOnlyGitignore:
                     ensure_gitignore_block(tmp_path, ENTRIES)
         finally:
             gi.chmod(stat.S_IREAD | stat.S_IWRITE)
+
+
+class TestRecommendedEntries:
+    """Verify .vault/ is not blanket-ignored; only generated subdirs are."""
+
+    def test_vault_dir_not_blanket_ignored(self, tmp_path):
+        (tmp_path / ".vaultspec").mkdir()
+        (tmp_path / ".vault").mkdir()
+        entries = get_recommended_entries(tmp_path)
+        assert ".vault/" not in entries
+
+    def test_vault_generated_subdirs_ignored(self, tmp_path):
+        (tmp_path / ".vaultspec").mkdir()
+        (tmp_path / ".vault").mkdir()
+        entries = get_recommended_entries(tmp_path)
+        assert ".vault/.obsidian/" in entries
+        assert ".vault/.trash/" in entries
+        assert ".vault/data/" in entries
+        assert ".vault/logs/" in entries
+
+    def test_vaultspec_snapshots_always_ignored(self, tmp_path):
+        (tmp_path / ".vaultspec").mkdir()
+        entries = get_recommended_entries(tmp_path)
+        assert ".vaultspec/_snapshots/" in entries


### PR DESCRIPTION
## Summary

- Remove blanket `.vault/` from the managed gitignore block - vault documents (ADRs, plans, research, etc.) must be version-controlled
- Add fine-grained ignores for generated content only: `.vault/data/`, `.vault/.obsidian/`, `.vault/logs/`
- Add tests verifying `.vault/` is no longer blanket-ignored and that the fine-grained entries are present

Closes #50

## Test plan

- [x] All 25 gitignore unit tests pass (3 new)
- [x] All 115 sync/install/collector integration tests pass
- [x] Pre-commit hooks pass (ruff, ty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)