### PR TITLE
docs: refresh README for the plan command surface (#104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,12 @@ findings in `.vault/research/`, then progress through architectural decisions, p
 execution, and review. Each stage writes records to `.vault/` and references the output
 of earlier stages.
 
-You can also invoke skills explicitly to start a specific stage. The bundled skills
+You can also invoke skills explicitly to start a specific stage. The pipeline skills
 (`vaultspec-research`, `vaultspec-adr`, `vaultspec-write`, `vaultspec-execute`,
 `vaultspec-code-review`) read the relevant vault records and structure the AI's output
-accordingly.
+accordingly. Supporting skills round out the workflow: `vaultspec-code-research` grounds
+work in real reference implementations, `vaultspec-documentation` drafts user-facing
+docs, and `vaultspec-curate` keeps the vault's links and tags healthy.
 
 The [framework manual](./docs/framework.md) walks through each stage in detail with
 examples.
@@ -168,6 +170,31 @@ Valid document types are `adr`, `audit`, `exec`, `plan`, `reference`, and `resea
 Generated feature indexes live in `.vault/index/` and are managed by
 `vaultspec-core vault feature index`. See the
 [CLI reference](./docs/CLI.md#vault-commands) for the full command surface.
+
+______________________________________________________________________
+
+## Planning and execution
+
+Implementation plans carry structure beyond a flat checklist. A plan declares a
+complexity tier (`L1` through `L4`) and organises work into an
+`Epic > Wave > Phase > Step` hierarchy, so a large feature stays navigable as it grows.
+The `vaultspec-core vault plan` command group is the canonical surface for that
+structure:
+
+```bash
+# Inspect a plan's tier, counts, and completion
+vaultspec-core vault plan status .vault/plan/2026-06-01-search-api-plan.md
+
+# Validate convention compliance, then apply autofixes
+vaultspec-core vault plan check .vault/plan/2026-06-01-search-api-plan.md --fix
+```
+
+Steps, phases, and waves are added, moved, and checked off through the
+`vaultspec-core vault plan step`, `vaultspec-core vault plan phase`, and
+`vaultspec-core vault plan wave` subcommands, which preserve canonical identifiers so
+existing references never shift when work is inserted or removed. Completed features are
+archived with `vaultspec-core vault feature archive` and restored with
+`vaultspec-core vault feature unarchive`.
 
 ______________________________________________________________________
 


### PR DESCRIPTION
## Cluster 5 of the open-issue rollout (stacked on #129)

Base is `fix/cli-correctness` (#129); merge that first. Top of the stack.

### Issue addressed
- **#104** - the README predated the plan-hardening work and never mentioned the `vault plan` command group, the L1-L4 complexity tiers, or the `Epic > Wave > Phase > Step` hierarchy. Added a concise "Planning and execution" section (plan status/check + the identifier-preserving step/phase/wave subcommands, plus feature archive/unarchive) and refreshed the skills paragraph. (The bundled `cli.md`, handbook, and framework docs were already reconciled in cluster 1 / #126.)

### Out of scope (tracking)
- **#113** (CLI-simplification umbrella) stays open by design. Its concrete adjacent sharp edges (#108, #109, #111) are addressed elsewhere in this rollout; the umbrella's larger vocabulary/discoverability work is a separate effort.

### Verification
README command references and signatures pass the `cli-language-contract` and `reference-drift` gates; mdformat and pymarkdown clean.