### PR TITLE
fix(#76): correct Gemini tool names + live drift & load tests

### DIFF
--- a/src/vaultspec_core/core/agents.py
+++ b/src/vaultspec_core/core/agents.py
@@ -14,7 +14,7 @@ from typing import Any, Protocol
 
 from . import types as _t
 from .config_gen import _toml_quote
-from .enums import Tool
+from .enums import GeminiBuiltinTool, Tool
 from .exceptions import ResourceExistsError
 from .helpers import (
     _launch_editor,
@@ -33,15 +33,20 @@ logger = logging.getLogger(__name__)
 # .vaultspec/rules/agents/*.md to Gemini CLI's first-party tool identifiers.
 # Source agents are authored against Claude names; the Gemini renderer maps
 # at sync time so the source files stay single-authored.
-_CLAUDE_TO_GEMINI_TOOLS: dict[str, str] = {
-    "Read": "read_file",
-    "Write": "write_file",
-    "Edit": "edit",
-    "Glob": "glob",
-    "Grep": "grep",
-    "Bash": "shell",
-    "WebFetch": "web_fetch",
-    "WebSearch": "web_search",
+# Mapping from the Claude tool vocabulary used in
+# `.vaultspec/rules/agents/*.md` to canonical Gemini built-in tool
+# identifiers (`GeminiBuiltinTool` enum members). The enum values are
+# pinned to upstream gemini-cli constants by a live drift test in
+# `tests/cli/test_agents_render.py::TestUpstreamGeminiToolPin`.
+_CLAUDE_TO_GEMINI_TOOLS: dict[str, GeminiBuiltinTool] = {
+    "Read": GeminiBuiltinTool.READ_FILE,
+    "Write": GeminiBuiltinTool.WRITE_FILE,
+    "Edit": GeminiBuiltinTool.REPLACE,
+    "Glob": GeminiBuiltinTool.GLOB,
+    "Grep": GeminiBuiltinTool.GREP_SEARCH,
+    "Bash": GeminiBuiltinTool.RUN_SHELL_COMMAND,
+    "WebFetch": GeminiBuiltinTool.WEB_FETCH,
+    "WebSearch": GeminiBuiltinTool.GOOGLE_WEB_SEARCH,
 }
 
 
@@ -135,7 +140,7 @@ def _render_gemini_agent(
             if warnings is not None:
                 warnings.append(msg)
             continue
-        mapped.append(gemini_name)
+        mapped.append(gemini_name.value)
     if mapped:
         fm["tools"] = mapped
 

--- a/src/vaultspec_core/core/enums.py
+++ b/src/vaultspec_core/core/enums.py
@@ -82,6 +82,32 @@ class Tool(StrEnum):
     CODEX = "codex"
 
 
+class GeminiBuiltinTool(StrEnum):
+    """Canonical Gemini CLI built-in tool identifiers.
+
+    Each member's string value is the verbatim constant exported from
+    ``packages/core/src/tools/definitions/base-declarations.ts`` in
+    `google-gemini/gemini-cli`. The Gemini agent definition validator
+    (`packages/core/src/agents/agentLoader.ts`) calls
+    ``isValidToolName`` against these strings; any drift causes
+    ``Invalid tool name`` errors at agent load time.
+
+    Drift is guarded at test time by the live source-pin test
+    (``tests/cli/test_agents_render.py::TestUpstreamGeminiToolPin``),
+    which fetches ``base-declarations.ts`` from the upstream main
+    branch and asserts every enum value matches the upstream constant.
+    """
+
+    GLOB = "glob"
+    GREP_SEARCH = "grep_search"
+    READ_FILE = "read_file"
+    RUN_SHELL_COMMAND = "run_shell_command"
+    WRITE_FILE = "write_file"
+    REPLACE = "replace"
+    GOOGLE_WEB_SEARCH = "google_web_search"
+    WEB_FETCH = "web_fetch"
+
+
 class ProviderCapability(StrEnum):
     """Capabilities a provider can declare support for."""
 

--- a/src/vaultspec_core/tests/cli/test_agents_render.py
+++ b/src/vaultspec_core/tests/cli/test_agents_render.py
@@ -9,6 +9,12 @@ parametrized regression guard over every source agent under
 
 from __future__ import annotations
 
+import os
+import re
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import pytest
@@ -20,7 +26,7 @@ from vaultspec_core.core.agents import (
     _render_passthrough_agent,
     transform_agent,
 )
-from vaultspec_core.core.enums import Tool
+from vaultspec_core.core.enums import GeminiBuiltinTool, Tool
 from vaultspec_core.vaultcore import parse_frontmatter
 
 pytestmark = [pytest.mark.unit]
@@ -28,7 +34,36 @@ pytestmark = [pytest.mark.unit]
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _AGENTS_SRC = _REPO_ROOT / ".vaultspec" / "rules" / "agents"
-_GEMINI_TOOL_SET = frozenset(_CLAUDE_TO_GEMINI_TOOLS.values())
+_GEMINI_TOOL_SET = frozenset(t.value for t in GeminiBuiltinTool)
+
+# URL of the upstream gemini-cli source file that defines the canonical
+# tool name string constants. The live drift test below fetches this
+# file and asserts every `GeminiBuiltinTool` enum value still matches
+# the corresponding `*_TOOL_NAME` constant.
+_UPSTREAM_BASE_DECLARATIONS_URL = (
+    "https://raw.githubusercontent.com/google-gemini/gemini-cli/main/"
+    "packages/core/src/tools/definitions/base-declarations.ts"
+)
+
+# Mapping from `GeminiBuiltinTool` member name -> upstream constant
+# name in `base-declarations.ts`. The live test fetches the file,
+# parses each constant's string value with the regex below, and
+# asserts equality.
+_ENUM_TO_UPSTREAM_CONSTANT: dict[GeminiBuiltinTool, str] = {
+    GeminiBuiltinTool.GLOB: "GLOB_TOOL_NAME",
+    GeminiBuiltinTool.GREP_SEARCH: "GREP_TOOL_NAME",
+    GeminiBuiltinTool.READ_FILE: "READ_FILE_TOOL_NAME",
+    GeminiBuiltinTool.RUN_SHELL_COMMAND: "SHELL_TOOL_NAME",
+    GeminiBuiltinTool.WRITE_FILE: "WRITE_FILE_TOOL_NAME",
+    GeminiBuiltinTool.REPLACE: "EDIT_TOOL_NAME",
+    GeminiBuiltinTool.GOOGLE_WEB_SEARCH: "WEB_SEARCH_TOOL_NAME",
+    GeminiBuiltinTool.WEB_FETCH: "WEB_FETCH_TOOL_NAME",
+}
+
+_TOOL_NAME_DECL_RE = re.compile(
+    r"export\s+const\s+(?P<name>[A-Z_]+_TOOL_NAME)\s*[:=]\s*"
+    r"(?:[A-Za-z]+\s*=\s*)?['\"](?P<value>[^'\"]+)['\"]",
+)
 
 
 def _fm(rendered: str) -> dict[str, object]:
@@ -93,7 +128,7 @@ class TestRenderGeminiAgent:
         warnings: list[str] = []
         meta = {"tools": ["Read", "BogusTool", "Bash"]}
         out = _render_gemini_agent("vaultspec-x.md", meta, "body", warnings=warnings)
-        assert _fm(out)["tools"] == ["read_file", "shell"]
+        assert _fm(out)["tools"] == ["read_file", "run_shell_command"]
         assert any("BogusTool" in w for w in warnings)
         assert any("vaultspec-x" in w for w in warnings)
 
@@ -113,7 +148,7 @@ class TestRenderGeminiAgent:
     def test_non_string_tool_entries_ignored(self):
         meta = {"tools": ["Read", 42, None, "Grep"]}
         out = _render_gemini_agent("x.md", meta, "body")
-        assert _fm(out)["tools"] == ["read_file", "grep"]
+        assert _fm(out)["tools"] == ["read_file", "grep_search"]
 
 
 class TestTransformAgentDispatch:
@@ -218,3 +253,175 @@ class TestSourceAgentCoverage:
         assert rendered_meta.get("name") == agent_path.stem
         assert "tier" not in rendered_meta
         assert "mode" not in rendered_meta
+
+
+def _fetch_upstream_base_declarations() -> str:
+    """Fetch `base-declarations.ts` from gemini-cli main.
+
+    Hard-fails on any network or HTTP error. The integration marker on
+    the calling test class is the opt-in gate; once selected, the test
+    must reach upstream and verify the constants.
+    """
+    req = urllib.request.Request(
+        _UPSTREAM_BASE_DECLARATIONS_URL,
+        headers={"User-Agent": "vaultspec-core-tests"},
+    )
+    with urllib.request.urlopen(req, timeout=15) as resp:
+        return resp.read().decode("utf-8")
+
+
+@pytest.mark.integration
+class TestUpstreamGeminiToolPin:
+    """Live drift guard against `google-gemini/gemini-cli` main.
+
+    Fetches `packages/core/src/tools/definitions/base-declarations.ts`
+    from the upstream main branch, parses every `*_TOOL_NAME` constant,
+    and asserts that every `GeminiBuiltinTool` enum value still equals
+    the corresponding upstream constant. Any drift fails immediately.
+    """
+
+    @pytest.fixture(scope="class")
+    def upstream_constants(self) -> dict[str, str]:
+        source = _fetch_upstream_base_declarations()
+        constants: dict[str, str] = {}
+        for match in _TOOL_NAME_DECL_RE.finditer(source):
+            constants[match.group("name")] = match.group("value")
+        assert constants, (
+            "regex failed to extract any *_TOOL_NAME constants from upstream "
+            "base-declarations.ts; the upstream file format may have changed"
+        )
+        return constants
+
+    @pytest.mark.parametrize(
+        "enum_member",
+        list(_ENUM_TO_UPSTREAM_CONSTANT.keys()),
+        ids=lambda m: m.name,
+    )
+    def test_enum_value_matches_upstream(
+        self,
+        enum_member: GeminiBuiltinTool,
+        upstream_constants: dict[str, str],
+    ):
+        upstream_name = _ENUM_TO_UPSTREAM_CONSTANT[enum_member]
+        assert upstream_name in upstream_constants, (
+            f"upstream constant {upstream_name!r} not found in "
+            f"base-declarations.ts; the upstream file may have removed or "
+            f"renamed it"
+        )
+        upstream_value = upstream_constants[upstream_name]
+        assert enum_member.value == upstream_value, (
+            f"GeminiBuiltinTool.{enum_member.name} drift: "
+            f"local={enum_member.value!r} upstream={upstream_value!r} "
+            f"({upstream_name})"
+        )
+
+    def test_no_local_enum_member_is_orphaned(self, upstream_constants: dict[str, str]):
+        for member in GeminiBuiltinTool:
+            assert member in _ENUM_TO_UPSTREAM_CONSTANT, (
+                f"GeminiBuiltinTool.{member.name} has no entry in "
+                f"_ENUM_TO_UPSTREAM_CONSTANT; add the upstream constant "
+                f"name so the live drift test can verify it"
+            )
+
+
+@pytest.mark.gemini
+@pytest.mark.integration
+class TestGeminiCliLoadsRenderedAgents:
+    """Live load test: invoke real `gemini` CLI against rendered agents.
+
+    For each source agent under `.vaultspec/rules/agents/`:
+      1. render via `transform_agent(Tool.GEMINI, ...)`
+      2. write the result into a tmp `.gemini/agents/` directory
+      3. invoke `gemini -p "<probe>"` with the tmp dir as CWD - this
+         triggers full session startup, which is the only path that
+         actually validates local agent definitions; ``--version``,
+         ``mcp list``, ``extensions list`` etc. exit before the
+         agentLoader runs.
+      4. assert no `Agent loading error` / `Invalid tool name` lines
+         appear in the combined stdout/stderr.
+
+    The `@pytest.mark.gemini` marker is the opt-in gate; the test
+    asserts the binary is present once the marker selects it.
+
+    The probe also verifies the bogus agent path actually fails: a
+    deliberately broken agent file is written alongside the rendered
+    ones, gemini is invoked once with both, and the test asserts that
+    the broken agent shows up in the error list AND that none of the
+    rendered ones do. This prevents false greens from a probe command
+    that does not actually load agents.
+    """
+
+    _PROBE_PROMPT = "respond with only the word READY"
+
+    def _invoke_gemini(self, gemini_bin: str, cwd: Path) -> tuple[str, list[str]]:
+        env = os.environ.copy()
+        env["NO_COLOR"] = "1"
+        env["CI"] = "1"
+        result = subprocess.run(
+            [gemini_bin, "-p", self._PROBE_PROMPT],
+            cwd=cwd,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+        combined = (result.stdout or "") + "\n" + (result.stderr or "")
+        errors = [
+            line
+            for line in combined.splitlines()
+            if "Agent loading error" in line or "Invalid tool name" in line
+        ]
+        return combined, errors
+
+    def test_all_source_agents_load(self, tmp_path: Path):
+        gemini_bin = shutil.which("gemini")
+        assert gemini_bin is not None, (
+            "gemini CLI not on PATH; the @pytest.mark.gemini marker is the "
+            "opt-in gate - install gemini-cli before running this marker"
+        )
+
+        agents_dir = tmp_path / ".gemini" / "agents"
+        agents_dir.mkdir(parents=True)
+
+        # Render every shipped source agent.
+        rendered_names: set[str] = set()
+        for agent_path in _SOURCE_AGENTS:
+            meta, body = parse_frontmatter(agent_path.read_text(encoding="utf-8"))
+            rendered = transform_agent(Tool.GEMINI, agent_path.name, meta, body)
+            (agents_dir / agent_path.name).write_text(rendered, encoding="utf-8")
+            rendered_names.add(agent_path.stem)
+
+        # Plant a deliberately invalid agent so we can prove the probe
+        # actually triggers agent validation in this gemini build. Without
+        # this canary a future gemini change that defers loading would
+        # silently turn the test into a no-op.
+        canary_name = "vaultspec-render-canary-invalid"
+        (agents_dir / f"{canary_name}.md").write_text(
+            "---\n"
+            f"name: {canary_name}\n"
+            "description: deliberately invalid; proves the probe loads agents\n"
+            "tools: [zzz_definitely_not_a_real_gemini_tool]\n"
+            "---\n\nx\n",
+            encoding="utf-8",
+        )
+
+        _combined, errors = self._invoke_gemini(gemini_bin, tmp_path)
+
+        # The canary MUST show up in errors; if it doesn't, the probe is
+        # not actually loading agents and the test is a false green.
+        canary_hit = [e for e in errors if canary_name in e]
+        assert canary_hit, (
+            "Canary check failed: gemini did not emit an Agent loading error "
+            f"for the deliberately broken {canary_name}.md. The probe command "
+            "no longer triggers agent validation; update the test."
+        )
+
+        # Every rendered shipped agent must be absent from the error list.
+        offenders = [
+            line for line in errors if any(name in line for name in rendered_names)
+        ]
+        assert not offenders, (
+            "gemini CLI rejected at least one rendered shipped agent:\n"
+            + "\n".join(offenders)
+        )


### PR DESCRIPTION
Follow-up to #77. Closes #76 properly this time.

## Why this exists

#77 shipped wrong tool identifiers. They were eyeballed from a tool-names re-export file rather than the canonical `base-declarations.ts`. Gemini CLI still rejects every shipped agent with `Invalid tool name` on `tools.1/3/4/5`. Four of eight identifiers were wrong:

| Source | #77 (wrong) | This PR (verified) |
|---|---|---|
| Grep | `grep` | `grep_search` |
| Edit | `edit` | `replace` |
| Bash | `shell` | `run_shell_command` |
| WebSearch | `web_search` | `google_web_search` |

## What this PR does

1. **Enums, not bare strings.** New `core.enums.GeminiBuiltinTool` (StrEnum), values verbatim from `packages/core/src/tools/definitions/base-declarations.ts` in `google-gemini/gemini-cli@main`. `_CLAUDE_TO_GEMINI_TOOLS` is retyped to `dict[str, GeminiBuiltinTool]` so the mapping is enforced at the type level.

2. **Live drift test against upstream source code.** `TestUpstreamGeminiToolPin` (`@pytest.mark.integration`) fetches `base-declarations.ts` from upstream main, parses every `*_TOOL_NAME = '...'` constant with a regex, asserts each `GeminiBuiltinTool` value still equals the upstream constant. Any upstream rename or value change fails immediately. Hard-fail on network errors (no skips per the project testing rules); the integration marker is the opt-in gate.

3. **Live load test against the real `gemini` binary.** `TestGeminiCliLoadsRenderedAgents::test_all_source_agents_load` (`@pytest.mark.gemini @pytest.mark.integration`) renders every shipped source agent, plants a deliberately invalid canary, invokes `gemini -p "..."` (the only command that triggers full agent validation; `--version`/`mcp list`/`extensions list` exit before `agentLoader` runs), and asserts:
   - the canary shows up in gemini's error list (proves the probe actually loads agents — without this a future gemini change deferring loading would silently green the test)
   - no shipped rendered agent shows up

## Verification

Local run on this branch:

- ruff format / check / `ty check`: clean.
- `pytest src/vaultspec_core/tests/cli/test_agents_render.py -m "unit or integration or gemini"`: **52 passed in 19.18s** (the 18.7s slow test is the gemini spawn).
- `pytest src/vaultspec_core/tests`: **795 passed in 201.12s**.

## Test plan

- [x] Live drift test passes against upstream `main` (8 enum members verified)
- [x] Live load test passes: 10 shipped rendered agents accepted, canary rejected
- [x] Canary check inside the load test prevents false greens
- [x] No skips, no mocks, no patches in the new tests
- [x] `GeminiBuiltinTool` is a real enum, not a string constant

Refs: #76, #77