### PR TITLE
fix: PyPI publish - resolve missing .vaultspec/rules in CI build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,13 @@ jobs:
       - name: Install Python
         run: uv python install 3.13
 
+      - name: Verify .vaultspec/rules present
+        run: |
+          if [ ! -d ".vaultspec/rules" ]; then
+            echo "::error::.vaultspec/rules is missing - wheel build will fail"
+            exit 1
+          fi
+
       - name: Build package
         run: uv build
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,9 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/vaultspec_core"]
 
+[tool.hatch.build.targets.sdist.force-include]
+".vaultspec/rules" = ".vaultspec/rules"
+
 [tool.hatch.build.targets.wheel.force-include]
 ".vaultspec/rules" = "vaultspec_core/builtins"
 


### PR DESCRIPTION
## Summary

- Adds sdist `force-include` for `.vaultspec/rules` in `pyproject.toml` so the directory survives the sdist round-trip when hatchling builds the wheel
- Adds a CI guard step in `publish.yml` to fail fast if `.vaultspec/rules` is missing

**Root cause:** hatchling's sdist builder respects `.gitignore`, which excludes `.vaultspec/`. The wheel `force-include` then fails with `FileNotFoundError` when building from the sdist. This blocked all PyPI publishes from v0.1.3 onward.

**Result:** v0.1.8 successfully published to PyPI after merge.

Closes #60

## Test plan

- [x] `uv build` succeeds locally and produces correct sdist + wheel
- [x] Wheel contains `vaultspec_core/builtins/` with all rule files
- [x] Sdist contains `.vaultspec/rules/` directory
- [x] CI publish workflow passes (run 24287229968)
- [x] v0.1.8 confirmed on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)