### PR TITLE
fix: trigger PyPI publish automatically on release-please releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,6 @@
 name: Publish
 
 on:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       tag:
@@ -26,7 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.tag }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
@@ -60,7 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.event.release.tag_name }}
+          ref: ${{ inputs.tag }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: release-please
@@ -48,3 +49,12 @@ jobs:
             git commit -m "chore: update uv.lock for release"
             git push
           fi
+
+      - name: Dispatch PyPI publish workflow
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          echo "Dispatching publish.yml for tag: $TAG"
+          gh workflow run publish.yml --ref "$TAG" -f tag="$TAG"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,5 +56,22 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.release.outputs.tag_name }}
         run: |
-          echo "Dispatching publish.yml for tag: $TAG"
-          gh workflow run publish.yml --ref "$TAG" -f tag="$TAG"
+          if [ -z "${TAG}" ]; then
+            echo "::error::release-please reported release_created=true but tag_name output is empty"
+            exit 1
+          fi
+          echo "Dispatching publish.yml for tag: ${TAG}"
+          gh workflow run publish.yml --ref "${TAG}" -f tag="${TAG}"
+          echo "Waiting for dispatched run to appear..."
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            RUN_ID=$(gh run list --workflow=publish.yml --event=workflow_dispatch --limit=1 --json databaseId,headBranch \
+              --jq ".[] | select(.headBranch==\"${TAG}\") | .databaseId")
+            if [ -n "${RUN_ID}" ]; then
+              echo "Dispatched run: ${RUN_ID}"
+              echo "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" >> "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::publish.yml dispatch did not produce a visible run within 30s"
+          exit 1

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -63,7 +63,7 @@ jobs:
           echo "Dispatching publish.yml for tag: ${TAG}"
           gh workflow run publish.yml --ref "${TAG}" -f tag="${TAG}"
           echo "Waiting for dispatched run to appear..."
-          for i in 1 2 3 4 5 6 7 8 9 10; do
+          for _ in 1 2 3 4 5 6 7 8 9 10; do
             RUN_ID=$(gh run list --workflow=publish.yml --event=workflow_dispatch --limit=1 --json databaseId,headBranch \
               --jq ".[] | select(.headBranch==\"${TAG}\") | .databaseId")
             if [ -n "${RUN_ID}" ]; then


### PR DESCRIPTION
## Summary

- Dispatch `publish.yml` directly from the release-please job when `release_created == 'true'`, so PyPI upload is guaranteed whenever release-please cuts a release
- Drop the `release: published` trigger from `publish.yml` (it was not firing for release-please v4 releases, leaving v0.1.9 unpublished)
- Add `actions: write` permission to release-please job so it can dispatch the publish workflow
- Harden the dispatch step: fail loudly if `tag_name` is empty, verify the dispatched run actually appears, and link it in the job summary

## Why

The `release: published` event is not firing reliably for release-please releases. v0.1.9 shipped on GitHub (2026-04-11) but never triggered publish, leaving PyPI at v0.1.8. Chaining publish directly off the release-please job output bypasses the unreliable event entirely — release-please knows exactly when it created a release, so we trigger from that signal.

release-please-action v4's [README](https://github.com/googleapis/release-please-action#outputs) documents that for a single-package manifest at path `.`, the root-level outputs `release_created` and `tag_name` are emitted for the root component — which matches this repo's `release-please-config.json` (single package `"."`). The exact `if: steps.release.outputs.release_created` + `${{ steps.release.outputs.tag_name }}` pattern used here is shown verbatim in the action's own README.

## Immediate workaround

Manually dispatched publish for `vaultspec-core-v0.1.9` to unblock current PyPI state.

Closes #65

## Test plan

**Verified pre-merge:**

- [x] Manual dispatch of `publish.yml` for `vaultspec-core-v0.1.9` completes successfully — run [24300054290](https://github.com/wgergely/vaultspec-core/actions/runs/24300054290), all three jobs green (Build, Smoke Test, Publish to PyPI)
- [x] PyPI simple index lists `vaultspec_core-0.1.9-py3-none-any.whl` and `vaultspec_core-0.1.9.tar.gz`
- [x] `uv run --isolated --no-project --with vaultspec-core==0.1.9` installs cleanly from PyPI and `importlib.metadata.version('vaultspec-core')` reports `0.1.9`
- [x] `publish.yml` no longer contains a `release:` trigger — only `workflow_dispatch` remains, preventing duplicate runs
- [x] `gh run list --workflow=publish.yml` shows `workflow_dispatch` as the trigger source for every recent run
- [x] release-please-action v4 output schema confirmed: `release_created` / `tag_name` are the documented outputs for a single-package manifest at path `.`
- [x] Dispatch step primitives dry-run against run `24300054290`: tag passthrough OK, `gh run list --event=workflow_dispatch ... --jq 'select(.headBranch==$TAG)'` correctly locates the dispatched run by ref — confirming the post-dispatch verification loop will resolve a real run id when release-please fires it
- [x] Dispatch step fails fast on empty `tag_name` and on missing downstream run — no silent failure modes remain

**To verify post-merge (next release-please cycle, unavoidable — requires a real release to fire):**

- [ ] Next release-please PR merge produces a new GitHub release AND the `release-please.yml` run shows a successful "Dispatch PyPI publish workflow" step with the downstream run URL in the job summary
- [ ] The auto-dispatched `publish.yml` run completes all jobs: build, smoke-test, publish-pypi
- [ ] PyPI latest version matches the new GitHub release tag with zero manual intervention

The three items above cannot be ticked pre-merge: they describe the behavior of release-please itself on `main`, which only exercises after a release-please PR is merged. The hardened dispatch step guarantees that if any primitive fails in that run, the release-please job will error loudly with a specific message (empty tag / missing run) rather than silently swallowing the dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)