### PR TITLE
fix: manifest/migration version cluster (#119, #121, #124)

### DIFF
--- a/src/vaultspec_core/cli/migrations_cmd.py
+++ b/src/vaultspec_core/cli/migrations_cmd.py
@@ -84,9 +84,15 @@ def cmd_migrations_status(
     console.print(f"  manifest version: {manifest_version or '(unset)'}")
     console.print(f"  registered: {len(REGISTRY)}")
     for m in REGISTRY:
-        marker = (
-            "[yellow]pending[/yellow]" if m in pending else "[green]applied[/green]"
-        )
+        if status == MigrationStatus.UNKNOWN:
+            # No manifest baseline: applied state is genuinely unknowable, so do
+            # not assert that any entry has been applied (issue #121). Labelling
+            # everything "applied" here previously hid truly-pending migrations.
+            marker = "[dim]unknown[/dim]"
+        elif m in pending:
+            marker = "[yellow]pending[/yellow]"
+        else:
+            marker = "[green]applied[/green]"
         console.print(f"    {marker} {m.target_version}  {m.name}")
     if status == MigrationStatus.PENDING:
         console.print()

--- a/src/vaultspec_core/core/resolver.py
+++ b/src/vaultspec_core/core/resolver.py
@@ -886,7 +886,25 @@ def _resolve_version_warning(
     try:
         running_parts = parse_version_tuple(running_version)
         manifest_parts = parse_version_tuple(manifest_version)
-        if manifest_parts > running_parts:
+
+        # A bundled migration legitimately stamps the manifest to its own
+        # target_version, which can exceed the running package version (e.g.
+        # 0.1.20 shipped a migration tagged 0.1.21). Gating the advisory on the
+        # package version alone then points users at a release that does not
+        # exist on PyPI, an unresolvable warning (issue #119). Raise the
+        # threshold to the highest version this package actually knows about:
+        # the greater of the running version and the highest registered
+        # migration target. Only a manifest beyond that genuinely came from a
+        # newer install and warrants the upgrade advisory.
+        from ..migrations import REGISTRY
+
+        known_ceiling = running_parts
+        for migration in REGISTRY:
+            target_parts = parse_version_tuple(migration.target_version)
+            if target_parts > known_ceiling:
+                known_ceiling = target_parts
+
+        if manifest_parts > known_ceiling:
             plan.warnings.append(
                 f"Manifest was written by vaultspec-core {manifest_version}, "
                 f"but running version is {running_version}. "

--- a/src/vaultspec_core/core/rules.py
+++ b/src/vaultspec_core/core/rules.py
@@ -185,6 +185,13 @@ def rules_sync(dry_run: bool = False, prune: bool = False) -> SyncResult:
         all active tool destinations.
     """
     parse_warnings: list[str] = []
+    if not dry_run:
+        try:
+            rules_src_dir = _t.get_context().rules_src_dir
+        except (LookupError, AttributeError):
+            rules_src_dir = None
+        if rules_src_dir is not None:
+            converge_spec_layer_gitignore(Path(rules_src_dir))
     result = sync_to_all_tools(
         sources=collect_rules(warnings=parse_warnings),
         dir_attr="rules_dir",
@@ -195,6 +202,68 @@ def rules_sync(dry_run: bool = False, prune: bool = False) -> SyncResult:
     )
     result.warnings.extend(parse_warnings)
     return result
+
+
+# Active (non-comment, non-blank) lines of the pre-0.1.20 nested rules
+# .gitignore that un-tracked project-authored rule sources. Convergence only
+# rewrites a file whose active policy is a subset of these, so an operator's
+# hand-authored nested .gitignore is never clobbered (issue #124).
+_STALE_RULES_GITIGNORE_POLICY: frozenset[str] = frozenset({"*.md", "!*.builtin.md"})
+
+
+def converge_spec_layer_gitignore(rules_src_dir: Path) -> bool:
+    """Refresh the nested ``rules/.gitignore`` to the shipped team-shared policy.
+
+    Pre-0.1.20 installs left a ``*.md`` / ``!*.builtin.md`` policy in
+    ``.vaultspec/rules/rules/.gitignore`` that silently un-tracks the
+    project-authored rule sources now relocated under ``project/`` - the exact
+    failure the ``gitignore_reversal`` migration was meant to end. Only
+    ``install --force`` previously refreshed it; this convergence lets ``sync``
+    (and the migration) repair the drift idempotently.
+
+    Conservative, like the migration: a file whose active lines fall outside the
+    known stale policy is treated as operator-customised and left untouched.
+
+    Returns:
+        ``True`` if the file was rewritten, ``False`` otherwise.
+    """
+    from vaultspec_core.builtins import _builtins_root
+
+    template = _builtins_root() / "rules" / ".gitignore"
+    try:
+        want = template.read_bytes()
+    except OSError:
+        return False
+
+    dest = rules_src_dir / ".gitignore"
+    if dest.exists():
+        try:
+            current = dest.read_bytes()
+        except OSError:
+            return False
+        if current == want:
+            return False
+        active = {
+            line.strip()
+            for line in current.decode("utf-8", errors="replace").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        }
+        if not active <= _STALE_RULES_GITIGNORE_POLICY:
+            logger.debug(
+                "Nested rules .gitignore at %s carries custom entries; "
+                "leaving untouched",
+                dest,
+            )
+            return False
+
+    try:
+        rules_src_dir.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(want)
+    except OSError as exc:
+        logger.error("Failed to converge nested rules .gitignore at %s: %s", dest, exc)
+        return False
+    logger.info("Converged nested rules .gitignore at %s to shipped policy", dest)
+    return True
 
 
 def migrate_flat_custom_rules(rules_src_dir: Path) -> None:

--- a/src/vaultspec_core/migrations/m_0_1_20_gitignore_reversal.py
+++ b/src/vaultspec_core/migrations/m_0_1_20_gitignore_reversal.py
@@ -106,8 +106,18 @@ def migrate(workspace: Path) -> MigrationResult:
         ensure_gitignore_block,
         get_recommended_entries,
     )
+    from ..core.rules import converge_spec_layer_gitignore
 
-    counts = {"rewritten": 0, "skipped": 0}
+    counts = {"rewritten": 0, "skipped": 0, "nested_gitignore": 0}
+
+    # The reversal's intent - stop hiding a project's authoritative policy from
+    # teammates - also covers the nested .vaultspec/rules/rules/.gitignore, which
+    # pre-0.1.20 un-tracked project-authored rule sources. Converge it here so an
+    # upgrade repairs the drift, not only install --force (issue #124).
+    rules_src_dir = workspace / ".vaultspec" / "rules" / "rules"
+    if rules_src_dir.exists() and converge_spec_layer_gitignore(rules_src_dir):
+        counts["nested_gitignore"] = 1
+
     gi_path = workspace / ".gitignore"
     if not gi_path.exists():
         return MigrationResult(

--- a/src/vaultspec_core/migrations/tests/test_gitignore_reversal.py
+++ b/src/vaultspec_core/migrations/tests/test_gitignore_reversal.py
@@ -149,7 +149,7 @@ class TestNoopCases:
 
         result = migrate(tmp_path)
 
-        assert result.counts == {"rewritten": 0, "skipped": 0}
+        assert result.counts == {"rewritten": 0, "skipped": 0, "nested_gitignore": 0}
         assert "nothing to migrate" in result.summary
 
     def test_no_managed_block_is_noop(self, tmp_path: Path):
@@ -157,5 +157,5 @@ class TestNoopCases:
 
         result = migrate(tmp_path)
 
-        assert result.counts == {"rewritten": 0, "skipped": 0}
+        assert result.counts == {"rewritten": 0, "skipped": 0, "nested_gitignore": 0}
         assert "nothing to migrate" in result.summary

--- a/src/vaultspec_core/tests/cli/test_manifest_migration_cluster.py
+++ b/src/vaultspec_core/tests/cli/test_manifest_migration_cluster.py
@@ -1,0 +1,202 @@
+"""Regression tests for the manifest / migration version cluster.
+
+Covers three rough edges reported against 0.1.20, exercised against a real
+``WorkspaceFactory`` install with on-disk manifests. No mocks or patches.
+
+- #119: the "manifest newer than package" advisory must not fire when the
+  manifest version equals the highest version the running package knows about,
+  which includes a bundled migration target above the package version (0.1.20
+  shipped a migration tagged 0.1.21).
+- #121: ``migrations status`` must not label entries "applied" when the manifest
+  has no version baseline - the applied state is genuinely unknown.
+- #124: ``sync`` and the ``gitignore_reversal`` migration must converge the
+  nested ``.vaultspec/rules/rules/.gitignore`` to the shipped team-shared policy
+  so custom rule sources stop being silently un-tracked.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.config import reset_config
+from vaultspec_core.core.helpers import package_version, parse_version_tuple
+from vaultspec_core.core.manifest import read_manifest_data, write_manifest_data
+from vaultspec_core.migrations import REGISTRY, reset_workspace_cache
+from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Iterator[None]:
+    reset_config()
+    reset_workspace_cache()
+    yield
+    reset_config()
+    reset_workspace_cache()
+
+
+def _activate_context(root: Path) -> None:
+    from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.types import init_paths
+
+    init_paths(resolve_workspace(target_override=root))
+
+
+def _known_ceiling() -> str:
+    """Highest version the running package knows about (package or migration)."""
+    versions = [package_version(), *(m.target_version for m in REGISTRY)]
+    return max(versions, key=parse_version_tuple)
+
+
+def _bump_patch(version: str) -> str:
+    parts = list(parse_version_tuple(version))
+    parts[-1] += 1
+    return ".".join(str(p) for p in parts)
+
+
+# ---------------------------------------------------------------------------
+# #119 - version advisory must respect bundled migration targets
+# ---------------------------------------------------------------------------
+class TestVersionAdvisoryGating:
+    def _warn_for_manifest_version(self, root: Path, version: str) -> bool:
+        from vaultspec_core.core.diagnosis.diagnosis import WorkspaceDiagnosis
+        from vaultspec_core.core.diagnosis.signals import FrameworkSignal
+        from vaultspec_core.core.resolver import (
+            ResolutionPlan,
+            _resolve_version_warning,
+        )
+
+        data = read_manifest_data(root)
+        data.vaultspec_version = version
+        write_manifest_data(root, data)
+        plan = ResolutionPlan()
+        _resolve_version_warning(
+            plan, WorkspaceDiagnosis(framework=FrameworkSignal.PRESENT)
+        )
+        return any("Consider upgrading" in w for w in plan.warnings)
+
+    def test_manifest_at_known_ceiling_does_not_warn(self, tmp_path: Path) -> None:
+        """A manifest stamped to a bundled migration target must not advise upgrade.
+
+        The 0.1.20 package bundles a migration tagged 0.1.21, so running
+        ``migrations run`` stamps the manifest to 0.1.21 - above the package
+        version. The advisory previously pointed at a release that does not
+        exist on PyPI (issue #119).
+        """
+        WorkspaceFactory(tmp_path).install("core")
+        _activate_context(tmp_path)
+        assert self._warn_for_manifest_version(tmp_path, _known_ceiling()) is False
+
+    def test_manifest_beyond_known_ceiling_still_warns(self, tmp_path: Path) -> None:
+        """A manifest genuinely newer than anything the package knows still warns."""
+        WorkspaceFactory(tmp_path).install("core")
+        _activate_context(tmp_path)
+        beyond = _bump_patch(_known_ceiling())
+        assert self._warn_for_manifest_version(tmp_path, beyond) is True
+
+
+# ---------------------------------------------------------------------------
+# #121 - migrations status must not assert "applied" without a baseline
+# ---------------------------------------------------------------------------
+class TestMigrationStatusUnknownBaseline:
+    def test_unset_manifest_renders_unknown_not_applied(self, tmp_path: Path) -> None:
+        from typer.testing import CliRunner
+
+        from vaultspec_core.cli import app
+
+        WorkspaceFactory(tmp_path).install("core")
+        data = read_manifest_data(tmp_path)
+        data.vaultspec_version = ""
+        write_manifest_data(tmp_path, data)
+
+        result = CliRunner(env={"NO_COLOR": "1"}).invoke(
+            app, ["migrations", "status", "--target", str(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "(unset)" in result.output
+        # Without a baseline the applied state is unknowable; never claim applied.
+        assert "applied" not in result.output
+        assert "unknown" in result.output
+
+
+# ---------------------------------------------------------------------------
+# #124 - the nested rules/.gitignore must converge on sync and migration
+# ---------------------------------------------------------------------------
+_STALE_NESTED_GITIGNORE = (
+    "# Custom rules (plain *.md) are gitignored.\n*.md\n!*.builtin.md\n"
+)
+
+
+def _nested_gitignore(root: Path) -> Path:
+    return root / ".vaultspec" / "rules" / "rules" / ".gitignore"
+
+
+def _shipped_policy() -> str:
+    from vaultspec_core.builtins import _builtins_root
+
+    return (_builtins_root() / "rules" / ".gitignore").read_text(encoding="utf-8")
+
+
+class TestNestedGitignoreConvergence:
+    def test_sync_converges_stale_nested_gitignore(self, tmp_path: Path) -> None:
+        WorkspaceFactory(tmp_path).install("core")
+        nested = _nested_gitignore(tmp_path)
+        nested.parent.mkdir(parents=True, exist_ok=True)
+        nested.write_text(_STALE_NESTED_GITIGNORE, encoding="utf-8")
+
+        WorkspaceFactory(tmp_path).sync("all")
+
+        assert nested.read_text(encoding="utf-8") == _shipped_policy()
+
+    def test_convergence_leaves_operator_customised_file_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        from vaultspec_core.core.rules import converge_spec_layer_gitignore
+
+        rules_src = tmp_path / ".vaultspec" / "rules" / "rules"
+        rules_src.mkdir(parents=True, exist_ok=True)
+        custom = "# our policy\nsecrets/*.md\n"
+        (rules_src / ".gitignore").write_text(custom, encoding="utf-8")
+
+        changed = converge_spec_layer_gitignore(rules_src)
+
+        assert changed is False
+        assert (rules_src / ".gitignore").read_text(encoding="utf-8") == custom
+
+    def test_convergence_is_idempotent(self, tmp_path: Path) -> None:
+        from vaultspec_core.core.rules import converge_spec_layer_gitignore
+
+        rules_src = tmp_path / ".vaultspec" / "rules" / "rules"
+        rules_src.mkdir(parents=True, exist_ok=True)
+        (rules_src / ".gitignore").write_text(_STALE_NESTED_GITIGNORE, encoding="utf-8")
+
+        first = converge_spec_layer_gitignore(rules_src)
+        second = converge_spec_layer_gitignore(rules_src)
+
+        assert first is True
+        assert second is False
+        assert (rules_src / ".gitignore").read_text(
+            encoding="utf-8"
+        ) == _shipped_policy()
+
+    def test_gitignore_reversal_migration_converges_nested(
+        self, tmp_path: Path
+    ) -> None:
+        from vaultspec_core.migrations.m_0_1_20_gitignore_reversal import migrate
+
+        WorkspaceFactory(tmp_path).install("core")
+        nested = _nested_gitignore(tmp_path)
+        nested.parent.mkdir(parents=True, exist_ok=True)
+        nested.write_text(_STALE_NESTED_GITIGNORE, encoding="utf-8")
+
+        result = migrate(tmp_path)
+
+        assert result.counts.get("nested_gitignore") == 1
+        assert nested.read_text(encoding="utf-8") == _shipped_policy()


### PR DESCRIPTION
## Cluster 2 of the open-issue rollout (stacked on #126)

Base is `fix/critical-bugs` (#126); merge that first. Rebase to `main` on merge.

### Issues fixed
- **#119** - `migrations run` applies the bundled `frontmatter_lifecycle` migration tagged 0.1.21 (shipped inside the 0.1.20 package), stamping the manifest to 0.1.21. The "manifest newer than package" advisory gated only on the package version and so recommended upgrading to a release that does not exist on PyPI - permanently unresolvable. Now gated on the highest version the package knows about (package version or highest registered migration target).
- **#121** - `migrations status` labelled every registered entry `applied` when the manifest had no version baseline (status `unknown`), hiding genuinely-pending migrations. Entries now render `unknown` when the baseline is absent.
- **#124** - a scoped `spec rules sync` relocated custom rules to `project/` but left the nested `.vaultspec/rules/rules/.gitignore` on the pre-0.1.20 `*.md`/`!*.builtin.md` policy that silently un-tracks them. Added `converge_spec_layer_gitignore` (conservative - leaves operator-customised files untouched), wired into `rules_sync` and the `gitignore_reversal` migration, so `sync` (not only `install --force`) repairs the drift.

### Verification
New `test_manifest_migration_cluster.py` exercises all three against a real `WorkspaceFactory` install (no mocks); existing gitignore-reversal no-op tests updated for the expanded `counts` schema.