### PR TITLE
fix(codex): emit valid TOML for agent prompts containing '''(#143)

### DIFF
--- a/src/vaultspec_core/core/agents.py
+++ b/src/vaultspec_core/core/agents.py
@@ -216,8 +216,20 @@ def transform_agent(
 
 
 def _toml_multiline(value: str) -> str:
-    escaped = value.replace("'''", "'''\"'''\"'''")
-    return f"'''\n{escaped}\n'''"
+    """Render *value* as a TOML multiline string.
+
+    Prefers a literal (single-quote) multiline string so the body is preserved
+    verbatim with no escape processing. A literal string cannot contain a
+    ``'''`` run - it would terminate the string and there is no escape inside a
+    literal - so a body carrying ``'''`` falls back to a basic (double-quote)
+    multiline string with the minimal escaping required to stay valid TOML:
+    backslashes are doubled and every ``"`` is escaped so no ``\"\"\"`` run can
+    form. Both forms round-trip through a TOML parser to the original text.
+    """
+    if "'''" not in value:
+        return f"'''\n{value}\n'''"
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"""\n{escaped}\n"""'
 
 
 def _coerce_codex_model(meta: dict[str, Any]) -> str | None:

--- a/src/vaultspec_core/tests/cli/test_agents_render.py
+++ b/src/vaultspec_core/tests/cli/test_agents_render.py
@@ -13,6 +13,7 @@ import os
 import re
 import shutil
 import subprocess
+import tomllib
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -22,8 +23,10 @@ import pytest
 from vaultspec_core.core.agents import (
     _CLAUDE_TO_GEMINI_TOOLS,
     _render_claude_agent,
+    _render_codex_agent,
     _render_gemini_agent,
     _render_passthrough_agent,
+    _toml_multiline,
     transform_agent,
 )
 from vaultspec_core.core.enums import GeminiBuiltinTool, Tool
@@ -149,6 +152,37 @@ class TestRenderGeminiAgent:
         meta = {"tools": ["Read", 42, None, "Grep"]}
         out = _render_gemini_agent("x.md", meta, "body")
         assert _fm(out)["tools"] == ["read_file", "grep_search"]
+
+
+class TestCodexMultilinePrompt:
+    """Codex agent prompts must round-trip through a TOML parser (#143).
+
+    ``_render_codex_agent`` frames the body with a leading and trailing
+    newline, and TOML strips the first newline after the opening delimiter, so
+    the parsed prompt carries a single trailing newline; the body content
+    itself must survive verbatim.
+    """
+
+    @staticmethod
+    def _roundtrip(body: str) -> str:
+        rendered = _render_codex_agent("worker.md", {"description": "d"}, body)
+        return tomllib.loads(rendered)["agents"]["worker"]["prompt"]
+
+    def test_plain_body_uses_literal_string(self):
+        out = _toml_multiline("hello\nworld")
+        assert out.startswith("'''")
+        assert self._roundtrip("hello\nworld") == "hello\nworld\n"
+
+    def test_body_with_triple_single_quotes_is_valid_toml(self):
+        body = "before '''quoted''' after"
+        out = _toml_multiline(body)
+        # A literal string cannot hold ''', so the basic form is used instead.
+        assert out.startswith('"""')
+        assert self._roundtrip(body) == body + "\n"
+
+    def test_body_with_backslashes_and_quotes_round_trips(self):
+        body = "path C:\\x '''y''' \"z\""
+        assert self._roundtrip(body) == body + "\n"
 
 
 class TestTransformAgentDispatch:


### PR DESCRIPTION
## Summary

Fixes #143. `_toml_multiline` rendered Codex agent prompts as a TOML **literal** multiline string (`'''...'''`) and tried to escape an embedded `'''` by string replacement. Literal strings perform no escape processing and cannot contain a `'''` run, so any prompt body with `'''` produced invalid TOML.

## Fix

- Keep the literal form as the default so bodies are preserved verbatim (no escaping).
- Fall back to a **basic** multiline string (`"""..."""`) with minimal escaping only when the body contains `'''`: double backslashes, then escape every `"` so no `"""` run can form.

## Verification

New `tomllib` round-trip tests assert plain, triple-single-quote, and backslash+quote bodies parse back to the original text. Full agents-render suite: 57 passed; ruff/ty clean.
