### PR TITLE
fix(#80): install-layer hygiene + audit-driven hardening

### DIFF
--- a/.vault/adr/2026-03-30-audit-findings-adr.md
+++ b/.vault/adr/2026-03-30-audit-findings-adr.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - '#adr'
+  - '#audit-findings'
+date: '2026-03-30'
+related:
+  - '[[2026-03-30-audit-findings-plan]]'
+  - '[[2026-03-27-cli-ambiguous-states-audit]]'
+  - '[[2026-03-27-cli-ambiguous-states-resolver-adr]]'
+  - '[[2026-03-27-cli-ambiguous-states-gitignore-adr]]'
+  - '[[2026-03-23-audit-fixes-research]]'
+  - '[[2026-03-27-cli-ambiguous-states-prior-art-research]]'
+---
+
+# `audit-findings` adr: triage charter for the 91-finding rolling audit
+
+Status: Accepted
+Supersedes: n/a
+Superseded by: n/a
+
+## context
+
+The cli-ambiguous-states rolling audit produced 91 open findings across 6 rounds of review. Individual decisions about how to resolve each finding live in the finding-level work (commit messages, PR diffs, and the inherited decisions recorded in `[[2026-03-27-cli-ambiguous-states-resolver-adr]]` and `[[2026-03-27-cli-ambiguous-states-gitignore-adr]]`). This ADR captures the *meta* decision that made those 91 items shippable: how we triaged, grouped, and sequenced them.
+
+Without this record the audit-findings feature carries a plan (`[[2026-03-30-audit-findings-plan]]`) with no backing ADR, violating the vaultspec pipeline contract that every plan trace to an architectural decision.
+
+## decision
+
+Triage the 91 findings by **root cause** and **risk class**, not by finding ID or round. Concretely:
+
+1. **De-duplicate by root cause.** Audit IDs across rounds frequently describe the same underlying defect. Merge every such cluster into a single work item so that each fix is applied exactly once.
+1. **Partition by risk class into five ordered phases.**
+   1. Data-loss first - anything that can silently corrupt or lose user content.
+   1. Visibility next - signals that a user-facing operation behaves differently from what the CLI reports.
+   1. Correctness third - defects that produce a wrong result without user-visible signal.
+   1. Hardening fourth - defences in depth (input validation, error paths, timeouts).
+   1. Coverage last - test gaps that do not correspond to a known defect.
+1. **Inherit the resolver and gitignore decisions** recorded in `[[2026-03-27-cli-ambiguous-states-resolver-adr]]` and `[[2026-03-27-cli-ambiguous-states-gitignore-adr]]`. These set the architectural invariants for the entire cli-ambiguous-states surface; audit-findings consumes them rather than re-ratifying them.
+1. **No partial plans.** Every finding either lands in a phase or is explicitly closed with rationale. No "open" state after triage.
+
+The companion plan (`[[2026-03-30-audit-findings-plan]]`) operationalises this triage across the five phases.
+
+## consequences
+
+### positive
+
+- The audit-findings feature is now fully traceable: research (`[[2026-03-23-audit-fixes-research]]`) -> ADR (this document) -> plan -> execution.
+- Risk-ordered phasing means data-loss class fixes ship ahead of hardening, so a partial merge of the 91 items still reduces the top-line risk surface.
+- Inheriting prior ADRs avoids duplicating architectural ratifications that the cli-ambiguous-states feature already made.
+
+### negative
+
+- Operators reading only this ADR will not find the detailed mitigation designs for individual findings; they must cross-read the inherited ADRs.
+- "Root-cause de-duplication" is a judgement call; the triage author's clustering is not mechanically re-checkable.
+
+### neutral
+
+- Future audit-findings plans (follow-up rounds) may choose to re-tag under a different feature rather than extend this one.
+
+## plan reference
+
+See `[[2026-03-30-audit-findings-plan]]` for the phased execution.

--- a/.vault/adr/2026-04-21-flow-bugs-adr.md
+++ b/.vault/adr/2026-04-21-flow-bugs-adr.md
@@ -1,0 +1,120 @@
+---
+tags:
+  - '#adr'
+  - '#flow-bugs'
+date: '2026-04-21'
+related:
+  - '[[2026-04-21-flow-bugs-research]]'
+  - '[[2026-03-16-managed-content-blocks-adr]]'
+  - '[[2026-03-27-cli-ambiguous-states-gitignore-adr]]'
+---
+
+# `flow-bugs` adr: install-layer hygiene contract
+
+Status: Accepted
+Supersedes: n/a
+Superseded by: n/a
+
+## context
+
+Issue 80 bundles five install-layer defects. Research (`[[2026-04-21-flow-bugs-research]]`) documented each as a distinct problem domain with repro, root cause, and candidate remediations. This ADR ratifies the five decisions and the cross-cutting hygiene contract they imply.
+
+## decision
+
+The install/guard layer owns a **hygiene contract** with three invariants:
+
+1. **The managed gitignore block is authoritative.** If a path appears in the managed entries, no part of the install flow may leave that path dirty in the working tree. This applies to previously-tracked state files and to ephemeral sentinels produced by our own code.
+1. **Tool-specific scaffolding respects the project's active toolchain.** `_scaffold_precommit` must not write files that conflict with a detected alternative (`prek.toml`).
+1. **Pre-commit hooks distinguish operator intent from accidental commits.** `check-providers` treats staged deletions as remediation, not violation.
+
+Concretely, the five decisions are:
+
+### d1 - untrack previously-tracked managed paths on install
+
+On `install` and `install --upgrade`, iterate the effective managed gitignore entries and invoke `git rm --cached --ignore-unmatch` on any path that is (a) tracked by git and (b) under a directory owned by vaultspec (`.vaultspec/`, or any provider directory whose presence is recorded in the manifest). The set must exclude root-level managed files that operators may legitimately commit (e.g. `.mcp.json`, `CLAUDE.md`, `.pre-commit-config.yaml`) - those are covered by other decisions or by operator choice.
+
+The effective allow-list for untracking is:
+
+- Everything under `.vaultspec/` (internal state, never user content).
+- Each provider's scope directory recorded in the manifest (`.claude/`, `.gemini/`, `.agents/`, `.codex/`), only for files that match the managed gitignore entries.
+
+Operation is a no-op when the target is not a git repo. Failures from the subprocess call are logged and do not abort install.
+
+### d2 - extend managed gitignore entries to cover advisory-lock sentinels
+
+Augment `get_recommended_entries` with:
+
+- `/.gitignore.lock`
+- `/.mcp.json.lock`
+- `/.pre-commit-config.yaml.lock`
+- `.vaultspec/*.lock`
+
+Entries are emitted only when their parent context exists (the root-level triple conditional on the companion file; the `.vaultspec/` glob conditional on the directory). A broader `*.lock` is rejected because `uv.lock`, `Cargo.lock`, `bun.lock`, and friends are legitimately tracked.
+
+The advisory-lock implementation itself is unchanged in this release. A centralised lock directory is left as follow-up.
+
+### d3 - skip `.pre-commit-config.yaml` generation when `prek.toml` is present
+
+`_scaffold_precommit` returns early with a one-shot info log pointing the operator at the prek config format when `prek.toml` exists at the target root. The existing `_scaffold_precommit` return contract (list of `(relpath, label)` tuples) returns an empty list in that branch. No hooks are transplanted into `prek.toml`; that is out of scope for this release.
+
+The `_ALL_MANAGED_HOOK_IDS` uninstall path is unaffected - if a legacy `.pre-commit-config.yaml` exists alongside `prek.toml`, uninstall still strips vaultspec hooks from it.
+
+### d4 - `check-providers` uses `--diff-filter=ACMR`
+
+`check_staged_provider_artifacts` invokes `git diff --cached --name-only --diff-filter=ACMR`. Deletions and type changes fall outside the filter; additions, copies, modifications, and renames continue to be guarded.
+
+### d5 - `_fix_filename` rewrites incoming wiki-link references atomically with the rename
+
+When `_fix_filename` renames `OLD-STEM.md` to `NEW-STEM.md`, it walks the surviving vault snapshot and rewrites any wiki-link tokens carrying `OLD-STEM` to the new stem. Scope for this release:
+
+- Tokens of the form `- "wiki-link-pointing-at-OLD-STEM"` inside frontmatter `related:` lists are rewritten to point at `NEW-STEM`.
+- Body prose wiki-link rewriting is deferred to a follow-up so that free-text mentions of the old stem do not mutate unexpectedly. This matches how `check_dangling --fix` already scopes its rewrites to frontmatter only.
+
+The rewrite uses the same graph and parser infrastructure already imported by `check_structure`. Each rewrite increments `result.fixed_count` with a dedicated diagnostic so operators can audit the change in `--verbose` output. Rewrite failures (read/parse errors) log a warning and do not abort the rename - the rename itself has already succeeded.
+
+#### d5 - implementation notes ratified in audit loop
+
+The first two review iterations surfaced edge cases that shipped inside D5 rather than as separate decisions. They are ratified here so future reviewers can verify against spec:
+
+- **Transitive rename chains.** If the same check run renames `A -> B` and `B -> C`, the rewrite map collapses into `{A: C}` so that incoming references to `A` land on `C` directly. Cycles (`A -> B`, `B -> A`) are detected by step-limit plus a terminal-equals-source filter, and the affected entries are dropped from the rewrite map entirely - no phantom self-rewrites are emitted.
+- **Collision on rename target.** If `_fix_filename` computes a target path that already exists on disk, the rename is skipped and the attempt is surfaced as a `Severity.ERROR` diagnostic on the `CheckResult` so the overall run does not claim success with a broken file still present.
+- **UTF-8 BOM.** `_rewrite_incoming_refs` reads bytes, strips a leading UTF-8 BOM before scanning, and restores the BOM on write so BOM-authored docs (Obsidian on Windows, VS Code Git) keep their byte prefix.
+- **CRLF preservation.** The same function detects `\r\n` dominance in the source, scans via `splitlines`, and rejoins on the detected newline; trailing newline is preserved when present. Mixed endings are not introduced.
+- **Missing closing fence.** A fixed line-budget (`_FRONTMATTER_LINE_BUDGET = 200`) caps the scan, and a `fence_closed` flag gates the write - documents whose opening fence was never followed by a closing fence are skipped with a warning rather than risking a rewrite of prose that was mis-read as frontmatter.
+
+## consequences
+
+### positive
+
+- The managed gitignore block becomes self-sufficient: clean clone or legacy clone, install leaves the working tree clean.
+- CI fresh checkouts no longer surface lock sentinels as dirty state.
+- prek-based projects no longer have a permanent "duplicate config" warning.
+- Operators can act on our own hook's advice (`git rm --cached`) without the hook vetoing the remediation.
+- Auto-fix renames stop shipping dangling links to downstream readers.
+
+### negative
+
+- `install` now invokes `git` via subprocess. This is acceptable - the install flow already probes git repo state via `WorkspaceLayout.git`, and failures are logged not raised.
+- Skipping `_scaffold_precommit` in prek projects shifts responsibility to the operator. Mitigated by a one-shot informational log.
+- The rewrite pass in `_fix_filename` costs one additional snapshot traversal per rename. With typical vault sizes (\<500 docs) the cost is negligible; the operation is bounded and not recursive.
+
+### neutral
+
+- The advisory-lock implementation is unchanged. If the centralised lock directory idea is pursued later, this ADR's gitignore entries become redundant but harmless.
+- `.pre-commit-config.yaml` in prek projects is not added to the managed gitignore - it is simply not generated, so it will not appear in the working tree unless pre-existing.
+
+## test contract
+
+Every decision ships with a factory-based integration test against the real filesystem and real `git` subprocess (where applicable):
+
+- **d1** - legacy-tracked `providers.json` scenario: stage the file via `git add`, run install, assert `git status --porcelain` reports no modifications and the file is no longer in `git ls-files`.
+- **d2** - post-install assertion: after install, `git status --porcelain` is empty (no untracked `.lock` sentinels).
+- **d3** - prek presence scenario: write `prek.toml` before install, assert `.pre-commit-config.yaml` is not created and the log contains the skip notice.
+- **d4** - staged deletion scenario: track `.mcp.json`, stage a `git rm --cached .mcp.json`, invoke `check_staged_provider_artifacts`, assert empty result.
+- **d5** - rename-with-backref scenario: seed `docA-review.md` plus `docB.md` whose `related:` list points at the stem `docA-review`, run `check_structure(fix=True)`, assert `docA-review.md` becomes `docA-review-audit.md` and `docB.md`'s `related:` list now points at the stem `docA-review-audit`.
+
+All tests use `WorkspaceFactory` for setup; zero mocks, patches, or stubs.
+
+## plan reference
+
+The phased implementation is recorded in the companion plan document (linked via the `related:` frontmatter above).

--- a/.vault/audit-findings.index.md
+++ b/.vault/audit-findings.index.md
@@ -1,0 +1,34 @@
+---
+generated: true
+tags:
+  - '#audit-findings'
+date: '2026-04-21'
+related:
+  - '[[2026-03-30-audit-findings-adr]]'
+  - '[[2026-03-30-audit-findings-phase1-4-exec]]'
+  - '[[2026-03-30-audit-findings-phase5-exec]]'
+  - '[[2026-03-30-audit-findings-phase6-8-exec]]'
+  - '[[2026-03-30-audit-findings-plan]]'
+  - '[[2026-03-30-audit-findings-summary-exec]]'
+---
+
+# `audit-findings` feature index
+
+Auto-generated index of all documents tagged with `#audit-findings`.
+
+## Documents
+
+### adr
+
+- `2026-03-30-audit-findings-adr` - `audit-findings` adr: triage charter for the 91-finding rolling audit
+
+### exec
+
+- `2026-03-30-audit-findings-phase1-4-exec` - `audit-findings` phase 1-4 step
+- `2026-03-30-audit-findings-phase5-exec` - `audit-findings` phase 5 exec
+- `2026-03-30-audit-findings-phase6-8-exec` - `audit-findings` phase 6-8 exec
+- `2026-03-30-audit-findings-summary-exec` - `audit-findings` summary
+
+### plan
+
+- `2026-03-30-audit-findings-plan` - `audit-findings` plan

--- a/.vault/audit-fixes.index.md
+++ b/.vault/audit-fixes.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#audit-fixes'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-audit-fixes-adr]]'
   - '[[2026-02-22-audit-fixes-execution-summary-exec]]'

--- a/.vault/builtins-build-strategy.index.md
+++ b/.vault/builtins-build-strategy.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#builtins-build-strategy'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-21-builtins-build-strategy-adr]]'
 ---

--- a/.vault/check-engine-perf.index.md
+++ b/.vault/check-engine-perf.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#check-engine-perf'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-21-check-engine-perf-adr]]'
   - '[[2026-03-21-check-engine-perf-plan]]'

--- a/.vault/clci-release.index.md
+++ b/.vault/clci-release.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#clci-release'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-22-clci-release-adr]]'
   - '[[2026-03-22-clci-release-phase1-implementation-exec]]'

--- a/.vault/cli-ambiguous-states.index.md
+++ b/.vault/cli-ambiguous-states.index.md
@@ -1,0 +1,39 @@
+---
+generated: true
+tags:
+  - '#cli-ambiguous-states'
+date: '2026-04-21'
+related:
+  - '[[2026-03-27-cli-ambiguous-states-audit]]'
+  - '[[2026-03-27-cli-ambiguous-states-gitignore-adr]]'
+  - '[[2026-03-27-cli-ambiguous-states-plan]]'
+  - '[[2026-03-27-cli-ambiguous-states-prior-art-research]]'
+  - '[[2026-03-27-cli-ambiguous-states-research]]'
+  - '[[2026-03-27-cli-ambiguous-states-resolver-adr]]'
+  - '[[2026-03-28-cli-ambiguous-states-audit-fixes-plan]]'
+---
+
+# `cli-ambiguous-states` feature index
+
+Auto-generated index of all documents tagged with `#cli-ambiguous-states`.
+
+## Documents
+
+### adr
+
+- `2026-03-27-cli-ambiguous-states-gitignore-adr` - `cli-ambiguous-states` adr: gitignore managed block support | (**status:** `accepted`)
+- `2026-03-27-cli-ambiguous-states-resolver-adr` - `cli-ambiguous-states` adr: workspace state diagnosis and resolution engine | (**status:** `accepted`)
+
+### audit
+
+- `2026-03-27-cli-ambiguous-states-audit` - `cli-ambiguous-states` rolling audit
+
+### plan
+
+- `2026-03-27-cli-ambiguous-states-plan` - `cli-ambiguous-states` implementation plan
+- `2026-03-28-cli-ambiguous-states-audit-fixes-plan` - `cli-ambiguous-states` audit fix plan
+
+### research
+
+- `2026-03-27-cli-ambiguous-states-prior-art-research` - `cli-ambiguous-states` research: prior art grounding
+- `2026-03-27-cli-ambiguous-states-research` - `cli-ambiguous-states` research: workspace state detection matrix

--- a/.vault/cli-architecture.index.md
+++ b/.vault/cli-architecture.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#cli-architecture'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-05-cli-architecture-audit]]'
   - '[[2026-03-05-cli-audit-notes-reference]]'

--- a/.vault/cli-ecosystem-factoring.index.md
+++ b/.vault/cli-ecosystem-factoring.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#cli-ecosystem-factoring'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-cli-ecosystem-factoring-adr]]'
   - '[[2026-02-22-cli-ecosystem-factoring-phase1-summary-exec]]'

--- a/.vault/cli-logging.index.md
+++ b/.vault/cli-logging.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#cli-logging'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-cli-logging-adr]]'
   - '[[2026-02-22-cli-logging-execution-summary-exec]]'

--- a/.vault/cli-output.index.md
+++ b/.vault/cli-output.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#cli-output'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-23-cli-output-architecture-adr]]'
   - '[[2026-02-23-cli-output-architecture-research]]'

--- a/.vault/cli-restructure.index.md
+++ b/.vault/cli-restructure.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#cli-restructure'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-16-cli-restructure-plan]]'
   - '[[2026-03-23-cli-restructure-adr]]'

--- a/.vault/cli-target-refactor.index.md
+++ b/.vault/cli-target-refactor.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#cli-target-refactor'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-05-cli-target-refactor-phase0-step1-exec]]'
   - '[[2026-03-05-cli-target-refactor-phase1-step1-exec]]'

--- a/.vault/cli-test-coverage.index.md
+++ b/.vault/cli-test-coverage.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#cli-test-coverage'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-23-cli-test-coverage-plan]]'
   - '[[2026-03-23-cli-test-coverage-adr]]'

--- a/.vault/code-health.index.md
+++ b/.vault/code-health.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#code-health'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-18-health-audit-deep-error-propagation-audit]]'
   - '[[2026-02-18-health-audit-investigator1-core-vault-orch-audit]]'

--- a/.vault/codebase-audit.index.md
+++ b/.vault/codebase-audit.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#codebase-audit'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-codebase-audit-research]]'
   - '[[2026-02-22-codebase-audit]]'

--- a/.vault/concurrency.index.md
+++ b/.vault/concurrency.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#concurrency'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-18-health-audit]]'
 ---

--- a/.vault/docs-curation.index.md
+++ b/.vault/docs-curation.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#docs-curation'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-21-docs-curation-exec]]'
   - '[[2026-03-23-docs-curation-adr]]'

--- a/.vault/documentation.index.md
+++ b/.vault/documentation.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#documentation'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-11-readme-wrapper-doc-audit]]'
 ---

--- a/.vault/exec/2026-04-21-flow-bugs/2026-04-21-flow-bugs-phase-1-summary-exec.md
+++ b/.vault/exec/2026-04-21-flow-bugs/2026-04-21-flow-bugs-phase-1-summary-exec.md
@@ -1,0 +1,77 @@
+---
+tags:
+  - '#exec'
+  - '#flow-bugs'
+date: '2026-04-21'
+related:
+  - '[[2026-04-21-flow-bugs-plan]]'
+  - '[[2026-04-21-flow-bugs-adr]]'
+  - '[[2026-04-21-flow-bugs-research]]'
+---
+
+# `flow-bugs` phase-1 summary
+
+Five install-layer defects from GH issue 80 plus a round of audit-driven hardening are implemented, tested, and green on the `feature/flow-bugs` branch.
+
+## changes landed
+
+- `src/vaultspec_core/core/commands.py`
+
+  - `check_staged_provider_artifacts` accepts an optional `cwd` parameter and runs `git diff --cached --name-only --diff-filter=ACMR`; staged deletions no longer block remediation commits (domain 4).
+  - `_scaffold_precommit` short-circuits when `prek.toml` is present, logs a skip notice, and returns an empty manifest (domain 3).
+  - New helpers `_is_git_repo`, `_untrack_managed_paths`, and constants `_UNTRACK_PREFIXES` reconcile the git index with the managed gitignore block on install: historically-committed `.vaultspec/providers.json` and orphan `.lock` sentinels get `git rm --cached`-ed (domain 1). Called from both the first-install branch and the `--upgrade --force` branch of `install_run`.
+
+- `src/vaultspec_core/core/gitignore.py`
+
+  - `get_recommended_entries` emits `.vaultspec/*.lock` and anchored root-level entries (`/.gitignore.lock`, `/.mcp.json.lock`, `/.pre-commit-config.yaml.lock`) when the framework is installed and the companion file exists (domain 2). The root-level entries are gated behind `framework_installed` so that bare workspaces do not accumulate spurious recommendations.
+
+- `src/vaultspec_core/vaultcore/checks/structure.py`
+
+  - `_fix_filename` now returns the `(old_stem, new_stem)` pair for each rename it performs.
+  - New `_rewrite_incoming_refs` walks `.vault/**/*.md` and rewrites matching `[[old_stem]]` references inside `related:` frontmatter (body prose is untouched to avoid churn). Each rewrite emits an INFO diagnostic and bumps `fixed_count` (domain 5).
+  - `check_structure` collects renames across the run and invokes the rewrite pass once after all renames complete, which keeps cross-file rename sequences consistent.
+
+## tests
+
+- New `src/vaultspec_core/tests/cli/test_flow_bugs.py` covers every domain end-to-end against a real filesystem and real `git` subprocess. Nineteen tests after audit-loop expansion (BOM, CRLF, collision, chain, cycle, and frontmatter-budget-overflow scenarios). Zero mocks, patches, stubs, skips.
+- Extensions to `src/vaultspec_core/tests/cli/test_gitignore.py::TestRecommendedEntries` for the new lock-sentinel managed entries.
+- Full adjacent suite (install, collectors, gitignore, vault-core checks) green.
+- Default `pytest src/vaultspec_core` pass (unit + integration; excludes the `live` marker) is green after cleaning the pre-existing `test_resolver.py::TestContentRules::test_clean_content_no_steps` flake (`_make_diagnosis` now defaults `precommit=PrecommitSignal.COMPLETE`).
+
+## audit follow-ups
+
+From the lingering-issue sweep (phase 2 of the plan):
+
+- `.bak` restore path in `check_dangling._remove_related_entries` and siblings is structurally sound - failure of `bak.replace(path)` intentionally preserves the backup as the only safe copy. No change made.
+- `install_run` post_errors path reports errors in the return dict but does not escalate to a non-zero exit. Intentional product behaviour (partial installs succeed); out of scope for issue 80.
+- Refactored `check_staged_provider_artifacts` API as part of the fix to keep the regression test free of any `monkeypatch.chdir` calls - test now passes an explicit `cwd` and touches no global process state.
+
+## quality gates
+
+- `ruff check src/vaultspec_core` - all checks passed.
+- `ty check` on every modified module - all checks passed.
+- No new `# type: ignore`, `# noqa`, `pytest.mark.skip`, or mock/patch surface was introduced.
+
+## out of scope / deferred
+
+- Centralised advisory-lock directory (`.vaultspec/_locks/<hash>.lock`): left as follow-up.
+- Writing vaultspec hooks directly into `prek.toml`: left to operators.
+- Body-link rewriting inside `_fix_filename` (only `related:` frontmatter is rewritten in this release): deferred until operator demand emerges.
+- Decoupling `install --upgrade --force` from downstream `vault-fix` pre-commit behaviour: the cascade lives entirely in the pre-commit hook and is now defused by the D5 rewrite pass.
+
+## code review
+
+Post-implementation review by `vaultspec-code-reviewer` flagged one HIGH finding plus three MEDIUM items, all addressed:
+
+- **HIGH** - `_untrack_managed_paths` ownership gate used a bare `stem.endswith(".lock")` tail-match. Even though only our three sentinels could reach the helper via `get_recommended_entries`, the contract was a data-loss footgun one refactor away (e.g. a future caller passing `["uv.lock"]`). Fixed by introducing a named `_MANAGED_LOCK_SENTINELS` allowlist (`.gitignore.lock`, `.mcp.json.lock`, `.pre-commit-config.yaml.lock`) and keying the gate against the basename of the candidate. Two regression tests added (`test_does_not_untrack_uv_lock`, `test_does_not_untrack_arbitrary_lock_file`) to pin the invariant.
+- **MEDIUM** - `_rewrite_incoming_refs` uses a block-sequence regex rather than `vaultcore.parser.parse_vault_metadata`. Accepted and documented in the docstring: the vault template enforces block style, `vault check frontmatter` enforces it, and rewriting through the parser would re-serialise unrelated frontmatter keys (higher churn, more places to go wrong). Flow-style lists are left to `vault check frontmatter` to normalise first.
+- **MEDIUM** - `_rewrite_incoming_refs` walks `.vault/**/*.md` directly rather than consuming the `VaultSnapshot` parameter. Intentional: the snapshot is stale once renames have landed. Documented in the updated docstring.
+- **MEDIUM** - D4 test narrative thin. Strengthened with a sanity-check assertion that `git diff --cached --diff-filter=D` sees the deletion before the hook proves it ignores it.
+
+No further blockers.
+
+## next steps
+
+- Manual smoke test against the original reporter's repro scenario.
+- Open PR referencing issue 80; include the five repro items and their verification steps.
+- Cut a 0.1.14 release once the PR merges.

--- a/.vault/feature-documentation.index.md
+++ b/.vault/feature-documentation.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#feature-documentation'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-21-cli-release-readiness-audit]]'
   - '[[2026-03-21-feature-documentation-code-review-audit]]'

--- a/.vault/flow-bugs.index.md
+++ b/.vault/flow-bugs.index.md
@@ -1,0 +1,33 @@
+---
+generated: true
+tags:
+  - '#flow-bugs'
+date: '2026-04-21'
+related:
+  - '[[2026-04-21-flow-bugs-adr]]'
+  - '[[2026-04-21-flow-bugs-phase-1-summary-exec]]'
+  - '[[2026-04-21-flow-bugs-plan]]'
+  - '[[2026-04-21-flow-bugs-research]]'
+---
+
+# `flow-bugs` feature index
+
+Auto-generated index of all documents tagged with `#flow-bugs`.
+
+## Documents
+
+### adr
+
+- `2026-04-21-flow-bugs-adr` - `flow-bugs` adr: install-layer hygiene contract
+
+### exec
+
+- `2026-04-21-flow-bugs-phase-1-summary-exec` - `flow-bugs` phase-1 summary
+
+### plan
+
+- `2026-04-21-flow-bugs-plan` - `flow-bugs` plan: install-layer hygiene fixes
+
+### research
+
+- `2026-04-21-flow-bugs-research` - `flow-bugs` research: five install-layer hygiene defects from production

--- a/.vault/framework.index.md
+++ b/.vault/framework.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#framework'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-16-env-var-research]]'
   - '[[2026-02-16-environment-variable-adr]]'

--- a/.vault/gemini-agent-render.index.md
+++ b/.vault/gemini-agent-render.index.md
@@ -1,0 +1,37 @@
+---
+generated: true
+tags:
+  - '#gemini-agent-render'
+date: '2026-04-21'
+related:
+  - '[[2026-04-12-gemini-agent-render-adr]]'
+  - '[[2026-04-12-gemini-agent-render-phase1-review-exec]]'
+  - '[[2026-04-12-gemini-agent-render-phase1-step1-exec]]'
+  - '[[2026-04-12-gemini-agent-render-phase1-summary-exec]]'
+  - '[[2026-04-12-gemini-agent-render-plan]]'
+  - '[[2026-04-12-gemini-agent-render-research]]'
+---
+
+# `gemini-agent-render` feature index
+
+Auto-generated index of all documents tagged with `#gemini-agent-render`.
+
+## Documents
+
+### adr
+
+- `2026-04-12-gemini-agent-render-adr` - gemini-agent-render adr
+
+### exec
+
+- `2026-04-12-gemini-agent-render-phase1-review-exec` - gemini-agent-render phase-1 review
+- `2026-04-12-gemini-agent-render-phase1-step1-exec` - gemini-agent-render phase-1 step-1
+- `2026-04-12-gemini-agent-render-phase1-summary-exec` - gemini-agent-render phase-1 summary
+
+### plan
+
+- `2026-04-12-gemini-agent-render-plan` - gemini-agent-render plan
+
+### research
+
+- `2026-04-12-gemini-agent-render-research` - gemini-agent-render research

--- a/.vault/graph-hardening.index.md
+++ b/.vault/graph-hardening.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#graph-hardening'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-22-graph-hardening-adr]]'
   - '[[2026-03-22-graph-hardening-phase1-audit]]'

--- a/.vault/health-audit.index.md
+++ b/.vault/health-audit.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#health-audit'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-18-health-audit-deep-contracts-abstractions-audit]]'
   - '[[2026-02-18-health-audit-investigator3-data-functional-audit]]'

--- a/.vault/hooks-maturity.index.md
+++ b/.vault/hooks-maturity.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#hooks-maturity'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-23-hooks-maturity-adr]]'
   - '[[2026-02-23-hooks-maturity-plan]]'

--- a/.vault/install-cmds.index.md
+++ b/.vault/install-cmds.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#install-cmds'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-15-claude-code-provider-research]]'
   - '[[2026-03-15-gemini-cli-provider-research]]'

--- a/.vault/marketing-and-documentation.index.md
+++ b/.vault/marketing-and-documentation.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#marketing-and-documentation'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-20-marketing-and-documentation-adr]]'
   - '[[2026-02-20-marketing-and-documentation-p1-plan]]'

--- a/.vault/marketing-audit.index.md
+++ b/.vault/marketing-audit.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#marketing-audit'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-18-marketing-audit-competitor-landscape-research]]'
   - '[[2026-02-18-marketing-audit-documentation-quality-research]]'

--- a/.vault/mcp-cli-interface.index.md
+++ b/.vault/mcp-cli-interface.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#mcp-cli-interface'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-11-mcp-cli-interface-audit]]'
   - '[[2026-03-17-mcp-interface-alignment-audit]]'

--- a/.vault/mcp-consolidation.index.md
+++ b/.vault/mcp-consolidation.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#mcp-consolidation'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-mcp-consolidation-adr]]'
   - '[[2026-02-22-mcp-consolidation-plan]]'

--- a/.vault/mcp-installation.index.md
+++ b/.vault/mcp-installation.index.md
@@ -1,0 +1,18 @@
+---
+generated: true
+tags:
+  - '#mcp-installation'
+date: '2026-04-21'
+related:
+  - '[[2026-03-28-mcp-installation-patterns-research]]'
+---
+
+# `mcp-installation` feature index
+
+Auto-generated index of all documents tagged with `#mcp-installation`.
+
+## Documents
+
+### research
+
+- `2026-03-28-mcp-installation-patterns-research` - `mcp-installation` research: industry patterns for MCP server registration

--- a/.vault/mcp-registry.index.md
+++ b/.vault/mcp-registry.index.md
@@ -1,0 +1,33 @@
+---
+generated: true
+tags:
+  - '#mcp-registry'
+date: '2026-04-21'
+related:
+  - '[[2026-04-11-mcp-registry-adr]]'
+  - '[[2026-04-11-mcp-registry-audit]]'
+  - '[[2026-04-11-mcp-registry-phase1-plan]]'
+  - '[[2026-04-11-mcp-registry-research]]'
+---
+
+# `mcp-registry` feature index
+
+Auto-generated index of all documents tagged with `#mcp-registry`.
+
+## Documents
+
+### adr
+
+- `2026-04-11-mcp-registry-adr` - `mcp-registry` adr: built-in MCP definitions with install/sync/uninstall lifecycle | (**status:** `accepted`)
+
+### audit
+
+- `2026-04-11-mcp-registry-audit` - `mcp-registry` Code Review
+
+### plan
+
+- `2026-04-11-mcp-registry-phase1-plan` - `mcp-registry` `phase-1` plan
+
+### research
+
+- `2026-04-11-mcp-registry-research` - `mcp-registry` research: built-in MCP definitions with install/sync/uninstall lifecycle

--- a/.vault/mcp-testing.index.md
+++ b/.vault/mcp-testing.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#mcp-testing'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-mcp-testing-adr]]'
   - '[[2026-02-22-mcp-testing-plan]]'

--- a/.vault/module-exports.index.md
+++ b/.vault/module-exports.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#module-exports'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-21-module-exports-adr]]'
   - '[[2026-02-21-module-exports-p1-step07-exec]]'

--- a/.vault/naming-surface.index.md
+++ b/.vault/naming-surface.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#naming-surface'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-11-naming-surface-audit]]'
 ---

--- a/.vault/packaging-restructure.index.md
+++ b/.vault/packaging-restructure.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#packaging-restructure'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-21-packaging-restructure-adr]]'
   - '[[2026-02-21-packaging-restructure-p1-review-exec]]'

--- a/.vault/pip-install-deployment.index.md
+++ b/.vault/pip-install-deployment.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#pip-install-deployment'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-23-pip-install-deployment-research]]'
 ---

--- a/.vault/plan/2026-03-30-audit-findings-plan.md
+++ b/.vault/plan/2026-03-30-audit-findings-plan.md
@@ -8,6 +8,8 @@ related:
   - '[[2026-03-27-cli-ambiguous-states-resolver-adr]]'
   - '[[2026-03-27-cli-ambiguous-states-gitignore-adr]]'
   - '[[2026-03-28-cli-ambiguous-states-audit-fixes-plan]]'
+  - '[[2026-03-27-cli-ambiguous-states-prior-art-research]]'
+  - '[[2026-03-23-audit-fixes-research]]'
 ---
 
 # `audit-findings` plan

--- a/.vault/plan/2026-04-21-flow-bugs-plan.md
+++ b/.vault/plan/2026-04-21-flow-bugs-plan.md
@@ -1,0 +1,96 @@
+---
+tags:
+  - '#plan'
+  - '#flow-bugs'
+date: '2026-04-21'
+related:
+  - '[[2026-04-21-flow-bugs-adr]]'
+  - '[[2026-04-21-flow-bugs-research]]'
+---
+
+# `flow-bugs` plan: install-layer hygiene fixes
+
+## scope
+
+Implement the five decisions in `[[2026-04-21-flow-bugs-adr]]`. Single phase; each decision is a separate step record under `.vault/exec/2026-04-21-flow-bugs/`.
+
+## phase 1 - install-layer hygiene
+
+### step 1 - domain 4 - `check-providers` respects deletions
+
+Target: `src/vaultspec_core/core/commands.py` line 221.
+
+- Add `--diff-filter=ACMR` to the `git diff --cached --name-only` command.
+- Add `src/vaultspec_core/tests/cli/test_check_providers.py` with two tests: one verifying additions are still flagged, one verifying deletions are not.
+- Use a real git repo in `tmp_path` - no mocks.
+
+### step 2 - domain 2 - lock sentinels in managed gitignore
+
+Target: `src/vaultspec_core/core/gitignore.py` `get_recommended_entries`.
+
+- Within the existing try block, after `entries.add(".vaultspec/")`, add `.vaultspec/*.lock`.
+- After `(target / ".mcp.json").exists()` branch, add the root-level lock entries for each of the three companion files when they exist:
+  - `.gitignore.lock` when `.gitignore` exists.
+  - `.mcp.json.lock` when `.mcp.json` exists.
+  - `.pre-commit-config.yaml.lock` when `.pre-commit-config.yaml` exists.
+- Extend `src/vaultspec_core/tests/cli/test_gitignore.py` with a test that installs, triggers an `advisory_lock` via a no-op call against each companion, asserts `git status --porcelain` is empty.
+
+### step 3 - domain 3 - prek skip
+
+Target: `src/vaultspec_core/core/commands.py` `_scaffold_precommit` at lines 302-420.
+
+- At the top of the function, check `(target / "prek.toml").exists()`. If true, log `logger.info("prek.toml detected; skipping .pre-commit-config.yaml scaffold. Add hooks to prek.toml manually.")` and return `[]`.
+- Add a test in `src/vaultspec_core/tests/cli/test_install.py` (or a new `test_precommit_scaffold.py`) that writes `prek.toml` into a factory-built workspace, calls install, asserts `.pre-commit-config.yaml` does not exist post-install, and that the expected log message fired.
+
+### step 4 - domain 1 - untrack historically-tracked managed paths
+
+Target: `src/vaultspec_core/core/commands.py`. Add a helper `_untrack_managed_paths(target, entries)` that:
+
+1. Returns early unless `(target / ".git").is_dir()` (works with worktrees too - detect via `.git` file or dir).
+1. Filters `entries` to those strictly under `.vaultspec/` or under a recorded provider directory (read manifest; do not untrack root-level entries like `.mcp.json` / `CLAUDE.md`).
+1. Invokes `git ls-files --error-unmatch <path>` per candidate in a single `git ls-files` batch to determine which are tracked.
+1. Runs `git rm --cached --ignore-unmatch -- <path>...` for the tracked subset in one call.
+1. Logs each untracked path at INFO level.
+1. Any subprocess failure is caught and logged as a warning; install continues.
+
+Call the helper from `install_run` after `ensure_gitignore_block` succeeds, both in the first-install and `--upgrade` branches.
+
+Add a test in `src/vaultspec_core/tests/cli/test_install_untrack.py`: initialise a git repo, commit a placeholder `.vaultspec/providers.json`, run install, assert `git ls-files --error-unmatch .vaultspec/providers.json` exits non-zero (= no longer tracked) and `git status --porcelain` reports only the expected un-untracked entries.
+
+### step 5 - domain 5 - rename updates incoming wiki-link references
+
+Target: `src/vaultspec_core/vaultcore/checks/structure.py` `_fix_filename`.
+
+- After the first `doc_path.rename(new_path)` block (suffix rename), call a new module-private `_rewrite_incoming_refs(old_stem, new_stem, snapshot_root)` that:
+  - Walks every `*.md` file under `snapshot_root` (via the existing `_base.VaultSnapshot` iteration).
+  - For each document, parse its frontmatter via `vaultcore.parser.parse_vault_metadata`, check `related:` entries for `[[<old_stem>]]`, rewrite to `[[<new_stem>]]`.
+  - Write changes back via `atomic_write`.
+  - Return the count of updated documents.
+- Append a diagnostic per updated document to `result.diagnostics` (severity INFO, message `"Updated wiki-link: [[<old>]] -> [[<new>]]"`).
+- Apply the same after the date-prefix rename block.
+- Add `src/vaultspec_core/vaultcore/checks/tests/test_structure_rename.py` with the rewrite scenario from the ADR's test contract.
+
+## phase 2 - lingering issue audit (domain 6)
+
+Post-execution sweep:
+
+- Run the full test suite (`pytest -xvs`) to verify no regression.
+- Inspect `guards.py`, `gitignore.py`, `commands.py` for any similar "compute managed surface but don't reconcile with git" patterns.
+- Inspect `advisory_lock` callers for any path that would leak a sentinel outside `.vaultspec/`.
+- Check CHANGELOG plus release notes draft entries for each decision.
+
+Findings from phase 2 are captured in the phase summary under `.vault/exec/2026-04-21-flow-bugs/` and, if any surface new code changes, a follow-up step record.
+
+## verification
+
+- All existing tests pass on the `feature/flow-bugs` branch.
+- New tests pass.
+- Manual dry-run against a throwaway git repo with committed `.vaultspec/providers.json` demonstrates the untrack.
+- `vaultspec-code-review` agent audits the final diff before merge.
+
+## out of scope
+
+- Centralised `advisory_lock` redirect to `.vaultspec/_locks/`.
+- Writing vaultspec hooks into `prek.toml`.
+- Body-link rewriting in `_fix_filename` (only `related:` frontmatter rewrites ship).
+- Decoupling `install --upgrade --force` manifest repair from any downstream hook cascade (the cascade lives in the pre-commit hook, not install itself).

--- a/.vault/pytest-e2e.index.md
+++ b/.vault/pytest-e2e.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#pytest-e2e'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-21-pytest-e2e-impl-phase1-exec]]'
   - '[[2026-02-21-pytest-e2e-impl-phase2-exec]]'

--- a/.vault/repo-manager-extension.index.md
+++ b/.vault/repo-manager-extension.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#repo-manager-extension'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-23-repo-manager-manifest-reference]]'
 ---

--- a/.vault/repo-manager-extensions.index.md
+++ b/.vault/repo-manager-extensions.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#repo-manager-extensions'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-23-repo-manager-extensions-reference]]'
 ---

--- a/.vault/research/2026-04-21-flow-bugs-research.md
+++ b/.vault/research/2026-04-21-flow-bugs-research.md
@@ -1,0 +1,145 @@
+---
+tags:
+  - '#research'
+  - '#flow-bugs'
+date: '2026-04-21'
+related:
+  - '[[2026-03-16-managed-content-blocks-adr]]'
+  - '[[2026-03-27-cli-ambiguous-states-gitignore-adr]]'
+  - '[[2026-04-11-mcp-registry-adr]]'
+---
+
+# `flow-bugs` research: five install-layer hygiene defects from production
+
+Production use of `vaultspec-core` 0.1.13 on a consuming repo (aeat) surfaced five defects that share the same root: the install/guard layer leaks mutable state into the working tree and fails to update its own git-tracking assumptions on repos that predate current contracts. GitHub issue 80 bundles the five together. Each one is treated here as an isolated problem domain with repro, root cause in source, and candidate remediations.
+
+All line references point at `feature-flow-bugs` worktree head (branch `feature/flow-bugs`).
+
+______________________________________________________________________
+
+## Domain 1 - `providers.json` stays tracked on repos that predate the managed gitignore block
+
+### Repro
+
+A repo committed `.vaultspec/providers.json` before the managed `.gitignore` block landed. `install` rewrites the manifest on every run (serial, timestamps, per-provider `last_synced`), so `git status` always reports `.vaultspec/providers.json` as modified, even though the managed gitignore block lists `.vaultspec/`. Git ignore rules do not retroactively untrack files - an `--assume-unchanged` or `git rm --cached` step is required to stop the drift.
+
+### Root cause
+
+`src/vaultspec_core/core/commands.py` install_run (lines 596-863) persists `ManifestData` via `write_manifest_data` on every execution. The manifest schema is intentionally mutable (`serial`, `installed_at`, `last_synced`). `get_recommended_entries` (`src/vaultspec_core/core/gitignore.py` lines 22-77) already emits `.vaultspec/` when the directory exists. For new repos the entry prevents tracking. For legacy repos where the file is already in the index, the pattern is silently ignored by git.
+
+No code path in the install flow attempts to detect or remediate historically-tracked state files. No user-facing surface explains the quirk.
+
+### Candidate remediations
+
+1. On install, iterate the effective managed gitignore entries and invoke `git rm --cached --ignore-unmatch` on any that are currently tracked. Requires `git` presence and a gated execution (workspace layout already exposes `git` via `WorkspaceLayout.git`).
+1. Emit a one-shot warning plus a printed `git rm --cached ...` command - defer the fix to the operator.
+1. Scope narrowly: untrack only `.vaultspec/providers.json` and `.mcp.json` (the two known offenders). Lower blast radius, weaker contract.
+
+Option 1 is preferred: it keeps the managed-block contract honest ("if we tell you to ignore it, we also tell git we no longer want it tracked"). It must be bounded to files whose parent directory we own (`.vaultspec/` + any provider directory) to avoid accidentally untracking legitimately-committed paths like `.mcp.json` when the operator wants it committed.
+
+______________________________________________________________________
+
+## Domain 2 - `advisory_lock` emits 0-byte `.lock` sentinels that never get cleaned up
+
+### Repro
+
+After any install or sync, the working tree has new untracked files at:
+
+```
+.gitignore.lock
+.mcp.json.lock
+.pre-commit-config.yaml.lock
+.vaultspec/providers.json.lock
+.vaultspec/providers.lock    (legacy - included in PROVIDER_ARTIFACT_PATTERNS)
+```
+
+None are in the managed block. `git status` stays permanently dirty. CI recreates them on every fresh checkout without cleanup.
+
+### Root cause
+
+`src/vaultspec_core/core/helpers.py` `advisory_lock` (lines 39-88) implements `<path>.lock` as the OS-level lock file via `msvcrt.locking` / `fcntl.flock`. `os.open(..., O_CREAT | O_RDWR)` creates the sentinel; the lock is released via `msvcrt.locking(..., LK_UNLCK)` / `fcntl.flock(..., LOCK_UN)` but the file itself is never removed. This is intentional for concurrency safety - unlinking under lock is racy - but the side effect is permanent sentinels.
+
+### Candidate remediations
+
+1. **Managed gitignore entries.** Extend `get_recommended_entries` to include the five lock sentinels when their companion file exists. Minimal change, preserves existing locking behaviour. Risk: any new file we lock in future will leak again.
+1. **Glob pattern in managed block.** Emit `.vaultspec/*.lock` + a narrow glob like `/.*.lock` (dotfiles only, at root). Durable against future lock targets. Risk: `.gitignore.lock` etc must survive any user-edit of the managed block; if a user commits the glob out, the sentinels come back. That matches domain 1's story, so the glob option composes naturally with the untrack-on-install fix.
+1. **Centralised lock directory.** Route all advisory locks through `.vaultspec/_locks/<hash>.lock` so the sentinels live in a directory already covered by `.vaultspec/`. Requires `advisory_lock` API change - all callers pass a path, but the lock target is now a hash-keyed sibling. Cleanest long-term but largest blast radius.
+1. **Cleanup on exit.** Remove sentinels at process exit via `atexit`. Rejected: racy on concurrent processes, Windows can fail to unlink a file another process has open.
+
+Option 2 (glob) + 3 (centralised) combine cleanly: glob is the immediate fix for 0.1.14; centralised is a follow-up. For this pass, ship option 2 to the `/.gitignore.lock`, `/.mcp.json.lock`, `/.pre-commit-config.yaml.lock` triple plus `.vaultspec/*.lock`.
+
+______________________________________________________________________
+
+## Domain 3 - `.pre-commit-config.yaml` is regenerated even when the project uses `prek`
+
+### Repro
+
+Project has `prek.toml`. `install --upgrade` re-runs `_scaffold_precommit`, which writes `.pre-commit-config.yaml` unconditionally. `prek` warns `Multiple configuration files`; neither tool executes the hooks.
+
+### Root cause
+
+`src/vaultspec_core/core/commands.py` `_scaffold_precommit` (lines 302-420) unconditionally writes `.pre-commit-config.yaml`. `install_run` (line 725) calls it on every `--upgrade` run. The managed gitignore block does not list `.pre-commit-config.yaml` (domain 2 kinship) and there is no probe for `prek.toml`.
+
+### Candidate remediations
+
+1. Detect `prek.toml` and short-circuit `_scaffold_precommit`. Simplest fix. Cost: prek users get no vaultspec-provided hooks and must wire them manually. Acceptable because prek is opt-in.
+1. Detect `prek.toml` and scaffold the hooks into it (prek supports the same `[[repos]]` layout in TOML). Larger change, requires a second renderer; prek schema is still evolving.
+1. Leave `_scaffold_precommit` as-is but add `.pre-commit-config.yaml` to the managed gitignore block so commits are clean. Does not fix the "warning in prek" complaint, only the "tracked churn" one.
+
+Option 1 is preferred. Pair it with a one-shot notice pointing the operator at prek's config format; do not attempt to write TOML hooks in this release.
+
+______________________________________________________________________
+
+## Domain 4 - `check-providers` hook blocks staged **deletions**
+
+### Repro
+
+Operator runs `git rm --cached .vaultspec/providers.json` to fix domain 1. The pre-commit hook `check-providers` inspects the staging area and blocks the commit because the file matches a provider-artifact pattern, even though it is being removed.
+
+### Root cause
+
+`src/vaultspec_core/core/commands.py` `check_staged_provider_artifacts` (lines 212-245) runs `git diff --cached --name-only` with no `--diff-filter`. `git diff` reports every staged path including deletions; the pattern match does not discriminate between "added" and "deleted".
+
+### Candidate remediation
+
+Pass `--diff-filter=ACMR` (added / copied / modified / renamed). Deletions fall outside the filter and the hook stops punishing the remediation path. The fix is a three-character change plus an integration test.
+
+______________________________________________________________________
+
+## Domain 5 - `install --upgrade --force` cascades into `vault check all --fix` renames that break wiki-links
+
+### Repro
+
+Repo has pre-existing `.vault/` that predates the current structure-check rules (files like `2026-03-01-xyz-review.md`). Operator runs `install --upgrade --force` to reset a corrupted manifest. A later pre-commit hook (`vault-fix`) runs `vault check all --fix`, which renames the file to `2026-03-01-xyz-review-audit.md` via `_fix_filename`. Incoming `[[2026-03-01-xyz-review]]` references in other documents are left pointing at a filename that no longer exists, producing dozens of dangling links.
+
+### Root cause
+
+`src/vaultspec_core/vaultcore/checks/structure.py` `_fix_filename` (lines 31-100) renames the on-disk file but never updates incoming wiki-link references. The graph already exposes reverse-adjacency data (`VaultGraph` can enumerate all documents that link to a given stem) but the rename path does not consult it.
+
+Install itself does not invoke `vault check --fix`. The cascade enters via the pre-commit hook after the install-era changes are staged. The user-perceived bundle ("install triggers the rename") is accurate from their vantage point: the hook fires on the next commit, and the rename is invisible until they `git status`.
+
+### Candidate remediations
+
+1. **Rewrite references during rename.** In `_fix_filename`, after `doc_path.rename(new_path)`, walk every document whose `related:` frontmatter or body contains the old stem and rewrite the reference to the new stem. Uses existing `VaultGraph` or a direct scan.
+1. **Gate the rename behind an opt-in flag.** Split `vault check structure --fix` into "report" and "rewrite" modes; the rewrite mode is the only one that renames. Pre-commit hook uses report-only by default.
+1. **Decouple manifest repair from the fix cascade.** Give `install --upgrade --force` a dedicated path that repairs the manifest and nothing else; do not rely on downstream hooks.
+
+Option 1 is the correct long-term fix - a rename that does not update its references is broken by definition. Option 3 is a valid orthogonal concern (`install --upgrade --force` should not need to pass through the vault check path at all; it already does not in the current code, so no change needed there - the cascade is entirely in the pre-commit hook).
+
+The minimal shipping fix: option 1 (rewrite references during rename) plus an integration test that verifies `[[stem]]` references survive a rename. Option 2 can be a follow-up if the operator pool wants more control.
+
+______________________________________________________________________
+
+## Test & quality gate gaps exposed
+
+- No test covers "legacy repo with pre-existing tracked `providers.json`".
+- No test covers "advisory_lock does not leave untracked files in the managed tree".
+- No test covers "`_scaffold_precommit` respects `prek.toml`".
+- No test covers "`check-providers` allows staged deletions".
+- No test covers "vault structure rename updates incoming references".
+
+The existing `WorkspaceFactory` test fixture already supports install/uninstall lifecycle composition; all five gaps can be filled without mocks by adding factory states and assertions over real filesystem output.
+
+## Next step
+
+Produce a companion ADR (`2026-04-21-flow-bugs-adr.md`) that ratifies the five candidate remediations (Option 1 for D1, Option 2 for D2, Option 1 for D3, the diff-filter fix for D4, Option 1 for D5), then a single combined plan to execute the lot.

--- a/.vault/roadmap.index.md
+++ b/.vault/roadmap.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#roadmap'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-17-audit-summary-audit]]'
   - '[[2026-02-17-competitive-landscape-audit]]'

--- a/.vault/rules-path-audit.index.md
+++ b/.vault/rules-path-audit.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#rules-path-audit'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-20-rules-path-audit-reference]]'
 ---

--- a/.vault/skill-audit.index.md
+++ b/.vault/skill-audit.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#skill-audit'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-skill-audit-adr]]'
   - '[[2026-02-22-skill-audit-execution-summary]]'

--- a/.vault/system-prompt-injection.index.md
+++ b/.vault/system-prompt-injection.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#system-prompt-injection'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-system-prompt-injection-adr]]'
   - '[[2026-02-22-system-prompt-injection-execution-summary-exec]]'

--- a/.vault/system-prompt.index.md
+++ b/.vault/system-prompt.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#system-prompt'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-18-append-system-prompt-adr]]'
   - '[[2026-02-18-system-prompt-architecture-research]]'

--- a/.vault/task-tool-dispatch.index.md
+++ b/.vault/task-tool-dispatch.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#task-tool-dispatch'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-22-task-tool-dispatch-research]]'
 ---

--- a/.vault/test-project-removal.index.md
+++ b/.vault/test-project-removal.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#test-project-removal'
-date: '2026-04-12'
+date: '2026-04-21'
 related:
   - '[[2026-04-12-test-project-removal-adr]]'
   - '[[2026-04-12-test-project-removal-phase1-lift-extend-exec]]'

--- a/.vault/test-quality.index.md
+++ b/.vault/test-quality.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#test-quality'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-24-scout-beta-report-exec]]'
   - '[[2026-02-24-strict-audit-verdict-exec]]'

--- a/.vault/test-runtime.index.md
+++ b/.vault/test-runtime.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#test-runtime'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-11-test-runtime-audit]]'
 ---

--- a/.vault/uncategorized.index.md
+++ b/.vault/uncategorized.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#uncategorized'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-20-stale-path-audit-reference]]'
   - '[[2026-02-24-scout-alpha-report-exec]]'

--- a/.vault/vault-api.index.md
+++ b/.vault/vault-api.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#vault-api'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-08-vault-api-adr]]'
   - '[[2026-02-08-vault-api-plan]]'

--- a/.vault/vault-data-dir.index.md
+++ b/.vault/vault-data-dir.index.md
@@ -1,0 +1,18 @@
+---
+generated: true
+tags:
+  - '#vault-data-dir'
+date: '2026-04-21'
+related:
+  - '[[2026-04-11-vault-data-dir-review-audit]]'
+---
+
+# `vault-data-dir` feature index
+
+Auto-generated index of all documents tagged with `#vault-data-dir`.
+
+## Documents
+
+### audit
+
+- `2026-04-11-vault-data-dir-review-audit` - `vault-data-dir` Code Review

--- a/.vault/vault-doctor-suite.index.md
+++ b/.vault/vault-doctor-suite.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#vault-doctor-suite'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-24-vault-doctor-suite-adr]]'
   - '[[2026-02-24-vault-doctor-suite-p1-plan]]'

--- a/.vault/workspace-context.index.md
+++ b/.vault/workspace-context.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#workspace-context'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-03-21-workspace-context-adr]]'
   - '[[2026-03-21-workspace-context-phase1-exec]]'

--- a/.vault/workspace-paths.index.md
+++ b/.vault/workspace-paths.index.md
@@ -2,7 +2,7 @@
 generated: true
 tags:
   - '#workspace-paths'
-date: '2026-03-23'
+date: '2026-04-21'
 related:
   - '[[2026-02-19-workspace-path-decoupling-adr]]'
   - '[[2026-02-19-workspace-path-decoupling-research]]'

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -259,7 +259,9 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
         #   1. under a prefix in :data:`_UNTRACK_PREFIXES` (currently only
         #      ``.vaultspec/``);
         #   2. a managed lock sentinel whose basename is in
-        #      :data:`_MANAGED_LOCK_SENTINELS`.
+        #      :data:`_MANAGED_LOCK_SENTINELS` **and** sits at the workspace
+        #      root (``stem == basename``) so that subdirectory matches like
+        #      ``docs/.gitignore.lock`` cannot hit the allowlist.
         #
         # The sentinel allowlist is explicit so that sibling lockfiles such
         # as ``uv.lock`` or ``Cargo.lock`` can never be untracked even if
@@ -269,7 +271,7 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
         owned = (
             any(stem == prefix.rstrip("/") for prefix in _UNTRACK_PREFIXES)
             or any(stem.startswith(prefix) for prefix in _UNTRACK_PREFIXES)
-            or basename in _MANAGED_LOCK_SENTINELS
+            or (stem == basename and basename in _MANAGED_LOCK_SENTINELS)
         )
         if not owned:
             continue

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -11,10 +11,13 @@ from __future__ import annotations
 import contextvars
 import logging
 import shutil
+import subprocess
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
+
+import yaml
 
 from . import types as _t
 from .enums import ManagedState, PrecommitHook, ProviderCapability, Tool
@@ -259,8 +262,6 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
     if not _is_git_repo(target):
         return []
 
-    import subprocess
-
     candidates: list[str] = []
     for entry in entries:
         # Skip glob patterns; git rm --cached does not expand them on our behalf.
@@ -373,8 +374,6 @@ def check_staged_provider_artifacts(cwd: Path | None = None) -> list[str]:
             working directory (pre-commit hook behaviour).  Tests pass an
             explicit path to avoid mutating global process state.
     """
-    import subprocess
-
     cmd = ["git"]
     if cwd is not None:
         cmd.extend(["-C", str(cwd)])
@@ -477,9 +476,6 @@ def _scaffold_precommit(
     to execute our hooks.  The operator is expected to transplant hooks
     into ``prek.toml`` manually.
     """
-    import yaml
-
-    from .helpers import atomic_write
 
     if (target / "prek.toml").exists():
         logger.info(
@@ -1230,8 +1226,6 @@ def uninstall_run(
         if "precommit" not in skip:
             if precommit_path.exists() and not dry_run:
                 try:
-                    import yaml
-
                     raw = precommit_path.read_text(encoding="utf-8")
                     data = yaml.safe_load(raw)
                     if isinstance(data, dict):

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -207,7 +207,22 @@ def _is_git_repo(target: Path) -> bool:
 # untracked on install if they were historically committed.  Root-level
 # files (CLAUDE.md, .mcp.json, .pre-commit-config.yaml, etc.) are excluded
 # because operators may have legitimate reasons to commit them.
-_UNTRACK_PREFIXES: tuple[str, ...] = (".vaultspec/",)
+#
+# Provider-scope directories (``.claude/``, ``.gemini/``, ``.agents/``,
+# ``.codex/``) are included per ADR D1: "Each provider's scope directory
+# recorded in the manifest, only for files that match the managed
+# gitignore entries."  Concretely, ``get_recommended_entries`` emits
+# these directories when the manifest records the provider as installed
+# and the directory exists on disk; :func:`_untrack_managed_paths` only
+# acts on entries it receives, so a provider that was never installed
+# cannot be accidentally untracked.
+_UNTRACK_PREFIXES: tuple[str, ...] = (
+    ".vaultspec/",
+    ".claude/",
+    ".gemini/",
+    ".agents/",
+    ".codex/",
+)
 
 # Advisory-lock sentinel basenames we create ourselves.  Matched against
 # the stripped candidate (no leading slash, no trailing slash) in the

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -299,11 +299,7 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
     # The candidate list comes from :func:`get_recommended_entries` and is
     # bounded by the number of managed prefixes we own (``.vaultspec/``,
     # ``.claude/``, ``.gemini/``, ``.agents/``, ``.codex/``, plus a handful
-    # of root-level lock sentinels).  It is safe to splat onto the
-    # argv.  The *tracked* list returned by ``ls-files`` is the one that
-    # can grow arbitrarily large on a legacy repo; that call uses
-    # ``git rm --pathspec-from-file=-`` via stdin so it survives past
-    # ``ARG_MAX`` (~32 KiB on Windows, larger on Linux).
+    # of root-level lock sentinels).  It is safe to splat onto the argv.
     try:
         ls_result = subprocess.run(
             ["git", "-C", str(target), "ls-files", "--", *candidates],
@@ -319,26 +315,46 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
     if not tracked:
         return []
 
-    tracked_payload = "\n".join(tracked)
-    try:
-        subprocess.run(
-            [
-                "git",
-                "-C",
-                str(target),
-                "rm",
-                "--cached",
-                "--ignore-unmatch",
-                "--pathspec-from-file=-",
-            ],
-            input=tracked_payload,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
-        logger.warning("git rm --cached failed during install untrack: %s", exc)
-        return []
+    # Chunk ``git rm --cached`` calls so the argv stays well below
+    # ``ARG_MAX`` (~32 KiB on Windows, much larger on Linux) even on
+    # legacy repos with thousands of tracked managed files.  Chunking
+    # is preferred over ``--pathspec-from-file=-`` because that flag
+    # was introduced in git 2.26 (March 2020) and some CI runners
+    # still carry older git (notably Ubuntu 18.04 LTS with git 2.17).
+    # 200 paths at ~256 chars each ~= 50 KiB which could spill ARG_MAX on
+    # Windows under edge conditions; 100 keeps us firmly inside the
+    # budget.
+    _chunk_size = 100
+    for chunk_start in range(0, len(tracked), _chunk_size):
+        chunk = tracked[chunk_start : chunk_start + _chunk_size]
+        try:
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(target),
+                    "rm",
+                    "--cached",
+                    "--ignore-unmatch",
+                    "--",
+                    *chunk,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except (
+            subprocess.CalledProcessError,
+            FileNotFoundError,
+            OSError,
+        ) as exc:
+            logger.warning(
+                "git rm --cached failed during install untrack (chunk %d-%d): %s",
+                chunk_start,
+                chunk_start + len(chunk),
+                exc,
+            )
+            return []
 
     for path in tracked:
         logger.info("Untracked previously-committed managed path: %s", path)

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -193,6 +193,131 @@ def _scaffold_provider(
 
 CANONICAL_ENTRY_PREFIX = "uv run --no-sync vaultspec-core"
 
+
+def _is_git_repo(target: Path) -> bool:
+    """Return ``True`` if *target* is inside a git repository.
+
+    Detects both plain clones (``.git`` is a directory) and linked
+    worktrees (``.git`` is a file pointing at the real gitdir).
+    """
+    return (target / ".git").exists()
+
+
+# Paths under these prefixes are owned by vaultspec-core and may be
+# untracked on install if they were historically committed.  Root-level
+# files (CLAUDE.md, .mcp.json, .pre-commit-config.yaml, etc.) are excluded
+# because operators may have legitimate reasons to commit them.
+_UNTRACK_PREFIXES: tuple[str, ...] = (".vaultspec/",)
+
+# Advisory-lock sentinel basenames we create ourselves.  Matched against
+# the stripped candidate (no leading slash, no trailing slash) in the
+# ``.lock`` ownership gate so that unrelated lockfiles (``uv.lock``,
+# ``Cargo.lock``, ``bun.lock``, ``package-lock.json`` siblings, etc.)
+# can never be untracked even if they reach the helper by accident.
+_MANAGED_LOCK_SENTINELS: frozenset[str] = frozenset(
+    {
+        ".gitignore.lock",
+        ".mcp.json.lock",
+        ".pre-commit-config.yaml.lock",
+    }
+)
+
+
+def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
+    """Stop tracking managed paths that were committed before they became ignored.
+
+    Iterates *entries* and retains only those under :data:`_UNTRACK_PREFIXES`
+    or those that are advisory-lock sentinels (``*.lock`` that vaultspec
+    itself produces).  For each retained candidate, invokes
+    ``git rm --cached --ignore-unmatch -- <path>``.  No-ops when the target
+    is not a git repository.  Subprocess failures are logged and do not
+    raise.
+
+    Args:
+        target: Workspace root directory.
+        entries: Managed gitignore entries computed for *target*.
+
+    Returns:
+        List of paths that were actually untracked (best-effort; may be
+        empty if git is unavailable or nothing was previously tracked).
+    """
+    if not _is_git_repo(target):
+        return []
+
+    import subprocess
+
+    candidates: list[str] = []
+    for entry in entries:
+        # Skip glob patterns; git rm --cached does not expand them on our behalf.
+        if "*" in entry or "?" in entry:
+            continue
+        # Strip leading slash from anchored entries ("/foo.lock" -> "foo.lock").
+        candidate = entry[1:] if entry.startswith("/") else entry
+        if not candidate:
+            continue
+        # Only act on paths we own.  Two ownership gates:
+        #   1. under a prefix in :data:`_UNTRACK_PREFIXES` (currently only
+        #      ``.vaultspec/``);
+        #   2. a managed lock sentinel whose basename is in
+        #      :data:`_MANAGED_LOCK_SENTINELS`.
+        #
+        # The sentinel allowlist is explicit so that sibling lockfiles such
+        # as ``uv.lock`` or ``Cargo.lock`` can never be untracked even if
+        # a future caller passes them in.
+        stem = candidate.rstrip("/")
+        basename = stem.rsplit("/", 1)[-1]
+        owned = (
+            any(stem == prefix.rstrip("/") for prefix in _UNTRACK_PREFIXES)
+            or any(stem.startswith(prefix) for prefix in _UNTRACK_PREFIXES)
+            or basename in _MANAGED_LOCK_SENTINELS
+        )
+        if not owned:
+            continue
+        candidates.append(candidate)
+
+    if not candidates:
+        return []
+
+    try:
+        ls_result = subprocess.run(
+            ["git", "-C", str(target), "ls-files", "--", *candidates],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        logger.warning("git ls-files probe failed during install untrack: %s", exc)
+        return []
+
+    tracked = [line.strip() for line in ls_result.stdout.splitlines() if line.strip()]
+    if not tracked:
+        return []
+
+    try:
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(target),
+                "rm",
+                "--cached",
+                "--ignore-unmatch",
+                "--",
+                *tracked,
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        logger.warning("git rm --cached failed during install untrack: %s", exc)
+        return []
+
+    for path in tracked:
+        logger.info("Untracked previously-committed managed path: %s", path)
+    return tracked
+
+
 # Patterns that must never be committed.  Used by the
 # check-provider-artifacts pre-commit hook.
 PROVIDER_ARTIFACT_PATTERNS: tuple[str, ...] = (
@@ -209,17 +334,29 @@ PROVIDER_ARTIFACT_PATTERNS: tuple[str, ...] = (
 )
 
 
-def check_staged_provider_artifacts() -> list[str]:
+def check_staged_provider_artifacts(cwd: Path | None = None) -> list[str]:
     """Return staged file paths that match provider artifact patterns.
 
-    Runs ``git diff --cached --name-only`` and filters against
-    :data:`PROVIDER_ARTIFACT_PATTERNS`.
+    Runs ``git diff --cached --name-only --diff-filter=ACMR`` and filters
+    against :data:`PROVIDER_ARTIFACT_PATTERNS`.  The ``ACMR`` filter excludes
+    staged deletions so remediation commits (``git rm --cached ...``) are
+    not blocked by the hook that recommends them.
+
+    Args:
+        cwd: Directory to run ``git`` in.  Defaults to the caller's current
+            working directory (pre-commit hook behaviour).  Tests pass an
+            explicit path to avoid mutating global process state.
     """
     import subprocess
 
+    cmd = ["git"]
+    if cwd is not None:
+        cmd.extend(["-C", str(cwd)])
+    cmd.extend(["diff", "--cached", "--name-only", "--diff-filter=ACMR"])
+
     try:
         result = subprocess.run(
-            ["git", "diff", "--cached", "--name-only"],
+            cmd,
             capture_output=True,
             text=True,
             check=True,
@@ -307,10 +444,32 @@ def _scaffold_precommit(
     Ensures the full canonical hook set is present with canonical entry
     patterns.  Existing hooks with matching IDs are updated to the
     canonical entry; missing hooks are appended.
+
+    Skips scaffolding entirely when ``prek.toml`` is present at *target*:
+    prek treats ``.pre-commit-config.yaml`` as a duplicate configuration
+    source and emits a warning, and writing both would cause neither tool
+    to execute our hooks.  The operator is expected to transplant hooks
+    into ``prek.toml`` manually.
     """
     import yaml
 
     from .helpers import atomic_write
+
+    if (target / "prek.toml").exists():
+        logger.info(
+            "prek.toml detected at %s; skipping .pre-commit-config.yaml scaffold. "
+            "Add vaultspec-core hooks to prek.toml manually.",
+            target,
+        )
+        if (target / ".pre-commit-config.yaml").exists():
+            logger.warning(
+                "Both prek.toml and .pre-commit-config.yaml are present at %s. "
+                "prek reads prek.toml exclusively; vaultspec will not refresh the "
+                "YAML hooks.  Remove .pre-commit-config.yaml or migrate its hooks "
+                "into prek.toml to avoid stale pre-commit config.",
+                target,
+            )
+        return []
 
     config_file = target / ".pre-commit-config.yaml"
 
@@ -751,6 +910,12 @@ def install_run(
 
         write_manifest_data(path, mdata)
 
+        # Reconcile git index with the managed gitignore block so that
+        # historically-committed state files (e.g. .vaultspec/providers.json
+        # from a pre-managed-block install) stop showing up as dirty on
+        # every subsequent run.
+        _untrack_managed_paths(path, get_recommended_entries(path))
+
         return {"action": "upgrade", "seeded_count": len(seeded), "path": path}
 
     fw_dir = path / ".vaultspec"
@@ -849,6 +1014,12 @@ def install_run(
         mdata.provider_state.setdefault(name, {})
         mdata.provider_state[name]["installed_at"] = mdata.installed_at
     write_manifest_data(path, mdata)
+
+    # Reconcile git index with the managed gitignore block so that
+    # historically-committed state files (e.g. .vaultspec/providers.json
+    # from a pre-managed-block install) stop showing up as dirty on
+    # every subsequent run.
+    _untrack_managed_paths(path, recommended)
 
     result: dict[str, Any] = {
         "action": "install",

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -295,6 +295,14 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
     if not candidates:
         return []
 
+    # The candidate list comes from :func:`get_recommended_entries` and is
+    # bounded by the number of managed prefixes we own (``.vaultspec/``,
+    # ``.claude/``, ``.gemini/``, ``.agents/``, ``.codex/``, plus a handful
+    # of root-level lock sentinels).  It is safe to splat onto the
+    # argv.  The *tracked* list returned by ``ls-files`` is the one that
+    # can grow arbitrarily large on a legacy repo; that call uses
+    # ``git rm --pathspec-from-file=-`` via stdin so it survives past
+    # ``ARG_MAX`` (~32 KiB on Windows, larger on Linux).
     try:
         ls_result = subprocess.run(
             ["git", "-C", str(target), "ls-files", "--", *candidates],
@@ -310,6 +318,7 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
     if not tracked:
         return []
 
+    tracked_payload = "\n".join(tracked)
     try:
         subprocess.run(
             [
@@ -319,9 +328,9 @@ def _untrack_managed_paths(target: Path, entries: list[str]) -> list[str]:
                 "rm",
                 "--cached",
                 "--ignore-unmatch",
-                "--",
-                *tracked,
+                "--pathspec-from-file=-",
             ],
+            input=tracked_payload,
             capture_output=True,
             text=True,
             check=True,

--- a/src/vaultspec_core/core/gitignore.py
+++ b/src/vaultspec_core/core/gitignore.py
@@ -31,9 +31,13 @@ def get_recommended_entries(target: Path) -> list[str]:
 
     try:
         # Internal state that must ALWAYS be ignored if framework exists
-        if (target / ".vaultspec").is_dir():
+        framework_installed = (target / ".vaultspec").is_dir()
+        if framework_installed:
             entries.add(".vaultspec/_snapshots/")
             entries.add(".vaultspec/")
+            # Advisory-lock sentinels left by helpers.advisory_lock on any
+            # file persisted under .vaultspec/ (providers.json, etc.).
+            entries.add(".vaultspec/*.lock")
         if (target / ".vault").is_dir():
             entries.add(".vault/.obsidian/")
             entries.add(".vault/.trash/")
@@ -45,6 +49,23 @@ def get_recommended_entries(target: Path) -> list[str]:
         # Global files
         if (target / ".mcp.json").exists():
             entries.add(".mcp.json")
+
+        # Root-level advisory-lock sentinels produced by ``advisory_lock``
+        # when vaultspec locks each of these managed files during install
+        # or sync.  Listed explicitly rather than via a broad ``*.lock``
+        # glob because legitimately-tracked lockfiles (uv.lock, bun.lock,
+        # Cargo.lock, ...) must not be ignored.  Each entry is anchored
+        # with a leading slash so it matches only at the repo root.  Only
+        # emitted when vaultspec itself is installed, to avoid polluting
+        # the recommended set on bare workspaces.
+        if framework_installed:
+            for managed_file in (
+                ".gitignore",
+                ".mcp.json",
+                ".pre-commit-config.yaml",
+            ):
+                if (target / managed_file).exists():
+                    entries.add(f"/{managed_file}.lock")
 
         # Use the local artifact collection logic to ensure gitignore is
         # perfectly synced with provider artifacts.

--- a/src/vaultspec_core/tests/cli/test_flow_bugs.py
+++ b/src/vaultspec_core/tests/cli/test_flow_bugs.py
@@ -666,6 +666,42 @@ class TestStructureRenameUpdatesRefs:
             f"expected budget WARNING, saw {[d.message for d in warnings]!r}"
         )
 
+    def test_rewrite_skips_three_node_rename_cycle(self, tmp_path: Path) -> None:
+        """A 3-cycle (A -> B -> C -> A) must be detected and dropped."""
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-tri-cycle-adr.md"
+        original = (
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#tri-cycle"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[alpha]]"\n'
+            "---\n\n# tri-cycle adr\n"
+        )
+        backref.write_text(original, encoding="utf-8")
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(
+            tmp_path,
+            [("alpha", "beta"), ("beta", "gamma"), ("gamma", "alpha")],
+            result,
+        )
+
+        assert backref.read_text(encoding="utf-8") == original, (
+            "3-cycle must produce no rewrite; file must be byte-identical"
+        )
+        assert result.fixed_count == 0
+        assert not any("Updated wiki-link" in d.message for d in result.diagnostics)
+
     def test_rewrite_skips_rename_cycles(self, tmp_path: Path) -> None:
         """A 2-cycle in raw_map must not produce phantom self-rewrites."""
         from vaultspec_core.vaultcore.checks._base import CheckResult

--- a/src/vaultspec_core/tests/cli/test_flow_bugs.py
+++ b/src/vaultspec_core/tests/cli/test_flow_bugs.py
@@ -795,6 +795,125 @@ class TestStructureRenameUpdatesRefs:
             "Dropped duplicate wiki-link" in d.message for d in result.diagnostics
         )
 
+    def test_rewrite_skips_vault_data_and_logs_dirs(self, tmp_path: Path) -> None:
+        """Files under ``.vault/data/`` and ``.vault/logs/`` must not be
+        rewritten - those dirs hold internal state and log output.
+        """
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        data_dir = vault / "data"
+        logs_dir = vault / "logs"
+        data_dir.mkdir(parents=True)
+        logs_dir.mkdir(parents=True)
+
+        data_doc = data_dir / "snapshot.md"
+        logs_doc = logs_dir / "run.md"
+        original = (
+            "---\n"
+            "tags:\n"
+            '  - "#research"\n'
+            '  - "#internal"\n'
+            "date: '2026-03-01'\n"
+            "related:\n"
+            '  - "[[alpha]]"\n'
+            "---\n\n# internal\n"
+        )
+        data_doc.write_text(original, encoding="utf-8")
+        logs_doc.write_text(original, encoding="utf-8")
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta")], result)
+
+        assert data_doc.read_text(encoding="utf-8") == original, (
+            ".vault/data/ docs must not be mutated"
+        )
+        assert logs_doc.read_text(encoding="utf-8") == original, (
+            ".vault/logs/ docs must not be mutated"
+        )
+        assert result.fixed_count == 0
+
+    def test_rewrite_handles_case_insensitive_wiki_links(self, tmp_path: Path) -> None:
+        """Obsidian resolves wiki-links case-insensitively; the rewrite
+        must still hit the rename map when only the case differs.
+        """
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-case-adr.md"
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#case"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[My-Doc]]"\n'
+            "---\n\n# case adr\n",
+            encoding="utf-8",
+        )
+
+        # rename_map key is the lowercase on-disk stem.
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("my-doc", "your-doc")], result)
+
+        written = backref.read_text(encoding="utf-8")
+        assert "[[your-doc]]" in written, (
+            "Case-insensitive fallback should rewrite [[My-Doc]] "
+            "when the rename map contains lowercase 'my-doc'"
+        )
+        assert "[[My-Doc]]" not in written
+        assert result.fixed_count == 1
+
+    def test_rewrite_exact_case_takes_precedence_over_lowercase(
+        self, tmp_path: Path
+    ) -> None:
+        """When both exact-case and case-insensitive matches are
+        available, the exact-case rename wins so Linux users with
+        both ``My-Doc.md`` and ``my-doc.md`` coexisting get
+        deterministic, intent-preserving behaviour.
+        """
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-case-exact-adr.md"
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#case-exact"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[My-Doc]]"\n'
+            "---\n\n# case exact adr\n",
+            encoding="utf-8",
+        )
+
+        # Both an exact-case and a lowercase entry in the rename_map.
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(
+            tmp_path,
+            [("My-Doc", "exact-target"), ("my-doc", "lowercase-target")],
+            result,
+        )
+
+        written = backref.read_text(encoding="utf-8")
+        assert "[[exact-target]]" in written
+        assert "[[lowercase-target]]" not in written
+
     def test_rewrite_skips_hidden_obsidian_docs(self, tmp_path: Path) -> None:
         """Files under ``.vault/.obsidian/`` and ``.vault/.trash/`` must not
         be rewritten - they hold editor state, not vault content.

--- a/src/vaultspec_core/tests/cli/test_flow_bugs.py
+++ b/src/vaultspec_core/tests/cli/test_flow_bugs.py
@@ -210,6 +210,37 @@ class TestUntrackManagedPaths:
             == 0
         )
 
+    def test_untracks_large_candidate_list_via_stdin(self, tmp_path: Path) -> None:
+        """Batching via ``--pathspec-from-file=-`` must survive large inputs.
+
+        Historically the helper splatted candidates onto the argv, which
+        would hit ``ARG_MAX`` (~32 KiB on Windows) once the list grew
+        past a few hundred entries.  This test seeds several hundred
+        tracked files under ``.vaultspec/`` and asserts they all get
+        untracked in one call.
+        """
+        _init_git_repo(tmp_path)
+        vaultspec_dir = tmp_path / ".vaultspec"
+        vaultspec_dir.mkdir()
+        # 400 tracked files - each name is ~30 chars long, so the bare
+        # argv payload would be ~12KB and safely within ARG_MAX, but
+        # the pathspec-from-file path proves it stays correct.
+        paths = [f".vaultspec/legacy-{i:04d}.json" for i in range(400)]
+        for rel in paths:
+            (tmp_path / rel).write_text("{}", encoding="utf-8")
+        _run_git(tmp_path, "add", *paths)
+        _run_git(tmp_path, "commit", "-q", "-m", "seed many legacy files")
+
+        untracked = _untrack_managed_paths(tmp_path, [".vaultspec/"])
+
+        assert sorted(untracked) == sorted(paths), (
+            f"Expected all {len(paths)} files untracked; got {len(untracked)}"
+        )
+        for rel in paths:
+            assert (
+                _run_git(tmp_path, "ls-files", "--error-unmatch", rel).returncode != 0
+            ), f"{rel} should no longer be tracked"
+
     def test_untracks_committed_claude_dir_content(self, tmp_path: Path) -> None:
         """Files under a provider scope directory (.claude/, .gemini/, .agents/,
         .codex/) must be eligible for untracking when passed in via the
@@ -688,6 +719,80 @@ class TestStructureRenameUpdatesRefs:
         warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
         assert any("Frontmatter exceeds" in d.message for d in warnings), (
             f"expected budget WARNING, saw {[d.message for d in warnings]!r}"
+        )
+
+    def test_rewrite_preserves_anchor_and_alias_suffixes(self, tmp_path: Path) -> None:
+        """Wiki-links with ``#anchor`` or ``|alias`` must rewrite the stem
+        only, leaving the anchor/alias intact."""
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-anchor-adr.md"
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#anchor"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[alpha#section-one]]"\n'
+            '  - "[[alpha|shown label]]"\n'
+            '  - "[[alpha#heading|alias]]"\n'
+            "---\n\n# anchor adr\n",
+            encoding="utf-8",
+        )
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta")], result)
+
+        written = backref.read_text(encoding="utf-8")
+        assert "[[beta#section-one]]" in written
+        assert "[[beta|shown label]]" in written
+        assert "[[beta#heading|alias]]" in written
+        assert "[[alpha" not in written
+        assert result.fixed_count == 3
+
+    def test_rewrite_drops_duplicate_after_collapse(self, tmp_path: Path) -> None:
+        """When a rewrite would produce a duplicate ``related:`` entry
+        the duplicate line must be dropped, not written twice."""
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-dup-adr.md"
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#dup"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[alpha]]"\n'
+            '  - "[[beta]]"\n'
+            "---\n\n# dup adr\n",
+            encoding="utf-8",
+        )
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        # Both alpha and beta collapse onto gamma: alpha -> beta, beta -> gamma.
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta"), ("beta", "gamma")], result)
+
+        written = backref.read_text(encoding="utf-8")
+        # Only one [[gamma]] line should remain.
+        assert written.count("[[gamma]]") == 1
+        assert "[[alpha]]" not in written
+        assert "[[beta]]" not in written
+        assert any(
+            "Dropped duplicate wiki-link" in d.message for d in result.diagnostics
         )
 
     def test_rewrite_skips_hidden_obsidian_docs(self, tmp_path: Path) -> None:

--- a/src/vaultspec_core/tests/cli/test_flow_bugs.py
+++ b/src/vaultspec_core/tests/cli/test_flow_bugs.py
@@ -1,0 +1,604 @@
+"""Regression tests for GH issue 80 install-layer hygiene defects.
+
+Covers the five problem domains ratified in
+``2026-04-21-flow-bugs-adr``:
+
+* D1 - ``_untrack_managed_paths`` drops historically-tracked
+  ``.vaultspec/providers.json`` from the git index on install.
+* D2 - lock sentinels are absent from ``git status --porcelain`` after
+  install because the managed block now ignores them.
+* D3 - ``_scaffold_precommit`` skips when ``prek.toml`` is present.
+* D4 - ``check_staged_provider_artifacts`` ignores staged deletions.
+* D5 - ``_fix_filename`` rewrites incoming ``related:`` wiki-link
+  references so renames do not leave dangling links.
+
+All tests drive the real filesystem and a real ``git`` subprocess where
+relevant; no mocks, patches, or stubs.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.core.commands import (
+    _scaffold_precommit,
+    _untrack_managed_paths,
+    check_staged_provider_artifacts,
+    install_run,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.integration]
+
+
+def _null_device() -> str:
+    """Return a platform-correct null device path for git config isolation."""
+    import sys
+
+    return "NUL" if sys.platform == "win32" else "/dev/null"
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke ``git`` inside *cwd* with deterministic author/committer env.
+
+    Uses the platform-correct null device for ``GIT_CONFIG_GLOBAL`` /
+    ``GIT_CONFIG_SYSTEM`` so host filter/core settings (``filter.lfs.*``,
+    ``core.autocrlf``) cannot leak into the test repo.
+    """
+    null = _null_device()
+    env = {
+        "GIT_AUTHOR_NAME": "vaultspec-test",
+        "GIT_AUTHOR_EMAIL": "test@vaultspec.local",
+        "GIT_COMMITTER_NAME": "vaultspec-test",
+        "GIT_COMMITTER_EMAIL": "test@vaultspec.local",
+        "GIT_CONFIG_GLOBAL": null,
+        "GIT_CONFIG_SYSTEM": null,
+        "HOME": str(cwd),
+    }
+    import os
+
+    full_env = {**os.environ, **env}
+    result = subprocess.run(
+        ["git", "-C", str(cwd), *args],
+        capture_output=True,
+        text=True,
+        env=full_env,
+        check=False,
+    )
+    return result
+
+
+def _init_git_repo(path: Path) -> None:
+    """Initialise a git repo at *path* with an initial empty commit."""
+    _run_git(path, "init", "-q", "-b", "main")
+    _run_git(path, "commit", "--allow-empty", "-q", "-m", "init")
+
+
+# ---- Domain 4: staged deletions ---------------------------------------------
+
+
+class TestCheckProvidersIgnoresDeletions:
+    """``check_staged_provider_artifacts`` must allow remediation commits."""
+
+    def test_staged_deletion_is_not_flagged(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        # Track .mcp.json then stage its removal.
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        _run_git(tmp_path, "add", ".mcp.json")
+        _run_git(tmp_path, "commit", "-q", "-m", "track mcp")
+        _run_git(tmp_path, "rm", "--cached", ".mcp.json")
+
+        # Sanity check: confirm the staged change is indeed a deletion.
+        staged = _run_git(
+            tmp_path, "diff", "--cached", "--name-only", "--diff-filter=D"
+        )
+        assert ".mcp.json" in staged.stdout.splitlines()
+
+        violations = check_staged_provider_artifacts(cwd=tmp_path)
+
+        assert violations == []
+
+    def test_staged_addition_is_flagged(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        _run_git(tmp_path, "add", ".mcp.json")
+
+        violations = check_staged_provider_artifacts(cwd=tmp_path)
+
+        assert ".mcp.json" in violations
+
+
+# ---- Domain 1: untrack historically-committed managed paths -----------------
+
+
+class TestUntrackManagedPaths:
+    """``_untrack_managed_paths`` drops tracked files from the index."""
+
+    def test_untracks_providers_json_when_tracked(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        vaultspec_dir = tmp_path / ".vaultspec"
+        vaultspec_dir.mkdir()
+        manifest = vaultspec_dir / "providers.json"
+        manifest.write_text('{"version": "2.0"}', encoding="utf-8")
+
+        _run_git(tmp_path, "add", ".vaultspec/providers.json")
+        _run_git(tmp_path, "commit", "-q", "-m", "track manifest")
+        assert (
+            _run_git(
+                tmp_path, "ls-files", "--error-unmatch", ".vaultspec/providers.json"
+            ).returncode
+            == 0
+        )
+
+        untracked = _untrack_managed_paths(tmp_path, [".vaultspec/"])
+
+        assert untracked == [".vaultspec/providers.json"]
+        assert (
+            _run_git(
+                tmp_path, "ls-files", "--error-unmatch", ".vaultspec/providers.json"
+            ).returncode
+            != 0
+        )
+        assert manifest.exists(), "working tree copy must be preserved"
+
+    def test_does_not_untrack_root_mcp_json(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        _run_git(tmp_path, "add", ".mcp.json")
+        _run_git(tmp_path, "commit", "-q", "-m", "track mcp")
+
+        untracked = _untrack_managed_paths(tmp_path, [".mcp.json"])
+
+        assert untracked == []
+        assert (
+            _run_git(tmp_path, "ls-files", "--error-unmatch", ".mcp.json").returncode
+            == 0
+        )
+
+    def test_untracks_root_lock_sentinel(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        sentinel = tmp_path / ".mcp.json.lock"
+        sentinel.write_bytes(b"")
+        _run_git(tmp_path, "add", ".mcp.json.lock")
+        _run_git(tmp_path, "commit", "-q", "-m", "accidentally committed sentinel")
+
+        untracked = _untrack_managed_paths(tmp_path, ["/.mcp.json.lock"])
+
+        assert untracked == [".mcp.json.lock"]
+        assert (
+            _run_git(
+                tmp_path, "ls-files", "--error-unmatch", ".mcp.json.lock"
+            ).returncode
+            != 0
+        )
+
+    def test_no_git_repo_is_noop(self, tmp_path: Path) -> None:
+        untracked = _untrack_managed_paths(tmp_path, [".vaultspec/"])
+        assert untracked == []
+
+    def test_does_not_untrack_uv_lock(self, tmp_path: Path) -> None:
+        """Sibling lockfiles (uv.lock, Cargo.lock, etc.) must survive."""
+        _init_git_repo(tmp_path)
+        (tmp_path / "uv.lock").write_text("version = 1", encoding="utf-8")
+        _run_git(tmp_path, "add", "uv.lock")
+        _run_git(tmp_path, "commit", "-q", "-m", "track uv.lock")
+
+        untracked = _untrack_managed_paths(tmp_path, ["uv.lock"])
+
+        assert untracked == []
+        assert (
+            _run_git(tmp_path, "ls-files", "--error-unmatch", "uv.lock").returncode == 0
+        )
+
+    def test_does_not_untrack_arbitrary_lock_file(self, tmp_path: Path) -> None:
+        """Only explicitly-managed lock sentinels are eligible for untracking."""
+        _init_git_repo(tmp_path)
+        (tmp_path / "custom.lock").write_text("", encoding="utf-8")
+        _run_git(tmp_path, "add", "custom.lock")
+        _run_git(tmp_path, "commit", "-q", "-m", "track custom.lock")
+
+        untracked = _untrack_managed_paths(tmp_path, ["/custom.lock"])
+
+        assert untracked == []
+        assert (
+            _run_git(tmp_path, "ls-files", "--error-unmatch", "custom.lock").returncode
+            == 0
+        )
+
+
+# ---- Domain 3: prek.toml short-circuit --------------------------------------
+
+
+class TestPrekShortCircuit:
+    """``_scaffold_precommit`` must not write YAML when ``prek.toml`` exists."""
+
+    def test_skips_when_prek_toml_present(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        (tmp_path / "prek.toml").write_text("", encoding="utf-8")
+
+        caplog.set_level("INFO", logger="vaultspec_core.core.commands")
+        result = _scaffold_precommit(tmp_path)
+
+        assert result == []
+        assert not (tmp_path / ".pre-commit-config.yaml").exists()
+        assert any("prek.toml detected" in rec.message for rec in caplog.records)
+
+    def test_scaffolds_when_prek_toml_absent(self, tmp_path: Path) -> None:
+        result = _scaffold_precommit(tmp_path)
+
+        assert result == [(".pre-commit-config.yaml", "precommit")]
+        assert (tmp_path / ".pre-commit-config.yaml").exists()
+
+
+# ---- Domain 2 + domain 1 end-to-end: install leaves a clean tree -------------
+
+
+class TestInstallLeavesCleanTree:
+    """Post-install ``git status --porcelain`` must be empty."""
+
+    def test_fresh_install_no_untracked_lock_sentinels(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        (tmp_path / ".gitignore").write_text("", encoding="utf-8")
+        _run_git(tmp_path, "add", ".gitignore")
+        _run_git(tmp_path, "commit", "-q", "-m", "seed gitignore")
+
+        install_run(
+            path=tmp_path,
+            provider="all",
+            upgrade=False,
+            dry_run=False,
+            force=True,
+        )
+
+        # After install, the working tree contains freshly created
+        # scaffolds; we only assert that no ``.lock`` sentinel appears as
+        # a dirty entry in git status.  The managed block should ignore
+        # them via the ``.vaultspec/*.lock`` and ``/.*.lock`` patterns.
+        status = _run_git(tmp_path, "status", "--porcelain")
+        lock_entries = [
+            line for line in status.stdout.splitlines() if line.endswith(".lock")
+        ]
+        assert lock_entries == [], (
+            f"Expected no lock sentinels in git status, saw: {lock_entries!r}"
+        )
+
+    def test_legacy_tracked_providers_json_gets_untracked(self, tmp_path: Path) -> None:
+        _init_git_repo(tmp_path)
+        vaultspec_dir = tmp_path / ".vaultspec"
+        vaultspec_dir.mkdir()
+        (vaultspec_dir / "providers.json").write_text(
+            '{"version": "2.0", "installed": []}', encoding="utf-8"
+        )
+        _run_git(tmp_path, "add", ".vaultspec/providers.json")
+        _run_git(tmp_path, "commit", "-q", "-m", "legacy tracked manifest")
+
+        install_run(
+            path=tmp_path,
+            provider="all",
+            upgrade=False,
+            dry_run=False,
+            force=True,
+        )
+
+        ls = _run_git(
+            tmp_path, "ls-files", "--error-unmatch", ".vaultspec/providers.json"
+        )
+        assert ls.returncode != 0, (
+            "providers.json must no longer be tracked after install"
+        )
+
+
+# ---- Domain 5: rename updates incoming wiki-link references ------------------
+
+
+class TestStructureRenameUpdatesRefs:
+    """``check_structure(fix=True)`` must rewrite incoming wiki-links."""
+
+    def test_rename_updates_related_refs(self, tmp_path: Path) -> None:
+        from vaultspec_core.graph import VaultGraph
+        from vaultspec_core.vaultcore.checks import check_structure
+
+        vault = tmp_path / ".vault"
+        audit_dir = vault / "audit"
+        adr_dir = vault / "adr"
+        audit_dir.mkdir(parents=True)
+        adr_dir.mkdir(parents=True)
+
+        # Source doc with a non-canonical suffix (``-review`` instead of
+        # ``-audit``) - triggers a rename.
+        misnamed = audit_dir / "2026-03-01-widget-review.md"
+        misnamed.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#audit"\n'
+            '  - "#widget"\n'
+            "date: '2026-03-01'\n"
+            "related:\n"
+            '  - "[[2026-03-01-widget-research]]"\n'
+            "---\n\n"
+            "# widget audit\n",
+            encoding="utf-8",
+        )
+
+        # Doc that links to the misnamed doc via its current stem.
+        backref = adr_dir / "2026-03-02-widget-adr.md"
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#widget"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[2026-03-01-widget-review]]"\n'
+            "---\n\n"
+            "# widget adr\n",
+            encoding="utf-8",
+        )
+
+        graph = VaultGraph(tmp_path)
+        snapshot = graph.to_snapshot()
+        result = check_structure(tmp_path, snapshot=snapshot, fix=True)
+
+        renamed = audit_dir / "2026-03-01-widget-review-audit.md"
+        assert renamed.exists(), "expected file to be renamed to -audit suffix"
+        assert not misnamed.exists()
+
+        backref_text = backref.read_text(encoding="utf-8")
+        assert "[[2026-03-01-widget-review-audit]]" in backref_text
+        assert "[[2026-03-01-widget-review]]" not in backref_text
+        expected_msg = (
+            "Updated wiki-link: [[2026-03-01-widget-review]] -> "
+            "[[2026-03-01-widget-review-audit]]"
+        )
+        assert any(expected_msg in d.message for d in result.diagnostics), (
+            f"Expected precise rewrite diagnostic; saw "
+            f"{[d.message for d in result.diagnostics]!r}"
+        )
+
+    def test_rename_survives_bom_prefixed_backref(self, tmp_path: Path) -> None:
+        """Files with UTF-8 BOM must still get their related: refs rewritten."""
+        from vaultspec_core.graph import VaultGraph
+        from vaultspec_core.vaultcore.checks import check_structure
+
+        vault = tmp_path / ".vault"
+        audit_dir = vault / "audit"
+        adr_dir = vault / "adr"
+        audit_dir.mkdir(parents=True)
+        adr_dir.mkdir(parents=True)
+
+        misnamed = audit_dir / "2026-03-01-bom-review.md"
+        misnamed.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#audit"\n'
+            '  - "#bom"\n'
+            "date: '2026-03-01'\n"
+            "---\n\n# bom audit\n",
+            encoding="utf-8",
+        )
+
+        # BOM-prefixed document referencing the misnamed doc.
+        backref = adr_dir / "2026-03-02-bom-adr.md"
+        backref.write_bytes(
+            b"\xef\xbb\xbf"
+            + (
+                b"---\n"
+                b"tags:\n"
+                b'  - "#adr"\n'
+                b'  - "#bom"\n'
+                b"date: '2026-03-02'\n"
+                b"related:\n"
+                b'  - "[[2026-03-01-bom-review]]"\n'
+                b"---\n\n# bom adr\n"
+            )
+        )
+
+        graph = VaultGraph(tmp_path)
+        snapshot = graph.to_snapshot()
+        check_structure(tmp_path, snapshot=snapshot, fix=True)
+
+        written = backref.read_bytes()
+        assert written.startswith(b"\xef\xbb\xbf"), "BOM must be preserved"
+        text = written.decode("utf-8-sig")
+        assert "[[2026-03-01-bom-review-audit]]" in text
+        assert "[[2026-03-01-bom-review]]" not in text
+
+    def test_rename_preserves_crlf_endings(self, tmp_path: Path) -> None:
+        """CRLF-authored files must not get mixed LF endings on rewrite."""
+        from vaultspec_core.graph import VaultGraph
+        from vaultspec_core.vaultcore.checks import check_structure
+
+        vault = tmp_path / ".vault"
+        audit_dir = vault / "audit"
+        adr_dir = vault / "adr"
+        audit_dir.mkdir(parents=True)
+        adr_dir.mkdir(parents=True)
+
+        misnamed = audit_dir / "2026-03-01-crlf-review.md"
+        misnamed.write_bytes(
+            b"---\r\n"
+            b"tags:\r\n"
+            b'  - "#audit"\r\n'
+            b'  - "#crlf"\r\n'
+            b"date: '2026-03-01'\r\n"
+            b"---\r\n\r\n# crlf audit\r\n"
+        )
+
+        backref = adr_dir / "2026-03-02-crlf-adr.md"
+        backref.write_bytes(
+            b"---\r\n"
+            b"tags:\r\n"
+            b'  - "#adr"\r\n'
+            b'  - "#crlf"\r\n'
+            b"date: '2026-03-02'\r\n"
+            b"related:\r\n"
+            b'  - "[[2026-03-01-crlf-review]]"\r\n'
+            b"---\r\n\r\n# crlf adr\r\n"
+        )
+
+        graph = VaultGraph(tmp_path)
+        snapshot = graph.to_snapshot()
+        check_structure(tmp_path, snapshot=snapshot, fix=True)
+
+        written = backref.read_bytes()
+        assert b"[[2026-03-01-crlf-review-audit]]" in written
+        assert b"\r\n" in written, "CRLF convention must be preserved"
+        # Guard against mixed endings - no lone LFs outside a CRLF pair.
+        stripped = written.replace(b"\r\n", b"")
+        assert b"\n" not in stripped, (
+            "Rewrite must not introduce lone LFs alongside CRLF"
+        )
+
+    def test_rename_collision_emits_error(self, tmp_path: Path) -> None:
+        """When two source files would rename to the same target, emit ERROR."""
+        from vaultspec_core.graph import VaultGraph
+        from vaultspec_core.vaultcore.checks import check_structure
+        from vaultspec_core.vaultcore.checks._base import Severity
+
+        vault = tmp_path / ".vault"
+        audit_dir = vault / "audit"
+        audit_dir.mkdir(parents=True)
+
+        # Pre-existing canonical target that matches the fix output
+        # of the stale file (stale "-review.md" fix target is
+        # "-review-audit.md").
+        (audit_dir / "2026-03-01-collision-review-audit.md").write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#audit"\n'
+            '  - "#collision"\n'
+            "date: '2026-03-01'\n"
+            "---\n\n# collision canonical\n",
+            encoding="utf-8",
+        )
+        # Misnamed sibling whose fix target collides with the canonical.
+        stale = audit_dir / "2026-03-01-collision-review.md"
+        stale.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#audit"\n'
+            '  - "#collision"\n'
+            "date: '2026-03-01'\n"
+            "---\n\n# collision stale\n",
+            encoding="utf-8",
+        )
+
+        graph = VaultGraph(tmp_path)
+        snapshot = graph.to_snapshot()
+        result = check_structure(tmp_path, snapshot=snapshot, fix=True)
+
+        assert stale.exists(), "stale file must remain since rename collided"
+        assert any(
+            d.severity == Severity.ERROR and "target already exists" in d.message
+            for d in result.diagnostics
+        ), "collision must surface as ERROR diagnostic"
+
+    def test_rename_chain_resolved_transitively(self, tmp_path: Path) -> None:
+        """Chained renames (A -> B -> C) rewrite [[A]] directly to [[C]]."""
+        from vaultspec_core.vaultcore.checks._base import (
+            CheckResult,
+        )
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-chain-adr.md"
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#chain"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[alpha]]"\n'
+            "---\n\n# chain adr\n",
+            encoding="utf-8",
+        )
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta"), ("beta", "gamma")], result)
+
+        written = backref.read_text(encoding="utf-8")
+        assert "[[gamma]]" in written
+        assert "[[alpha]]" not in written
+        assert "[[beta]]" not in written
+        # Exactly one rewrite should fire; the chain collapse must not
+        # double-count when both [[alpha]] and [[beta]] resolve to gamma.
+        assert result.fixed_count == 1
+        rewrite_diags = [
+            d for d in result.diagnostics if "Updated wiki-link" in d.message
+        ]
+        assert len(rewrite_diags) == 1
+        assert "[[alpha]] -> [[gamma]]" in rewrite_diags[0].message
+
+    def test_rewrite_warns_on_frontmatter_budget_overflow(self, tmp_path: Path) -> None:
+        """Frontmatter exceeding the line budget must surface a WARNING."""
+        from vaultspec_core.vaultcore.checks._base import (
+            CheckResult,
+            Severity,
+        )
+        from vaultspec_core.vaultcore.checks.structure import (
+            _FRONTMATTER_LINE_BUDGET,
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        # Build a pathological doc: opening fence, then enough filler lines
+        # to overflow the budget before the scanner could reach the
+        # related: block or the closing fence.
+        filler_lines = ["filler: value" for _ in range(_FRONTMATTER_LINE_BUDGET + 20)]
+        pathological = adr_dir / "2026-03-02-budget-adr.md"
+        pathological.write_text(
+            "---\n" + "\n".join(filler_lines) + "\n",
+            encoding="utf-8",
+        )
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta")], result)
+
+        warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
+        assert any("Frontmatter exceeds" in d.message for d in warnings), (
+            f"expected budget WARNING, saw {[d.message for d in warnings]!r}"
+        )
+
+    def test_rewrite_skips_rename_cycles(self, tmp_path: Path) -> None:
+        """A 2-cycle in raw_map must not produce phantom self-rewrites."""
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-cycle-adr.md"
+        original = (
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#cycle"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[alpha]]"\n'
+            "---\n\n# cycle adr\n"
+        )
+        backref.write_text(original, encoding="utf-8")
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta"), ("beta", "alpha")], result)
+
+        # Cycle resolution must drop both entries; file must be unchanged.
+        assert backref.read_text(encoding="utf-8") == original
+        assert result.fixed_count == 0
+        assert not any("Updated wiki-link" in d.message for d in result.diagnostics)

--- a/src/vaultspec_core/tests/cli/test_flow_bugs.py
+++ b/src/vaultspec_core/tests/cli/test_flow_bugs.py
@@ -210,6 +210,30 @@ class TestUntrackManagedPaths:
             == 0
         )
 
+    def test_untracks_committed_claude_dir_content(self, tmp_path: Path) -> None:
+        """Files under a provider scope directory (.claude/, .gemini/, .agents/,
+        .codex/) must be eligible for untracking when passed in via the
+        managed gitignore entries (ADR D1 scope).
+        """
+        _init_git_repo(tmp_path)
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        stale = claude_dir / "settings.json"
+        stale.write_text("{}", encoding="utf-8")
+        _run_git(tmp_path, "add", ".claude/settings.json")
+        _run_git(tmp_path, "commit", "-q", "-m", "legacy tracked claude settings")
+
+        untracked = _untrack_managed_paths(tmp_path, [".claude/"])
+
+        assert untracked == [".claude/settings.json"]
+        assert (
+            _run_git(
+                tmp_path, "ls-files", "--error-unmatch", ".claude/settings.json"
+            ).returncode
+            != 0
+        )
+        assert stale.exists(), "working tree copy must be preserved"
+
     def test_does_not_untrack_subdir_sentinel_match(self, tmp_path: Path) -> None:
         """Sentinel basenames only match at the workspace root.
 
@@ -665,6 +689,47 @@ class TestStructureRenameUpdatesRefs:
         assert any("Frontmatter exceeds" in d.message for d in warnings), (
             f"expected budget WARNING, saw {[d.message for d in warnings]!r}"
         )
+
+    def test_rewrite_skips_hidden_obsidian_docs(self, tmp_path: Path) -> None:
+        """Files under ``.vault/.obsidian/`` and ``.vault/.trash/`` must not
+        be rewritten - they hold editor state, not vault content.
+        """
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        obsidian_dir = vault / ".obsidian"
+        obsidian_dir.mkdir(parents=True)
+        trash_dir = vault / ".trash"
+        trash_dir.mkdir(parents=True)
+
+        obsidian_doc = obsidian_dir / "workspace.md"
+        trash_doc = trash_dir / "2026-03-01-old-reference-research.md"
+        original = (
+            "---\n"
+            "tags:\n"
+            '  - "#research"\n'
+            '  - "#internal"\n'
+            "date: '2026-03-01'\n"
+            "related:\n"
+            '  - "[[alpha]]"\n'
+            "---\n\n# internal\n"
+        )
+        obsidian_doc.write_text(original, encoding="utf-8")
+        trash_doc.write_text(original, encoding="utf-8")
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta")], result)
+
+        assert obsidian_doc.read_text(encoding="utf-8") == original, (
+            ".obsidian/ docs must not be mutated"
+        )
+        assert trash_doc.read_text(encoding="utf-8") == original, (
+            ".trash/ docs must not be mutated"
+        )
+        assert result.fixed_count == 0
 
     def test_rewrite_skips_three_node_rename_cycle(self, tmp_path: Path) -> None:
         """A 3-cycle (A -> B -> C -> A) must be detected and dropped."""

--- a/src/vaultspec_core/tests/cli/test_flow_bugs.py
+++ b/src/vaultspec_core/tests/cli/test_flow_bugs.py
@@ -210,6 +210,30 @@ class TestUntrackManagedPaths:
             == 0
         )
 
+    def test_does_not_untrack_subdir_sentinel_match(self, tmp_path: Path) -> None:
+        """Sentinel basenames only match at the workspace root.
+
+        A user-authored ``docs/.gitignore.lock`` must not be swept up even
+        though its basename matches :data:`_MANAGED_LOCK_SENTINELS`.
+        """
+        _init_git_repo(tmp_path)
+        docs = tmp_path / "docs"
+        docs.mkdir()
+        subdir_sentinel = docs / ".gitignore.lock"
+        subdir_sentinel.write_text("custom content", encoding="utf-8")
+        _run_git(tmp_path, "add", "docs/.gitignore.lock")
+        _run_git(tmp_path, "commit", "-q", "-m", "track subdir sentinel")
+
+        untracked = _untrack_managed_paths(tmp_path, ["docs/.gitignore.lock"])
+
+        assert untracked == []
+        assert (
+            _run_git(
+                tmp_path, "ls-files", "--error-unmatch", "docs/.gitignore.lock"
+            ).returncode
+            == 0
+        )
+
 
 # ---- Domain 3: prek.toml short-circuit --------------------------------------
 
@@ -539,6 +563,76 @@ class TestStructureRenameUpdatesRefs:
         ]
         assert len(rewrite_diags) == 1
         assert "[[alpha]] -> [[gamma]]" in rewrite_diags[0].message
+
+    def test_rewrite_preserves_trailing_yaml_comment(self, tmp_path: Path) -> None:
+        """A ``related:`` entry with a trailing YAML comment must be rewritten."""
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-comment-adr.md"
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#comment"\n'
+            "date: '2026-03-02'\n"
+            "related:\n"
+            '  - "[[alpha]]"  # see research note\n'
+            "---\n\n# comment adr\n",
+            encoding="utf-8",
+        )
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta")], result)
+
+        written = backref.read_text(encoding="utf-8")
+        assert '"[[beta]]"' in written
+        assert "# see research note" in written, (
+            "Trailing YAML comment must survive the rewrite"
+        )
+        assert result.fixed_count == 1
+
+    def test_rewrite_detects_indented_related_key(self, tmp_path: Path) -> None:
+        """An indented ``related:`` key must still enter the rewrite scan.
+
+        YAML frontmatter permits (though the vault template does not
+        typically use) indentation of top-level keys.  The scanner must
+        not assume column-zero anchoring.
+        """
+        from vaultspec_core.vaultcore.checks._base import CheckResult
+        from vaultspec_core.vaultcore.checks.structure import (
+            _rewrite_incoming_refs,
+        )
+
+        vault = tmp_path / ".vault"
+        adr_dir = vault / "adr"
+        adr_dir.mkdir(parents=True)
+        backref = adr_dir / "2026-03-02-indent-adr.md"
+        # `related:` intentionally indented by two spaces.
+        backref.write_text(
+            "---\n"
+            "tags:\n"
+            '  - "#adr"\n'
+            '  - "#indent"\n'
+            "date: '2026-03-02'\n"
+            "  related:\n"
+            '    - "[[alpha]]"\n'
+            "---\n\n# indent adr\n",
+            encoding="utf-8",
+        )
+
+        result = CheckResult(check_name="structure", supports_fix=True)
+        _rewrite_incoming_refs(tmp_path, [("alpha", "beta")], result)
+
+        written = backref.read_text(encoding="utf-8")
+        assert '"[[beta]]"' in written
+        assert '"[[alpha]]"' not in written
+        assert result.fixed_count == 1
 
     def test_rewrite_warns_on_frontmatter_budget_overflow(self, tmp_path: Path) -> None:
         """Frontmatter exceeding the line budget must surface a WARNING."""

--- a/src/vaultspec_core/tests/cli/test_gitignore.py
+++ b/src/vaultspec_core/tests/cli/test_gitignore.py
@@ -330,3 +330,29 @@ class TestRecommendedEntries:
         (tmp_path / ".vaultspec").mkdir()
         entries = get_recommended_entries(tmp_path)
         assert ".vaultspec/_snapshots/" in entries
+
+    def test_vaultspec_lock_glob_covers_advisory_sentinels(self, tmp_path):
+        (tmp_path / ".vaultspec").mkdir()
+        entries = get_recommended_entries(tmp_path)
+        assert ".vaultspec/*.lock" in entries
+
+    def test_root_lock_sentinel_when_companion_exists(self, tmp_path):
+        (tmp_path / ".vaultspec").mkdir()
+        (tmp_path / ".gitignore").write_text("", encoding="utf-8")
+        (tmp_path / ".mcp.json").write_text("{}", encoding="utf-8")
+        (tmp_path / ".pre-commit-config.yaml").write_text("", encoding="utf-8")
+
+        entries = get_recommended_entries(tmp_path)
+
+        assert "/.gitignore.lock" in entries
+        assert "/.mcp.json.lock" in entries
+        assert "/.pre-commit-config.yaml.lock" in entries
+
+    def test_root_lock_sentinel_skipped_when_companion_absent(self, tmp_path):
+        (tmp_path / ".vaultspec").mkdir()
+
+        entries = get_recommended_entries(tmp_path)
+
+        assert "/.gitignore.lock" not in entries
+        assert "/.mcp.json.lock" not in entries
+        assert "/.pre-commit-config.yaml.lock" not in entries

--- a/src/vaultspec_core/tests/cli/test_resolver.py
+++ b/src/vaultspec_core/tests/cli/test_resolver.py
@@ -15,6 +15,7 @@ from vaultspec_core.core.diagnosis.signals import (
     FrameworkSignal,
     GitignoreSignal,
     ManifestEntrySignal,
+    PrecommitSignal,
     ProviderDirSignal,
     ResolutionAction,
 )
@@ -28,9 +29,15 @@ def _make_diagnosis(
     framework: FrameworkSignal = FrameworkSignal.PRESENT,
     builtin_version: BuiltinVersionSignal = BuiltinVersionSignal.CURRENT,
     gitignore: GitignoreSignal = GitignoreSignal.COMPLETE,
+    precommit: PrecommitSignal = PrecommitSignal.COMPLETE,
     providers: dict[Tool, ProviderDiagnosis] | None = None,
 ) -> WorkspaceDiagnosis:
-    """Build a WorkspaceDiagnosis with sensible defaults for testing."""
+    """Build a WorkspaceDiagnosis with sensible defaults for testing.
+
+    The default ``precommit`` signal is ``COMPLETE`` so that tests which
+    focus on other axes (content, manifest, gitignore) do not inadvertently
+    trigger the resolver's ``REPAIR_PRECOMMIT`` step.
+    """
     if providers is None:
         providers = {}
     return WorkspaceDiagnosis(
@@ -38,6 +45,7 @@ def _make_diagnosis(
         providers=providers,
         builtin_version=builtin_version,
         gitignore=gitignore,
+        precommit=precommit,
     )
 
 

--- a/src/vaultspec_core/vaultcore/checks/structure.py
+++ b/src/vaultspec_core/vaultcore/checks/structure.py
@@ -210,6 +210,17 @@ def _rewrite_incoming_refs(
         return
 
     for md_path in sorted(vault_root.rglob("*.md")):
+        # Skip hidden internal directories (e.g. ``.obsidian/``,
+        # ``.trash/``, ``.vaultspec``-style dotfile scratch).  These
+        # are covered by the managed gitignore block and must not be
+        # mutated - Obsidian in particular keeps its own state files
+        # under ``.obsidian/`` that should never be edited externally.
+        try:
+            rel_parts = md_path.relative_to(vault_root).parts
+        except ValueError:
+            continue
+        if any(part.startswith(".") for part in rel_parts[:-1]):
+            continue
         try:
             # Read as bytes first so CRLF endings survive the decode;
             # ``read_text`` collapses them via universal newlines.

--- a/src/vaultspec_core/vaultcore/checks/structure.py
+++ b/src/vaultspec_core/vaultcore/checks/structure.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from ...core.helpers import atomic_write
@@ -106,7 +106,10 @@ def _fix_filename(
                 return renames
 
     if not re.match(r"^\d{4}-\d{2}-\d{2}-", filename):
-        today = datetime.now().strftime("%Y-%m-%d")
+        # UTC date prefix so the rename is deterministic regardless of
+        # the runner's local timezone.  Matches the manifest timestamps
+        # in ``core/commands.py`` that also use ``datetime.UTC``.
+        today = datetime.now(UTC).strftime("%Y-%m-%d")
         new_filename = f"{today}-{filename}"
         new_path = doc_path.parent / new_filename
 
@@ -212,6 +215,8 @@ def _rewrite_incoming_refs(
 
         # Preserve a UTF-8 BOM if present; the scanner strips it so the
         # opening ``---`` fence matches but the write-back restores it.
+        # Use the ``﻿`` escape rather than the literal character so
+        # the source is legible in editors that hide zero-width glyphs.
         bom = ""
         if content.startswith("﻿"):
             bom = "﻿"

--- a/src/vaultspec_core/vaultcore/checks/structure.py
+++ b/src/vaultspec_core/vaultcore/checks/structure.py
@@ -137,7 +137,7 @@ def _fix_filename(
     return renames
 
 
-_RELATED_ENTRY_RE = re.compile(r'^(\s*-\s*["\']?\[\[)(.+?)(\]\]["\']?\s*)$')
+_RELATED_ENTRY_RE = re.compile(r'^(\s*-\s*["\']?\[\[)(.+?)(\]\]["\']?.*)$')
 _FRONTMATTER_LINE_BUDGET = 200
 
 
@@ -247,7 +247,7 @@ def _rewrite_incoming_refs(
             if not in_frontmatter:
                 continue
 
-            if line.startswith("related:"):
+            if line.strip().startswith("related:"):
                 in_related = True
                 continue
 

--- a/src/vaultspec_core/vaultcore/checks/structure.py
+++ b/src/vaultspec_core/vaultcore/checks/structure.py
@@ -209,17 +209,37 @@ def _rewrite_incoming_refs(
     if not vault_root.is_dir():
         return
 
+    # Build a case-insensitive mirror of ``rename_map`` for fallback
+    # lookups.  Obsidian resolves wiki-links case-insensitively
+    # (``[[My-Doc]]`` hits ``my-doc.md``) but the filesystem on Linux
+    # is case-sensitive.  We try the exact-case lookup first to
+    # preserve intent and only fall back to lowercase when no exact
+    # match exists.
+    rename_map_lower = {k.lower(): v for k, v in rename_map.items()}
+
+    # Top-level vault subdirectories that are expected to contain
+    # schema-conforming documents.  Non-schema directories such as
+    # ``data/`` and ``logs/`` (explicitly recommended for gitignore
+    # by :func:`vaultspec_core.core.gitignore.get_recommended_entries`)
+    # are skipped to avoid scanning large or non-vault files.  Hidden
+    # directories (``.obsidian/``, ``.trash/``, ...) are skipped
+    # by the dot-prefix filter below.
+    non_schema_dirs = frozenset({"data", "logs"})
+
     for md_path in sorted(vault_root.rglob("*.md")):
         # Skip hidden internal directories (e.g. ``.obsidian/``,
-        # ``.trash/``, ``.vaultspec``-style dotfile scratch).  These
-        # are covered by the managed gitignore block and must not be
-        # mutated - Obsidian in particular keeps its own state files
-        # under ``.obsidian/`` that should never be edited externally.
+        # ``.trash/``, ``.vaultspec``-style dotfile scratch) and
+        # non-schema data/log directories.  These are covered by the
+        # managed gitignore block and must not be mutated - Obsidian
+        # in particular keeps its own state files under ``.obsidian/``
+        # that should never be edited externally.
         try:
             rel_parts = md_path.relative_to(vault_root).parts
         except ValueError:
             continue
-        if any(part.startswith(".") for part in rel_parts[:-1]):
+        if any(
+            part.startswith(".") or part in non_schema_dirs for part in rel_parts[:-1]
+        ):
             continue
         try:
             # Read as bytes first so CRLF endings survive the decode;
@@ -307,9 +327,16 @@ def _rewrite_incoming_refs(
                 stem_only = target[:cut]
                 trailer = target[cut:]
 
+            # Case-sensitive lookup first (preserves exact-case intent
+            # when both ``My-Doc.md`` and ``my-doc.md`` legitimately
+            # coexist on Linux); fall back to case-insensitive match
+            # so Obsidian-style cross-case links (``[[My-Doc]]`` at
+            # pointing ``my-doc.md``) are still rewritten.
             final_stem: str | None = None
             if stem_only in rename_map:
                 final_stem = rename_map[stem_only]
+            elif stem_only.lower() in rename_map_lower:
+                final_stem = rename_map_lower[stem_only.lower()]
             if final_stem is None:
                 # Remember the existing (unrewritten) full target so
                 # later rewrites can avoid creating a duplicate.  The

--- a/src/vaultspec_core/vaultcore/checks/structure.py
+++ b/src/vaultspec_core/vaultcore/checks/structure.py
@@ -2,7 +2,10 @@
 
 Wraps VaultConstants.validate_vault_structure() and validate_filename()
 which exist but were never wired to a CLI command.  With ``--fix``,
-renames files that have wrong suffixes or missing date prefixes.
+renames files that have wrong suffixes or missing date prefixes, and
+updates incoming ``[[wiki-link]]`` references in the ``related:``
+frontmatter of other documents so the rename does not leave dangling
+links behind.
 """
 
 from __future__ import annotations
@@ -12,6 +15,7 @@ import re
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from ...core.helpers import atomic_write
 from ._base import (
     CheckDiagnostic,
     CheckResult,
@@ -28,14 +32,25 @@ __all__ = ["check_structure"]
 logger = logging.getLogger(__name__)
 
 
-def _fix_filename(doc_path: Path, root_dir: Path, result: CheckResult) -> None:
-    """Attempt to fix filename issues: wrong suffix, missing date prefix."""
+def _fix_filename(
+    doc_path: Path, root_dir: Path, result: CheckResult
+) -> list[tuple[str, str]]:
+    """Attempt to fix filename issues: wrong suffix, missing date prefix.
+
+    Returns a list of ``(old_stem, new_stem)`` tuples for every successful
+    rename performed on *doc_path* (zero, one, or two renames per call).
+    Callers use the returned list to drive a follow-up
+    :func:`_rewrite_incoming_refs` pass so incoming ``[[wiki-link]]``
+    references stay in sync with the new filenames.
+    """
     from ..models import DocType
     from ..scanner import get_doc_type
 
+    renames: list[tuple[str, str]] = []
+
     doc_type = get_doc_type(doc_path, root_dir)
     if not doc_type:
-        return
+        return renames
 
     filename = doc_path.name
     rel = doc_path.relative_to(root_dir)
@@ -62,8 +77,10 @@ def _fix_filename(doc_path: Path, root_dir: Path, result: CheckResult) -> None:
             new_path = doc_path.parent / new_filename
 
             if not new_path.exists():
+                old_stem = doc_path.stem
                 doc_path.rename(new_path)
                 result.fixed_count += 1
+                renames.append((old_stem, new_path.stem))
                 doc_path = new_path
                 rel = doc_path.relative_to(root_dir)
                 filename = new_filename
@@ -77,7 +94,16 @@ def _fix_filename(doc_path: Path, root_dir: Path, result: CheckResult) -> None:
                 logger.info("Renamed %s -> %s", filename, new_filename)
             else:
                 logger.warning("Cannot rename %s: target exists", filename)
-                return
+                result.diagnostics.append(
+                    CheckDiagnostic(
+                        path=rel,
+                        message=(
+                            f"Cannot rename to {new_filename}: target already exists"
+                        ),
+                        severity=Severity.ERROR,
+                    )
+                )
+                return renames
 
     if not re.match(r"^\d{4}-\d{2}-\d{2}-", filename):
         today = datetime.now().strftime("%Y-%m-%d")
@@ -85,8 +111,10 @@ def _fix_filename(doc_path: Path, root_dir: Path, result: CheckResult) -> None:
         new_path = doc_path.parent / new_filename
 
         if not new_path.exists():
+            old_stem = doc_path.stem
             doc_path.rename(new_path)
             result.fixed_count += 1
+            renames.append((old_stem, new_path.stem))
             rel = new_path.relative_to(root_dir)
             result.diagnostics.append(
                 CheckDiagnostic(
@@ -98,6 +126,203 @@ def _fix_filename(doc_path: Path, root_dir: Path, result: CheckResult) -> None:
             logger.info("Renamed %s -> %s", filename, new_filename)
         else:
             logger.warning("Cannot rename %s: target exists", filename)
+            result.diagnostics.append(
+                CheckDiagnostic(
+                    path=rel,
+                    message=(f"Cannot rename to {new_filename}: target already exists"),
+                    severity=Severity.ERROR,
+                )
+            )
+
+    return renames
+
+
+_RELATED_ENTRY_RE = re.compile(r'^(\s*-\s*["\']?\[\[)(.+?)(\]\]["\']?\s*)$')
+_FRONTMATTER_LINE_BUDGET = 200
+
+
+def _rewrite_incoming_refs(
+    root_dir: Path,
+    renames: list[tuple[str, str]],
+    result: CheckResult,
+) -> None:
+    """Rewrite ``[[old_stem]]`` -> ``[[new_stem]]`` in ``related:`` frontmatter.
+
+    Walks every ``*.md`` file under ``root_dir / ".vault"`` directly off
+    the filesystem (the renames have already happened on disk; the
+    in-memory :class:`VaultSnapshot` is now stale).  Inspects the YAML
+    frontmatter ``related:`` list and rewrites any matching wiki-link
+    entry.  Only operates on the ``related:`` block - body prose is left
+    untouched so free-text mentions of the old filename do not
+    accidentally mutate.
+
+    The scanner recognises the block-sequence form
+    (``- "[[stem]]"`` / ``- '[[stem]]'`` / ``- [[stem]]``) which is the
+    form enforced by the vault template and used throughout this
+    project.  YAML flow-style lists (``related: ["[[stem]]"]``) are not
+    currently rewritten; ``vault check frontmatter`` enforces block
+    style.
+
+    Each rewrite bumps :attr:`CheckResult.fixed_count` and appends an
+    INFO diagnostic.  Read/write failures for individual documents log a
+    warning and do not abort the pass.
+
+    Args:
+        root_dir: Project root (the caller's workspace).
+        renames: List of ``(old_stem, new_stem)`` pairs produced by
+            :func:`_fix_filename`.
+        result: :class:`CheckResult` to accumulate diagnostics and fix
+            counts into.
+    """
+    if not renames:
+        return
+
+    raw_map = {old: new for old, new in renames if old != new}
+    if not raw_map:
+        return
+
+    # Collapse rename chains so [[A]] -> [[C]] when ``A -> B`` and ``B -> C``
+    # both happened in the same check run.  Guards against cycles by
+    # capping traversal at the number of raw entries and dropping any
+    # entry whose terminal value is the original key (self-cycle).
+    rename_map: dict[str, str] = {}
+    limit = len(raw_map) + 1
+    for old in raw_map:
+        current = raw_map[old]
+        steps = 0
+        while current in raw_map and steps < limit:
+            current = raw_map[current]
+            steps += 1
+        if current != old:
+            rename_map[old] = current
+
+    vault_root = root_dir / ".vault"
+    if not vault_root.is_dir():
+        return
+
+    for md_path in sorted(vault_root.rglob("*.md")):
+        try:
+            # Read as bytes first so CRLF endings survive the decode;
+            # ``read_text`` collapses them via universal newlines.
+            raw = md_path.read_bytes()
+            content = raw.decode("utf-8")
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.warning("Failed to read %s for ref rewrite: %s", md_path, exc)
+            continue
+
+        # Preserve a UTF-8 BOM if present; the scanner strips it so the
+        # opening ``---`` fence matches but the write-back restores it.
+        bom = ""
+        if content.startswith("﻿"):
+            bom = "﻿"
+            content = content[1:]
+
+        # Preserve the file's line-ending convention across the rewrite
+        # so we do not ship mixed CRLF/LF endings back to disk.
+        newline = "\r\n" if "\r\n" in content else "\n"
+        lines = content.splitlines()
+        in_frontmatter = False
+        in_related = False
+        changed = False
+        fence_closed = False
+        budget_exceeded = False
+
+        for idx, line in enumerate(lines):
+            # Guard against a missing closing fence: if the file is not
+            # a real vault document, bail out of the scan after a fixed
+            # line budget rather than scanning prose forever.
+            if in_frontmatter and idx > _FRONTMATTER_LINE_BUDGET:
+                budget_exceeded = True
+                break
+
+            stripped = line.strip()
+            if stripped == "---":
+                if not in_frontmatter:
+                    in_frontmatter = True
+                else:
+                    fence_closed = True
+                    break
+                continue
+
+            if not in_frontmatter:
+                continue
+
+            if line.startswith("related:"):
+                in_related = True
+                continue
+
+            if in_related and line and not line.startswith((" ", "\t", "-")):
+                in_related = False
+
+            if not in_related:
+                continue
+
+            match = _RELATED_ENTRY_RE.match(line)
+            if not match:
+                continue
+
+            target = match.group(2)
+            if target in rename_map:
+                new_target = rename_map[target]
+                lines[idx] = f"{match.group(1)}{new_target}{match.group(3)}"
+                changed = True
+                result.fixed_count += 1
+                try:
+                    rel = md_path.relative_to(root_dir)
+                except ValueError:
+                    rel = md_path
+                result.diagnostics.append(
+                    CheckDiagnostic(
+                        path=rel,
+                        message=(
+                            f"Updated wiki-link: [[{target}]] -> [[{new_target}]]"
+                        ),
+                        severity=Severity.INFO,
+                    )
+                )
+
+        # Surface a warning diagnostic when the frontmatter exceeds the
+        # line budget so operators can investigate documents whose
+        # frontmatter may have been skipped mid-scan.
+        if budget_exceeded:
+            try:
+                rel_path = md_path.relative_to(root_dir)
+            except ValueError:
+                rel_path = md_path
+            result.diagnostics.append(
+                CheckDiagnostic(
+                    path=rel_path,
+                    message=(
+                        "Frontmatter exceeds "
+                        f"{_FRONTMATTER_LINE_BUDGET} lines; "
+                        "ref rewrite stopped at budget"
+                    ),
+                    severity=Severity.WARNING,
+                )
+            )
+
+        if not changed:
+            continue
+
+        # If the scan never saw a closing fence we are in unknown
+        # territory; skip writing rather than risk corrupting a file
+        # whose frontmatter layout we misread.
+        if in_frontmatter and not fence_closed:
+            logger.warning(
+                "Skipping rewrite of %s: closing frontmatter fence not found",
+                md_path,
+            )
+            continue
+
+        new_content = bom + newline.join(lines)
+        # Preserve a trailing newline convention: if the original ended
+        # with the detected newline, keep it.
+        if content.endswith(newline):
+            new_content += newline
+        try:
+            atomic_write(md_path, new_content)
+        except OSError as exc:
+            logger.warning("Failed to rewrite %s: %s", md_path, exc)
 
 
 def check_structure(
@@ -126,6 +351,7 @@ def check_structure(
     from ..scanner import get_doc_type
 
     result = CheckResult(check_name="structure", supports_fix=True)
+    all_renames: list[tuple[str, str]] = []
 
     for msg in VaultConstants.validate_vault_structure(root_dir):
         result.diagnostics.append(
@@ -145,7 +371,8 @@ def check_structure(
         errors = VaultConstants.validate_filename(doc_path.name, doc_type)
 
         if errors and fix:
-            _fix_filename(doc_path, root_dir, result)
+            renames = _fix_filename(doc_path, root_dir, result)
+            all_renames.extend(renames)
             if doc_path.exists():
                 remaining = VaultConstants.validate_filename(doc_path.name, doc_type)
                 for msg in remaining:
@@ -167,5 +394,8 @@ def check_structure(
                         fix_description="Run with --fix to attempt auto-rename",
                     )
                 )
+
+    if fix and all_renames:
+        _rewrite_incoming_refs(root_dir, all_renames, result)
 
     return result

--- a/src/vaultspec_core/vaultcore/checks/structure.py
+++ b/src/vaultspec_core/vaultcore/checks/structure.py
@@ -248,6 +248,14 @@ def _rewrite_incoming_refs(
         changed = False
         fence_closed = False
         budget_exceeded = False
+        # Tracks wiki-link targets already present in the ``related:``
+        # block so we can drop duplicate lines that the rewrite would
+        # otherwise introduce (e.g. when two sources collapse onto the
+        # same terminal or when the terminal already appeared in the
+        # list).  Anchored/aliased forms are normalised to their stem
+        # component for dedup purposes.
+        seen_targets: set[str] = set()
+        drop_idx: list[int] = []
 
         for idx, line in enumerate(lines):
             # Guard against a missing closing fence: if the file is not
@@ -284,11 +292,40 @@ def _rewrite_incoming_refs(
                 continue
 
             target = match.group(2)
-            if target in rename_map:
-                new_target = rename_map[target]
-                lines[idx] = f"{match.group(1)}{new_target}{match.group(3)}"
+            # Extract the bare stem from Obsidian link forms:
+            # ``stem``, ``stem#heading``, ``stem|alias``, or
+            # ``stem#heading|alias``.  Rename matching is always on
+            # the stem alone; the anchor and alias are preserved on
+            # the rewritten line.
+            stem_only = target
+            trailer = ""
+            anchor_hash = stem_only.find("#")
+            alias_pipe = stem_only.find("|")
+            cut_candidates = [i for i in (anchor_hash, alias_pipe) if i >= 0]
+            if cut_candidates:
+                cut = min(cut_candidates)
+                stem_only = target[:cut]
+                trailer = target[cut:]
+
+            final_stem: str | None = None
+            if stem_only in rename_map:
+                final_stem = rename_map[stem_only]
+            if final_stem is None:
+                # Remember the existing (unrewritten) full target so
+                # later rewrites can avoid creating a duplicate.  The
+                # full target - not just the stem - is used because
+                # ``[[beta]]`` and ``[[beta#heading]]`` are distinct
+                # wiki-links that should both survive side by side.
+                seen_targets.add(target)
+                continue
+
+            new_target = f"{final_stem}{trailer}"
+            # If the exact post-rewrite target is already represented
+            # by an earlier line in this related: block, drop this
+            # line to avoid emitting a duplicate entry.
+            if new_target in seen_targets:
+                drop_idx.append(idx)
                 changed = True
-                result.fixed_count += 1
                 try:
                     rel = md_path.relative_to(root_dir)
                 except ValueError:
@@ -297,11 +334,29 @@ def _rewrite_incoming_refs(
                     CheckDiagnostic(
                         path=rel,
                         message=(
-                            f"Updated wiki-link: [[{target}]] -> [[{new_target}]]"
+                            f"Dropped duplicate wiki-link: [[{target}]] "
+                            f"-> [[{new_target}]] already present"
                         ),
                         severity=Severity.INFO,
                     )
                 )
+                continue
+
+            lines[idx] = f"{match.group(1)}{new_target}{match.group(3)}"
+            seen_targets.add(new_target)
+            changed = True
+            result.fixed_count += 1
+            try:
+                rel = md_path.relative_to(root_dir)
+            except ValueError:
+                rel = md_path
+            result.diagnostics.append(
+                CheckDiagnostic(
+                    path=rel,
+                    message=f"Updated wiki-link: [[{target}]] -> [[{new_target}]]",
+                    severity=Severity.INFO,
+                )
+            )
 
         # Surface a warning diagnostic when the frontmatter exceeds the
         # line budget so operators can investigate documents whose
@@ -325,6 +380,11 @@ def _rewrite_incoming_refs(
 
         if not changed:
             continue
+
+        # Drop duplicate-collapsed lines in descending order so the
+        # surviving indices stay stable while we mutate the list.
+        for del_idx in sorted(drop_idx, reverse=True):
+            del lines[del_idx]
 
         # If the scan never saw a closing fence we are in unknown
         # territory; skip writing rather than risk corrupting a file

--- a/src/vaultspec_core/vaultcore/checks/structure.py
+++ b/src/vaultspec_core/vaultcore/checks/structure.py
@@ -185,18 +185,24 @@ def _rewrite_incoming_refs(
         return
 
     # Collapse rename chains so [[A]] -> [[C]] when ``A -> B`` and ``B -> C``
-    # both happened in the same check run.  Guards against cycles by
-    # capping traversal at the number of raw entries and dropping any
-    # entry whose terminal value is the original key (self-cycle).
+    # both happened in the same check run.  Cycles of any length
+    # (``A -> B -> A``, ``A -> B -> C -> A``, ...) are detected by
+    # tracking the set of visited nodes during the traversal: as soon as
+    # we encounter a node we have already seen, the chain is a cycle and
+    # the entry is dropped from the rewrite map rather than emitted as a
+    # false rewrite.
     rename_map: dict[str, str] = {}
-    limit = len(raw_map) + 1
     for old in raw_map:
+        visited: set[str] = {old}
         current = raw_map[old]
-        steps = 0
-        while current in raw_map and steps < limit:
+        cycle = False
+        while current in raw_map:
+            if current in visited:
+                cycle = True
+                break
+            visited.add(current)
             current = raw_map[current]
-            steps += 1
-        if current != old:
+        if not cycle:
             rename_map[old] = current
 
     vault_root = root_dir / ".vault"
@@ -215,11 +221,11 @@ def _rewrite_incoming_refs(
 
         # Preserve a UTF-8 BOM if present; the scanner strips it so the
         # opening ``---`` fence matches but the write-back restores it.
-        # Use the ``﻿`` escape rather than the literal character so
+        # Use the ``\ufeff`` escape rather than the literal character so
         # the source is legible in editors that hide zero-width glyphs.
         bom = ""
-        if content.startswith("﻿"):
-            bom = "﻿"
+        if content.startswith("\ufeff"):
+            bom = "\ufeff"
             content = content[1:]
 
         # Preserve the file's line-ending convention across the rewrite


### PR DESCRIPTION
## Summary

Fixes GH issue #80, a bundle of five install-layer hygiene defects surfaced on a vaultspec-consuming repo (aeat, 0.1.13). Each domain is treated as its own problem with research, ADR, plan, and execution artifacts under `.vault/`. Audit-loop hardening added BOM / CRLF / chain-collapse / collision / budget / cycle handling in the rename pass.

Five domains landed:

1. **`providers.json` untrack** — `install` now runs `git rm --cached --ignore-unmatch` on historically-tracked managed paths via a new `_untrack_managed_paths` helper gated by `_UNTRACK_PREFIXES` + `_MANAGED_LOCK_SENTINELS` allowlists. Sibling lockfiles (`uv.lock`, `Cargo.lock`, etc.) are explicitly excluded.
2. **Advisory-lock sentinels** — `get_recommended_entries` emits `.vaultspec/*.lock` plus anchored root-level `/.gitignore.lock`, `/.mcp.json.lock`, `/.pre-commit-config.yaml.lock` when the framework is installed and the companion file exists.
3. **prek short-circuit** — `_scaffold_precommit` skips `.pre-commit-config.yaml` generation when `prek.toml` is present, logs an info notice, and emits a WARNING when a legacy YAML coexists.
4. **`check-providers` respects deletions** — `--diff-filter=ACMR` excludes deletions; the helper also accepts an optional `cwd` so tests do not mutate CWD.
5. **`_fix_filename` rewrites incoming wiki-links** — `_rewrite_incoming_refs` walks `.vault/**/*.md`, collapses chains (A→B→C yields A→C), drops self-cycles, preserves BOM + CRLF, budgets the scan, surfaces rename-collisions as `Severity.ERROR`, and surfaces budget overflow as `Severity.WARNING`.

Refs: #80

## Test plan

- [x] 19 integration tests in `test_flow_bugs.py` cover every domain and the hardening edge cases against a real filesystem + real `git` subprocess (platform-correct null device isolation).
- [x] 4 new `TestRecommendedEntries` cases in `test_gitignore.py` for the lock-sentinel managed entries.
- [x] Full `pytest src/vaultspec_core` green (1192 tests).
- [x] `ruff check`, `ty check`, `pymarkdown`, `mdformat`: all clean.
- [x] `vaultspec-core vault check all`: zero errors, zero warnings.
- [x] Seven rounds of `vaultspec-code-reviewer` audit loops converged clean.

## Pipeline artifacts

- `.vault/research/2026-04-21-flow-bugs-research.md`
- `.vault/adr/2026-04-21-flow-bugs-adr.md`
- `.vault/plan/2026-04-21-flow-bugs-plan.md`
- `.vault/exec/2026-04-21-flow-bugs/2026-04-21-flow-bugs-phase-1-summary-exec.md`

## Housekeeping

Same PR also closes pre-existing `vault check` warnings:

- New `.vault/adr/2026-03-30-audit-findings-adr.md` backs the orphan audit-findings plan.
- `2026-03-30-audit-findings-plan.md` now lists research references.
- Regenerated feature index files.
- Unblocked the `test_resolver::test_clean_content_no_steps` flake via a default-signal fix in `_make_diagnosis`.

## Out of scope / deferred

- Centralised `advisory_lock` redirect to `.vaultspec/_locks/`.
- Writing hooks directly into `prek.toml`.
- Body-prose wiki-link rewriting inside `_fix_filename` (only `related:` frontmatter is rewritten in this release).