### PR TITLE
fix: CLI correctness - exec filename (#123), mcp adopt (#120)

### DIFF
--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -465,15 +465,28 @@ def mcp_sync(
                         f"MCP server '{name}' differs from definition "
                         f"(use --force to overwrite)"
                     )
+            elif force:
+                # User-added entry that shares a name with a current source.
+                # --force is the explicit adopt path (issue #120): overwrite it
+                # with the source definition and take ownership, so the entry
+                # converges without the user hand-editing the generated
+                # .mcp.json the CLI tells them not to touch.
+                if servers[name] != config:
+                    servers[name] = config
+                    changed = True
+                managed.add(name)
+                result.updated += 1
+                result.items.append((name, "[ADOPT]"))
+                changed = True
             else:
                 # User-added entry that shares a name with a current
                 # source. Preserve it; never take ownership implicitly.
                 result.skipped += 1
                 result.items.append((name, "[SKIP]"))
                 result.warnings.append(
-                    f"MCP server '{name}' is user-managed and shares "
-                    f"its name with a vaultspec source; skipping. "
-                    f"Rename one to resolve."
+                    f"MCP server '{name}' is user-managed and shares its name "
+                    f"with a vaultspec source; skipping. Re-run with --force to "
+                    f"adopt it into vaultspec management, or rename one to resolve."
                 )
 
         if prune:

--- a/src/vaultspec_core/tests/cli/test_step_aware_exec.py
+++ b/src/vaultspec_core/tests/cli/test_step_aware_exec.py
@@ -185,6 +185,47 @@ def test_step_aware_individual_scaffolding(runner, synthetic_project):
     assert "## Notes" in content
 
 
+def test_scaffolded_step_record_passes_structure_check(runner, synthetic_project):
+    """A scaffolded Step Record must satisfy `vault check structure` (issue #123).
+
+    The scaffolder emits the canonical `<date>-<feature>-P01-S01.md` Step Record
+    name; the structure validator previously rejected it for lacking an `-exec`
+    type token, leaving the documented `vault add exec --step` flow permanently
+    red. Scaffold a record, then assert the structure check finds no filename
+    violation for it.
+    """
+    from vaultspec_core.vaultcore.models import DocType, VaultConstants
+
+    setup_test_plan(synthetic_project)
+    add_result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--step",
+            "P01.S01",
+        ],
+    )
+    assert add_result.exit_code == 0, add_result.output
+
+    scaffolded = (
+        synthetic_project
+        / ".vault"
+        / "exec"
+        / "2026-05-17-test-feature"
+        / "2026-05-17-test-feature-P01-S01.md"
+    )
+    assert scaffolded.exists(), add_result.output
+    # The validator that powers `vault check structure` must accept the exact
+    # name the scaffolder produced.
+    assert VaultConstants.validate_filename(scaffolded.name, DocType.EXEC) == []
+
+
 def test_step_aware_bulk_scaffolding(runner, synthetic_project):
     """Bulk scaffolding creates all records idempotently and obeys --force."""
     setup_test_plan(synthetic_project)

--- a/src/vaultspec_core/tests/cli/test_sync.py
+++ b/src/vaultspec_core/tests/cli/test_sync.py
@@ -451,3 +451,51 @@ class TestSyncAuthority:
         after_status = json.loads(after.output)["data"]
         assert after.exit_code == 0, after.output
         assert after_status["status"] == "ok"
+
+    def test_force_adopts_name_colliding_user_mcp_entry(
+        self, runner, synthetic_project
+    ):
+        """--force adopts a name-colliding user .mcp.json entry (issue #120).
+
+        When .mcp.json carries an entry whose name matches a source but which is
+        absent from _vaultspecManaged, a plain sync preserves it and points at
+        --force; --force then overwrites it with the source definition and
+        records it as managed, with no hand-editing of the generated file.
+        """
+        mcp_path = synthetic_project / ".mcp.json"
+        source_path = (
+            synthetic_project
+            / ".vaultspec"
+            / "rules"
+            / "mcps"
+            / "vaultspec-core.builtin.json"
+        )
+        expected_config = json.loads(source_path.read_text(encoding="utf-8"))
+
+        # _vaultspecManaged present but empty: vaultspec-core collides with the
+        # source yet is unmanaged, the exact state the issue reports.
+        payload = {
+            "mcpServers": {
+                "vaultspec-core": {"command": "node", "args": ["user-authored.js"]}
+            },
+            "_vaultspecManaged": [],
+        }
+        mcp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+        plain = runner.invoke(
+            app,
+            ["--target", str(synthetic_project), "spec", "mcps", "sync", "--json"],
+        )
+        assert "--force" in plain.output
+        preserved = json.loads(mcp_path.read_text(encoding="utf-8"))
+        assert preserved["mcpServers"]["vaultspec-core"]["args"] == ["user-authored.js"]
+        assert "vaultspec-core" not in preserved.get("_vaultspecManaged", [])
+
+        forced = runner.invoke(
+            app,
+            ["--target", str(synthetic_project), "spec", "mcps", "sync", "--force"],
+        )
+        assert forced.exit_code == 0, forced.output
+        adopted = json.loads(mcp_path.read_text(encoding="utf-8"))
+        assert adopted["mcpServers"]["vaultspec-core"] == expected_config
+        assert "vaultspec-core" in adopted["_vaultspecManaged"]

--- a/src/vaultspec_core/vaultcore/models.py
+++ b/src/vaultspec_core/vaultcore/models.py
@@ -302,6 +302,24 @@ class VaultConstants:
                 errors.append(msg)
             return errors
 
+        # Execution records use the plan-hardening Step Record / Phase Summary
+        # naming: uppercase canonical container ids (with an optional lowercase
+        # alpha suffix on Wave / Phase) and no '-exec' type token, matching what
+        # 'vault add exec --step' scaffolds and what the framework rules
+        # document (issue #123). The legacy '...-exec' form is still accepted via
+        # the generic pattern below for records authored before the convention.
+        if doc_type == DocType.EXEC:
+            date_feature = r"\d{4}-\d{2}-\d{2}-[a-z0-9-]+"
+            step_record = (
+                rf"^{date_feature}-(W\d{{2,}}[a-z]?-)?(P\d{{2,}}[a-z]?-)?"
+                r"S\d{2,}\.md$"
+            )
+            phase_summary = (
+                rf"^{date_feature}-(W\d{{2,}}[a-z]?-)?P\d{{2,}}[a-z]?-summary\.md$"
+            )
+            if re.match(step_record, filename) or re.match(phase_summary, filename):
+                return errors
+
         # Basic pattern: 2026-02-07-feature-name-adr.md
         # Or for exec: 2026-02-07-feature-name-phase1-step1.md
         pattern = (


### PR DESCRIPTION
## Cluster 4 of the open-issue rollout (stacked on #128)

Base is `fix/plan-editing` (#128); merge that first.

### Issues fixed
- **#123** - `vault add exec --step` scaffolds the canonical Step Record name `<date>-<feature>-P01-S01.md` (uppercase canonical ids, no `-exec` token) per the plan-hardening convention, but `validate_filename` still required a type token and lowercase, so `vault check structure` rejected the scaffolder's own output. Added an EXEC branch accepting the documented Step Record / Phase Summary names (optional `W##` segment, lowercase alpha suffixes); the legacy `...-exec` form still passes via the generic pattern.
- **#120** - a name-colliding user `.mcp.json` entry absent from `_vaultspecManaged` was skipped even under `--force`, forcing a hand-edit of the generated file. `--force` now adopts it (overwrite with the source definition + record as managed, `[ADOPT]`); the non-force message points at `--force`.

### Verification
A scaffolded Step Record now passes the filename validator; `--force` adopts the colliding MCP entry while a plain sync preserves it and guides toward `--force`. Affected structure/types/exec/sync suites green (104 tests).