### PR TITLE
fix(#93): drop spec-check false positive on source repo

### DIFF
--- a/.vault/adr/2026-04-30-doctor-dev-repo-adr.md
+++ b/.vault/adr/2026-04-30-doctor-dev-repo-adr.md
@@ -1,0 +1,101 @@
+---
+tags:
+  - '#adr'
+  - '#doctor-dev-repo'
+date: '2026-04-30'
+related:
+  - '[[2026-04-30-doctor-dev-repo-research]]'
+  - '[[2026-04-30-doctor-dev-repo-plan]]'
+---
+
+# `doctor-dev-repo` adr: `consult is_dev_repo in collect_framework_presence` | (**status:** `accepted`)
+
+## Problem Statement
+
+`collect_framework_presence` declares the framework `CORRUPTED` whenever
+`.vaultspec/providers.json` is absent. The vaultspec-core source
+repository never carries that file (it is an install artifact
+generated on consumer projects), so `spec doctor` and the
+`spec-check` pre-commit / pre-push hook fail on every commit and push
+to this repo. Contributors are forced to use `--no-verify`. We need
+the diagnosis to recognise the source repo as a legitimately present
+framework while still catching consumer projects whose installs are
+genuinely broken.
+
+## Considerations
+
+- A robust dev-repo detector already exists at
+  `src/vaultspec_core/core/guards.py:37` (`is_dev_repo`) with a
+  memoized `_cached_is_dev_repo` wrapper. It requires both a
+  `pyproject.toml` declaring `name = "vaultspec-core"` AND the
+  package source layout at `src/vaultspec_core/__init__.py`, which
+  cannot collide with consumer projects without a deliberate fork.
+- The only callsites of `collect_framework_presence` are the
+  diagnose orchestrator and the test module. No new enum value is
+  needed if we route the dev repo through `FrameworkSignal.PRESENT`,
+  which is semantically correct: the framework directory IS the
+  canonical source of truth on the dev repo.
+- The existing `collect_gitignore_state` already calls
+  `is_dev_repo` for an analogous reason (#88), so the precedent is
+  in the codebase.
+
+## Constraints
+
+- Must not regress consumer-side detection: a project that ships
+  `.vaultspec/` without `providers.json` and is not the
+  vaultspec-core source repo must still report `CORRUPTED`.
+- Must not change the `FrameworkSignal` enum surface; downstream
+  consumers (`spec_cmd.py` rendering, `resolver.py`) already handle
+  `PRESENT` correctly.
+- Must keep the cost low: `spec doctor` may collect framework
+  presence twice during a single run, so the dev-repo check must be
+  memoized.
+
+## Implementation
+
+In `collect_framework_presence`, after the manifest-existence check
+fails, import `_cached_is_dev_repo` from
+`vaultspec_core.core.guards` and consult it with the resolved target
+path. On a positive match return `FrameworkSignal.PRESENT`; on a
+negative match retain the existing `FrameworkSignal.CORRUPTED`
+return. The import is deferred inside the function body to honour
+the module's documented "imports from `core.*` modules are deferred
+inside function bodies to prevent import cycles" rule (see the
+collector module docstring).
+
+Add two test cases in `src/vaultspec_core/tests/cli/test_collectors.py`
+under `TestFrameworkPresence`:
+
+- A dev-repo workspace built inline via `tmp_path` (pyproject with
+  `name = "vaultspec-core"` plus `src/vaultspec_core/__init__.py`
+  plus an empty `.vaultspec/` directory), asserting `PRESENT`.
+- A near-miss workspace (correct pyproject but no package source
+  layout), asserting `CORRUPTED`. This locks the boundary against
+  hand-crafted-pyproject false negatives on consumer projects.
+
+The existing `test_corrupted_no_manifest` continues to assert
+`CORRUPTED` because its workspace has no `pyproject.toml` at all.
+
+## Rationale
+
+Reusing `is_dev_repo` is the smallest, most obvious change. It
+shares the dev-repo detection contract with `guard_dev_repo` and
+`collect_gitignore_state`, so behaviour stays consistent across
+diagnosis and write-guarding code paths. Adding a new
+`FrameworkSignal.DEV_REPO` member would force every consumer of the
+enum (status renderer, resolver, exit-code mapping) to handle a new
+case for no semantic gain, since the desired outcome is exactly
+"PRESENT" everywhere.
+
+## Consequences
+
+- `spec doctor` exits clean on the source repo, which means the
+  `spec-check` pre-commit / pre-push hook stops false-positiving and
+  contributors can drop `--no-verify`.
+- A consumer project that adopts the vaultspec-core source layout
+  wholesale (forking, not consuming) would also pass the dev-repo
+  test. That is a legitimate dev-repo state and the right answer
+  for that case too.
+- The dev-repo signal becomes a tacit invariant of three diagnosis
+  collectors. Any future change to `is_dev_repo` semantics needs to
+  consider all three callers.

--- a/.vault/doctor-dev-repo.index.md
+++ b/.vault/doctor-dev-repo.index.md
@@ -7,6 +7,7 @@ related:
   - '[[2026-04-30-doctor-dev-repo-adr]]'
   - '[[2026-04-30-doctor-dev-repo-plan]]'
   - '[[2026-04-30-doctor-dev-repo-research]]'
+  - '[[2026-04-30-doctor-dev-repo-self-review-exec]]'
 ---
 
 # `doctor-dev-repo` feature index
@@ -18,6 +19,10 @@ Auto-generated index of all documents tagged with `#doctor-dev-repo`.
 ### adr
 
 - `2026-04-30-doctor-dev-repo-adr` - `doctor-dev-repo` adr: `consult is_dev_repo in collect_framework_presence` | (**status:** `accepted`)
+
+### exec
+
+- `2026-04-30-doctor-dev-repo-self-review-exec` - `doctor-dev-repo` `self-review`
 
 ### plan
 

--- a/.vault/doctor-dev-repo.index.md
+++ b/.vault/doctor-dev-repo.index.md
@@ -1,0 +1,28 @@
+---
+generated: true
+tags:
+  - '#doctor-dev-repo'
+date: '2026-05-01'
+related:
+  - '[[2026-04-30-doctor-dev-repo-adr]]'
+  - '[[2026-04-30-doctor-dev-repo-plan]]'
+  - '[[2026-04-30-doctor-dev-repo-research]]'
+---
+
+# `doctor-dev-repo` feature index
+
+Auto-generated index of all documents tagged with `#doctor-dev-repo`.
+
+## Documents
+
+### adr
+
+- `2026-04-30-doctor-dev-repo-adr` - `doctor-dev-repo` adr: `consult is_dev_repo in collect_framework_presence` | (**status:** `accepted`)
+
+### plan
+
+- `2026-04-30-doctor-dev-repo-plan` - `doctor-dev-repo` `fix collect_framework_presence dev-repo handling` plan
+
+### research
+
+- `2026-04-30-doctor-dev-repo-research` - `doctor-dev-repo` research: `spec doctor false positive on source repo`

--- a/.vault/exec/2026-04-30-doctor-dev-repo/2026-04-30-doctor-dev-repo-self-review-exec.md
+++ b/.vault/exec/2026-04-30-doctor-dev-repo/2026-04-30-doctor-dev-repo-self-review-exec.md
@@ -1,0 +1,113 @@
+---
+tags:
+  - '#exec'
+  - '#doctor-dev-repo'
+date: '2026-04-30'
+related:
+  - '[[2026-04-30-doctor-dev-repo-plan]]'
+  - '[[2026-04-30-doctor-dev-repo-adr]]'
+  - '[[2026-04-30-doctor-dev-repo-research]]'
+---
+
+# `doctor-dev-repo` `self-review`
+
+Self-review of the GitHub issue #93 fix landed on branch
+`fix/93-doctor-dev-repo`.
+
+- Modified: `src/vaultspec_core/core/diagnosis/collectors.py`
+- Modified: `src/vaultspec_core/tests/cli/test_collectors.py`
+- Created: `.vault/research/2026-04-30-doctor-dev-repo-research.md`
+- Created: `.vault/adr/2026-04-30-doctor-dev-repo-adr.md`
+- Created: `.vault/plan/2026-04-30-doctor-dev-repo-plan.md`
+- Created: `.vault/doctor-dev-repo.index.md`
+
+## Description
+
+`collect_framework_presence` now defers an import of
+`_cached_is_dev_repo` from `vaultspec_core.core.guards` and consults
+the resolved target path after the manifest-existence check fails.
+On a positive multi-signal dev-repo match the collector returns
+`FrameworkSignal.PRESENT`; otherwise the original
+`FrameworkSignal.CORRUPTED` return is preserved verbatim. No
+`FrameworkSignal` enum members were added or renamed, and no
+downstream consumer (`spec_cmd.py` rendering, `resolver.py`
+gating, `diagnosis.py` orchestrator branching) needed to change.
+
+The deferred-import pattern matches the rest of the module, which
+documents in its top-of-file docstring that imports from `core.*`
+are deferred inside function bodies to prevent cycles. The
+`_cached_is_dev_repo` wrapper is memoized via `functools.lru_cache`
+upstream, so collecting framework presence twice in a single
+`spec doctor` run does not re-parse `pyproject.toml`.
+
+## Tests
+
+Two new test methods were added to
+`TestFrameworkPresence` in
+`src/vaultspec_core/tests/cli/test_collectors.py`:
+
+- `test_dev_repo_present_without_manifest` builds a real-on-disk
+  dev-repo workspace from `tmp_path` (pyproject with
+  `name = "vaultspec-core"`, the canonical
+  `src/vaultspec_core/__init__.py` layout, and an empty
+  `.vaultspec/` directory) and asserts `PRESENT`. The
+  `_cached_is_dev_repo` LRU cache is cleared before and after the
+  assertion so neighbouring tests cannot mask a regression by
+  pre-warming the cache against the real source repo.
+- `test_consumer_pyproject_match_alone_still_corrupted` builds a
+  pyproject-only workspace (no package source layout) and asserts
+  `CORRUPTED`. This locks the multi-signal contract: a hand-crafted
+  pyproject naming `vaultspec-core` cannot trigger the dev-repo
+  branch on its own.
+
+Both tests use the real filesystem; no mocks, patches, stubs, or
+skips. The pre-existing `test_corrupted_no_manifest` continues to
+assert `CORRUPTED` because its workspace has no `pyproject.toml`
+at all, and that path is unchanged.
+
+## Quality gates
+
+- `uv run --no-sync pytest src/vaultspec_core/tests/cli/test_collectors.py::TestFrameworkPresence -v`
+  - 7 passed in 0.16s
+- `uv run --no-sync pytest`
+  - 1377 passed, 8 pre-existing failures unrelated to issue #93
+    (`tests/test_mcp_config.py` requires a `.mcp.json` not tracked
+    in the repo; `test_agents_render.py::TestGeminiCliLoadsRenderedAgents`
+    fails the same way on `main`).
+- `uv run --no-sync ty check src/vaultspec_core` -> all checks
+  passed
+- `uv run --no-sync ruff check` and `ruff format --check` -> clean
+- `uv run --no-sync vaultspec-core vault check all` -> clean
+- `uv run --no-sync vaultspec-core spec doctor` -> framework: ok /
+  `.vaultspec/` present; exit 0
+- `uv run --no-sync prek run --all-files` -> the issue-#93-relevant
+  hooks (`Vault Doctor (Fix)`, `Vault Doctor (Check)`) pass; the
+  remaining `mdformat`, `pymarkdown`, `block-manual-changelog`
+  failures are pre-existing CHANGELOG.md baseline issues untouched
+  by this branch.
+
+## Acceptance test
+
+The headline acceptance test for this fix is the absence of
+`--no-verify`. The bootstrap commit (`chore(#93): bootstrap research stub for doctor dev-repo fix`) used `--no-verify` once because it
+necessarily lands before the fix. Every commit and push thereafter
+on this branch (the `fix(#93): ...` commit and any review-loop
+commits) must pass the spec-check pre-commit and pre-push hook
+naturally. The `fix(#93): ...` commit was created and pushed
+without `--no-verify`; both the pre-commit and pre-push runs of
+`Vault Doctor (Check)` reported `Passed`.
+
+## Audit sweep
+
+Grepping `FrameworkSignal\.CORRUPTED` across the repository
+confirmed the remaining production sites do not produce the signal
+on a dev-repo path: the two surviving `CORRUPTED` returns in
+`collectors.py` are downstream of the manifest existing but
+failing to parse or omitting the `installed` key (the dev repo
+hits neither because it has no `providers.json` to begin with).
+The `spec_cmd.py`, `diagnosis.py`, and `resolver.py` references
+only consume the signal for rendering, exit-code mapping, and
+resolver branching; none of them produce it. The
+`test_resolver.py` references feed the signal directly into
+resolver tests and are unaffected by the collector contract
+change.

--- a/.vault/plan/2026-04-30-doctor-dev-repo-plan.md
+++ b/.vault/plan/2026-04-30-doctor-dev-repo-plan.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - '#plan'
+  - '#doctor-dev-repo'
+date: '2026-04-30'
+related:
+  - '[[2026-04-30-doctor-dev-repo-adr]]'
+  - '[[2026-04-30-doctor-dev-repo-research]]'
+---
+
+# `doctor-dev-repo` `fix collect_framework_presence dev-repo handling` plan
+
+Land the smallest production change required to stop `spec doctor`
+from false-positiving on the vaultspec-core source repository, plus
+two real-filesystem tests that lock the new behaviour and the
+preserved consumer-corruption path.
+
+## Proposed Changes
+
+Modify `collect_framework_presence` in
+`src/vaultspec_core/core/diagnosis/collectors.py`. After the
+manifest-existence check fails, defer-import `_cached_is_dev_repo`
+from `vaultspec_core.core.guards` and consult it with the resolved
+target path. Return `FrameworkSignal.PRESENT` on a positive match,
+otherwise retain the existing `FrameworkSignal.CORRUPTED` path. No
+other production files change.
+
+Add two test cases in
+`src/vaultspec_core/tests/cli/test_collectors.py` under
+`TestFrameworkPresence`:
+
+- A dev-repo workspace built inline from `tmp_path` (real
+  pyproject.toml with `name = "vaultspec-core"`, real
+  `src/vaultspec_core/__init__.py`, real `.vaultspec/` directory,
+  no `providers.json`), asserting `PRESENT`.
+- A near-miss consumer workspace (real pyproject.toml with the
+  matching name but no `src/vaultspec_core/__init__.py`),
+  asserting `CORRUPTED`. The existing
+  `test_corrupted_no_manifest` already covers the no-pyproject
+  case; this new test locks the multi-signal contract.
+
+## Tasks
+
+- Apply the production change in `collectors.py` (deferred import of
+  `_cached_is_dev_repo`, dev-repo branch returning `PRESENT`).
+- Add two `TestFrameworkPresence` test methods using `tmp_path`
+  (no mocks, no patches; real on-disk fixture).
+- Run the targeted test module, then the full suite, then `ty`,
+  `ruff`, `vault check all`, and `spec doctor` on this repo.
+- Push the fix; the `spec-check` pre-commit and pre-push hook must
+  pass naturally without `--no-verify` from this commit forward.
+- Loop on gemini code review until two consecutive clean rounds.
+
+## Parallelization
+
+Single-file production change; no parallel tracks. Tests can be
+written in the same commit as the fix because the production change
+flips the assertion they would make.
+
+## Verification
+
+- `uv run --no-sync pytest src/vaultspec_core/tests/cli/test_collectors.py -v`
+  passes, including the two new tests.
+- `uv run --no-sync pytest` passes the full suite with no regressions.
+- `uv run --no-sync ty check src/vaultspec_core` is clean.
+- `uv run --no-sync ruff check` and
+  `uv run --no-sync ruff format --check` are clean.
+- `uv run --no-sync vaultspec-core vault check all` passes.
+- `uv run --no-sync vaultspec-core spec doctor` reports the
+  framework as `ok / present` on this repo.
+- `uv run --no-sync prek run --all-files` passes.
+- A subsequent `git commit` and `git push` on this branch succeed
+  without `--no-verify`. This is the headline acceptance signal:
+  if any push needs `--no-verify` after the fix lands, the fix is
+  incomplete.

--- a/.vault/research/2026-04-30-doctor-dev-repo-research.md
+++ b/.vault/research/2026-04-30-doctor-dev-repo-research.md
@@ -1,33 +1,111 @@
 ---
-# REQUIRED TAGS (minimum 2): one directory tag + one feature tag
-# DIRECTORY TAGS: #adr #audit #exec #plan #reference #research
-# Directory tag (hardcoded - DO NOT CHANGE - based on .vault/research/ location)
-# Feature tag (replace doctor-dev-repo with your feature name, e.g., #editor-demo)
-# Additional tags may be appended below the required pair
 tags:
   - '#research'
   - '#doctor-dev-repo'
-# ISO date format (e.g., 2026-02-06)
 date: '2026-04-30'
-# Related documents as quoted wiki-links
-# (e.g., "[[2026-02-04-feature-plan]]")
-related: []
+related:
+  - '[[2026-04-30-doctor-dev-repo-adr]]'
+  - '[[2026-04-30-doctor-dev-repo-plan]]'
 ---
-
-<!-- DO NOT add 'Related:', 'tags:', 'date:', or other frontmatter fields
-     outside the YAML frontmatter above -->
-
-<!-- LINK RULES:
-     - [[wiki-links]] are ONLY for .vault/ documents in the related: field above.
-     - NEVER use [[wiki-links]] or markdown links in the document body.
-     - NEVER reference file paths in the body. If you must name a source file,
-       class, or function, use inline backtick code: `src/module.py`. -->
 
 # `doctor-dev-repo` research: `spec doctor false positive on source repo`
 
-Brief description of what was researched, why, and how it relates to
-`doctor-dev-repo`.
+GitHub issue #93 reports that `spec doctor` and the `spec-check`
+pre-commit / pre-push hook fail on every commit and push to the
+vaultspec-core source repository. The diagnosis classifies the
+framework as `CORRUPTED`, which forces contributors to use
+`--no-verify` to land any change. PR #92 hit this repeatedly. This
+research confirms the root cause, lists every callsite that depends on
+`collect_framework_presence`, and inventories the test fixtures that
+construct `.vaultspec/` without `providers.json`.
 
 ## Findings
 
-Adapt format based on content.
+### Root cause
+
+`collect_framework_presence` in `src/vaultspec_core/core/diagnosis/collectors.py`
+returns `FrameworkSignal.CORRUPTED` whenever `.vaultspec/` exists but
+`.vaultspec/providers.json` does not. `providers.json` is an install
+artifact written by `install_run` on consumer projects. The source
+repository ships `.vaultspec/` as its canonical content and never
+generates `providers.json`, so the corruption signal fires
+unconditionally.
+
+Reproduction on a fresh worktree: `uv run --no-sync vaultspec-core spec doctor` -> `framework: error / .vaultspec/ corrupted manifest`. The
+exit status is non-zero, so the `spec-check` hook entry
+`uv run --no-sync vaultspec-core spec doctor` blocks every commit.
+
+### Callsites of `collect_framework_presence`
+
+- `src/vaultspec_core/core/diagnosis/collectors.py:63` - definition.
+- `src/vaultspec_core/core/diagnosis/diagnosis.py:103` - the orchestrator
+  invokes it once per `diagnose()` call. The orchestrator branches on
+  `FrameworkSignal.CORRUPTED` at line 143 to skip content-integrity
+  collection, but otherwise passes the signal through to the caller.
+- `src/vaultspec_core/cli/spec_cmd.py:1236, 1242, 1438` - status
+  rendering and error gating in `spec doctor`.
+- `src/vaultspec_core/core/resolver.py:208` - resolver branches when
+  the framework is corrupted.
+
+### Existing dev-repo guard
+
+`src/vaultspec_core/core/guards.py:37` already defines
+`is_dev_repo(root)` with multi-signal detection. The function requires
+both:
+
+- `pyproject.toml` parses with `[project].name == "vaultspec-core"`.
+- `src/vaultspec_core/__init__.py` exists at the canonical layout.
+
+A consumer that ships a stale `pyproject.toml` declaring
+`name = "vaultspec-core"` cannot trigger the guard without also
+materialising the package source layout, which would be a deliberate
+fork. The guard ships a memoized wrapper `_cached_is_dev_repo(root_str)`
+already used by `guard_dev_repo` and `collect_gitignore_state`.
+
+### Test fixtures that build `.vaultspec/` without `providers.json`
+
+Direct construction in `src/vaultspec_core/tests/cli/test_collectors.py`:
+
+- `TestFrameworkPresence.test_corrupted_no_manifest` - creates an
+  empty `.vaultspec/` and asserts `CORRUPTED`. Genuinely a
+  consumer-shaped corrupted install (no `pyproject.toml`).
+- `TestFrameworkPresence.test_corrupted_invalid_json` - creates
+  `.vaultspec/providers.json` with invalid JSON. Unaffected by the
+  fix (manifest path exists, decode fails downstream).
+- `TestFrameworkPresence.test_corrupted_no_installed_key` - creates
+  `.vaultspec/providers.json` with valid JSON but no `installed`
+  key. Unaffected by the fix.
+- `TestBuiltinVersionState.test_no_snapshots` - creates `.vaultspec/`
+  without `providers.json` but does not invoke
+  `collect_framework_presence`.
+
+The `WorkspaceFactory` always installs through the real `install_run`,
+which writes `providers.json`, so factory-built workspaces never hit
+the bug naturally.
+
+### Constraints on the fix
+
+- Must not regress consumer corruption detection: a non-source-repo
+  workspace with `.vaultspec/` and no `providers.json` must still
+  report `CORRUPTED`.
+- Must not introduce a new `FrameworkSignal` member; the issue body
+  explicitly states the dev repo IS present, so reusing
+  `FrameworkSignal.PRESENT` matches the semantics and avoids a
+  cascade through every consumer of the enum (status renderer,
+  resolver, exit-code mapping).
+- Must memoize the dev-repo check to keep `spec doctor` cheap on
+  workspaces that hit the framework path twice (orchestrator +
+  status rendering).
+
+### Conclusion
+
+Reuse `_cached_is_dev_repo` from `guards.py` inside
+`collect_framework_presence` after the manifest-existence check fails.
+Returns `FrameworkSignal.PRESENT` when the workspace passes the
+multi-signal dev-repo test, otherwise falls through to the existing
+`FrameworkSignal.CORRUPTED` path. Add two tests: one inline
+dev-repo workspace asserting `PRESENT`, one consumer-shaped
+workspace re-asserting `CORRUPTED` (the existing
+`test_corrupted_no_manifest` already covers this; we add an
+explicit pyproject-bearing-but-not-vaultspec case to lock the
+boundary).

--- a/.vault/research/2026-04-30-doctor-dev-repo-research.md
+++ b/.vault/research/2026-04-30-doctor-dev-repo-research.md
@@ -1,0 +1,33 @@
+---
+# REQUIRED TAGS (minimum 2): one directory tag + one feature tag
+# DIRECTORY TAGS: #adr #audit #exec #plan #reference #research
+# Directory tag (hardcoded - DO NOT CHANGE - based on .vault/research/ location)
+# Feature tag (replace doctor-dev-repo with your feature name, e.g., #editor-demo)
+# Additional tags may be appended below the required pair
+tags:
+  - '#research'
+  - '#doctor-dev-repo'
+# ISO date format (e.g., 2026-02-06)
+date: '2026-04-30'
+# Related documents as quoted wiki-links
+# (e.g., "[[2026-02-04-feature-plan]]")
+related: []
+---
+
+<!-- DO NOT add 'Related:', 'tags:', 'date:', or other frontmatter fields
+     outside the YAML frontmatter above -->
+
+<!-- LINK RULES:
+     - [[wiki-links]] are ONLY for .vault/ documents in the related: field above.
+     - NEVER use [[wiki-links]] or markdown links in the document body.
+     - NEVER reference file paths in the body. If you must name a source file,
+       class, or function, use inline backtick code: `src/module.py`. -->
+
+# `doctor-dev-repo` research: `spec doctor false positive on source repo`
+
+Brief description of what was researched, why, and how it relates to
+`doctor-dev-repo`.
+
+## Findings
+
+Adapt format based on content.

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -63,6 +63,14 @@ def _validate_tool_dir() -> None:
 def collect_framework_presence(target: Path) -> FrameworkSignal:
     """Check whether the vaultspec framework directory is present and valid.
 
+    On the vaultspec-core source repository ``.vaultspec/providers.json``
+    is intentionally absent because the manifest is an install artifact
+    written by :func:`~vaultspec_core.core.commands.install_run` on
+    consumer projects.  Consult
+    :func:`~vaultspec_core.core.guards._cached_is_dev_repo` before
+    declaring corruption so ``spec doctor`` does not false-positive on
+    the source repo or any of its worktrees.  See GitHub issue #93.
+
     Args:
         target: Workspace root directory.
 
@@ -76,6 +84,10 @@ def collect_framework_presence(target: Path) -> FrameworkSignal:
 
     manifest_path = fw_dir / "providers.json"
     if not manifest_path.exists():
+        from ..guards import _cached_is_dev_repo
+
+        if _cached_is_dev_repo(str(target.resolve())):
+            return FrameworkSignal.PRESENT
         return FrameworkSignal.CORRUPTED
 
     try:

--- a/src/vaultspec_core/tests/cli/test_collectors.py
+++ b/src/vaultspec_core/tests/cli/test_collectors.py
@@ -76,6 +76,57 @@ class TestFrameworkPresence:
         _write_manifest(tmp_path, ["claude"])
         assert collect_framework_presence(tmp_path) == FrameworkSignal.PRESENT
 
+    def test_dev_repo_present_without_manifest(self, tmp_path: Path) -> None:
+        """Source-repo workspace reports PRESENT without ``providers.json``.
+
+        Reproduces the GitHub issue #93 layout: ``pyproject.toml`` declares
+        ``name = "vaultspec-core"``, the canonical package source layout
+        exists at ``src/vaultspec_core/__init__.py``, and ``.vaultspec/``
+        is the canonical content (no install-artifact ``providers.json``).
+        """
+        from vaultspec_core.core.guards import _cached_is_dev_repo
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "vaultspec-core"\nversion = "0.0.0"\n',
+            encoding="utf-8",
+        )
+        pkg = tmp_path / "src" / "vaultspec_core"
+        pkg.mkdir(parents=True)
+        (pkg / "__init__.py").write_text("", encoding="utf-8")
+        (tmp_path / ".vaultspec").mkdir()
+
+        _cached_is_dev_repo.cache_clear()
+        try:
+            assert collect_framework_presence(tmp_path) == FrameworkSignal.PRESENT
+        finally:
+            _cached_is_dev_repo.cache_clear()
+
+    def test_consumer_pyproject_match_alone_still_corrupted(
+        self, tmp_path: Path
+    ) -> None:
+        """A pyproject name match without the package layout is CORRUPTED.
+
+        Locks the multi-signal contract: a consumer that ships a stale or
+        hand-crafted ``pyproject.toml`` declaring ``name = "vaultspec-core"``
+        must not trigger the dev-repo branch unless the canonical
+        ``src/vaultspec_core/__init__.py`` layout is also present.  Without
+        the layout the workspace is a genuinely broken consumer install
+        and must continue to report CORRUPTED.
+        """
+        from vaultspec_core.core.guards import _cached_is_dev_repo
+
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "vaultspec-core"\nversion = "0.0.0"\n',
+            encoding="utf-8",
+        )
+        (tmp_path / ".vaultspec").mkdir()
+
+        _cached_is_dev_repo.cache_clear()
+        try:
+            assert collect_framework_presence(tmp_path) == FrameworkSignal.CORRUPTED
+        finally:
+            _cached_is_dev_repo.cache_clear()
+
 
 # ---------------------------------------------------------------------------
 # collect_manifest_coherence


### PR DESCRIPTION
## Summary

Closes #93. `collect_framework_presence` returns `FrameworkSignal.CORRUPTED` for the source repo because `.vaultspec/providers.json` is an install artifact that does not exist here. That makes `spec doctor` and the `spec-check` pre-commit/pre-push hook false-positive on every commit on this repo, forcing contributors to use `--no-verify` to land any change.

The fix consults the existing `is_dev_repo()` guard (multi-signal detection: `pyproject.toml` name match plus `src/vaultspec_core/__init__.py` layout) before declaring corruption. When the workspace is the vaultspec-core source repository, the framework directory IS the canonical source and is reported as `PRESENT`. Real broken consumer installs still report `CORRUPTED`.

## Pipeline

- Research: `.vault/research/2026-04-30-doctor-dev-repo-research.md`
- ADR: `.vault/adr/2026-04-30-doctor-dev-repo-adr.md`
- Plan: `.vault/plan/2026-04-30-doctor-dev-repo-plan.md`
- Execute / self-review: `.vault/exec/2026-04-30-doctor-dev-repo/`

## Status

- [x] Bootstrap commit pushed (uses --no-verify, documented in commit message).
- [x] Research / ADR / Plan vault docs filled in.
- [x] Production fix in `collect_framework_presence` applied.
- [x] Tests added in `test_collectors.py` (dev-repo PRESENT, consumer-name-only CORRUPTED).
- [x] Quality gates green: `pytest TestFrameworkPresence` (7 pass), full suite (1377 pass; 8 pre-existing failures unrelated to #93), `ty`, `ruff check`, `ruff format --check`, `vault check all`, `spec doctor` exits clean (`framework: ok / .vaultspec/ present`).
- [x] Self-review exec record committed.
- [x] Fix commit and push went through `spec-check` pre-commit and pre-push naturally without `--no-verify`. Headline acceptance test for issue #93 is satisfied.
- [x] gemini review converged: review id 4210404295 explicitly states "I have no feedback to provide" against the current head; earlier review 4210378762 against the bootstrap commit was superseded by 9f74e33 and replies posted on each inline comment.
- [x] Draft -> ready, CI green (5/5: Workflow Lint, Lint Type Config Link Markdown Checks, Tests, Dependency Audit, Vault Audit).

## Test plan

- [x] `uv run --no-sync pytest src/vaultspec_core/tests/cli/test_collectors.py -v`
- [x] `uv run --no-sync pytest`
- [x] `uv run --no-sync ty check src/vaultspec_core`
- [x] `uv run --no-sync ruff check && uv run --no-sync ruff format --check`
- [x] `uv run --no-sync vaultspec-core vault check all`
- [x] `uv run --no-sync vaultspec-core spec doctor` exits clean on this repo
- [x] `uv run --no-sync prek run --all-files` (issue-#93-relevant hooks pass; remaining failures are pre-existing CHANGELOG.md baseline)