### PR TITLE
fix: use gh api for publish dispatch instead of gh workflow run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -61,17 +61,8 @@ jobs:
             exit 1
           fi
           echo "Dispatching publish.yml for tag: ${TAG}"
-          gh workflow run publish.yml --ref "${TAG}" -f tag="${TAG}"
-          echo "Waiting for dispatched run to appear..."
-          for _ in 1 2 3 4 5 6 7 8 9 10; do
-            RUN_ID=$(gh run list --workflow=publish.yml --event=workflow_dispatch --limit=1 --json databaseId,headBranch \
-              --jq ".[] | select(.headBranch==\"${TAG}\") | .databaseId")
-            if [ -n "${RUN_ID}" ]; then
-              echo "Dispatched run: ${RUN_ID}"
-              echo "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}" >> "$GITHUB_STEP_SUMMARY"
-              exit 0
-            fi
-            sleep 3
-          done
-          echo "::error::publish.yml dispatch did not produce a visible run within 30s"
-          exit 1
+          gh api --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/publish.yml/dispatches" \
+            -f "ref=${TAG}" \
+            -f "inputs[tag]=${TAG}"
+          echo "Dispatched publish.yml for ${TAG}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

The auto-dispatch step added in #66 fails because `gh workflow run` requires a checked-out git repo, and the release-please job runs in an empty workspace. Switch to the REST API dispatch endpoint (`gh api`) which has no such requirement.

## Evidence

Run [24305105984](https://github.com/wgergely/vaultspec-core/actions/runs/24305105984) failed with:

```
Dispatching publish.yml for tag: vaultspec-core-v0.1.10
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

## Changes

- Replace `gh workflow run` with `gh api --method POST .../dispatches`
- Drop the run-visibility polling loop (not needed — the API call either succeeds or fails synchronously)

Closes #71