### PR TITLE
feat: reconciling mcp_sync — prune orphaned managed entries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ license = { file = "LICENSE" }
 name = "vaultspec-core"
 readme = "README.md"
 requires-python = ">=3.13"
-version = "0.1.9"
+version = "0.1.10"
 
   [project.urls]
   "Bug Tracker" = "https://github.com/wgergely/vaultspec-core/issues"

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -1329,7 +1329,10 @@ def sync_provider(
         ]
         if "mcp" not in skip:
             sync_passes.append(
-                (lambda: _mcp_sync(dry_run=dry_run, force=force), "mcps")
+                (
+                    lambda: _mcp_sync(dry_run=dry_run, force=force, prune=force),
+                    "mcps",
+                )
             )
         for sync_fn, label in sync_passes:
             try:

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -64,6 +64,30 @@ def _get_mcps_src_dir() -> Path | None:
         return None
 
 
+def _existing_source_server_names() -> set[str]:
+    """Return server names whose source file physically exists on disk.
+
+    Unlike :func:`collect_mcp_servers`, this never opens or parses the
+    JSON files — a definition that exists but currently fails to parse
+    (e.g. transient typo) is still reported as present. This is the
+    correct signal for the prune step in :func:`mcp_sync`: a server
+    must only be considered for orphan removal when its source file
+    is *definitively absent*, not when parsing happened to fail this
+    run. Otherwise a single typo in a managed definition would
+    silently delete the corresponding ``.mcp.json`` entry on the next
+    ``sync --force``, which is destructive and hard to recover from.
+    """
+    mcps_dir = _get_mcps_src_dir()
+    if mcps_dir is None or not mcps_dir.exists():
+        return set()
+    names: set[str] = set()
+    for f in mcps_dir.glob("*.json"):
+        name = _server_name(f.name)
+        if name:
+            names.add(name)
+    return names
+
+
 def collect_mcp_servers(
     warnings: list[str] | None = None,
 ) -> dict[str, tuple[Path, dict[str, Any]]]:
@@ -289,6 +313,15 @@ def mcp_sync(
             # entries. After this sync the sidecar is written and
             # future syncs use strict ownership.
             managed = set(servers.keys()) & set(sources.keys())
+            if managed:
+                msg = (
+                    f"Legacy .mcp.json migration: taking ownership of "
+                    f"{len(managed)} pre-existing entries that match "
+                    f"current sources ({sorted(managed)}). Future syncs "
+                    f"will use strict ownership tracking."
+                )
+                logger.warning(msg)
+                result.warnings.append(msg)
 
         changed = False
         for name, (_path, config) in sources.items():
@@ -324,9 +357,19 @@ def mcp_sync(
                     f"Rename one to resolve."
                 )
 
-        source_names = set(sources.keys())
         if prune:
-            for name in sorted(managed - source_names):
+            # Critical: prune is gated on the source file being
+            # *physically absent* from disk, not merely missing from
+            # the parsed sources dict. ``collect_mcp_servers`` omits
+            # files that exist but failed JSON parsing or read; if we
+            # treated those as deletions, a transient typo would
+            # silently destroy the corresponding ``.mcp.json`` entry
+            # under ``sync --force``. ``_existing_source_server_names``
+            # walks the directory without opening files, so a parse
+            # failure leaves the entry intact until the source is
+            # fixed (or the file is genuinely deleted).
+            on_disk = _existing_source_server_names()
+            for name in sorted(managed - on_disk):
                 if name in servers:
                     servers.pop(name)
                     result.pruned += 1

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -352,9 +352,16 @@ def mcp_sync(
                 changed = True
 
         if changed and not dry_run:
-            # If pruning emptied the file entirely, remove it instead
-            # of leaving an orphan ``{"mcpServers": {}}`` artefact.
-            if not servers and _MANAGED_KEY not in existing:
+            # If pruning emptied the file entirely AND no other
+            # user-defined top-level keys remain, remove the file
+            # instead of leaving an orphan ``{"mcpServers": {}}``
+            # artefact. ``mcpServers`` is guaranteed to exist via
+            # ``setdefault`` above and ``_MANAGED_KEY`` is explicitly
+            # removed when the managed set is empty, so a single
+            # remaining key means the file holds nothing but the empty
+            # ``mcpServers`` dict. Anything else (custom user keys
+            # like ``inputs``) keeps the file alive.
+            if not servers and len(existing) == 1:
                 if mcp_json.exists():
                     mcp_json.unlink()
             else:

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -212,19 +212,35 @@ def mcp_remove(name: str) -> Path:
     raise ResourceNotFoundError(f"MCP definition '{name}' not found.")
 
 
+_MANAGED_KEY = "_vaultspecManaged"
+
+
 def mcp_sync(
     dry_run: bool = False,
     force: bool = False,
+    prune: bool = False,
 ) -> SyncResult:
     """Sync MCP server definitions into ``.mcp.json``.
 
     Collects all definitions from the MCP source directory, merges them
-    into the workspace ``.mcp.json`` file.  User-added entries (not
-    matching any definition file) are always preserved.
+    into the workspace ``.mcp.json`` file, and (when ``prune`` is set)
+    removes managed entries whose source files have been deleted.
+
+    Ownership tracking is persisted in ``.mcp.json`` itself under the
+    reserved top-level key ``_vaultspecManaged`` (a sorted list of
+    server names that vaultspec created via this function). Entries
+    that pre-existed without being added by ``mcp_sync`` never enter
+    the managed set, so user-added servers are always preserved —
+    even if they happen to share a name with a current source. This
+    mirrors the content-marker ownership pattern used by
+    ``sync_files`` for rule/agent/skill files.
 
     Args:
         dry_run: If ``True``, compute changes without writing.
         force: Overwrite entries that differ from their definitions.
+        prune: If ``True``, remove managed entries whose source files
+            have been deleted. Mirrors the ``prune`` behavior of
+            ``rules_sync``/``agents_sync``/``skills_sync``.
 
     Returns:
         :class:`~vaultspec_core.core.types.SyncResult` with sync statistics.
@@ -258,17 +274,36 @@ def mcp_sync(
             servers = {}
             existing["mcpServers"] = servers
 
+        if _MANAGED_KEY in existing:
+            raw_managed = existing.get(_MANAGED_KEY, [])
+            if isinstance(raw_managed, list):
+                managed: set[str] = {str(n) for n in raw_managed if isinstance(n, str)}
+            else:
+                managed = set()
+        else:
+            # Legacy migration: workspaces created before ownership
+            # tracking shipped have no sidecar key. Treat any
+            # pre-existing entry whose name matches a current source
+            # as managed — this preserves the legacy "differs, use
+            # --force" warning behaviour for already-installed
+            # entries. After this sync the sidecar is written and
+            # future syncs use strict ownership.
+            managed = set(servers.keys()) & set(sources.keys())
+
         changed = False
         for name, (_path, config) in sources.items():
             if name not in servers:
+                # New entry — vaultspec creates it and takes ownership.
                 servers[name] = config
+                managed.add(name)
                 result.added += 1
                 result.items.append((name, "added"))
                 changed = True
-            elif servers[name] == config:
-                result.skipped += 1
-            else:
-                if force:
+            elif name in managed:
+                # Previously managed by vaultspec — sync content.
+                if servers[name] == config:
+                    result.skipped += 1
+                elif force:
                     servers[name] = config
                     result.updated += 1
                     result.items.append((name, "updated"))
@@ -279,9 +314,51 @@ def mcp_sync(
                         f"MCP server '{name}' differs from definition "
                         f"(use --force to overwrite)"
                     )
+            else:
+                # User-added entry that shares a name with a current
+                # source. Preserve it; never take ownership implicitly.
+                result.skipped += 1
+                result.warnings.append(
+                    f"MCP server '{name}' is user-managed and shares "
+                    f"its name with a vaultspec source; skipping. "
+                    f"Rename one to resolve."
+                )
+
+        source_names = set(sources.keys())
+        if prune:
+            for name in sorted(managed - source_names):
+                if name in servers:
+                    servers.pop(name)
+                    result.pruned += 1
+                    result.items.append((name, "[DELETE]"))
+                    changed = True
+                managed.discard(name)
+
+        # Reconcile managed set with what is actually in ``servers``
+        # (defensive cleanup against external mutations).
+        managed &= set(servers.keys())
+
+        # Persist managed set; remove the key entirely when empty so
+        # we never write a dangling sidecar.
+        prior_managed = existing.get(_MANAGED_KEY)
+        new_managed_value = sorted(managed) if managed else None
+        if new_managed_value is None:
+            if _MANAGED_KEY in existing:
+                del existing[_MANAGED_KEY]
+                changed = True
+        else:
+            if prior_managed != new_managed_value:
+                existing[_MANAGED_KEY] = new_managed_value
+                changed = True
 
         if changed and not dry_run:
-            atomic_write(mcp_json, json.dumps(existing, indent=2) + "\n")
+            # If pruning emptied the file entirely, remove it instead
+            # of leaving an orphan ``{"mcpServers": {}}`` artefact.
+            if not servers and _MANAGED_KEY not in existing:
+                if mcp_json.exists():
+                    mcp_json.unlink()
+            else:
+                atomic_write(mcp_json, json.dumps(existing, indent=2) + "\n")
 
     return result
 

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -892,6 +892,44 @@ class TestMcpSyncPrune:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
 
+    def test_prune_preserves_user_top_level_keys(self):
+        """Regression: when pruning empties ``mcpServers`` AND clears
+        the managed sidecar, the file must still survive if the user
+        added other top-level keys (e.g. ``inputs``, custom config).
+        Only when the file holds nothing but an empty ``mcpServers``
+        dict may it be unlinked.
+        """
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "ephemeral.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            # First sync: install. After this the file has
+            # mcpServers + _vaultspecManaged.
+            mcp_sync()
+
+            # User manually adds a custom top-level key (e.g. inputs).
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            data["inputs"] = [{"type": "promptString", "id": "api-key"}]
+            (path / ".mcp.json").write_text(json.dumps(data), encoding="utf-8")
+
+            # Delete the source and prune.
+            (mcps_dir / "ephemeral.builtin.json").unlink()
+            mcp_sync(prune=True)
+
+            # File MUST still exist with the user's custom key intact.
+            assert (path / ".mcp.json").exists()
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert data["inputs"] == [{"type": "promptString", "id": "api-key"}]
+            assert data["mcpServers"] == {}
+            assert "_vaultspecManaged" not in data
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
     def test_round_trip_install_uninstall_via_sync_provider(self):
         """End-to-end: install seeds an entry via sync_provider, then
         deleting the source and re-running sync_provider with force=True

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -716,6 +716,234 @@ class TestUninstallRemovesCustomMcps:
 
 
 @pytest.mark.unit
+class TestMcpSyncPrune:
+    """Reconciling sync — prune orphans on companion uninstall."""
+
+    def test_prune_removes_orphan_managed_entry(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "ephemeral.builtin.json").write_text(
+                json.dumps({"command": "uv", "args": ["run", "ephemeral"]}),
+                encoding="utf-8",
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            # First sync: install
+            result = mcp_sync()
+            assert result.added == 1
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "ephemeral" in data["mcpServers"]
+            assert data["_vaultspecManaged"] == ["ephemeral"]
+
+            # Delete the source file to simulate companion uninstall
+            (mcps_dir / "ephemeral.builtin.json").unlink()
+
+            # Second sync with prune=True: should remove the orphan
+            result = mcp_sync(prune=True)
+            assert result.pruned == 1
+            assert ("ephemeral", "[DELETE]") in result.items
+
+            # File should be removed entirely (no managed, no servers)
+            assert not (path / ".mcp.json").exists()
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_prune_default_false_leaves_orphans(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "stay.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            mcp_sync()
+            (mcps_dir / "stay.builtin.json").unlink()
+
+            # Default prune=False: orphan stays put
+            result = mcp_sync()
+            assert result.pruned == 0
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "stay" in data["mcpServers"]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_prune_preserves_user_added_entries(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "managed.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            user_data = {"mcpServers": {"my-tool": {"command": "custom", "args": []}}}
+            (path / ".mcp.json").write_text(json.dumps(user_data), encoding="utf-8")
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            mcp_sync()
+            (mcps_dir / "managed.builtin.json").unlink()
+
+            result = mcp_sync(prune=True)
+            assert result.pruned == 1
+
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            # User entry survives the orphan prune
+            assert "my-tool" in data["mcpServers"]
+            assert "managed" not in data["mcpServers"]
+            # No managed key remains since the only managed entry was pruned
+            assert "_vaultspecManaged" not in data
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_user_added_with_shared_name_never_taken_over(self):
+        """A user-added entry must not be taken over just because a
+        source file appears with the same name later. The strict
+        ownership rule: only entries created by mcp_sync itself
+        enter the managed set.
+        """
+        path, mcps_dir = _make_workspace()
+        try:
+            # User pre-registers an entry — note: file already has the
+            # _vaultspecManaged sidecar (empty), so legacy migration
+            # does NOT take ownership.
+            existing = {
+                "mcpServers": {"shared": {"command": "user-binary"}},
+                "_vaultspecManaged": [],
+            }
+            (path / ".mcp.json").write_text(json.dumps(existing), encoding="utf-8")
+
+            # Source file with the same name appears
+            (mcps_dir / "shared.builtin.json").write_text(
+                json.dumps({"command": "vaultspec-binary"}), encoding="utf-8"
+            )
+
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync()
+            # Should NOT add (entry already there) and NOT enter managed
+            assert result.added == 0
+            assert result.skipped == 1
+            assert any("user-managed" in w for w in result.warnings), result.warnings
+
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            # User's entry preserved unchanged
+            assert data["mcpServers"]["shared"]["command"] == "user-binary"
+            # Source name did NOT get added to managed set
+            assert "shared" not in data.get("_vaultspecManaged", [])
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_legacy_migration_treats_pre_existing_as_managed(self):
+        """Workspaces created before ownership tracking shipped have
+        no `_vaultspecManaged` sidecar. The migration heuristic treats
+        any pre-existing entry whose name matches a current source as
+        managed (preserves the legacy 'differs, use --force' warning).
+        """
+        path, mcps_dir = _make_workspace()
+        try:
+            # Pre-existing .mcp.json without sidecar key (legacy)
+            existing = {"mcpServers": {"legacy": {"command": "old"}}}
+            (path / ".mcp.json").write_text(json.dumps(existing), encoding="utf-8")
+            (mcps_dir / "legacy.builtin.json").write_text(
+                json.dumps({"command": "new"}), encoding="utf-8"
+            )
+
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            # First sync after upgrade — legacy migration kicks in
+            result = mcp_sync(force=True)
+            assert result.updated == 1
+
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert data["mcpServers"]["legacy"]["command"] == "new"
+            # Sidecar now persisted with the migrated entry
+            assert data["_vaultspecManaged"] == ["legacy"]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_managed_key_persisted_across_syncs(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "alpha.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            (mcps_dir / "beta.builtin.json").write_text(
+                json.dumps({"command": "uv"}), encoding="utf-8"
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            mcp_sync()
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert data["_vaultspecManaged"] == ["alpha", "beta"]
+
+            # Re-sync: managed set should remain identical
+            mcp_sync()
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert data["_vaultspecManaged"] == ["alpha", "beta"]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_round_trip_install_uninstall_via_sync_provider(self):
+        """End-to-end: install seeds an entry via sync_provider, then
+        deleting the source and re-running sync_provider with force=True
+        prunes the orphan cleanly. This is the canonical companion
+        install/uninstall flow rag relies on.
+        """
+        path = PROJECT_ROOT / ".pytest-tmp" / f"mcp-roundtrip-{uuid4().hex}"
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            reset_config()
+
+            from vaultspec_core.core.commands import (
+                install_run,
+                sync_provider,
+            )
+
+            install_run(
+                path=path,
+                provider="all",
+                upgrade=False,
+                dry_run=False,
+                force=False,
+            )
+
+            # Simulate a companion package dropping a source file
+            mcps_dir = path / ".vaultspec" / "rules" / "mcps"
+            (mcps_dir / "companion.builtin.json").write_text(
+                json.dumps({"command": "uv", "args": ["run", "companion"]}),
+                encoding="utf-8",
+            )
+
+            # Companion install: sync to propagate
+            sync_provider("all", force=False)
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "companion" in data["mcpServers"]
+            assert "companion" in data["_vaultspecManaged"]
+
+            # Companion uninstall: delete source + sync
+            (mcps_dir / "companion.builtin.json").unlink()
+            sync_provider("all", force=True)
+
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "companion" not in data["mcpServers"]
+            assert "companion" not in data.get("_vaultspecManaged", [])
+            # vaultspec-core's own MCP entry is preserved
+            assert "vaultspec-core" in data["mcpServers"]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.mark.unit
 class TestInstallSeedsMcps:
     def test_install_creates_mcp_json_from_registry(self):
         path = PROJECT_ROOT / ".pytest-tmp" / f"mcps-install-{uuid4().hex}"

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -838,6 +838,42 @@ class TestMcpSyncPrune:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
 
+    def test_legacy_migration_emits_explicit_warning(self):
+        """Security: legacy migration silently transferring ownership
+        of pre-existing entries is auditable. The first sync against
+        a workspace without ``_vaultspecManaged`` MUST surface a
+        warning naming every entry it took ownership of, so an
+        operator can spot unexpected migrations (e.g. an attacker
+        having dropped a ``foo.json`` source file matching a user
+        entry name).
+        """
+        path, mcps_dir = _make_workspace()
+        try:
+            existing = {
+                "mcpServers": {
+                    "alpha": {"command": "old-a"},
+                    "beta": {"command": "old-b"},
+                }
+            }
+            (path / ".mcp.json").write_text(json.dumps(existing), encoding="utf-8")
+            (mcps_dir / "alpha.builtin.json").write_text(
+                json.dumps({"command": "new-a"}), encoding="utf-8"
+            )
+            (mcps_dir / "beta.builtin.json").write_text(
+                json.dumps({"command": "new-b"}), encoding="utf-8"
+            )
+
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync()
+            assert any(
+                "Legacy" in w and "alpha" in w and "beta" in w for w in result.warnings
+            ), f"expected legacy-migration warning, got: {result.warnings}"
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
     def test_legacy_migration_treats_pre_existing_as_managed(self):
         """Workspaces created before ownership tracking shipped have
         no `_vaultspecManaged` sidecar. The migration heuristic treats
@@ -888,6 +924,59 @@ class TestMcpSyncPrune:
             mcp_sync()
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert data["_vaultspecManaged"] == ["alpha", "beta"]
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_prune_skips_entries_whose_source_failed_to_parse(self):
+        """Critical regression: a managed source file that exists but
+        currently fails JSON parsing must NOT be treated as deleted by
+        the prune loop. Otherwise a single typo + ``sync --force``
+        would silently destroy the corresponding ``.mcp.json`` entry,
+        which is destructive and very hard to recover from.
+
+        The fix: prune is gated on physical absence of the source
+        file, not on whether it parsed successfully this run.
+        """
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "fragile.builtin.json").write_text(
+                json.dumps({"command": "uv", "args": ["run", "fragile"]}),
+                encoding="utf-8",
+            )
+            _init_context(path)
+            from vaultspec_core.core.mcps import mcp_sync
+
+            # First sync: install — entry takes ownership.
+            mcp_sync()
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "fragile" in data["mcpServers"]
+            assert "fragile" in data["_vaultspecManaged"]
+
+            # Corrupt the source: file still exists but is invalid JSON.
+            (mcps_dir / "fragile.builtin.json").write_text(
+                "{not valid json", encoding="utf-8"
+            )
+
+            # Sync with prune=True. The entry MUST survive because the
+            # source file is still present on disk — only the parser
+            # is failing. A parse warning should be reported.
+            result = mcp_sync(prune=True)
+            assert result.pruned == 0, (
+                "Entry was destructively pruned despite source file "
+                "being present (parse failure should not trigger prune)"
+            )
+            assert any("fragile" in w for w in result.warnings)
+
+            data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "fragile" in data["mcpServers"]
+            assert "fragile" in data["_vaultspecManaged"]
+
+            # Now genuinely delete the source — prune SHOULD remove it.
+            (mcps_dir / "fragile.builtin.json").unlink()
+            result = mcp_sync(prune=True)
+            assert result.pruned == 1
+            assert not (path / ".mcp.json").exists()
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)

--- a/uv.lock
+++ b/uv.lock
@@ -1402,7 +1402,7 @@ wheels = [
 
 [[package]]
 name = "vaultspec-core"
-version = "0.1.9"
+version = "0.1.10"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

- Adds a \`prune\` parameter to \`mcp_sync()\`, mirroring the existing parity pattern of \`rules_sync\` / \`agents_sync\` / \`skills_sync\`.
- Persists ownership tracking in \`.mcp.json\` itself under a reserved \`_vaultspecManaged\` sidecar key.
- \`sync_provider("all", force=True)\` now passes \`prune=force\` to \`mcp_sync\`, completing the pattern that already existed for the other three sync surfaces.
- Bumps version to **0.1.10**.

## Why

\`mcp_sync()\` was the only sync surface that was purely additive. \`rules_sync\`, \`agents_sync\`, and \`skills_sync\` already accept \`prune\` and use the shared \`sync_files\` engine to remove destination files whose source has been deleted. \`mcp_sync\` had no equivalent path, so a companion package's MCP entry would orphan in \`.mcp.json\` after the source file was removed during uninstall.

This blocks the symmetric companion install/uninstall flow that vaultspec-rag's \`install\` / \`uninstall\` commands depend on (wgergely/vaultspec-rag#54 and wgergely/vaultspec-rag#55). Without it, rag's uninstall would leave an orphaned \`vaultspec-search-mcp\` entry behind.

## Ownership tracking design

User-added entries must never be silently taken over by sync. The fix tracks which entries \`mcp_sync\` itself created via a reserved top-level key in \`.mcp.json\`:

\`\`\`json
{
  "mcpServers": { "vaultspec-core": {...}, "user-added-thing": {...} },
  "_vaultspecManaged": ["vaultspec-core"]
}
\`\`\`

Strict ownership rules:

- An entry only enters the managed set when \`mcp_sync\` adds it from a source file.
- Entries pre-existing in \`.mcp.json\` are never taken over implicitly, even if a source file with the same name appears later (a warning is emitted instead).
- \`prune=True\` removes entries from the managed set whose source files are gone, leaving user-added entries untouched.

This mirrors the content-marker ownership pattern \`sync_files\` already uses for rule/agent/skill files (where ownership is detected from file headers), scoped to JSON's structure.

## Legacy migration

Workspaces created before ownership tracking shipped have no sidecar key. The first sync after upgrade treats any pre-existing entry whose name matches a current source as managed. This preserves the legacy "differs, use --force" warning for already-installed entries and enables strict ownership for all future syncs. See \`TestMcpSyncPrune::test_legacy_migration_treats_pre_existing_as_managed\`.

## Test plan

- [x] 7 new tests in \`tests/test_mcps.py::TestMcpSyncPrune\` covering: prune removes orphans; default prune=False leaves orphans; user-added entries preserved; strict ownership for shared-name entries; legacy migration; managed key persistence; full round-trip via \`sync_provider\`.
- [x] All 49 tests in \`tests/test_mcps.py\` pass (existing + new).
- [x] Full \`tests/\` suite green except 7 pre-existing failures in \`tests/test_mcp_config.py\` that depend on a worktree-root \`.mcp.json\` (untracked, unrelated to this change — verified by stashing and re-running on \`main\`).
- [x] Ruff lint + format clean.
- [x] Type check (Ty) clean.
- [x] All pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #70