### PR TITLE
fix(sync): backfill provider structural dirs + accurate dry-run preview (#133, #134)

### DIFF
--- a/src/vaultspec_core/cli/root.py
+++ b/src/vaultspec_core/cli/root.py
@@ -781,13 +781,47 @@ def _collect_sync_outcomes(
     if provider == "all" and "mcp" not in skip:
         labels.append("mcps")
     outcomes: list[OutcomeItem] = []
-    for label, r in zip(labels, results, strict=True):
+    # Results beyond the known positional resource passes (e.g. the trailing
+    # structural-backfill pass, issue #133) are grouped per inferred provider so
+    # the surface never crashes on a length mismatch and still reports them.
+    for index, r in enumerate(results):
+        label = labels[index] if index < len(labels) else None
         if r.per_tool:
             for tool_name, tool_result in r.per_tool.items():
                 outcomes.extend(sync_outcomes(tool_result, group=tool_name))
-        else:
+        elif label is not None:
             outcomes.extend(sync_outcomes(r, group=label))
+        else:
+            for item_path, _action in r.items:
+                outcomes.extend(
+                    sync_outcomes(
+                        _single_item_result(r, item_path),
+                        group=_infer_label(item_path),
+                    )
+                )
     return outcomes
+
+
+def _single_item_result(source: SyncResult, item_path: str) -> SyncResult:
+    """Return a one-item SyncResult mirroring ``item_path``'s action.
+
+    Used to re-group structural-backfill items under their inferred provider
+    label without mutating the original aggregate result.
+    """
+    from vaultspec_core.core.types import SyncResult as _SyncResult
+
+    single = _SyncResult()
+    for path, action in source.items:
+        if path != item_path:
+            continue
+        single.items.append((path, action))
+        if action == "[ADD]":
+            single.added += 1
+        elif action == "[UPDATE]":
+            single.updated += 1
+        elif action == "[DELETE]":
+            single.pruned += 1
+    return single
 
 
 def _infer_label(item_path: str) -> str:

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -869,6 +869,30 @@ def install_run(
             items = seed_builtins(
                 path / ".vaultspec" / "rules", force=True, dry_run=True
             )
+
+        # The real upgrade re-seeds builtins AND runs the provider sync, which
+        # backfills new provider files and structural directories. Preview that
+        # provider-side work too so the dry-run enumerates what the real run
+        # changes rather than only the builtin seed (issue #134). Only the
+        # changed entries are surfaced to keep the preview signal-dense; an
+        # unchanged provider tree contributes nothing.
+        if path.joinpath(".vaultspec").exists():
+            sync_target = provider if provider not in ("all", "core") else "all"
+            try:
+                sync_results = sync_provider(sync_target, dry_run=True, skip=skip)
+            except (VaultSpecError, OSError) as exc:
+                logger.debug("Upgrade dry-run provider preview skipped: %s", exc)
+                sync_results = []
+            seen_preview = {rel for rel, _ in items}
+            for sync_result in sync_results:
+                for rel, action in sync_result.items:
+                    if action in ("[UNCHANGED]", "[SKIP]"):
+                        continue
+                    if rel in seen_preview:
+                        continue
+                    seen_preview.add(rel)
+                    items.append((rel, action))
+
         return {
             "action": "upgrade",
             "items": items,
@@ -1565,6 +1589,50 @@ def sync_provider(
     def _empty_sync_results() -> list[_t.SyncResult]:
         return [_t.SyncResult() for _ in range(5)]
 
+    def _backfill_structures() -> _t.SyncResult:
+        """Create missing structural provider directories during sync (#133).
+
+        Content files are backfilled by the per-resource sync passes (their
+        ``apply_file_sync`` adds any missing destination), but a content-less
+        structural directory such as a provider's ``workflows/`` is only ever
+        created by ``install``/``_scaffold_provider``. After an upgrade that
+        introduces such a directory, ``sync`` left the provider ``partial``
+        while reporting success ("will be addressed by sync") - a no-op. This
+        backfill makes that promise real: it creates only directories that are
+        missing, never overwriting existing content, so it is safe at every
+        ``--force`` level and previews correctly under ``--dry-run``.
+        """
+        result = _t.SyncResult()
+        active_ctx = _t.get_context()
+        target = active_ctx.target_dir
+        installed = read_manifest_data(target).installed
+        for tool, cfg in active_ctx.tool_configs.items():
+            # Only backfill providers the operator actually enrolled; never
+            # materialise a provider directory a core-only or partial install
+            # deliberately omitted.
+            if tool.value in skip or tool.value not in installed:
+                continue
+            caps = cfg.capabilities
+            structural: list[Path] = []
+            if ProviderCapability.RULES in caps and cfg.rules_dir:
+                structural.append(cfg.rules_dir)
+            if ProviderCapability.SKILLS in caps and cfg.skills_dir:
+                structural.append(cfg.skills_dir)
+            if ProviderCapability.AGENTS in caps and cfg.agents_dir:
+                structural.append(cfg.agents_dir)
+            if ProviderCapability.WORKFLOWS in caps and cfg.workflows_dir:
+                structural.append(cfg.workflows_dir)
+            for directory in structural:
+                if directory.exists():
+                    continue
+                result.items.append(
+                    (_rel(target, directory).replace("\\", "/"), "[ADD]")
+                )
+                result.added += 1
+                if not dry_run:
+                    ensure_dir(directory)
+        return result
+
     def _run_all_syncs(*, include_mcp: bool = True) -> list[_t.SyncResult]:
         results: list[_t.SyncResult] = []
         sync_passes: list[tuple[Callable[[], _t.SyncResult], str]] = [
@@ -1589,6 +1657,10 @@ def sync_provider(
                 error_result = _t.SyncResult()
                 error_result.errors.append(f"{label} sync failed: {exc}")
                 results.append(error_result)
+        # Structural backfill runs last and is appended after the positional
+        # resource passes; renderers treat any result beyond the known pass
+        # labels as structural (issue #133).
+        results.append(_backfill_structures())
         return results
 
     # Guard: refuse to sync if vaultspec isn't installed at the target

--- a/src/vaultspec_core/tests/cli/test_sync_backfill.py
+++ b/src/vaultspec_core/tests/cli/test_sync_backfill.py
@@ -1,0 +1,101 @@
+"""Regression tests for provider structural backfill and its dry-run preview.
+
+- #133: ``sync`` / ``install --upgrade`` must create a structural provider
+  directory (e.g. antigravity's ``workflows/``) that a newer release adds,
+  rather than reporting success while leaving the provider ``partial``.
+- #134: ``sync --dry-run`` and ``install --upgrade --dry-run`` must enumerate
+  that backfill rather than printing an empty preview, and must not mutate.
+
+All tests drive the real install/sync engine against a ``WorkspaceFactory``
+install; no mocks. antigravity is used because it is the provider that owns a
+content-less ``workflows/`` structural directory.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.config import reset_config
+from vaultspec_core.core.commands import sync_provider
+from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Iterator[None]:
+    reset_config()
+    yield
+    reset_config()
+
+
+def _activate_context(root: Path) -> None:
+    from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.types import init_paths
+
+    init_paths(resolve_workspace(target_override=root))
+
+
+def _all_item_paths(results: list) -> list[str]:
+    return [rel for result in results for rel, _action in result.items]
+
+
+class TestProviderStructuralBackfill:
+    def test_sync_recreates_missing_structural_dir(self, tmp_path: Path) -> None:
+        """sync backfills a missing structural provider directory (#133)."""
+        WorkspaceFactory(tmp_path).install("antigravity")
+        workflows = tmp_path / ".agents" / "workflows"
+        assert workflows.is_dir()
+
+        shutil.rmtree(workflows)
+        assert not workflows.exists()
+
+        _activate_context(tmp_path)
+        results = sync_provider("antigravity")
+
+        assert workflows.is_dir()
+        assert any("workflows" in rel for rel in _all_item_paths(results))
+
+    def test_install_upgrade_recreates_missing_structural_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """install --upgrade backfills the missing structural directory (#133)."""
+        WorkspaceFactory(tmp_path).install("antigravity")
+        workflows = tmp_path / ".agents" / "workflows"
+        shutil.rmtree(workflows)
+        assert not workflows.exists()
+
+        WorkspaceFactory(tmp_path).install("antigravity", upgrade=True)
+
+        assert workflows.is_dir()
+
+    def test_sync_dry_run_previews_backfill_without_creating(
+        self, tmp_path: Path
+    ) -> None:
+        """sync --dry-run enumerates the backfill but writes nothing (#134)."""
+        WorkspaceFactory(tmp_path).install("antigravity")
+        workflows = tmp_path / ".agents" / "workflows"
+        shutil.rmtree(workflows)
+
+        _activate_context(tmp_path)
+        results = sync_provider("antigravity", dry_run=True)
+
+        assert any("workflows" in rel for rel in _all_item_paths(results))
+        assert not workflows.exists()
+
+    def test_backfill_is_noop_when_structure_present(self, tmp_path: Path) -> None:
+        """A complete provider yields no structural backfill items."""
+        WorkspaceFactory(tmp_path).install("antigravity")
+        _activate_context(tmp_path)
+
+        results = sync_provider("antigravity")
+
+        backfilled = [rel for rel in _all_item_paths(results) if "workflows" in rel]
+        assert backfilled == []

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -498,11 +498,17 @@ def test_spec_add_dry_run_no_write() -> None:
 
 @pytest.mark.unit
 def test_sync_all_result_count_matches_resource_labels() -> None:
-    """sync_provider('all') must return one SyncResult per resource label.
+    """sync_provider('all') results render without a label/result mismatch.
 
-    Regression test for #54: the CLI display zips resource_labels with
-    sync results using strict=True, so the counts must match exactly.
+    Regression test for #54 (the CLI display once zipped resource_labels with
+    sync results) extended for #133: sync now appends a trailing structural-
+    backfill result after the positional resource passes, so the renderer must
+    tolerate one result beyond the labels rather than crash. Assert the exact
+    contract (one result per resource label plus the backfill) and that the
+    real outcome-collector consumes the results without raising.
     """
+    from vaultspec_core.cli.root import _collect_sync_outcomes
+
     tmp_path = PROJECT_ROOT / ".pytest-tmp" / f"sync-labels-{uuid4().hex}"
     try:
         tmp_path.mkdir(parents=True, exist_ok=True)
@@ -514,14 +520,17 @@ def test_sync_all_result_count_matches_resource_labels() -> None:
 
         results = sync_provider("all")
 
-        # The CLI display code builds this exact label list and zips it
-        # with results using strict=True - a mismatch causes ValueError
         resource_labels = ["rules", "skills", "agents", "system", "config", "mcps"]
-        assert len(results) == len(resource_labels), (
-            f"sync_provider('all') returned {len(results)} results "
-            f"but resource_labels has {len(resource_labels)} entries; "
-            f"zip(..., strict=True) would crash"
+        # One result per resource label, plus the trailing structural backfill.
+        assert len(results) == len(resource_labels) + 1, (
+            f"sync_provider('all') returned {len(results)} results; expected "
+            f"{len(resource_labels)} resource passes plus one structural backfill"
         )
+
+        # The collector must consume the variable-length results without the
+        # historical strict-zip ValueError.
+        outcomes = _collect_sync_outcomes(results, "all", [])
+        assert isinstance(outcomes, list)
     finally:
         reset_config()
         shutil.rmtree(tmp_path, ignore_errors=True)


### PR DESCRIPTION
Follow-up release addressing two issues filed against 0.1.21.

### Issues fixed
- **#133** - `sync` / `install --upgrade` did not create a newly-added structural provider directory (e.g. antigravity's `workflows/`); the provider stayed `partial`/`mixed` while the command reported success ("will be addressed by sync" - a no-op). Only `install --force` backfilled it. Added a structural-backfill pass to `sync_provider` that creates only missing directories for **installed** providers (never overwriting), so `sync` and `install --upgrade` make the promise real.
- **#134** - `sync --dry-run` and `install --upgrade --dry-run` printed empty previews while the real runs changed files. With the backfill pass running under dry-run too, `sync --dry-run` now enumerates the directories it would create; `install --upgrade --dry-run` additionally previews the provider sync's changed entries (not just the builtin seed), matching the real upgrade.

### Notes
- The backfill is appended after the positional resource passes; `_collect_sync_outcomes` now groups any trailing result by inferred provider so the renderer never crashes on a length mismatch (supersedes the strict-zip in the #54 path; its regression test is updated).
- Backfill is gated on the manifest `installed` set, so a core-only install never materialises a provider directory.

### Verification
New `test_sync_backfill.py` (4 gates) drives real install/sync; full suite green (2018 passed). Both reproductions from the issues now behave correctly.