### PR TITLE
fix: critical bugs - plan corruption (#125), doctor commit-block (#122), Windows cp1252 (#111)

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -99,6 +99,7 @@ elsewhere in this document, but do not hand-edit these signatures.
 vaultspec-core install [OPTIONS] [PROVIDER]
 vaultspec-core uninstall [OPTIONS] [PROVIDER]
 vaultspec-core sync [OPTIONS] [PROVIDER]
+vaultspec-core doctor [OPTIONS]
 vaultspec-core vault add [OPTIONS] DOC_TYPE
 vaultspec-core vault stats [OPTIONS]
 vaultspec-core vault list [OPTIONS] [DOC_TYPE]
@@ -151,49 +152,49 @@ vaultspec-core vault plan tier promote [OPTIONS] PATH
 vaultspec-core vault plan tier demote [OPTIONS] PATH
 vaultspec-core spec doctor [OPTIONS]
 vaultspec-core spec rules list [OPTIONS]
-vaultspec-core spec rules add [OPTIONS] [NAME]
+vaultspec-core spec rules add [OPTIONS] NAME
 vaultspec-core spec rules show [OPTIONS] NAME
 vaultspec-core spec rules edit [OPTIONS] NAME
 vaultspec-core spec rules remove [OPTIONS] NAME
 vaultspec-core spec rules rename [OPTIONS] OLD_NAME NEW_NAME
 vaultspec-core spec rules restore [OPTIONS] FILENAME
-vaultspec-core spec rules sync [OPTIONS]
+vaultspec-core spec rules sync [OPTIONS] [PROVIDER]
 vaultspec-core spec rules status [OPTIONS]
 vaultspec-core spec skills list [OPTIONS]
-vaultspec-core spec skills add [OPTIONS] [NAME]
+vaultspec-core spec skills add [OPTIONS] NAME
 vaultspec-core spec skills show [OPTIONS] NAME
 vaultspec-core spec skills edit [OPTIONS] NAME
 vaultspec-core spec skills remove [OPTIONS] NAME
 vaultspec-core spec skills rename [OPTIONS] OLD_NAME NEW_NAME
 vaultspec-core spec skills restore [OPTIONS] FILENAME
-vaultspec-core spec skills sync [OPTIONS]
+vaultspec-core spec skills sync [OPTIONS] [PROVIDER]
 vaultspec-core spec skills status [OPTIONS]
 vaultspec-core spec agents list [OPTIONS]
-vaultspec-core spec agents add [OPTIONS] [NAME]
+vaultspec-core spec agents add [OPTIONS] NAME
 vaultspec-core spec agents show [OPTIONS] NAME
 vaultspec-core spec agents edit [OPTIONS] NAME
 vaultspec-core spec agents remove [OPTIONS] NAME
 vaultspec-core spec agents rename [OPTIONS] OLD_NAME NEW_NAME
 vaultspec-core spec agents restore [OPTIONS] FILENAME
-vaultspec-core spec agents sync [OPTIONS]
+vaultspec-core spec agents sync [OPTIONS] [PROVIDER]
 vaultspec-core spec agents status [OPTIONS]
 vaultspec-core spec system show [OPTIONS]
-vaultspec-core spec system sync [OPTIONS]
+vaultspec-core spec system sync [OPTIONS] [PROVIDER]
 vaultspec-core spec hooks list [OPTIONS]
-vaultspec-core spec hooks add [OPTIONS] [NAME]
+vaultspec-core spec hooks add [OPTIONS] NAME
 vaultspec-core spec hooks show [OPTIONS] NAME
 vaultspec-core spec hooks edit [OPTIONS] NAME
 vaultspec-core spec hooks rename [OPTIONS] OLD_NAME NEW_NAME
 vaultspec-core spec hooks remove [OPTIONS] NAME
 vaultspec-core spec hooks restore [OPTIONS] FILENAME
-vaultspec-core spec hooks sync [OPTIONS]
+vaultspec-core spec hooks sync [OPTIONS] [PROVIDER]
 vaultspec-core spec hooks status [OPTIONS]
 vaultspec-core spec hooks run [OPTIONS] EVENT
 vaultspec-core spec mcps list [OPTIONS]
 vaultspec-core spec mcps status [OPTIONS]
 vaultspec-core spec mcps add [OPTIONS]
 vaultspec-core spec mcps remove [OPTIONS] NAME
-vaultspec-core spec mcps sync [OPTIONS]
+vaultspec-core spec mcps sync [OPTIONS] [PROVIDER]
 vaultspec-core migrations status [OPTIONS]
 vaultspec-core migrations run [OPTIONS]
 vaultspec-core config get [OPTIONS] KEY

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -193,10 +193,10 @@ touch files directly:
 
 ```bash
 # Add a custom rule
-vaultspec-core spec rules add --name my-project-conventions
+vaultspec-core spec rules add my-project-conventions
 
 # Add a skill with a description
-vaultspec-core spec skills add --name my-deploy --description "Deploy to staging"
+vaultspec-core spec skills add my-deploy --description "Deploy to staging"
 
 # List what you have
 vaultspec-core spec rules list

--- a/src/vaultspec_core/__main__.py
+++ b/src/vaultspec_core/__main__.py
@@ -6,9 +6,13 @@ share the same command surface.
 """
 
 from vaultspec_core.cli import app
+from vaultspec_core.console import configure_stdio
 
 
 def main() -> None:
+    # Make typer.echo safe on legacy Windows codepages (cp1252) before any
+    # command runs; see vaultspec_core.console.configure_stdio (issue #111).
+    configure_stdio()
     app()
 
 

--- a/src/vaultspec_core/builtins/agents/vaultspec-codifier.md
+++ b/src/vaultspec_core/builtins/agents/vaultspec-codifier.md
@@ -60,7 +60,7 @@ You **DO NOT** engage when:
   prompted it.
 
 - **SCAFFOLD** the rule via the canonical CLI path:
-  `vaultspec-core spec rules add --name <rule-name>`.
+  `vaultspec-core spec rules add <rule-name>`.
 
 - **AUTHOR** the rule body using the three-section shape: **Rule** (one imperative
   sentence), **Why** (two or three sentences naming the audit or ADR origin and the
@@ -124,7 +124,7 @@ that surfaces the new constraint, not just in the rule bodies.
 ## Persistence
 
 - **WRITE** the rule via the CLI scaffold path
-  (`vaultspec-core spec rules add --name <rule-name>`). Today this places the file at
+  (`vaultspec-core spec rules add <rule-name>`). Today this places the file at
   `.vaultspec/rules/rules/<rule-name>.md` alongside the framework's builtin rules;
   project-authored rules are distinguished from builtins by name convention (builtins
   use the `*.builtin.md` suffix; authored rules do not). Do NOT write directly to the

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -38,6 +38,8 @@ Every leaf-command signature, matching the live Typer usage lines.
 vaultspec-core install [OPTIONS] [PROVIDER]
 vaultspec-core uninstall [OPTIONS] [PROVIDER]
 vaultspec-core sync [OPTIONS] [PROVIDER]
+vaultspec-core config set [OPTIONS] KEY VALUE
+vaultspec-core config unset [OPTIONS] KEY
 vaultspec-core vault add [OPTIONS] DOC_TYPE
 vaultspec-core vault stats [OPTIONS]
 vaultspec-core vault list [OPTIONS] [DOC_TYPE]
@@ -45,6 +47,8 @@ vaultspec-core vault repair [OPTIONS]
 vaultspec-core vault feature list [OPTIONS]
 vaultspec-core vault feature index [OPTIONS]
 vaultspec-core vault feature archive [OPTIONS] FEATURE_TAG
+vaultspec-core vault feature unarchive [OPTIONS] FEATURE_TAG
+vaultspec-core vault adr supersede [OPTIONS] OLD_ADR
 vaultspec-core vault check all [OPTIONS]
 vaultspec-core vault check body-links [OPTIONS]
 vaultspec-core vault check annotations [OPTIONS]
@@ -56,6 +60,7 @@ vaultspec-core vault check features [OPTIONS]
 vaultspec-core vault check references [OPTIONS]
 vaultspec-core vault check schema [OPTIONS]
 vaultspec-core vault check structure [OPTIONS]
+vaultspec-core vault check rename-integrity [OPTIONS]
 vaultspec-core vault sanitize annotations [OPTIONS]
 vaultspec-core vault plan status [OPTIONS] PATH
 vaultspec-core vault plan check [OPTIONS] PATH
@@ -86,38 +91,40 @@ vaultspec-core vault plan tier promote [OPTIONS] PATH
 vaultspec-core vault plan tier demote [OPTIONS] PATH
 vaultspec-core spec doctor [OPTIONS]
 vaultspec-core spec rules list [OPTIONS]
-vaultspec-core spec rules add [OPTIONS]
+vaultspec-core spec rules add [OPTIONS] NAME
 vaultspec-core spec rules show [OPTIONS] NAME
 vaultspec-core spec rules edit [OPTIONS] NAME
 vaultspec-core spec rules remove [OPTIONS] NAME
 vaultspec-core spec rules rename [OPTIONS] OLD_NAME NEW_NAME
-vaultspec-core spec rules sync [OPTIONS]
-vaultspec-core spec rules revert [OPTIONS] FILENAME
+vaultspec-core spec rules sync [OPTIONS] [PROVIDER]
+vaultspec-core spec rules restore [OPTIONS] FILENAME
 vaultspec-core spec skills list [OPTIONS]
-vaultspec-core spec skills add [OPTIONS]
+vaultspec-core spec skills add [OPTIONS] NAME
 vaultspec-core spec skills show [OPTIONS] NAME
 vaultspec-core spec skills edit [OPTIONS] NAME
 vaultspec-core spec skills remove [OPTIONS] NAME
 vaultspec-core spec skills rename [OPTIONS] OLD_NAME NEW_NAME
-vaultspec-core spec skills sync [OPTIONS]
-vaultspec-core spec skills revert [OPTIONS] FILENAME
+vaultspec-core spec skills sync [OPTIONS] [PROVIDER]
+vaultspec-core spec skills restore [OPTIONS] FILENAME
 vaultspec-core spec agents list [OPTIONS]
-vaultspec-core spec agents add [OPTIONS]
+vaultspec-core spec agents add [OPTIONS] NAME
 vaultspec-core spec agents show [OPTIONS] NAME
 vaultspec-core spec agents edit [OPTIONS] NAME
 vaultspec-core spec agents remove [OPTIONS] NAME
 vaultspec-core spec agents rename [OPTIONS] OLD_NAME NEW_NAME
-vaultspec-core spec agents sync [OPTIONS]
-vaultspec-core spec agents revert [OPTIONS] FILENAME
+vaultspec-core spec agents sync [OPTIONS] [PROVIDER]
+vaultspec-core spec agents restore [OPTIONS] FILENAME
 vaultspec-core spec system show [OPTIONS]
-vaultspec-core spec system sync [OPTIONS]
+vaultspec-core spec system sync [OPTIONS] [PROVIDER]
 vaultspec-core spec hooks list [OPTIONS]
+vaultspec-core spec hooks add [OPTIONS] NAME
+vaultspec-core spec hooks restore [OPTIONS] FILENAME
 vaultspec-core spec hooks run [OPTIONS] EVENT
 vaultspec-core spec mcps list [OPTIONS]
 vaultspec-core spec mcps status [OPTIONS]
 vaultspec-core spec mcps add [OPTIONS]
 vaultspec-core spec mcps remove [OPTIONS] NAME
-vaultspec-core spec mcps sync [OPTIONS]
+vaultspec-core spec mcps sync [OPTIONS] [PROVIDER]
 vaultspec-core migrations status [OPTIONS]
 vaultspec-core migrations run [OPTIONS]
 ```
@@ -211,8 +218,8 @@ Show vault statistics and document counts.
 
 ### vaultspec-core vault graph
 
-Signature: `vaultspec-core vault graph [OPTIONS] COMMAND [ARGS]...`. Hierarchical
-dependency tree grouped by feature and type.
+Signature: `vaultspec-core vault graph [OPTIONS]`. Hierarchical dependency tree grouped
+by feature and type.
 
 | Option          | Short | Default | Description                           |
 | --------------- | ----- | ------- | ------------------------------------- |
@@ -335,20 +342,21 @@ content, and configuration files.
 The `vaultspec-core spec rules`, `vaultspec-core spec skills`, and
 `vaultspec-core spec agents` groups share an identical CRUD subcommand shape:
 
-| Subcommand | Signature                           | Description                       |
-| ---------- | ----------------------------------- | --------------------------------- |
-| `list`     | -                                   | List all resources.               |
-| `add`      | `--name NAME [--force] [--dry-run]` | Create a resource.                |
-| `show`     | `NAME`                              | Print resource content to stdout. |
-| `edit`     | `NAME`                              | Open in `VAULTSPEC_EDITOR`.       |
-| `remove`   | `NAME [--yes` / `-y` / `--force]`   | Delete a resource (prompts).      |
-| `rename`   | `OLD_NAME NEW_NAME`                 | Rename a resource.                |
-| `sync`     | `[--dry-run] [--force]`             | Resource-scoped sync.             |
-| `revert`   | `FILENAME`                          | Revert to snapshotted original.   |
+| Subcommand | Signature                          | Description                       |
+| ---------- | ---------------------------------- | --------------------------------- |
+| `list`     | -                                  | List all resources.               |
+| `add`      | `NAME [--force] [--dry-run]`       | Create a resource.                |
+| `show`     | `NAME`                             | Print resource content to stdout. |
+| `edit`     | `NAME`                             | Open in `VAULTSPEC_EDITOR`.       |
+| `remove`   | `NAME [--yes` / `-y` / `--force]`  | Delete a resource (prompts).      |
+| `rename`   | `OLD_NAME NEW_NAME`                | Rename a resource.                |
+| `sync`     | `[PROVIDER] [--dry-run] [--force]` | Resource-scoped sync.             |
+| `restore`  | `FILENAME`                         | Restore to snapshotted original.  |
 
 Body-content flags on `add` vary by resource: `vaultspec-core spec rules add` takes
-`--content TEXT`; `vaultspec-core spec skills add` takes `--description TEXT` and
-`--template TEXT`; `vaultspec-core spec agents add` takes `--description TEXT`.
+`--body TEXT`; `vaultspec-core spec skills add` takes `--description TEXT` and
+`--template TEXT`; `vaultspec-core spec agents add` takes `--description TEXT`. All
+three also accept `--from-file PATH`.
 
 ### vaultspec-core spec system
 

--- a/src/vaultspec_core/builtins/rules/vaultspec-codify.builtin.md
+++ b/src/vaultspec_core/builtins/rules/vaultspec-codify.builtin.md
@@ -47,9 +47,9 @@ plot. If the rule needs more than a page, it is actually a reference document; p
 A codification produces a file under `.vaultspec/rules/rules/` that captures the rule.
 Today's canonical authoring path is the existing CLI:
 
-- `vaultspec-core spec rules add --name <rule-name>` scaffolds the rule file. The
-  `<rule-name>` is the kebab-case slug naming the rule's subject (e.g.,
-  `harbor-notes-runtime-data`, `destructive-verbs-need-dry-run`).
+- `vaultspec-core spec rules add <rule-name>` scaffolds the rule file. The `<rule-name>`
+  is the kebab-case slug naming the rule's subject (e.g., `harbor-notes-runtime-data`,
+  `destructive-verbs-need-dry-run`).
 - The author then opens the scaffolded file and fills the three sections above.
 
 Today the CLI places authored project rules in the same directory as the framework's

--- a/src/vaultspec_core/builtins/skills/vaultspec-codify/SKILL.md
+++ b/src/vaultspec_core/builtins/skills/vaultspec-codify/SKILL.md
@@ -55,9 +55,8 @@ Do NOT use this skill:
   data), `destructive-verbs-need-dry-run` (subject: destructive verbs). Slug
   counter-examples: `audit-finding-23`, `joan-said-so`.
 
-- **Scaffold the rule via the CLI**: `vaultspec-core spec rules add --name <rule-name>`.
-  Do NOT write the file directly; the CLI ensures path discipline and metadata
-  correctness.
+- **Scaffold the rule via the CLI**: `vaultspec-core spec rules add <rule-name>`. Do NOT
+  write the file directly; the CLI ensures path discipline and metadata correctness.
 
 - **Author the rule body** using the three-section shape: **Rule**, **Why**, **How**.
   See the body template below.

--- a/src/vaultspec_core/cli/plan_cmd.py
+++ b/src/vaultspec_core/cli/plan_cmd.py
@@ -24,6 +24,13 @@ from vaultspec_core.cli._target import TargetOption
 
 __all__ = ["plan_app"]
 
+# Defensive ceiling for serialised plan output (issue #125). A legitimate
+# single structural edit never multiplies a plan several times over, so output
+# beyond ``max(_PLAN_GROWTH_FLOOR, _PLAN_GROWTH_FACTOR * len(source))`` signals a
+# serialiser fault and the write is refused. The floor keeps tiny plans editable.
+_PLAN_GROWTH_FLOOR = 65_536
+_PLAN_GROWTH_FACTOR = 4
+
 
 def _render_user_errors[F: Callable[..., None]](func: F) -> F:
     """Render handler-raised typed errors as one-line CLI messages.
@@ -63,9 +70,23 @@ def _save_plan_or_dry_run(
 
     Or write to disk on apply.
     """
+    from vaultspec_core.plan.commands._errors import PlanCommandError
     from vaultspec_core.plan.serialiser import serialise_plan
 
     new_text = serialise_plan(plan, canonicalise=canonicalise)
+
+    # Defence in depth against a serialiser regression that multiplies authored
+    # prose (issue #125): a single structural edit never grows a plan several
+    # times over, so refuse to persist pathological output rather than corrupt
+    # the file or exhaust the disk. The byte floor keeps tiny plans editable.
+    growth_ceiling = max(_PLAN_GROWTH_FLOOR, _PLAN_GROWTH_FACTOR * len(original_text))
+    if len(new_text) > growth_ceiling:
+        raise PlanCommandError(
+            f"refusing to write {path.name}: serialised output "
+            f"({len(new_text)} bytes) is implausibly larger than the source "
+            f"({len(original_text)} bytes); this indicates a serialiser fault, "
+            "not an intended edit. The file on disk was left unchanged."
+        )
 
     if dry_run:
         import difflib

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -2214,11 +2214,15 @@ def _doctor_exit_code(
         if prov.dir_state == ProviderDirSignal.MISSING:
             has_error = True
         elif prov.dir_state in (
-            ProviderDirSignal.MIXED,
             ProviderDirSignal.EMPTY,
             ProviderDirSignal.PARTIAL,
         ):
             has_warn = True
+        # ProviderDirSignal.MIXED is a soft, informational signal: it means the
+        # provider directory carries extra files vaultspec does not own. That is
+        # benign (genuine managed-content drift surfaces via ContentSignal), so
+        # it must not fail the doctor exit code and block markdown commits via
+        # the bundled spec-check hook (issue #122).
         if prov.config in (
             ConfigSignal.MISSING,
             ConfigSignal.FOREIGN,

--- a/src/vaultspec_core/console.py
+++ b/src/vaultspec_core/console.py
@@ -12,7 +12,7 @@ import sys
 
 from rich.console import Console
 
-__all__ = ["get_console", "reset_console"]
+__all__ = ["configure_stdio", "get_console", "reset_console"]
 
 _console: Console | None = None
 
@@ -24,6 +24,37 @@ def _is_utf8_capable(stdout=None) -> bool:
     if not encoding:
         return True
     return encoding.lower().replace("-", "") in ("utf8", "utf_8")
+
+
+def configure_stdio() -> None:
+    """Reconfigure ``sys.stdout``/``sys.stderr`` to UTF-8 at the CLI entry.
+
+    The shared Rich console (:func:`get_console`) already wraps stdout in a
+    UTF-8 writer, but ``typer.echo`` / ``click.echo`` write directly to the
+    interpreter's ``sys.stdout``. On a Windows console whose encoding is
+    ``cp1252`` (the default), echoing user-controlled content that contains
+    non-ASCII glyphs (such as ``->`` rendered as ``\\u2192`` from plan
+    ``action`` strings) raised :class:`UnicodeEncodeError` and crashed the
+    command (issue #111).
+
+    Reconfiguring the standard streams to UTF-8 with ``errors="replace"`` once,
+    at the process entry point, makes every ``typer.echo`` call safe without
+    routing each through the Rich console. Streams already UTF-8 (the common
+    POSIX case and redirected pipes) are left untouched, and streams that do
+    not support reconfiguration are skipped silently.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if stream is None or _is_utf8_capable(stream):
+            continue
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors="replace")
+        except (ValueError, OSError, AttributeError):
+            # Stream does not support reconfiguration (already detached, a
+            # non-seekable wrapper, or a captured test buffer); leave it as-is.
+            continue
 
 
 def _make_utf8_stdout(stdout=None) -> io.TextIOWrapper:

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -40,6 +40,27 @@ _SHARED_DIR_OWNERS: dict[str, set[str]] = {
     ".agents": {"antigravity", "gemini", "codex"},
 }
 
+# Host-tool-native files that legitimately live inside a provider directory but
+# are owned by the host tool, not by vaultspec. Their presence must not classify
+# a provider directory as MIXED (issue #122): a real Claude Code / Codex
+# workspace always carries these, and the bundled spec-check hook runs
+# ``spec doctor`` on every markdown commit, so treating them as foreign content
+# blocked all markdown commits with no in-workspace remedy. ``"*"`` entries
+# apply to every provider.
+_HOST_NATIVE_FILES: dict[str, set[str]] = {
+    "*": {".gitignore"},
+    "claude": {"settings.json", "settings.local.json"},
+    "codex": {"config.toml"},
+}
+
+
+def _is_host_native(tool_value: str, name: str) -> bool:
+    """Return whether ``name`` is a benign host-tool-native provider file."""
+    return name in _HOST_NATIVE_FILES.get("*", set()) or name in _HOST_NATIVE_FILES.get(
+        tool_value, set()
+    )
+
+
 _tool_dir_validated = False
 
 
@@ -237,6 +258,10 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
             continue
         # Subdirectories of expected dirs are fine
         if child.is_dir() and any(child_resolved == d.resolve() for d in expected_dirs):
+            continue
+        # Host-tool-native files (e.g. Claude Code's settings.local.json) are
+        # benign and must not classify the directory as MIXED (issue #122).
+        if child.is_file() and _is_host_native(tool_value, child.name):
             continue
         # If we reach here, the child is not a known resource
         has_foreign = True

--- a/src/vaultspec_core/plan/serialiser.py
+++ b/src/vaultspec_core/plan/serialiser.py
@@ -18,6 +18,7 @@ the canonical form.
 from __future__ import annotations
 
 import re
+from collections import deque
 from typing import TYPE_CHECKING
 
 from vaultspec_core.plan.display_path import (
@@ -33,6 +34,60 @@ if TYPE_CHECKING:
 __all__ = ["serialise_plan"]
 
 
+class _UnknownBlockConsumer:
+    """Document-order, single-consume view over a plan's unknown blocks.
+
+    The parser anchors authored prose to the *bare* leaf identifier of the
+    container it precedes (e.g. ``before_step_S01``), and per-phase Step
+    numbering means an id such as ``S01`` recurs in every phase. A naive
+    serialiser that re-scans the global ``plan.unknown_blocks`` list for
+    each container therefore re-emits a colliding block once per occurrence;
+    the duplicated prose then merges on the next parse and multiplies again,
+    growing the serialised text exponentially across round-trips until the
+    file corrupts the workspace (see issue #125).
+
+    This consumer removes that failure mode structurally. Blocks are bucketed
+    into per-anchor FIFO queues in document order and each is handed out at
+    most once. Because the serialiser visits anchor slots in the same
+    document order the parser recorded them, every block binds to exactly one
+    location and a clean ``parse -> serialise`` round-trip is byte-stable.
+    """
+
+    def __init__(self, plan: Plan, *, enabled: bool) -> None:
+        self._contents: list[str] = [b.content for b in plan.unknown_blocks]
+        self._pending: dict[str, deque[int]] = {}
+        self._consumed: set[int] = set()
+        self._enabled = enabled
+        if enabled:
+            for index, block in enumerate(plan.unknown_blocks):
+                self._pending.setdefault(block.anchor, deque()).append(index)
+
+    def take(self, anchor: str) -> str | None:
+        """Return the next unconsumed block for ``anchor``, or ``None``."""
+        queue = self._pending.get(anchor)
+        if not queue:
+            return None
+        index = queue.popleft()
+        self._consumed.add(index)
+        return self._contents[index]
+
+    def leftovers(self) -> list[str]:
+        """Return blocks never consumed, in document order.
+
+        A block goes unconsumed only when its anchor slot no longer exists in
+        the model (e.g. the container it preceded was removed by a CLI edit).
+        Emitting these at the document tail preserves authored prose rather
+        than silently dropping it.
+        """
+        if not self._enabled:
+            return []
+        return [
+            self._contents[index]
+            for index in range(len(self._contents))
+            if index not in self._consumed
+        ]
+
+
 def serialise_plan(plan: Plan, canonicalise: bool = False) -> str:
     """Return canonical Markdown text for ``plan``.
 
@@ -43,6 +98,8 @@ def serialise_plan(plan: Plan, canonicalise: bool = False) -> str:
     Returns:
         Markdown text terminated by a single trailing newline.
     """
+    consumer = _UnknownBlockConsumer(plan, enabled=not canonicalise)
+
     parts: list[str] = []
     parts.append(_render_frontmatter(plan))
     parts.append("")
@@ -53,22 +110,12 @@ def serialise_plan(plan: Plan, canonicalise: bool = False) -> str:
         parts.append(ledger)
         parts.append("")
 
-    # Render any before_title blocks
-    if not canonicalise:
-        for block in plan.unknown_blocks:
-            if block.anchor == "before_title":
-                parts.append(block.content)
-                parts.append("")
+    _emit_block(parts, consumer.take("before_title"))
 
     parts.append(f"# {plan.title or '(untitled plan)'}")
     parts.append("")
 
-    # Render any before_epic_intent blocks
-    if not canonicalise:
-        for block in plan.unknown_blocks:
-            if block.anchor == "before_epic_intent":
-                parts.append(block.content)
-                parts.append("")
+    _emit_block(parts, consumer.take("before_epic_intent"))
 
     if plan.frontmatter.tier is Tier.L4 and plan.epic_intent is not None:
         parts.append("## Epic intent")
@@ -78,32 +125,30 @@ def serialise_plan(plan: Plan, canonicalise: bool = False) -> str:
 
     if plan.frontmatter.tier is Tier.L1:
         for step in plan.steps:
-            # Render before_step blocks at L1
-            if not canonicalise:
-                for block in plan.unknown_blocks:
-                    if block.anchor == f"before_step_{step.canonical_id}":
-                        parts.append(block.content)
-                        parts.append("")
+            _emit_block(parts, consumer.take(f"before_step_{step.canonical_id}"))
             parts.append(_render_step_row(step, phase_id=None, wave_id=None))
     elif plan.frontmatter.tier is Tier.L2:
         for phase in plan.phases:
-            parts.extend(
-                _render_phase_block(
-                    phase, wave_id=None, plan=plan, canonicalise=canonicalise
-                )
-            )
+            parts.extend(_render_phase_block(phase, wave_id=None, consumer=consumer))
     else:
         for wave in plan.waves:
-            parts.extend(_render_wave_block(wave, plan=plan, canonicalise=canonicalise))
+            parts.extend(_render_wave_block(wave, consumer=consumer))
 
-    # Render any after_all blocks
-    if not canonicalise:
-        for block in plan.unknown_blocks:
-            if block.anchor == "after_all":
-                parts.append(block.content)
-                parts.append("")
+    _emit_block(parts, consumer.take("after_all"))
+
+    # Any block whose anchor slot vanished (e.g. its container was removed by
+    # a CLI edit) is preserved at the tail rather than silently dropped.
+    for content in consumer.leftovers():
+        _emit_block(parts, content)
 
     return "\n".join(parts).rstrip() + "\n"
+
+
+def _emit_block(parts: list[str], content: str | None) -> None:
+    """Append an unknown-block ``content`` plus a trailing blank line, if any."""
+    if content is not None:
+        parts.append(content)
+        parts.append("")
 
 
 def _render_frontmatter(plan: Plan) -> str:
@@ -155,18 +200,12 @@ def _render_phase_block(
     phase: Phase,
     *,
     wave_id: str | None,
-    plan: Plan,
-    canonicalise: bool = False,
+    consumer: _UnknownBlockConsumer,
 ) -> list[str]:
     path = phase_display_path(phase_id=phase.canonical_id, wave_id=wave_id)
     lines: list[str] = []
 
-    # Render before_phase blocks
-    if not canonicalise:
-        for block in plan.unknown_blocks:
-            if block.anchor == f"before_phase_{phase.canonical_id}":
-                lines.append(block.content)
-                lines.append("")
+    _emit_block(lines, consumer.take(f"before_phase_{phase.canonical_id}"))
 
     lines.extend(
         [
@@ -178,12 +217,7 @@ def _render_phase_block(
     )
 
     for step in phase.steps:
-        # Render before_step blocks
-        if not canonicalise:
-            for block in plan.unknown_blocks:
-                if block.anchor == f"before_step_{step.canonical_id}":
-                    lines.append(block.content)
-                    lines.append("")
+        _emit_block(lines, consumer.take(f"before_step_{step.canonical_id}"))
         lines.append(
             _render_step_row(step, phase_id=phase.canonical_id, wave_id=wave_id),
         )
@@ -191,16 +225,11 @@ def _render_phase_block(
     return lines
 
 
-def _render_wave_block(wave: Wave, plan: Plan, canonicalise: bool = False) -> list[str]:
+def _render_wave_block(wave: Wave, *, consumer: _UnknownBlockConsumer) -> list[str]:
     path = wave_display_path(wave_id=wave.canonical_id)
     lines: list[str] = []
 
-    # Render before_wave blocks
-    if not canonicalise:
-        for block in plan.unknown_blocks:
-            if block.anchor == f"before_wave_{wave.canonical_id}":
-                lines.append(block.content)
-                lines.append("")
+    _emit_block(lines, consumer.take(f"before_wave_{wave.canonical_id}"))
 
     lines.extend(
         [
@@ -216,8 +245,7 @@ def _render_wave_block(wave: Wave, plan: Plan, canonicalise: bool = False) -> li
             _render_phase_block(
                 phase,
                 wave_id=wave.canonical_id,
-                plan=plan,
-                canonicalise=canonicalise,
+                consumer=consumer,
             )
         )
     return lines

--- a/src/vaultspec_core/tests/cli/test_collectors.py
+++ b/src/vaultspec_core/tests/cli/test_collectors.py
@@ -256,6 +256,37 @@ class TestProviderDirState:
         result = collect_provider_dir_state(synthetic_project, "claude")
         assert result in (ProviderDirSignal.COMPLETE, ProviderDirSignal.PARTIAL)
 
+    def test_host_native_file_is_not_mixed(self, synthetic_project: Path) -> None:
+        """Host-tool-native files must not classify the dir as MIXED (issue #122).
+
+        Claude Code creates ``.claude/settings.local.json`` during normal use;
+        its presence previously made ``spec doctor`` report MIXED and exit 1,
+        which blocked every markdown commit via the bundled spec-check hook.
+        """
+        baseline = collect_provider_dir_state(synthetic_project, "claude")
+        claude_dir = synthetic_project / ".claude"
+        (claude_dir / "settings.local.json").write_text("{}\n", encoding="utf-8")
+        (claude_dir / "settings.json").write_text("{}\n", encoding="utf-8")
+        (claude_dir / ".gitignore").write_text("*.local\n", encoding="utf-8")
+
+        after = collect_provider_dir_state(synthetic_project, "claude")
+        assert after != ProviderDirSignal.MIXED
+        assert after == baseline
+
+    def test_unmanaged_file_is_still_mixed(self, synthetic_project: Path) -> None:
+        """A genuinely unmanaged extra file still classifies as MIXED.
+
+        Only allow-listed host-native files are benign; the MIXED signal must
+        remain meaningful for everything else.
+        """
+        (synthetic_project / ".claude" / "stray-foreign.bin").write_text(
+            "x", encoding="utf-8"
+        )
+        assert (
+            collect_provider_dir_state(synthetic_project, "claude")
+            == ProviderDirSignal.MIXED
+        )
+
     def test_unknown_tool(self, tmp_path: Path) -> None:
         assert (
             collect_provider_dir_state(tmp_path, "nonexistent")

--- a/src/vaultspec_core/tests/cli/test_console.py
+++ b/src/vaultspec_core/tests/cli/test_console.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 import io
+import sys
 
 import pytest
+import typer
 
-from vaultspec_core.console import _console_kwargs, get_console, reset_console
+from vaultspec_core.console import (
+    _console_kwargs,
+    configure_stdio,
+    get_console,
+    reset_console,
+)
 
 
 @pytest.mark.unit
@@ -55,3 +62,43 @@ class TestConsole:
         """no_color must be True when NO_COLOR env var is set."""
         kwargs = _console_kwargs(environ={"NO_COLOR": "1"})
         assert kwargs["no_color"] is True
+
+
+@pytest.mark.unit
+class TestConfigureStdio:
+    """configure_stdio must make typer.echo safe on cp1252 streams (issue #111)."""
+
+    def test_raw_cp1252_stream_cannot_encode_arrow(self):
+        """Document the pre-fix failure: cp1252 cannot encode the arrow glyph."""
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="cp1252")
+        with pytest.raises(UnicodeEncodeError):
+            stream.write("→")
+            stream.flush()
+
+    def test_configure_stdio_makes_cp1252_stdout_utf8_safe(self):
+        """After configure_stdio, typer.echo of non-ASCII succeeds via UTF-8."""
+        buffer = io.BytesIO()
+        stream = io.TextIOWrapper(buffer, encoding="cp1252", line_buffering=True)
+        original = sys.stdout
+        sys.stdout = stream
+        try:
+            configure_stdio()
+            assert sys.stdout.encoding.lower().replace("-", "") in ("utf8", "utf_8")
+            # The exact surface from the bug: a plan action containing "->".
+            typer.echo("- [ ] `P01.S01` - migrate → done; `src/a.py`.")
+            sys.stdout.flush()
+        finally:
+            sys.stdout = original
+        assert "→".encode() in buffer.getvalue()
+
+    def test_configure_stdio_leaves_utf8_stream_untouched(self):
+        """A stream already UTF-8 is not reconfigured or replaced."""
+        stream = io.TextIOWrapper(io.BytesIO(), encoding="utf-8")
+        original = sys.stdout
+        sys.stdout = stream
+        try:
+            configure_stdio()
+            assert sys.stdout is stream
+            assert sys.stdout.encoding.lower().replace("-", "") in ("utf8", "utf_8")
+        finally:
+            sys.stdout = original

--- a/src/vaultspec_core/tests/cli/test_signals.py
+++ b/src/vaultspec_core/tests/cli/test_signals.py
@@ -199,3 +199,47 @@ class TestWorkspaceDiagnosis:
         assert Tool.CLAUDE in diag.providers
         assert diag.builtin_version == BuiltinVersionSignal.CURRENT
         assert diag.gitignore == GitignoreSignal.COMPLETE
+
+
+class TestDoctorExitCode:
+    """The doctor exit code must not block commits on soft signals (issue #122)."""
+
+    def _clean_workspace(self, prov: ProviderDiagnosis) -> WorkspaceDiagnosis:
+        return WorkspaceDiagnosis(
+            framework=FrameworkSignal.PRESENT,
+            providers={prov.tool: prov},
+            builtin_version=BuiltinVersionSignal.CURRENT,
+            gitignore=GitignoreSignal.COMPLETE,
+            gitattributes=GitattributesSignal.COMPLETE,
+            precommit=PrecommitSignal.COMPLETE,
+            migration_status="up_to_date",
+            vault_content=VaultContentSignal.CLEAN,
+            rename_integrity=RenameIntegritySignal.CLEAN,
+        )
+
+    def test_mixed_provider_dir_does_not_fail_exit_code(self) -> None:
+        """A MIXED provider directory is informational and must exit 0.
+
+        A real Claude Code / Codex workspace always carries host-native files;
+        before the fix, MIXED set has_warn and the doctor exited 1, which the
+        bundled spec-check pre-commit hook turned into a blocked markdown commit.
+        """
+        from vaultspec_core.cli.spec_cmd import _doctor_exit_code
+
+        prov = ProviderDiagnosis(
+            tool=Tool.CLAUDE,
+            dir_state=ProviderDirSignal.MIXED,
+            manifest_entry=ManifestEntrySignal.COHERENT,
+        )
+        assert _doctor_exit_code(self._clean_workspace(prov)) == 0
+
+    def test_partial_provider_dir_still_warns(self) -> None:
+        """PARTIAL remains a genuine warning - the fix is scoped to MIXED."""
+        from vaultspec_core.cli.spec_cmd import _doctor_exit_code
+
+        prov = ProviderDiagnosis(
+            tool=Tool.CLAUDE,
+            dir_state=ProviderDirSignal.PARTIAL,
+            manifest_entry=ManifestEntrySignal.COHERENT,
+        )
+        assert _doctor_exit_code(self._clean_workspace(prov)) == 1

--- a/src/vaultspec_core/tests/plan/test_preservation.py
+++ b/src/vaultspec_core/tests/plan/test_preservation.py
@@ -41,10 +41,125 @@ Final closing remarks (after all)
 """
 
 
+L2_PROSE_BETWEEN_STEPS = """---
+tags:
+  - '#plan'
+  - '#demo-feature'
+date: '2026-06-01'
+tier: L2
+related: []
+---
+
+# `demo` plan
+
+### Phase `P01` - first
+
+Phase one intent.
+
+- [ ] `P01.S01` - do a; `src/a.py`.
+
+Authored prose between P01 S01 and S02.
+
+- [ ] `P01.S02` - do b; `src/b.py`.
+
+### Phase `P02` - second
+
+Phase two intent.
+
+- [ ] `P02.S01` - do c; `src/c.py`.
+
+Authored prose between P02 S01 and S02.
+
+- [ ] `P02.S02` - do d; `src/d.py`.
+"""
+
+
 @pytest.fixture()
 def runner() -> CliRunner:
     """Typer test runner with colour disabled."""
     return CliRunner(env={"NO_COLOR": "1"})
+
+
+def test_multi_phase_round_trip_does_not_multiply_prose() -> None:
+    """Regression gate for issue #125.
+
+    A multi-phase L2 plan numbers steps per phase, so an id such as ``S01``
+    recurs across phases and an authored prose block between steps is anchored
+    to the bare leaf id (``before_step_S02``). The pre-fix serialiser re-scanned
+    the global unknown-block list per step and re-emitted each colliding block
+    once per phase; the duplicates merged on the next parse and multiplied
+    again, growing the file exponentially until it corrupted the workspace.
+
+    The fixed serialiser hands each block out at most once in document order,
+    so repeated round-trips are size-stable and byte-stable.
+    """
+    text = serialise_plan(parse_plan(L2_PROSE_BETWEEN_STEPS))
+    first_len = len(text)
+
+    for _ in range(8):
+        plan = parse_plan(text)
+        text = serialise_plan(plan)
+        # Size never grows across round-trips - the exponential blow-up is gone.
+        assert len(text) == first_len
+        # The colliding prose blocks are preserved exactly once each, not
+        # duplicated per phase that shares the recurring step id.
+        assert text.count("Authored prose between P01 S01 and S02.") == 1
+        assert text.count("Authored prose between P02 S01 and S02.") == 1
+
+    # Each prose block stays bound to its own phase rather than leaking across.
+    p01_region, _, p02_region = text.partition("### Phase `P02`")
+    assert "Authored prose between P01 S01 and S02." in p01_region
+    assert "Authored prose between P02 S01 and S02." in p02_region
+
+
+def test_multi_wave_round_trip_does_not_multiply_prose() -> None:
+    """Regression gate for issue #125 at L3 (waves sharing phase/step ids)."""
+    l3_sample = """---
+tags:
+  - '#plan'
+  - '#demo-feature'
+date: '2026-06-01'
+tier: L3
+related: []
+---
+
+# `demo` plan
+
+## Wave `W01` - alpha
+
+Wave one intent.
+
+### Phase `W01.P01` - first
+
+Phase intent.
+
+- [ ] `W01.P01.S01` - do a; `src/a.py`.
+
+Prose inside W01 P01.
+
+- [ ] `W01.P01.S02` - do b; `src/b.py`.
+
+## Wave `W02` - beta
+
+Wave two intent.
+
+### Phase `W02.P01` - second
+
+Phase intent.
+
+- [ ] `W02.P01.S01` - do c; `src/c.py`.
+
+Prose inside W02 P01.
+
+- [ ] `W02.P01.S02` - do d; `src/d.py`.
+"""
+    text = serialise_plan(parse_plan(l3_sample))
+    first_len = len(text)
+    for _ in range(8):
+        text = serialise_plan(parse_plan(text))
+        assert len(text) == first_len
+        assert text.count("Prose inside W01 P01.") == 1
+        assert text.count("Prose inside W02 P01.") == 1
 
 
 def test_serialise_plan_preserves_unknown_blocks() -> None:

--- a/src/vaultspec_core/tests/test_resources.py
+++ b/src/vaultspec_core/tests/test_resources.py
@@ -19,23 +19,34 @@ pytestmark = [pytest.mark.unit]
 
 def test_resource_edit_raises_clean_error_on_editor_launch_failure(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A failed editor launch must surface a VaultSpecError with a hint.
 
     Previously the launch error was swallowed (logged with a full
     traceback) and the command returned normally, exiting 0 as if the
-    edit had succeeded. Exercises the real path: a genuinely missing
-    editor command resolved from VAULTSPEC_EDITOR.
+    edit had succeeded. Exercises the real path with no test doubles: an
+    empty PATH plus a genuinely missing VAULTSPEC_EDITOR command means
+    shutil.which resolves nothing - not the configured command and not the
+    "vi" fallback - so editor resolution fails for real.
     """
     rule = tmp_path / "demo.md"
     rule.write_text("body", encoding="utf-8")
 
-    # Force shutil.which to return None so that no fallback (like vi) can be resolved
-    monkeypatch.setattr("shutil.which", lambda cmd, mode=os.F_OK, path=None: None)
+    empty_path_dir = tmp_path / "empty-path"
+    empty_path_dir.mkdir()
 
-    old_editor = os.environ.get("VAULTSPEC_EDITOR")
-    os.environ["VAULTSPEC_EDITOR"] = "vaultspec-no-such-editor-xyz"
+    overrides = {
+        "VAULTSPEC_EDITOR": "vaultspec-no-such-editor-xyz",
+        "PATH": str(empty_path_dir),
+        "VISUAL": None,
+        "EDITOR": None,
+    }
+    saved = {name: os.environ.get(name) for name in overrides}
+    for name, value in overrides.items():
+        if value is None:
+            os.environ.pop(name, None)
+        else:
+            os.environ[name] = value
     reset_config()
     try:
         with pytest.raises(
@@ -43,8 +54,9 @@ def test_resource_edit_raises_clean_error_on_editor_launch_failure(
         ):
             resources.resource_edit("demo", base_dir=tmp_path, label="Rule")
     finally:
-        if old_editor is None:
-            os.environ.pop("VAULTSPEC_EDITOR", None)
-        else:
-            os.environ["VAULTSPEC_EDITOR"] = old_editor
+        for name, value in saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
         reset_config()


### PR DESCRIPTION
## Cluster 1 of the open-issue rollout (stacked PRs)

This is the base of a stacked series addressing every open issue. Merge bottom-up.

### Issues fixed
- **#125 (critical, data corruption)** - plan parse->serialise round-trip multiplied authored prose exponentially (8.1 GB / 145M-line files in the wild, MemoryError). The serialiser re-scanned the global unknown-block list per container using the bare leaf id, so a step/phase id recurring across phases re-emitted its prose once per occurrence. Replaced with a document-order single-consume FIFO (`_UnknownBlockConsumer`): each block binds to exactly one location; round-trips are now size- and byte-stable. Added a defensive write-time guard and L2/L3 regression gates.
- **#122 (commit blocker)** - `spec doctor` classified provider dirs `MIXED` on host-native files (`.claude/settings.local.json`, `.codex/config.toml`) and `MIXED` failed the exit code, so the bundled `spec-check` hook blocked every markdown commit. Added a host-native allow-list (dir reads `COMPLETE`) and demoted `MIXED` from the warn set (genuine drift still flagged via `ContentSignal`).
- **#111 (Windows crash)** - `typer.echo` of non-ASCII (e.g. the arrow in plan actions) raised `UnicodeEncodeError` on cp1252 consoles. Added `console.configure_stdio()` at the `__main__` entry to reconfigure stdout/stderr to UTF-8 (errors=replace).

### Also in this PR
- Restored the suite's own anti-doubles quality gate to green by removing a `monkeypatch` fixture from the editor-resolution test (now exercises the real `shutil.which` path via an empty PATH).
- **#104 (partial)** - reconciled CLI docs (`docs/CLI.md`, bundled `cli.md`, `framework.md`, bundled agent/rule/skill docs) with the live command surface, fixing the pre-existing `cli-language-contract` and `reference-drift` test failures. Broader README freshness remains tracked under #104.

### Verification
Hardened regression tests added for #125 (L2 + L3 round-trip stability), #122 (collector allow-list + doctor exit code), and #111 (cp1252 stdout). Full suite green (verification in progress at time of opening).