### PR TITLE
fix(codex): dedupe agents tables in .codex/config.toml (#140)

### DIFF
--- a/src/vaultspec_core/core/agents.py
+++ b/src/vaultspec_core/core/agents.py
@@ -8,6 +8,7 @@ delegates cross-tool propagation to the shared sync engine.
 from __future__ import annotations
 
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any, Protocol
@@ -295,6 +296,173 @@ def _build_codex_agents_body(
     return "\n\n".join(rendered_agents)
 
 
+# Legacy sentinel markers used by pre-tag-system releases to delimit the
+# Codex agents region. Workspaces installed before the ``<vaultspec>`` tag
+# system landed carry these instead of (or in addition to) the managed block.
+_LEGACY_AGENTS_BEGIN = "# BEGIN VAULTSPEC MANAGED CODEX AGENTS"
+_LEGACY_AGENTS_END = "# END VAULTSPEC MANAGED CODEX AGENTS"
+
+# A TOML table header (``[table]`` or ``[a.b]``) at the start of a line.
+_TOML_TABLE_HEADER_RE = re.compile(r"^\s*\[")
+# An ``[agents.<name>]`` table header, with either a quoted or a bare key.
+_AGENTS_TABLE_RE = re.compile(
+    r'^\s*\[agents\.(?:"(?P<quoted>[^"]+)"|(?P<bare>[^\]]+))\]\s*$'
+)
+
+
+def _agents_table_name(line: str) -> str | None:
+    """Return the agent name from an ``[agents.<name>]`` header, else ``None``."""
+    match = _AGENTS_TABLE_RE.match(line)
+    if match is None:
+        return None
+    quoted = match.group("quoted")
+    if quoted is not None:
+        return quoted
+    bare = match.group("bare")
+    return bare.strip() if bare else None
+
+
+def _advance_multiline_state(line: str, state: str | None) -> str | None:
+    """Track open TOML multiline-string delimiters across physical lines.
+
+    *state* is the currently-open triple-delimiter (``'''`` or ``\"\"\"``) or
+    ``None`` when outside a multiline string. Returns the state after
+    consuming *line*. Used so structural ``[table]`` headers embedded inside
+    an agent ``prompt`` body are not mistaken for real table headers.
+    """
+    cursor = 0
+    length = len(line)
+    while cursor < length:
+        if state is None:
+            single = line.find("'''", cursor)
+            double = line.find('"""', cursor)
+            candidates = [pos for pos in (single, double) if pos != -1]
+            if not candidates:
+                return None
+            opener = min(candidates)
+            state = line[opener : opener + 3]
+            cursor = opener + 3
+        else:
+            close = line.find(state, cursor)
+            if close == -1:
+                return state
+            cursor = close + 3
+            state = None
+    return state
+
+
+def _strip_legacy_sentinel_block(content: str) -> str:
+    """Remove a legacy ``# BEGIN/END VAULTSPEC MANAGED CODEX AGENTS`` block.
+
+    The sentinel block is entirely vaultspec-owned, so it is removed wholesale.
+    Returns *content* unchanged when no sentinel block is present.
+    """
+    if _LEGACY_AGENTS_BEGIN not in content:
+        return content
+    out: list[str] = []
+    skipping = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if not skipping and stripped == _LEGACY_AGENTS_BEGIN:
+            skipping = True
+            continue
+        if skipping:
+            if stripped == _LEGACY_AGENTS_END:
+                skipping = False
+            continue
+        out.append(line)
+    return "\n".join(out)
+
+
+def _strip_agent_tables_in_segment(lines: list[str], names: set[str]) -> list[str]:
+    """Drop ``[agents.<name>]`` tables whose name is in *names* from *lines*.
+
+    Walks *lines* honouring TOML multiline-string state so a ``[`` inside a
+    prompt body is never mistaken for a table boundary. A matched table is
+    removed from its header through the line before the next real table header
+    (or end of segment), including any intervening blank lines.
+    """
+    out: list[str] = []
+    state: str | None = None
+    index = 0
+    total = len(lines)
+    while index < total:
+        line = lines[index]
+        if state is None and _agents_table_name(line) in names:
+            index += 1
+            while index < total:
+                inner = lines[index]
+                if state is None and _TOML_TABLE_HEADER_RE.match(inner):
+                    break
+                state = _advance_multiline_state(inner, state)
+                index += 1
+            continue
+        state = _advance_multiline_state(line, state)
+        out.append(line)
+        index += 1
+    return out
+
+
+def _codex_managed_agent_names(content: str) -> set[str]:
+    """Return agent names declared inside the managed ``agents`` block."""
+    from .tags import TagError, find_blocks
+
+    try:
+        blocks = find_blocks(content)
+    except TagError:
+        return set()
+    managed = next((b for b in blocks if b.block_type == "agents"), None)
+    if managed is None:
+        return set()
+    lines = content.splitlines()
+    names: set[str] = set()
+    for line in lines[managed.content_start - 1 : managed.content_end]:
+        name = _agents_table_name(line)
+        if name is not None:
+            names.add(name)
+    return names
+
+
+def _sanitize_legacy_codex_agents(content: str, names: set[str]) -> str:
+    """Strip stale duplicate agent tables that collide with the managed block.
+
+    Removes the legacy sentinel block wholesale, then removes any
+    ``[agents.<name>]`` table for a name in *names* that lives outside the
+    managed ``<vaultspec type="agents">`` block. The managed block itself is
+    preserved verbatim so the subsequent upsert owns the canonical copy.
+    Returns *content* unchanged when there is nothing stale to remove.
+    """
+    if not content:
+        return content
+
+    sanitized = _strip_legacy_sentinel_block(content)
+    if names:
+        from .tags import TagError, find_blocks
+
+        try:
+            blocks = find_blocks(sanitized)
+        except TagError:
+            blocks = []
+        managed = next((b for b in blocks if b.block_type == "agents"), None)
+        lines = sanitized.splitlines()
+        if managed is None:
+            kept = _strip_agent_tables_in_segment(lines, names)
+        else:
+            pre = lines[: managed.start_line - 1]
+            mid = lines[managed.start_line - 1 : managed.end_line]
+            post = lines[managed.end_line :]
+            kept = (
+                _strip_agent_tables_in_segment(pre, names)
+                + mid
+                + _strip_agent_tables_in_segment(post, names)
+            )
+        sanitized = "\n".join(kept)
+
+    if sanitized and not sanitized.endswith("\n"):
+        sanitized += "\n"
+    return sanitized
+
+
 def _sync_codex_agents(
     sources: dict[str, tuple[Path, dict[str, Any], str]],
     prune: bool = False,
@@ -309,18 +477,25 @@ def _sync_codex_agents(
 
     path = codex_cfg.native_config_file
     existed = path.exists()
-    existing = path.read_text(encoding="utf-8") if existed else ""
+    raw_existing = path.read_text(encoding="utf-8") if existed else ""
     body = _build_codex_agents_body(sources)
+    managed_names = {Path(name).stem for name in sources}
+    existing = _sanitize_legacy_codex_agents(raw_existing, managed_names)
 
     abs_path = str(path).replace("\\", "/")
 
     if not body:
-        if prune and existed and has_block(existing, "agents"):
-            try:
-                new_content = strip_block(existing, "agents")
-            except TagError as e:
-                logger.warning("Cannot prune agents from %s: %s", path, e)
-                result.errors.append(str(e))
+        if prune and existed:
+            new_content = existing
+            if has_block(existing, "agents"):
+                try:
+                    new_content = strip_block(existing, "agents")
+                except TagError as e:
+                    logger.warning("Cannot prune agents from %s: %s", path, e)
+                    result.errors.append(str(e))
+                    return result
+            if new_content == raw_existing:
+                result.skipped = 1
                 return result
             if dry_run:
                 result.items.append((abs_path, "[DELETE]"))
@@ -338,7 +513,10 @@ def _sync_codex_agents(
         result.errors.append(str(e))
         return result
 
-    if existing == new_content:
+    # Compare against the raw on-disk content, not the sanitized copy, so a
+    # file carrying only stale legacy duplicates (managed block already
+    # correct) is still rewritten rather than reported unchanged.
+    if raw_existing == new_content:
         result.skipped = len(sources) if sources else 1
         return result
 

--- a/src/vaultspec_core/migrations/__init__.py
+++ b/src/vaultspec_core/migrations/__init__.py
@@ -168,11 +168,13 @@ def _build_registry() -> list[Migration]:
     from .m_0_1_17_index_subfolder import MIGRATION as M_INDEX_SUBFOLDER
     from .m_0_1_20_gitignore_reversal import MIGRATION as M_GITIGNORE_REVERSAL
     from .m_0_1_21_frontmatter_lifecycle import MIGRATION as M_FRONTMATTER_LIFECYCLE
+    from .m_0_1_24_codex_agents_dedup import MIGRATION as M_CODEX_AGENTS_DEDUP
 
     entries: list[Migration] = [
         M_INDEX_SUBFOLDER,
         M_GITIGNORE_REVERSAL,
         M_FRONTMATTER_LIFECYCLE,
+        M_CODEX_AGENTS_DEDUP,
     ]
     return sorted(entries, key=lambda m: parse_version_tuple(m.target_version))
 

--- a/src/vaultspec_core/migrations/m_0_1_24_codex_agents_dedup.py
+++ b/src/vaultspec_core/migrations/m_0_1_24_codex_agents_dedup.py
@@ -1,0 +1,116 @@
+"""Remove duplicate Codex ``[agents.*]`` tables from ``.codex/config.toml``.
+
+Introduced for vaultspec-core 0.1.24 as the migration counterpart of issue
+#140. Pre-tag-system releases emitted the Codex agents region under a legacy
+``# BEGIN/END VAULTSPEC MANAGED CODEX AGENTS`` sentinel (or as raw, unwrapped
+tables). When a later release appends the current ``<vaultspec type="agents">``
+managed block, the two regions collide: ``[agents.<name>]`` and
+``[agents."<name>"]`` are the same TOML key, so the file fails ``taplo`` lint
+with ``conflicting keys`` and blocks every commit in repos whose pre-commit
+runs ``taplo`` over ``.codex/``.
+
+This migration strips the stale duplicates that sit outside the managed block,
+preferring the managed-block copy as canonical. It is conservative: an agent
+table whose name is not also declared inside the managed block is left
+untouched, and a workspace with no managed block (and hence no canonical set to
+dedup against) is left for the next ``sync`` to regenerate.
+
+See also:
+    :mod:`vaultspec_core.migrations` for the registry driver.
+    :func:`vaultspec_core.core.agents._sanitize_legacy_codex_agents` for the
+    shared sanitiser the live sync path also calls.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from . import Migration, MigrationError, MigrationResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ["MIGRATION", "migrate"]
+
+logger = logging.getLogger(__name__)
+
+_TARGET_VERSION = "0.1.24"
+_NAME = "codex_agents_dedup"
+
+
+def migrate(workspace: Path) -> MigrationResult:
+    """Strip duplicate Codex agent tables from ``<workspace>/.codex/config.toml``.
+
+    Locates the managed ``<vaultspec type="agents">`` block, takes the agent
+    names it declares as canonical, and removes any matching ``[agents.<name>]``
+    table that lives outside the block (plus any legacy sentinel block). When
+    the file is absent, has no managed block, or already carries no stale
+    duplicates, the migration is a true no-op.
+
+    Args:
+        workspace: Workspace root directory.
+
+    Returns:
+        :class:`MigrationResult` whose ``counts`` carries the ``deduped`` flag.
+
+    Raises:
+        MigrationError: When ``.codex/config.toml`` cannot be read or written.
+            The driver propagates the exception unchanged so the manifest
+            version is not bumped and the next invocation retries.
+    """
+    from ..core.agents import (
+        _codex_managed_agent_names,
+        _sanitize_legacy_codex_agents,
+    )
+    from ..core.helpers import atomic_write
+
+    counts = {"deduped": 0}
+
+    config_path = workspace / ".codex" / "config.toml"
+    if not config_path.exists():
+        return MigrationResult(
+            name=_NAME,
+            target_version=_TARGET_VERSION,
+            summary="no .codex/config.toml; nothing to migrate",
+            counts=counts,
+        )
+
+    try:
+        content = config_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MigrationError(f"{_NAME}: failed to read {config_path}: {exc}") from exc
+
+    names = _codex_managed_agent_names(content)
+    sanitized = _sanitize_legacy_codex_agents(content, names)
+    if sanitized == content:
+        return MigrationResult(
+            name=_NAME,
+            target_version=_TARGET_VERSION,
+            summary="no duplicate Codex agent tables; nothing to migrate",
+            counts=counts,
+        )
+
+    try:
+        atomic_write(config_path, sanitized)
+    except OSError as exc:
+        raise MigrationError(
+            f"{_NAME}: failed to rewrite {config_path}: {exc}"
+        ) from exc
+
+    counts["deduped"] = 1
+    summary = "removed duplicate Codex agent tables from .codex/config.toml"
+    logger.info("Migration %s: %s", _NAME, summary)
+    return MigrationResult(
+        name=_NAME,
+        target_version=_TARGET_VERSION,
+        summary=summary,
+        counts=counts,
+    )
+
+
+MIGRATION = Migration(
+    target_version=_TARGET_VERSION,
+    name=_NAME,
+    migrate=migrate,
+)

--- a/src/vaultspec_core/migrations/tests/test_codex_agents_dedup.py
+++ b/src/vaultspec_core/migrations/tests/test_codex_agents_dedup.py
@@ -1,0 +1,134 @@
+"""Tests for the ``codex_agents_dedup`` registry entry.
+
+Exercises
+:func:`vaultspec_core.migrations.m_0_1_24_codex_agents_dedup.migrate`
+against real on-disk ``.codex/config.toml`` fixtures. The migration strips
+stale duplicate ``[agents.*]`` tables that collide with the managed
+``<vaultspec type="agents">`` block (issue #140) and leaves clean or
+managed-block-less files untouched.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.migrations.m_0_1_24_codex_agents_dedup import migrate
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+_MANAGED_BLOCK = (
+    '# <vaultspec type="agents">\n'
+    '[agents."vaultspec-worker"]\n'
+    'description = "worker"\n'
+    "prompt = '''\n"
+    "Do the work.\n"
+    "'''\n"
+    "# </vaultspec>\n"
+)
+
+
+def _config(root: Path, content: str) -> Path:
+    path = root / ".codex" / "config.toml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _agent_headers(path: Path) -> list[str]:
+    return [
+        line.strip()
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip().startswith("[agents.")
+    ]
+
+
+class TestRemovesDuplicates:
+    """Stale duplicate tables outside the managed block are removed."""
+
+    def test_strips_raw_unwrapped_duplicate(self, tmp_path: Path):
+        legacy = (
+            "[agents.vaultspec-worker]\n"
+            'description = "old"\n'
+            'prompt = """\n[not a table]\n"""\n\n'
+        )
+        path = _config(tmp_path, legacy + _MANAGED_BLOCK)
+
+        result = migrate(tmp_path)
+
+        assert result.counts["deduped"] == 1
+        headers = _agent_headers(path)
+        assert headers == ['[agents."vaultspec-worker"]']
+
+    def test_strips_legacy_sentinel_block(self, tmp_path: Path):
+        legacy = (
+            "# BEGIN VAULTSPEC MANAGED CODEX AGENTS\n"
+            "[agents.vaultspec-worker]\n"
+            'description = "old"\n'
+            "# END VAULTSPEC MANAGED CODEX AGENTS\n\n"
+        )
+        path = _config(tmp_path, legacy + _MANAGED_BLOCK)
+
+        result = migrate(tmp_path)
+
+        assert result.counts["deduped"] == 1
+        content = path.read_text(encoding="utf-8")
+        assert "# BEGIN VAULTSPEC MANAGED CODEX AGENTS" not in content
+        assert _agent_headers(path) == ['[agents."vaultspec-worker"]']
+
+    def test_preserves_user_top_level_keys(self, tmp_path: Path):
+        legacy = '[agents.vaultspec-worker]\ndescription = "old"\n\n'
+        head = 'model = "gpt-5"\n\n'
+        path = _config(tmp_path, head + legacy + _MANAGED_BLOCK)
+
+        migrate(tmp_path)
+
+        assert 'model = "gpt-5"' in path.read_text(encoding="utf-8")
+
+
+class TestNoOp:
+    """The migration is a true no-op on clean or unaffected workspaces."""
+
+    def test_clean_managed_block_unchanged(self, tmp_path: Path):
+        path = _config(tmp_path, _MANAGED_BLOCK)
+        before = path.read_text(encoding="utf-8")
+
+        result = migrate(tmp_path)
+
+        assert result.counts["deduped"] == 0
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_idempotent(self, tmp_path: Path):
+        legacy = '[agents.vaultspec-worker]\ndescription = "old"\n\n'
+        path = _config(tmp_path, legacy + _MANAGED_BLOCK)
+
+        first = migrate(tmp_path)
+        after_first = path.read_text(encoding="utf-8")
+        second = migrate(tmp_path)
+
+        assert first.counts["deduped"] == 1
+        assert second.counts["deduped"] == 0
+        assert path.read_text(encoding="utf-8") == after_first
+
+    def test_missing_config_is_noop(self, tmp_path: Path):
+        result = migrate(tmp_path)
+
+        assert result.counts["deduped"] == 0
+        assert "nothing to migrate" in result.summary
+
+    def test_no_managed_block_leaves_unknown_tables(self, tmp_path: Path):
+        # Without a managed block there is no canonical set to dedup against;
+        # a lone raw table is not a duplicate, so it must be preserved.
+        raw = '[agents.custom]\ndescription = "mine"\n'
+        path = _config(tmp_path, raw)
+        before = path.read_text(encoding="utf-8")
+
+        result = migrate(tmp_path)
+
+        assert result.counts["deduped"] == 0
+        assert path.read_text(encoding="utf-8") == before

--- a/src/vaultspec_core/tests/cli/test_sync_operations.py
+++ b/src/vaultspec_core/tests/cli/test_sync_operations.py
@@ -244,6 +244,86 @@ class TestSyncAgents:
         assert 'model = "gpt-5"' in content
         assert "v2 prompt" in content
 
+    @staticmethod
+    def _agent_headers(text: str) -> list[str]:
+        return [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip().startswith("[agents.")
+        ]
+
+    def test_codex_removes_legacy_sentinel_agents_block(self, synthetic_project):
+        # Regression for #140: a pre-tag-system sentinel block must not collide
+        # with the freshly-upserted managed block (duplicate TOML keys).
+        agents_dir = synthetic_project / ".vaultspec" / "rules" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / "vaultspec-worker.md").write_text(
+            "---\ndescription: worker\n---\n\n# Worker\n\nDo work.",
+            encoding="utf-8",
+        )
+        codex_cfg = synthetic_project / ".codex" / "config.toml"
+        codex_cfg.parent.mkdir(parents=True, exist_ok=True)
+        codex_cfg.write_text(
+            "# BEGIN VAULTSPEC MANAGED CODEX AGENTS\n"
+            "[agents.vaultspec-worker]\n"
+            'description = "old"\n'
+            'prompt = """old"""\n'
+            "# END VAULTSPEC MANAGED CODEX AGENTS\n",
+            encoding="utf-8",
+        )
+
+        agents_sync()
+
+        content = codex_cfg.read_text(encoding="utf-8")
+        assert "# BEGIN VAULTSPEC MANAGED CODEX AGENTS" not in content
+        headers = self._agent_headers(content)
+        assert len(headers) == len(set(headers)), f"duplicate tables: {headers}"
+        assert headers.count('[agents."vaultspec-worker"]') == 1
+
+    def test_codex_removes_raw_duplicate_agent_tables(self, synthetic_project):
+        # Regression for #140: raw unwrapped legacy tables (no sentinel) that
+        # duplicate a managed name are stripped, even when a prompt body holds
+        # a line that looks like a TOML table header.
+        agents_dir = synthetic_project / ".vaultspec" / "rules" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / "vaultspec-worker.md").write_text(
+            "---\ndescription: worker\n---\n\n# Worker\n\nDo work.",
+            encoding="utf-8",
+        )
+        agents_sync()
+        codex_cfg = synthetic_project / ".codex" / "config.toml"
+        clean = codex_cfg.read_text(encoding="utf-8")
+        legacy = (
+            "[agents.vaultspec-worker]\n"
+            'description = "old"\n'
+            'prompt = """\n[not a table]\n"""\n\n'
+        )
+        codex_cfg.write_text(legacy + clean, encoding="utf-8")
+
+        result = agents_sync()
+
+        content = codex_cfg.read_text(encoding="utf-8")
+        headers = self._agent_headers(content)
+        assert len(headers) == len(set(headers)), f"duplicate tables: {headers}"
+        # The stale rewrite is reported as work done, not skipped unchanged.
+        assert result.per_tool[Tool.CODEX.value].updated == 1
+
+    def test_codex_agents_sync_is_idempotent(self, synthetic_project):
+        agents_dir = synthetic_project / ".vaultspec" / "rules" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        (agents_dir / "vaultspec-worker.md").write_text(
+            "---\ndescription: worker\n---\n\n# Worker\n\nDo work.",
+            encoding="utf-8",
+        )
+        agents_sync()
+        codex_cfg = synthetic_project / ".codex" / "config.toml"
+        first = codex_cfg.read_text(encoding="utf-8")
+
+        result = agents_sync()
+
+        assert codex_cfg.read_text(encoding="utf-8") == first
+        assert result.per_tool[Tool.CODEX.value].updated == 0
+
 
 class TestSyncSkillsCodex:
     """Verify skills sync lands in .agents/skills/ for Codex destination."""


### PR DESCRIPTION
## Summary

Fixes #140 — `vaultspec-core` generated a malformed `.codex/config.toml` with the
`[agents.*]` table emitted twice (two key-quoting styles), producing duplicate TOML
keys that fail `taplo` lint with `conflicting keys` and block every commit in repos
whose pre-commit runs taplo over `.codex/`.

## Root cause

Pre-tag-system releases emitted the Codex agents region under a legacy
`# BEGIN/END VAULTSPEC MANAGED CODEX AGENTS` sentinel (or as raw, unwrapped tables).
When a later release appended the current `<vaultspec type="agents">` managed block,
`upsert_block` could not find its block under the old marker, so it appended a second
one. `[agents.foo]` and `[agents."foo"]` are the same TOML key, so the two regions
collide. Because the managed-block content itself already matched, `sync` reported the
file `unchanged` — leaving no in-CLI recovery path short of `install --force`.

## Changes

- **Self-healing sync** (`core/agents.py`): `_sync_codex_agents` now sanitises the
  on-disk config before upserting — it strips the legacy sentinel block and any
  duplicate `[agents.<name>]` table that lives *outside* the managed block. The scan
  honours TOML multiline-string state, so a `[` inside a prompt body is never mistaken
  for a table boundary. The skip/write decision compares against the raw on-disk
  content, so a file carrying only stale duplicates is rewritten rather than reported
  `unchanged`. Plain `vaultspec-core sync` now repairs an affected workspace.
- **Migration** `m_0_1_24_codex_agents_dedup`: repairs existing workspaces proactively
  on `install --upgrade` and lazy vault triggers, preferring the managed-block copy as
  canonical. Conservative — leaves unknown tables and managed-block-less files
  untouched; fully idempotent.
- **Regression tests**: both legacy formats (sentinel + raw), a prompt body containing
  a `[bracket]` line, idempotency, user-key preservation, and no-op paths.

## Verification

- `ruff check` / `ruff format` / `ty` clean on changed files.
- Full suite: **2029 passed**.
- New tests assert no duplicate `[agents.*]` headers after sync and that the rewrite is
  reported as work done (not `unchanged`).
