### PR TITLE
fix(#88): drop env-var bypass, gate dev-mode on explicit --dev flag

### DIFF
--- a/src/vaultspec_core/cli/root.py
+++ b/src/vaultspec_core/cli/root.py
@@ -206,6 +206,18 @@ def cmd_install(
             help="Skip a component (core or provider name). Repeatable.",
         ),
     ] = None,
+    dev: Annotated[
+        bool,
+        typer.Option(
+            "--dev",
+            help=(
+                "Authorise install in the vaultspec-core source repository "
+                "or one of its worktrees.  Without this flag the source-repo "
+                "guard refuses the write to protect canonical .vaultspec/ "
+                "content."
+            ),
+        ),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
 ) -> None:
     """Deploy the vaultspec framework to the target directory.
@@ -213,6 +225,7 @@ def cmd_install(
     Scaffolds the workspace structure and syncs all managed resources.
     Use --upgrade to update builtin rules without re-scaffolding.
     Use --skip to exclude components on retry (e.g. --skip core --skip claude).
+    Use --dev to operate inside the vaultspec-core source repo or worktree.
 
     Examples:\n
       vaultspec-core install                       # install all providers in cwd\n
@@ -222,6 +235,7 @@ def cmd_install(
       vaultspec-core install --upgrade             # update firmware + re-sync\n
       vaultspec-core install claude --dry-run      # preview what would be created\n
       vaultspec-core install --skip claude         # install all except claude\n
+      vaultspec-core install --dev                 # authorise source-repo install\n
     """
     from vaultspec_core.core.commands import install_run
     from vaultspec_core.core.exceptions import VaultSpecError
@@ -269,6 +283,7 @@ def cmd_install(
             dry_run=dry_run,
             force=force,
             skip=set(skip),
+            dev=dev,
         )
     except VaultSpecError as exc:
         _handle_error(exc)
@@ -355,6 +370,17 @@ def cmd_uninstall(
             help="Skip a component (core or provider name). Repeatable.",
         ),
     ] = None,
+    dev: Annotated[
+        bool,
+        typer.Option(
+            "--dev",
+            help=(
+                "Authorise uninstall in the vaultspec-core source repository "
+                "or one of its worktrees.  Without this flag the source-repo "
+                "guard refuses the write."
+            ),
+        ),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
 ) -> None:
     """Remove the vaultspec framework from the target directory.
@@ -363,6 +389,7 @@ def cmd_uninstall(
     The .vault/ documentation corpus is preserved by default.
     Use a provider name to remove only that provider's artifacts.
     Use --skip to exclude components (e.g. --skip claude --skip codex).
+    Use --dev to operate inside the vaultspec-core source repo or worktree.
 
     Examples:\n
       vaultspec-core uninstall                    # remove framework, keep .vault/\n
@@ -371,6 +398,7 @@ def cmd_uninstall(
       vaultspec-core uninstall --remove-vault     # also remove .vault/ docs\n
       vaultspec-core uninstall --dry-run          # preview what would be removed\n
       vaultspec-core uninstall --skip codex       # remove all except codex\n
+      vaultspec-core uninstall --dev              # authorise source-repo uninstall\n
     """
     from vaultspec_core.core.commands import uninstall_run
     from vaultspec_core.core.exceptions import VaultSpecError
@@ -399,6 +427,7 @@ def cmd_uninstall(
             dry_run=dry_run,
             force=force,
             skip=set(skip),
+            dev=dev,
         )
     except VaultSpecError as exc:
         _handle_error(exc)
@@ -466,6 +495,17 @@ def cmd_sync(
             help="Skip a component (core or provider name). Repeatable.",
         ),
     ] = None,
+    dev: Annotated[
+        bool,
+        typer.Option(
+            "--dev",
+            help=(
+                "Authorise sync in the vaultspec-core source repository "
+                "or one of its worktrees.  Without this flag the source-repo "
+                "guard refuses the write."
+            ),
+        ),
+    ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
 ) -> None:
     """Sync rules, skills, agents, configs, and system prompts.
@@ -480,6 +520,7 @@ def cmd_sync(
     Defaults to syncing all providers. Pass a provider name to sync only
     that provider (e.g. 'vaultspec-core sync claude').
     Use --skip to exclude providers (e.g. --skip claude --skip codex).
+    Use --dev to operate inside the vaultspec-core source repo or worktree.
     """
     skip = list(skip or [])
     apply_target(target, split_source=True)
@@ -514,7 +555,9 @@ def cmd_sync(
     from vaultspec_core.core.exceptions import VaultSpecError
 
     try:
-        results = sync_provider(provider, dry_run=dry_run, force=force, skip=set(skip))
+        results = sync_provider(
+            provider, dry_run=dry_run, force=force, skip=set(skip), dev=dev
+        )
     except VaultSpecError as exc:
         _handle_error(exc)
         return

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -802,6 +802,7 @@ def install_run(
     dry_run: bool = False,
     force: bool = False,
     skip: set[str] | None = None,
+    dev: bool = False,
 ) -> dict[str, Any]:
     """Deploy the vaultspec framework to a project directory.
 
@@ -812,6 +813,10 @@ def install_run(
         dry_run: Preview the manifest of files that would be created.
         force: Override contents if installation already exists.
         skip: Set of component names to skip (``core`` and/or provider names).
+        dev: Authorise source-repo operation (the ``--dev`` flag).  Required
+            when *path* is the vaultspec-core source repository or one of
+            its worktrees; otherwise the dev-repo guard refuses the write.
+            See GitHub issue #88.
 
     Returns:
         A dict describing the result:
@@ -822,6 +827,9 @@ def install_run(
     Raises:
         ProviderError: If *provider* is invalid.
         ResourceExistsError: If already installed and *force*/*upgrade* not set.
+        DevRepoProtectionError: If *path* is the source repo and *dev* is
+            ``False``, or if *dev* is ``True`` but *path* is not the
+            source repo.
     """
     from vaultspec_core.config import reset_config
     from vaultspec_core.config.workspace import WorkspaceError, resolve_workspace
@@ -833,7 +841,7 @@ def install_run(
     _validate_provider(provider)
     skip = _validate_skip(skip)
 
-    guard_dev_repo(path)
+    guard_dev_repo(path, dev=dev)
 
     # Bootstrap a minimal context so downstream code can read target_dir
     _t.set_context(
@@ -938,7 +946,9 @@ def install_run(
         # Re-opt-in gitignore management on --upgrade --force
         if force:
             ensure_gitignore_block(
-                path, get_recommended_entries(path), state=ManagedState.PRESENT
+                path,
+                get_recommended_entries(path, dev=dev),
+                state=ManagedState.PRESENT,
             )
             mdata.gitignore_managed = True
 
@@ -957,7 +967,7 @@ def install_run(
         # historically-committed state files (e.g. .vaultspec/providers.json
         # from a pre-managed-block install) stop showing up as dirty on
         # every subsequent run.
-        _untrack_managed_paths(path, get_recommended_entries(path))
+        _untrack_managed_paths(path, get_recommended_entries(path, dev=dev))
 
         return {"action": "upgrade", "seeded_count": len(seeded), "path": path}
 
@@ -1002,7 +1012,7 @@ def install_run(
     has_mcp = (path / ".mcp.json").exists()
 
     # Manage gitignore block
-    recommended = get_recommended_entries(path)
+    recommended = get_recommended_entries(path, dev=dev)
 
     gi_written = ensure_gitignore_block(path, recommended, state=ManagedState.PRESENT)
     if gi_written:
@@ -1084,6 +1094,7 @@ def uninstall_run(
     dry_run: bool = False,
     force: bool = False,
     skip: set[str] | None = None,
+    dev: bool = False,
 ) -> dict[str, Any]:
     """Remove the vaultspec framework from a project directory.
 
@@ -1094,6 +1105,8 @@ def uninstall_run(
         dry_run: Preview what would be removed without deleting.
         force: Required to execute. Uninstall is destructive.
         skip: Set of component names to skip (``core`` and/or provider names).
+        dev: Authorise source-repo operation (the ``--dev`` flag).  See
+            GitHub issue #88.
 
     Returns:
         A dict describing the result:
@@ -1102,10 +1115,13 @@ def uninstall_run(
 
     Raises:
         ProviderError: If *provider* is invalid or *force* not set.
+        DevRepoProtectionError: If *path* is the source repo and *dev* is
+            ``False``, or if *dev* is ``True`` but *path* is not the
+            source repo.
     """
     from .guards import guard_dev_repo
 
-    guard_dev_repo(path)
+    guard_dev_repo(path, dev=dev)
 
     # Validate inputs before any state mutation
     _validate_provider(provider)
@@ -1374,7 +1390,7 @@ def uninstall_run(
         except Exception:
             mdata_after = ManifestData()
 
-        recommended = get_recommended_entries(path)
+        recommended = get_recommended_entries(path, dev=dev)
         # If no providers remain and we are not keeping the vault, remove the block.
         # Otherwise, we sync it if it was managed before.
         if not mdata_after.installed and not keep_vault:
@@ -1486,6 +1502,7 @@ def sync_provider(
     dry_run: bool = False,
     force: bool = False,
     skip: set[str] | None = None,
+    dev: bool = False,
 ) -> list[_t.SyncResult]:
     """Sync resources for a single provider target.
 
@@ -1502,6 +1519,8 @@ def sync_provider(
         dry_run: Preview changes without writing.
         force: Prune stale files and overwrite user-authored content.
         skip: Set of provider names to exclude from the sync.
+        dev: Authorise source-repo operation (the ``--dev`` flag).  See
+            GitHub issue #88.
 
     Returns:
         A list of :class:`SyncResult` objects from each sync pass.
@@ -1510,6 +1529,9 @@ def sync_provider(
         ProviderError: If *provider* is invalid.
         WorkspaceNotInitializedError: If ``.vaultspec/`` does not exist.
         ProviderNotInstalledError: If the specified provider is not installed.
+        DevRepoProtectionError: If the workspace is the source repo and
+            *dev* is ``False``, or if *dev* is ``True`` but the workspace
+            is not the source repo.
     """
     if provider not in SYNC_PROVIDERS:
         raise ProviderError(
@@ -1528,7 +1550,7 @@ def sync_provider(
     from .system import system_sync
 
     ctx = _t.get_context()
-    guard_dev_repo(ctx.target_dir)
+    guard_dev_repo(ctx.target_dir, dev=dev)
 
     def _run_all_syncs() -> list[_t.SyncResult]:
         results: list[_t.SyncResult] = []
@@ -1637,7 +1659,8 @@ def sync_provider(
 
                 if block_present:
                     ensure_gitignore_block(
-                        ctx.target_dir, get_recommended_entries(ctx.target_dir)
+                        ctx.target_dir,
+                        get_recommended_entries(ctx.target_dir, dev=dev),
                     )
                 else:
                     mdata.gitignore_managed = False

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -384,6 +384,7 @@ def collect_gitignore_state(target: Path) -> GitignoreSignal:
         reflecting the observed state.
     """
     from ..gitignore import _find_markers, get_recommended_entries
+    from ..guards import is_dev_repo
 
     gi_path = target / ".gitignore"
     if not gi_path.exists():
@@ -418,7 +419,14 @@ def collect_gitignore_state(target: Path) -> GitignoreSignal:
         if entry in unignored or entry.rstrip("/") in unignored:
             return GitignoreSignal.CORRUPTED
 
-    recommended = get_recommended_entries(target)
+    # The diagnosis is read-only (no `--dev` flag from any caller), but the
+    # *expected* shape of the managed block depends on whether *target* is
+    # the vaultspec-core source repo: in that mode the canonical
+    # `.vaultspec/rules/` content must NOT be ignored, so the recommended
+    # entry set diverges.  Auto-detect via `is_dev_repo` so `spec doctor`
+    # in a vaultspec source worktree reports COMPLETE rather than a
+    # spurious PARTIAL.  See GitHub issue #88.
+    recommended = get_recommended_entries(target, dev=is_dev_repo(target))
 
     # Check if all recommended entries are present in the block.
     # We allow extra entries (idempotency is handled by ensure_gitignore_block).

--- a/src/vaultspec_core/core/executor.py
+++ b/src/vaultspec_core/core/executor.py
@@ -217,8 +217,15 @@ def _execute_adopt_directory(target: Path, step: ResolutionStep) -> None:
 
 def _execute_repair_gitignore(target: Path, _step: ResolutionStep) -> None:
     """Repair the managed gitignore block."""
+    from .guards import is_dev_repo
+
     # TODO: Refine gitignore management to include more artifact types.
-    entries = get_recommended_entries(target)
+    # When *target* is the vaultspec-core source repository, the
+    # recommended entry shape changes (no bare `.vaultspec/` line) so
+    # the canonical rules content stays version-controlled.  This is the
+    # automated-repair counterpart to the explicit `--dev` flag on
+    # install/uninstall/sync.  See GitHub issue #88.
+    entries = get_recommended_entries(target, dev=is_dev_repo(target))
     ensure_gitignore_block(target, entries, state=ManagedState.PRESENT)
 
 

--- a/src/vaultspec_core/core/gitignore.py
+++ b/src/vaultspec_core/core/gitignore.py
@@ -19,11 +19,24 @@ MARKER_END = "# <<< vaultspec-managed <<<"
 DEFAULT_ENTRIES = [".vaultspec/_snapshots/"]
 
 
-def get_recommended_entries(target: Path) -> list[str]:
+def get_recommended_entries(target: Path, *, dev: bool = False) -> list[str]:
     """Return a list of gitignore entries for all managed paths.
 
     Uses :class:`~vaultspec_core.core.types.WorkspaceContext` and manifest
     data to dynamically discover provider directories and configuration files.
+
+    Args:
+        target: Workspace root directory.
+        dev: ``True`` when running in source-repo mode (caller passed
+            ``--dev``).  In that mode the bare ``.vaultspec/`` line is
+            **omitted** because ``.vaultspec/rules/`` is the canonical,
+            version-controlled source content (bundled into the wheel as
+            ``vaultspec_core/builtins/`` via ``pyproject.toml``
+            ``force-include``); a blanket ignore would silently swallow
+            new agents/skills/templates added under ``.vaultspec/rules/``
+            from ``git status``.  The truly-generated children
+            (``_snapshots/``, ``*.lock``, ``providers.json``) stay
+            ignored in both modes.  See GitHub issue #88.
     """
     entries: set[str] = set()
 
@@ -34,10 +47,17 @@ def get_recommended_entries(target: Path) -> list[str]:
         framework_installed = (target / ".vaultspec").is_dir()
         if framework_installed:
             entries.add(".vaultspec/_snapshots/")
-            entries.add(".vaultspec/")
+            if not dev:
+                entries.add(".vaultspec/")
             # Advisory-lock sentinels left by helpers.advisory_lock on any
             # file persisted under .vaultspec/ (providers.json, etc.).
             entries.add(".vaultspec/*.lock")
+            # In dev-mode the bare .vaultspec/ rule isn't there to mask
+            # providers.json; explicitly ignore it because it's local
+            # install state (manifest of which providers are deployed),
+            # not source-of-truth content.
+            if dev:
+                entries.add(".vaultspec/providers.json")
         if (target / ".vault").is_dir():
             entries.add(".vault/.obsidian/")
             entries.add(".vault/.trash/")

--- a/src/vaultspec_core/core/guards.py
+++ b/src/vaultspec_core/core/guards.py
@@ -1,21 +1,25 @@
 """Dev-repo protection guard for vaultspec-core.
 
 Detects when the effective ``TARGET_DIR`` is the vaultspec-core source
-repository and refuses destructive writes (install, uninstall, sync) that
-would corrupt the canonical ``.vaultspec/`` content.
+repository (or one of its worktrees) and refuses destructive writes
+(install, uninstall, sync) that would corrupt the canonical
+``.vaultspec/`` content unless the caller explicitly authorises
+dev-mode operation via the ``--dev`` CLI flag.
 
 Detection is definitive: a ``pyproject.toml`` at the target root whose
 ``[project].name`` equals ``"vaultspec-core"`` can never appear in any
-normal installed project.
+normal installed project.  Every git worktree of the source repo
+shares the same ``pyproject.toml``, so worktrees are covered for free.
 
-The guard can be bypassed with the ``VAULTSPEC_ALLOW_DEV_WRITES``
-environment variable for intentional development operations.
+There is no environment-variable bypass.  Any "yes I really mean it"
+authorisation has to come from an explicit ``--dev`` flag at the
+command line; environment variables are too coarse a signal to gate
+filesystem mutations on.  See GitHub issue #88.
 """
 
 from __future__ import annotations
 
 import logging
-import os
 from functools import lru_cache
 from pathlib import Path
 
@@ -24,7 +28,6 @@ from .exceptions import VaultSpecError
 logger = logging.getLogger(__name__)
 
 _PROJECT_NAME = "vaultspec-core"
-_ENV_OVERRIDE = "VAULTSPEC_ALLOW_DEV_WRITES"
 
 
 class DevRepoProtectionError(VaultSpecError):
@@ -34,8 +37,28 @@ class DevRepoProtectionError(VaultSpecError):
 def is_dev_repo(root: Path) -> bool:
     """Return ``True`` if *root* is the vaultspec-core source repository.
 
-    Checks for a ``pyproject.toml`` whose ``[project].name`` field matches
-    ``"vaultspec-core"``.  Uses ``tomllib`` (stdlib ≥3.11) for parsing.
+    Detection deliberately requires **multiple corroborating signals**, not
+    just a name match.  A consumer project that ships a stale or hand-
+    crafted ``pyproject.toml`` declaring ``name = "vaultspec-core"`` must
+    not trigger the guard, and a fresh worktree that hasn't yet
+    materialised some files must still be detected.  See GitHub issue #88.
+
+    Required signals (all must hold):
+
+    1. ``root / "pyproject.toml"`` exists and parses as TOML.
+    2. ``[project].name == "vaultspec-core"``.
+    3. The Python package source layout is present at the canonical
+       location (``src/vaultspec_core/__init__.py``).  This is the strong
+       signal: it pins us to the actual source bearer of the framework
+       rather than any project that happens to claim the name.
+
+    Optional corroborating signals (used when present, never required):
+
+    - ``[tool.hatch.build.targets.wheel.force-include]`` mentions
+      ``.vaultspec/rules`` -> proves this root is the build root that
+      bundles the canonical framework content into the wheel.
+    - A ``.git`` entry exists -> the directory is a git working tree or
+      worktree.
 
     Args:
         root: Directory to inspect.
@@ -48,46 +71,78 @@ def is_dev_repo(root: Path) -> bool:
 
     try:
         data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
-        return data.get("project", {}).get("name") == _PROJECT_NAME
     except Exception:
         return False
+
+    if data.get("project", {}).get("name") != _PROJECT_NAME:
+        return False
+
+    # Strong corroborating signal: the actual package source layout must
+    # be on disk.  This is what distinguishes the real source repo (and
+    # its worktrees, which all carry the layout) from a consumer that
+    # merely happens to declare the same project name.
+    package_init = root / "src" / "vaultspec_core" / "__init__.py"
+    return package_init.is_file()
 
 
 @lru_cache(maxsize=4)
 def _cached_is_dev_repo(root_str: str) -> bool:
-    """Memoized wrapper  - avoids re-parsing pyproject.toml on every call."""
+    """Memoized wrapper - avoids re-parsing pyproject.toml on every call."""
     return is_dev_repo(Path(root_str))
 
 
-def guard_dev_repo(target: Path) -> None:
-    """Raise :class:`DevRepoProtectionError` if *target* is the dev repo.
+def guard_dev_repo(target: Path, *, dev: bool = False) -> None:
+    """Enforce the dev-repo policy for *target*.
 
-    Does nothing when the ``VAULTSPEC_ALLOW_DEV_WRITES`` env var is set to
-    a truthy value (``1``, ``true``, ``yes``).
+    The three outcomes:
+
+    - ``dev=False`` and *target* **is** the source repo: raise
+      :class:`DevRepoProtectionError` to refuse the write.  This is the
+      default and protects the canonical ``.vaultspec/`` content from
+      being overwritten by consumer-style install/sync logic.
+    - ``dev=True`` and *target* **is** the source repo: log an info
+      message and return.  The calling command is then expected to use
+      the same ``dev`` signal to scope its writes (e.g. omit the bare
+      ``.vaultspec/`` line from the managed gitignore block) so the
+      source-of-truth content stays version-controlled.
+    - ``dev=True`` and *target* **is not** the source repo: raise
+      :class:`DevRepoProtectionError`.  ``--dev`` must not be a no-op
+      escape hatch in arbitrary projects; if the caller passed it
+      somewhere it doesn't apply, that's a mistake we surface loudly.
 
     Args:
         target: The effective ``TARGET_DIR`` for the current operation.
+        dev: ``True`` when the caller passed the ``--dev`` flag and
+            therefore authorises dev-mode operation in the source repo.
 
     Raises:
-        DevRepoProtectionError: If the target is detected as the source repo
-            and the override env var is not set.
+        DevRepoProtectionError: When the policy above forbids the write.
     """
-    override = os.environ.get(_ENV_OVERRIDE, "").strip().lower()
-    if override in ("1", "true", "yes"):
-        resolved = target.resolve()
-        if _cached_is_dev_repo(str(resolved)):
-            logger.warning(
-                "Dev-repo guard bypassed via %s for '%s'",
-                _ENV_OVERRIDE,
-                resolved,
+    resolved = target.resolve()
+    in_dev_repo = _cached_is_dev_repo(str(resolved))
+
+    if dev:
+        if not in_dev_repo:
+            raise DevRepoProtectionError(
+                f"--dev was passed but '{resolved}' is not a vaultspec-core "
+                f"source repository (no pyproject.toml with "
+                f'[project].name == "{_PROJECT_NAME}").',
+                hint=(
+                    "Drop the --dev flag, or run from inside the "
+                    "vaultspec-core repository or one of its worktrees."
+                ),
             )
+        logger.info(
+            "Dev-repo guard authorised by --dev for source repo at '%s'",
+            resolved,
+        )
         return
 
-    resolved = target.resolve()
-    if _cached_is_dev_repo(str(resolved)):
+    if in_dev_repo:
         raise DevRepoProtectionError(
-            f"Refusing to modify '{resolved}'  - this is the vaultspec-core "
+            f"Refusing to modify '{resolved}' - this is the vaultspec-core "
             f"source repository.\n"
-            f"  Use --target to specify a project directory.",
-            hint=f"Set {_ENV_OVERRIDE}=1 to override this protection.",
+            f"  Use --target to specify a project directory, or pass --dev "
+            f"to operate on the source repo intentionally.",
+            hint="Pass --dev to authorise source-repo writes.",
         )

--- a/src/vaultspec_core/core/tests/test_guards.py
+++ b/src/vaultspec_core/core/tests/test_guards.py
@@ -1,4 +1,10 @@
-"""Tests for dev-repo protection guard."""
+"""Tests for dev-repo protection guard.
+
+Issue #88: drop the ``VAULTSPEC_ALLOW_DEV_WRITES`` environment variable
+override and gate dev-mode operation on an explicit ``--dev`` flag
+plumbed through :func:`guard_dev_repo`.  These tests pin both the
+removal of the env-var bypass and the new ``dev=`` parameter contract.
+"""
 
 import pytest
 
@@ -20,14 +26,47 @@ def _clear_cache():
     _cached_is_dev_repo.cache_clear()
 
 
-# ── is_dev_repo ────────────────────────────────────────────────────
+# is_dev_repo ----------------------------------------------------------
+
+
+def _materialise_source_layout(root):
+    """Create the minimum on-disk shape that makes :func:`is_dev_repo` fire."""
+    pyproject = root / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "vaultspec-core"\n', encoding="utf-8")
+    pkg = root / "src" / "vaultspec_core"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    return root
 
 
 def test_detects_dev_repo_with_matching_pyproject(tmp_path):
-    """A pyproject.toml with name = 'vaultspec-core' triggers detection."""
+    """pyproject ``name`` AND ``src/vaultspec_core/__init__.py`` -> detected."""
+    _materialise_source_layout(tmp_path)
+    assert is_dev_repo(tmp_path) is True
+
+
+def test_pyproject_name_alone_is_not_enough(tmp_path):
+    """A spoofed pyproject.toml without the source layout is not the dev repo.
+
+    Hardened detection (issue #88): a consumer project that ships a
+    pyproject.toml declaring ``name = "vaultspec-core"`` (e.g. a stale
+    fork, a copied template, an attacker-crafted file) must not trigger
+    the guard.  The corroborating source-layout signal pins us to the
+    actual source bearer.
+    """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text('[project]\nname = "vaultspec-core"\n', encoding="utf-8")
-    assert is_dev_repo(tmp_path) is True
+    # No `src/vaultspec_core/__init__.py` -> not detected.
+    assert is_dev_repo(tmp_path) is False
+
+
+def test_source_layout_alone_is_not_enough(tmp_path):
+    """Source layout without a matching pyproject is not the dev repo."""
+    pkg = tmp_path / "src" / "vaultspec_core"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    # No pyproject.toml at root -> not detected.
+    assert is_dev_repo(tmp_path) is False
 
 
 def test_ignores_dir_without_pyproject(tmp_path):
@@ -56,48 +95,88 @@ def test_ignores_pyproject_without_project_table(tmp_path):
     assert is_dev_repo(tmp_path) is False
 
 
-# ── guard_dev_repo ─────────────────────────────────────────────────
+# guard_dev_repo (default behaviour, no --dev) ------------------------
 
 
-def test_guard_raises_on_dev_repo(tmp_path, monkeypatch):
-    """guard_dev_repo raises DevRepoProtectionError for the dev repo."""
-    monkeypatch.delenv("VAULTSPEC_ALLOW_DEV_WRITES", raising=False)
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nname = "vaultspec-core"\n', encoding="utf-8")
+def test_guard_raises_on_dev_repo(tmp_path):
+    """Without ``dev=True``, guard_dev_repo refuses to mutate the source repo."""
+    _materialise_source_layout(tmp_path)
     with pytest.raises(DevRepoProtectionError, match="source repository"):
         guard_dev_repo(tmp_path)
 
 
-def test_guard_passes_on_normal_dir(tmp_path):
+def test_guard_passes_on_normal_dir_without_dev(tmp_path):
     """guard_dev_repo does not raise for a normal project directory."""
     guard_dev_repo(tmp_path)
 
 
-def test_guard_respects_env_override(tmp_path, monkeypatch):
-    """The VAULTSPEC_ALLOW_DEV_WRITES env var bypasses the guard."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nname = "vaultspec-core"\n', encoding="utf-8")
-
-    monkeypatch.setenv("VAULTSPEC_ALLOW_DEV_WRITES", "1")
-    guard_dev_repo(tmp_path)  # should not raise
+# guard_dev_repo (--dev flag plumbed through) -------------------------
 
 
-def test_guard_env_override_truthy_values(tmp_path, monkeypatch):
-    """All documented truthy values bypass the guard."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nname = "vaultspec-core"\n', encoding="utf-8")
+def test_dev_flag_authorises_source_repo_writes(tmp_path):
+    """``dev=True`` allows the operation to proceed in the source repo."""
+    _materialise_source_layout(tmp_path)
+    # Must not raise.
+    guard_dev_repo(tmp_path, dev=True)
+
+
+def test_dev_flag_in_non_source_repo_raises(tmp_path):
+    """``dev=True`` outside the source repo is a misuse and surfaces loudly.
+
+    The flag is the explicit "yes I'm working on the source repo"
+    signal.  Passing it in a context where it cannot apply must not be
+    a silent no-op; the user's intent is unmet and they should know.
+    """
+    with pytest.raises(DevRepoProtectionError, match="not a vaultspec-core source"):
+        guard_dev_repo(tmp_path, dev=True)
+
+
+def test_dev_flag_keyword_only_in_signature() -> None:
+    """``dev`` is a keyword-only parameter in :func:`guard_dev_repo`.
+
+    Inspect the signature directly rather than calling positionally,
+    because static type checkers refuse positional misuse before the
+    runtime ``TypeError`` ever fires.
+    """
+    import inspect
+
+    sig = inspect.signature(guard_dev_repo)
+    assert sig.parameters["dev"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+# Env-var bypass removed (issue #88) ----------------------------------
+
+
+def test_env_var_no_longer_bypasses_guard(tmp_path, monkeypatch):
+    """``VAULTSPEC_ALLOW_DEV_WRITES`` must NOT bypass the guard.
+
+    The env-var override was the original "yes really" mechanism.  It
+    was too coarse: it converted the guard into a global no-op for any
+    process that inherited the variable, including the install/sync
+    logic that wrote the consumer-style gitignore block in the source
+    repo (the root cause of issue #88).  The fix removes the env var
+    entirely and gates everything on the explicit ``dev=`` parameter.
+    """
+    _materialise_source_layout(tmp_path)
 
     for val in ("1", "true", "yes", "True", "YES"):
         _cached_is_dev_repo.cache_clear()
         monkeypatch.setenv("VAULTSPEC_ALLOW_DEV_WRITES", val)
-        guard_dev_repo(tmp_path)  # should not raise
+        with pytest.raises(DevRepoProtectionError, match="source repository"):
+            guard_dev_repo(tmp_path)
 
 
-def test_guard_env_override_falsy_does_not_bypass(tmp_path, monkeypatch):
-    """Non-truthy env values do not bypass the guard."""
-    pyproject = tmp_path / "pyproject.toml"
-    pyproject.write_text('[project]\nname = "vaultspec-core"\n', encoding="utf-8")
+def test_guards_module_does_not_reference_env_var() -> None:
+    """The env-var name must not appear anywhere in the guards module.
 
-    monkeypatch.setenv("VAULTSPEC_ALLOW_DEV_WRITES", "0")
-    with pytest.raises(DevRepoProtectionError):
-        guard_dev_repo(tmp_path)
+    A residual ``os.environ.get("VAULTSPEC_ALLOW_DEV_WRITES")`` would
+    quietly resurrect the bypass; this regression test catches that.
+    """
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "guards.py"
+    text = src.read_text(encoding="utf-8")
+    assert "VAULTSPEC_ALLOW_DEV_WRITES" not in text
+    # ``os.environ`` should not be needed at all in the guard module
+    # after the bypass is removed.
+    assert "os.environ" not in text

--- a/tests/test_dev_mode.py
+++ b/tests/test_dev_mode.py
@@ -1,0 +1,176 @@
+"""End-to-end tests for the ``--dev`` flag and dev-shaped gitignore output.
+
+Issue #88: vaultspec-core is itself the source of the framework rules
+that the wheel bundles into ``vaultspec_core/builtins/``.  In a consumer
+project the install/sync logic correctly emits a managed
+``.gitignore`` block that includes a bare ``.vaultspec/`` line, so the
+generated install target does not pollute git history.  In the source
+repo that exact rule silently swallows new framework content from
+``git status`` and ``git add``.
+
+These tests pin the new contract:
+
+- ``get_recommended_entries(target, dev=False)`` keeps the consumer
+  shape (includes ``.vaultspec/``).
+- ``get_recommended_entries(target, dev=True)`` switches to the source
+  shape (omits ``.vaultspec/``, retains the truly-generated children).
+- The Typer commands ``install``, ``uninstall``, and ``sync`` accept a
+  ``--dev`` flag, surface it in ``--help`` output, and the CLI source
+  no longer references the dropped env-var bypass.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+def _make_dev_repo(root: Path) -> Path:
+    """Materialise the minimum on-disk shape for ``is_dev_repo`` to fire.
+
+    The hardened detection (issue #88) needs both signals to coincide:
+    a ``pyproject.toml`` declaring ``name = "vaultspec-core"`` *and*
+    the package source layout at ``src/vaultspec_core/__init__.py``.
+    """
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "vaultspec-core"\n', encoding="utf-8"
+    )
+    pkg = root / "src" / "vaultspec_core"
+    pkg.mkdir(parents=True, exist_ok=True)
+    (pkg / "__init__.py").write_text("", encoding="utf-8")
+    (root / ".vaultspec").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _make_consumer_repo(root: Path) -> Path:
+    """Materialise an unrelated consumer project with a ``.vaultspec/`` dir."""
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "downstream-app"\n', encoding="utf-8"
+    )
+    (root / ".vaultspec").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+class TestRecommendedEntriesShape:
+    """``get_recommended_entries`` must change shape on the ``dev=`` flag."""
+
+    def test_consumer_shape_includes_bare_vaultspec(self, tmp_path: Path) -> None:
+        from vaultspec_core.core.gitignore import get_recommended_entries
+
+        _make_consumer_repo(tmp_path)
+        entries = get_recommended_entries(tmp_path, dev=False)
+        # In consumer mode the bare ignore is correct: `.vaultspec/` is a
+        # generated install target.
+        assert ".vaultspec/" in entries
+        # Truly-generated children remain ignored in both modes.
+        assert ".vaultspec/_snapshots/" in entries
+        assert ".vaultspec/*.lock" in entries
+
+    def test_dev_shape_drops_bare_vaultspec(self, tmp_path: Path) -> None:
+        from vaultspec_core.core.gitignore import get_recommended_entries
+
+        _make_dev_repo(tmp_path)
+        entries = get_recommended_entries(tmp_path, dev=True)
+        # The bare line is the bug.  In dev mode it must NOT appear, so
+        # new agents/skills/templates added under .vaultspec/rules/ stay
+        # visible to git.
+        assert ".vaultspec/" not in entries
+        # Generated children stay ignored.
+        assert ".vaultspec/_snapshots/" in entries
+        assert ".vaultspec/*.lock" in entries
+        # providers.json is local install state in either mode; dev mode
+        # explicitly ignores it because the bare `.vaultspec/` line that
+        # would otherwise have masked it is gone.
+        assert ".vaultspec/providers.json" in entries
+
+    def test_dev_shape_default_false_preserves_consumer_behaviour(
+        self, tmp_path: Path
+    ) -> None:
+        """Calling without the keyword must keep the legacy consumer output."""
+        from vaultspec_core.core.gitignore import get_recommended_entries
+
+        _make_consumer_repo(tmp_path)
+        # No ``dev=`` keyword -> default False -> consumer shape.
+        entries = get_recommended_entries(tmp_path)
+        assert ".vaultspec/" in entries
+
+    def test_no_framework_no_entries(self, tmp_path: Path) -> None:
+        """Without a ``.vaultspec/`` directory the function emits nothing for it."""
+        from vaultspec_core.core.gitignore import get_recommended_entries
+
+        # No `.vaultspec/` dir.
+        entries = get_recommended_entries(tmp_path, dev=True)
+        assert ".vaultspec/" not in entries
+        assert ".vaultspec/_snapshots/" not in entries
+
+
+class TestCliSurface:
+    """The Typer commands must expose ``--dev`` and not the env var."""
+
+    def _help_for(self, command: str) -> str:
+        result = subprocess.run(
+            [sys.executable, "-m", "vaultspec_core", command, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=True,
+        )
+        return result.stdout + result.stderr
+
+    def test_install_help_lists_dev_flag(self) -> None:
+        out = self._help_for("install")
+        assert re.search(r"--dev\b", out), out
+
+    def test_uninstall_help_lists_dev_flag(self) -> None:
+        out = self._help_for("uninstall")
+        assert re.search(r"--dev\b", out), out
+
+    def test_sync_help_lists_dev_flag(self) -> None:
+        out = self._help_for("sync")
+        assert re.search(r"--dev\b", out), out
+
+    def test_cli_source_does_not_reference_env_var(self) -> None:
+        import pathlib
+
+        cli_root = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "src"
+            / "vaultspec_core"
+            / "cli"
+            / "root.py"
+        )
+        text = cli_root.read_text(encoding="utf-8")
+        assert "VAULTSPEC_ALLOW_DEV_WRITES" not in text
+
+
+class TestSourceRepoIntegration:
+    """Two full integration paths through ``install_run`` to confirm wiring."""
+
+    def test_install_run_in_source_repo_without_dev_raises(
+        self, tmp_path: Path
+    ) -> None:
+        from vaultspec_core.core.commands import install_run
+        from vaultspec_core.core.guards import DevRepoProtectionError
+
+        _make_dev_repo(tmp_path)
+        with pytest.raises(DevRepoProtectionError, match="source repository"):
+            install_run(path=tmp_path, dry_run=True)
+
+    def test_install_run_in_source_repo_with_dev_proceeds_dry_run(
+        self, tmp_path: Path
+    ) -> None:
+        """``dev=True`` lifts the guard; dry-run avoids any real writes."""
+        from vaultspec_core.core.commands import install_run
+
+        _make_dev_repo(tmp_path)
+        result = install_run(path=tmp_path, dry_run=True, dev=True)
+        assert result["action"] == "dry_run"


### PR DESCRIPTION
## Summary

Implements [#88](https://github.com/wgergely/vaultspec-core/issues/88) end-to-end. The dev-repo guard no longer honours the `VAULTSPEC_ALLOW_DEV_WRITES` environment variable, source-repo identification is hardened with a corroborating source-layout check, and the install/uninstall/sync commands accept an explicit `--dev` flag that scopes the managed gitignore block so canonical `.vaultspec/rules/` content stays version-controlled in this repo.

## Why this matters

The bare `.vaultspec/` line that the legacy install/sync wrote to the managed gitignore block silently swallows new agents/skills/templates added under `.vaultspec/rules/` from `git status` and `git add` — exactly the install-layer brittleness #85 was meant to harden against, observed concretely in the worktree at session start as 45 staged deletions covering every framework rule and template.

`get_recommended_entries(...)` had no awareness of who it was running for; in this repo it must omit the bare line because `.vaultspec/rules/` is the canonical source bundled into the wheel via `pyproject.toml`'s `force-include`.  In a consumer it must keep the line because `.vaultspec/` is a generated install target.  The `--dev` flag is the explicit signal that flips between the two shapes; the env var was too coarse to be that signal and is gone.

## Changes

- `guards.py`: env-var override deleted entirely (no `os.environ` left in the module).  `is_dev_repo` now requires both the pyproject name match AND `src/vaultspec_core/__init__.py` to be present, so a consumer with a stale or hand-crafted pyproject can't false-positive.  `guard_dev_repo(target, *, dev=False)`: explicit only; `dev=True` outside the source repo raises so misuse surfaces.
- `gitignore.py`: `get_recommended_entries(target, *, dev=False)` omits the bare `.vaultspec/` entry when `dev=True`.  Generated children (`_snapshots/`, `*.lock`, `providers.json`) stay ignored in both modes.
- `commands.py`: `install_run`, `uninstall_run`, `sync_provider` accept `dev` and plumb to every `guard_dev_repo` and `get_recommended_entries` call site.
- `diagnosis/collectors.py`, `executor.py`: read-only / repair paths auto-detect via `is_dev_repo(target)` so `spec doctor` and the doctor's resolver report the right shape in a vaultspec source worktree without any caller-supplied flag.
- `cli/root.py`: `--dev` Typer option on the three mutating subcommands, plumbed to the `*_run` calls.

## Tests

Local: 968 passed, 415 deselected (was 952 on main; +16 new).

New cases:

- `tests/test_dev_mode.py` (new file):
  - `TestRecommendedEntriesShape`: consumer shape includes `.vaultspec/`; dev shape omits it; default keyword is False; no framework -> no entries.
  - `TestCliSurface`: `--help` for install/uninstall/sync each surface `--dev`; `cli/root.py` source contains no env-var name.
  - `TestSourceRepoIntegration`: `install_run` raises in the source repo without `--dev`, proceeds (dry-run) with `--dev=True`.
- `src/vaultspec_core/core/tests/test_guards.py`:
  - `test_pyproject_name_alone_is_not_enough` and `test_source_layout_alone_is_not_enough` pin the hardened detection.
  - `test_dev_flag_authorises_source_repo_writes`, `test_dev_flag_in_non_source_repo_raises`, `test_dev_flag_keyword_only_in_signature` cover the new flag.
  - `test_env_var_no_longer_bypasses_guard` sweeps every documented truthy value and asserts the guard still raises.
  - `test_guards_module_does_not_reference_env_var` greps the module source so a future regression that re-introduces `os.environ.get("VAULTSPEC_ALLOW_DEV_WRITES")` fails CI.

Other gates: `ruff check`, `ruff format --check`, `ty check`, `uv audit` all clean.

## Test plan

- [x] `vaultspec-core install` (no `--dev`) in this source worktree raises `DevRepoProtectionError`.
- [x] `vaultspec-core install --dev --dry-run` in this source worktree proceeds.
- [x] `vaultspec-core install --help` shows `--dev`.
- [x] A consumer with a stale `pyproject.toml` declaring `name = "vaultspec-core"` but no `src/vaultspec_core/` layout does NOT trigger the guard.
- [x] CI gate green.

Closes #88.