### PR TITLE
perf(vaultcore): libyaml CSafeLoader for frontmatter + MCP busy-signal guard (#137)

### DIFF
--- a/src/vaultspec_core/vaultcore/parser.py
+++ b/src/vaultspec_core/vaultcore/parser.py
@@ -51,6 +51,15 @@ _yaml_load: Callable[[str], dict[str, Any]]
 try:
     import yaml
 
+    try:
+        # Prefer the libyaml-backed C loader: it parses frontmatter several
+        # times faster than the pure-Python SafeLoader with identical safe
+        # semantics. Every vault scan, graph build, check, and MCP tool call
+        # parses frontmatter, so this is the hottest parse path in the system.
+        from yaml import CSafeLoader as _SafeLoader
+    except ImportError:  # pragma: no cover - PyYAML built without libyaml
+        from yaml import SafeLoader as _SafeLoader
+
     def _yaml_load_impl(text: str) -> dict[str, Any]:
         """Load YAML text via PyYAML, falling back to the simple parser on error.
 
@@ -61,7 +70,7 @@ try:
             Dictionary of parsed key-value pairs.
         """
         try:
-            return yaml.safe_load(text) or {}
+            return yaml.load(text, Loader=_SafeLoader) or {}
         except yaml.YAMLError as e:
             # PyYAML chokes on unquoted colons in values (e.g.
             # ``description: A test: with colons``).  Fall back to

--- a/tests/mcp/test_mcp_entrypoint.py
+++ b/tests/mcp/test_mcp_entrypoint.py
@@ -70,7 +70,9 @@ def test_mcp_entrypoint_starts_and_keeps_stdout_clean(tmp_path: Path) -> None:
 
     try:
         startup_lines: list[str] = []
-        deadline = time.time() + 5
+        # Generous deadline: a cold subprocess + import on a busy CI runner can
+        # take several seconds to emit its first startup line.
+        deadline = time.time() + 15
         while time.time() < deadline:
             try:
                 line = stderr_queue.get(timeout=0.25).decode("utf-8", errors="replace")
@@ -96,3 +98,36 @@ def test_mcp_entrypoint_starts_and_keeps_stdout_clean(tmp_path: Path) -> None:
         except subprocess.TimeoutExpired:
             proc.kill()
             proc.wait(timeout=5)
+
+
+@pytest.mark.integration
+def test_mcp_entrypoint_exits_cleanly_on_stdin_eof(tmp_path: Path) -> None:
+    """The stdio server must exit promptly on stdin EOF, not spin or hang.
+
+    Regression guard for the busy-signal concern (#137): with no input and an
+    immediate EOF (``stdin`` closed), the server must terminate on its own
+    within a short window. A busy-loop or hang on EOF - the failure mode the
+    concern describes - would block until the timeout and fail this test.
+    """
+    _build_minimal_workspace(tmp_path)
+
+    env = os.environ.copy()
+    env["VAULTSPEC_TARGET_DIR"] = str(tmp_path)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "from vaultspec_core.mcp_server.app import run; run()"],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        returncode = proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+        pytest.fail(
+            "MCP stdio server did not exit on stdin EOF within 20s; "
+            "possible busy-loop or hang (#137)."
+        )
+    assert returncode == 0, proc.stderr.read().decode("utf-8", errors="replace")


### PR DESCRIPTION
Addresses #137 (MCP idle-CPU concern + secondary perf opportunities).

### Performance
- **Frontmatter parsing now uses the libyaml-backed `CSafeLoader`** (falling back to the pure-Python `SafeLoader` when PyYAML lacks libyaml). Profiling an 800-document vault showed `yaml.safe_load` dominating every vault operation's parse cost; the C loader is **~6x faster** on the frontmatter microbenchmark with identical safe semantics. Every scan, graph build, `vault check`, and MCP tool call speeds up proportionally.

### Busy-signal investigation (#137)
- Empirically, the MCP stdio server does **not** spin: idle (open stdin) ≈ 0% CPU, and it exits cleanly (rc 0) on stdin EOF. The forced `WindowsProactorEventLoopPolicy` is the asyncio default on Python 3.13, so it is not a cause.
- Added a **regression guard**: `test_mcp_entrypoint_exits_cleanly_on_stdin_eof` fails if the server hangs or busy-loops on EOF (the failure mode the concern describes). Also widened the startup-line deadline (5s → 15s) to reduce cold-subprocess CI flake.

### Verification
Full suite green (2019 passed). Parser tests confirm identical parse output under the C loader.