### PR TITLE
fix(deps): bump pyjwt to 2.13.0 to clear PYSEC-2026 advisories

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -657,11 +657,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

`pyjwt` 2.12.1 (pulled in transitively via `mcp[crypto]`) carries four known vulnerabilities (PYSEC-2026-175, -177, -178, -179), all fixed in **2.13.0**. The Dependency Audit CI job (`scripts/dependency_audit.py` / `uv audit`) fails on `main` as a result.

## Change

Lock-only upgrade: `uv lock --upgrade-package pyjwt` moves pyjwt 2.12.1 -> 2.13.0. `mcp[crypto]` 1.27.0 already permits 2.13.0, so no `pyproject.toml` constraint change is needed.

## Verification

`uv run python scripts/dependency_audit.py` -> `Found no known vulnerabilities and no adverse project statuses in 68 packages`.
