### PR TITLE
Fix unexpected retirements in plan serializer and prune obsolete codex agents

### DIFF
--- a/.vault/adr/2026-06-05-plan-serializer-fixes-adr.md
+++ b/.vault/adr/2026-06-05-plan-serializer-fixes-adr.md
@@ -1,0 +1,59 @@
+---
+tags:
+  - '#adr'
+  - '#plan-serializer-fixes'
+date: '2026-06-05'
+related:
+  - '[[2026-06-05-plan-serializer-fixes-research]]'
+---
+
+# `plan-serializer-fixes` adr: `serializer-verification-and-obsolete-agents` | (**status:** `accepted`)
+
+## Problem Statement
+
+Two issues require structural fixes to prevent data loss in plan files and configuration conflicts:
+
+1. Issue 150: During sequential plan mutations (adds/removes), visible phases or steps can be silently moved into the retired ledger comment block due to serializer constraints, parsing failures, or ordering conflicts.
+1. Issue 149: Obsolesence of `.codex/agents/` individual TOML files and duplicate keys in `.codex/config.toml` outside the managed block cause config loading warnings and parser failures.
+
+## Considerations
+
+- Data loss in plan files must be prevented deterministically. Bypassing validation is not an option.
+- The `_save_plan_or_dry_run` function handles all CLI write-backs, providing a single point of enforcement.
+- Codex configuration has moved to a unified config TOML block inside `.codex/config.toml`, rendering the directory-based agent roles folder obsolete.
+- Pruning obsolete files should be handled when `prune=True` is requested during `sync` or `install --upgrade`.
+
+## Constraints
+
+- We must not introduce new dependencies or libraries.
+- The validation check must be fast and performant.
+- `tomllib` standard library parser must be protected from crashes caused by duplicate keys.
+
+## Implementation
+
+1. **Serializer Verification (Issue 150)**:
+
+   - Introduce a verification check in `_save_plan_or_dry_run` that parses the original plan text.
+   - Compare the unioned set of retired IDs (`plan.retired_step_ids | plan.retired_phase_ids | plan.retired_wave_ids`) before and after the mutation.
+   - Calculate `newly_retired = new_retired - old_retired`.
+   - Pass an `expected_retired` set parameter from the CLI command handlers to `_save_plan_or_dry_run`.
+   - If any `unexpected = newly_retired - expected` exists, raise `PlanCommandError` and abort the write operation.
+
+1. **Obsolete Agents Pruning and Sanitization (Issue 149)**:
+
+   - Implement directory and file deletion inside `_sync_codex_agents` when `prune=True`. If `.codex/agents/` exists, recursively delete files in it, and delete the directory itself if empty.
+   - Refactor `_strip_agent_tables_in_segment` inside `src/vaultspec_core/core/agents.py` to match both `[agents.name]` tables and `name = ...` key assignments under `[agents]` tables that reside outside the managed comment blocks.
+
+## Rationale
+
+This design guarantees that any serializer or mutation bug that would silently retire visible plan rows is immediately caught and blocked. The file on disk remains completely untouched, preventing corruption. The Codex agents cleanup prevents duplicate configuration warnings and crashes in downstream IDE config loaders.
+
+## Consequences
+
+- CLI commands will fail fast and report an error if a bug or ordering constraint would silently retire active steps.
+- Obsolete files and config tables are cleanly removed, ensuring config consistency.
+
+## Codification candidates
+
+- **Rule slug:** `mutation-verification`.
+  **Rule:** Every plan mutation must verify that no unexpected identifiers are retired during the operation.

--- a/.vault/index/plan-serializer-fixes.index.md
+++ b/.vault/index/plan-serializer-fixes.index.md
@@ -1,0 +1,29 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#plan-serializer-fixes'
+date: '2026-06-05'
+related:
+  - '[[2026-06-05-plan-serializer-fixes-adr]]'
+  - '[[2026-06-05-plan-serializer-fixes-plan]]'
+  - '[[2026-06-05-plan-serializer-fixes-research]]'
+---
+
+# `plan-serializer-fixes` feature index
+
+Auto-generated index of all documents tagged with `#plan-serializer-fixes`.
+
+## Documents
+
+### adr
+
+- `2026-06-05-plan-serializer-fixes-adr` - `plan-serializer-fixes` adr: `serializer-verification-and-obsolete-agents` | (**status:** `accepted`)
+
+### plan
+
+- `2026-06-05-plan-serializer-fixes-plan` - `plan-serializer-fixes` `serializer validation and obsolete codex agents pruning` plan
+
+### research
+
+- `2026-06-05-plan-serializer-fixes-research` - `plan-serializer-fixes` research: `serializer-and-obsolete-agents`

--- a/.vault/plan/2026-06-05-plan-serializer-fixes-plan.md
+++ b/.vault/plan/2026-06-05-plan-serializer-fixes-plan.md
@@ -1,0 +1,49 @@
+---
+tags:
+  - '#plan'
+  - '#plan-serializer-fixes'
+date: '2026-06-05'
+tier: L2
+related:
+  - '[[2026-06-05-plan-serializer-fixes-adr]]'
+  - '[[2026-06-05-plan-serializer-fixes-research]]'
+---
+
+# `plan-serializer-fixes` `serializer validation and obsolete codex agents pruning` plan
+
+## Phases
+
+### Phase `P01` - serializer validation
+
+Ensure no unexpected active plan items are silently retired during mutations.
+
+- [x] `P01.S01` - implement validation check in \_save_plan_or_dry_run; `src/vaultspec_core/cli/plan_cmd.py`.
+- [x] `P01.S02` - update command handlers to compute and pass expected_retired; `src/vaultspec_core/cli/plan_cmd.py`.
+- [x] `P01.S03` - write unit/regression tests for unexpected retirement check; `tests/cli/test_plan_cmd.py`.
+
+### Phase `P02` - obsolete agents pruning
+
+Clean up legacy agents directory and strip unmanaged config duplicates.
+
+- [x] `P02.S04` - implement directory/file cleanup in \_sync_codex_agents; `src/vaultspec_core/core/agents.py`.
+- [x] `P02.S05` - implement unmanaged duplicate agents tables and key stripping in \_strip_agent_tables_in_segment; `src/vaultspec_core/core/agents.py`.
+- [x] `P02.S06` - write unit/integration tests for agents pruning and config stripping; `tests/core/test_agents.py`.
+
+## Description
+
+This plan addresses two main issues:
+
+1. Issue 150: Verification that plan serialization mutations do not retire any unexpected elements.
+1. Issue 149: Pruning legacy `.codex/agents/` directories and sanitizing unmanaged configurations to avoid duplicate agent definition errors.
+
+## Parallelization
+
+All steps are ordered linearly due to verification dependencies.
+
+## Verification
+
+Mission success criteria:
+
+- Unexpected retirement checks raise `PlanCommandError` and prevent file write.
+- Sync command successfully prunes obsolete `.codex/agents/` and strips duplicate unmanaged keys in `.codex/config.toml`.
+- All tests pass.

--- a/.vault/research/2026-06-05-plan-serializer-fixes-research.md
+++ b/.vault/research/2026-06-05-plan-serializer-fixes-research.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#research'
+  - '#plan-serializer-fixes'
+date: '2026-06-05'
+related: []
+---
+
+# `plan-serializer-fixes` research: `serializer-and-obsolete-agents`
+
+Research and investigation into two issues:
+
+1. Issue 150: The serializer moving visible phases/steps into the retired ledger comment block during later unrelated mutations.
+1. Issue 149: Pruning legacy `.codex/agents/` files and duplicate keys in `.codex/config.toml` that trigger loader warnings and TOML parse crashes.
+
+## Findings
+
+### 1. Issue 150 - Unexpected Retirements
+
+- The CLI command handlers like `step remove` or `step add` perform localized mutations on a parsed plan, then serialize the plan back to disk.
+- There is no logic that automatically retires visible phases or steps unless they are explicitly targeted by destructive commands like `step remove`, `phase remove`, `wave remove`, `renumber_phase`, or `demote_tier`.
+- However, if the parser fails to parse or associate phases/steps with their waves (e.g. because of non-monotonicity or layout issues), they are not rendered in the visible body but are preserved. If a user manually recovers or edits, they may be retired.
+- To prevent any silent retirement, we can add a check in `_save_plan_or_dry_run` that parses the original plan and compares the set of retired identifiers before and after the mutation. Any retirement not matching the target of the command (e.g. `remove_step` targets one step, `remove_phase` targets one phase and its steps) is rejected with a `PlanCommandError`.
+
+### 2. Issue 149 - Legacy Codex Agents
+
+- Legacy versions of `vaultspec-core` stored Codex agents in individual TOML files under `.codex/agents/`. The current system syncs them into a unified block in `.codex/config.toml` and configures `agents_dir` as `None` for Codex.
+- Because `agents_dir` is `None`, the sync engine does not prune `.codex/agents/` when `prune=True`. This causes the config loader to warning about duplicate agent role names.
+- In some environments, duplicates exist outside the managed comment block, e.g. as `[agents]` with sub-keys, causing standard TOML parser crashes with duplicate table keys.
+- To fix this:
+  - We will update `_sync_codex_agents` to check if `prune=True` is requested, and if so, prune `.codex/agents/` and remove the directory if empty.
+  - We will update `_strip_agent_tables_in_segment` in `src/vaultspec_core/core/agents.py` to match and strip both `[agents.name]` tables and `name = ...` key assignments under `[agents]` tables that lie outside the managed tag blocks.

--- a/src/vaultspec_core/cli/plan_cmd.py
+++ b/src/vaultspec_core/cli/plan_cmd.py
@@ -65,15 +65,45 @@ def _save_plan_or_dry_run(
     dry_run: bool,
     canonicalise: bool,
     success_msg: str,
+    expected_retired: set[str] | None = None,
 ) -> None:
     """Helper to serialise plan and output a unified diff on dry-run.
 
     Or write to disk on apply.
     """
     from vaultspec_core.plan.commands._errors import PlanCommandError
+    from vaultspec_core.plan.parser import parse_plan
     from vaultspec_core.plan.serialiser import serialise_plan
 
     new_text = serialise_plan(plan, canonicalise=canonicalise)
+
+    # Issue 150: Verify that no unexpected elements are retired during this mutation
+    try:
+        old_plan = parse_plan(original_text)
+        new_plan = parse_plan(new_text)
+    except Exception as exc:
+        raise PlanCommandError(f"Plan validation failed during parsing: {exc}") from exc
+
+    old_retired = (
+        old_plan.retired_step_ids
+        | old_plan.retired_phase_ids
+        | old_plan.retired_wave_ids
+    )
+    new_retired = (
+        new_plan.retired_step_ids
+        | new_plan.retired_phase_ids
+        | new_plan.retired_wave_ids
+    )
+    newly_retired = new_retired - old_retired
+
+    expected = expected_retired if expected_retired is not None else set()
+    unexpected = newly_retired - expected
+    if unexpected:
+        sorted_unexpected = sorted(unexpected)
+        raise PlanCommandError(
+            f"mutation aborted: unexpected retirement of active plan items: "
+            f"{', '.join(sorted_unexpected)}. This indicates a serialization conflict."
+        )
 
     # Defence in depth against a serialiser regression that multiplies authored
     # prose (issue #125): a single structural edit never grows a plan several
@@ -630,6 +660,7 @@ def cmd_step_remove(
         dry_run=dry_run,
         canonicalise=canonicalise,
         success_msg=f"Retired Step `{retired}`.",
+        expected_retired={retired},
     )
 
 
@@ -867,6 +898,7 @@ def cmd_phase_remove(
         dry_run=dry_run,
         canonicalise=canonicalise,
         success_msg=f"Retired Phase `{retired_phase}`; cascaded Steps: {cascaded_str}.",
+        expected_retired={retired_phase} | set(retired_steps),
     )
 
 
@@ -1062,6 +1094,7 @@ def cmd_wave_remove(
             f"Retired Wave `{retired_wave}`; cascaded Phases: {phases_str}; "
             f"cascaded Steps: {steps_str}."
         ),
+        expected_retired={retired_wave} | set(retired_phases) | set(retired_steps),
     )
 
 
@@ -1333,6 +1366,23 @@ def cmd_tier_demote(
     original_text = path.read_text(encoding="utf-8")
     plan = parse_plan(original_text)
     target_tier = Tier(target) if target is not None else None
+
+    # Calculate expected_retired before we mutate the plan
+    expected_retired: set[str] = set()
+    current_t = plan.frontmatter.tier
+    resolved_target = target_tier
+    if resolved_target is None:
+        from vaultspec_core.plan.commands.tier_ops import _previous_tier
+
+        resolved_target = _previous_tier(current_t)
+
+    if resolved_target is not None:
+        if current_t in (Tier.L4, Tier.L3) and resolved_target is Tier.L2:
+            expected_retired.update(w.canonical_id for w in plan.waves)
+        elif current_t in (Tier.L4, Tier.L3, Tier.L2) and resolved_target is Tier.L1:
+            expected_retired.update(w.canonical_id for w in plan.waves)
+            expected_retired.update(p.canonical_id for p in plan.phases)
+
     new_tier = demote_tier(plan, target=target_tier, force=force)
     _save_plan_or_dry_run(
         path=path,
@@ -1341,4 +1391,5 @@ def cmd_tier_demote(
         dry_run=dry_run,
         canonicalise=canonicalise,
         success_msg=f"Tier demoted to {new_tier.value}.",
+        expected_retired=expected_retired,
     )

--- a/src/vaultspec_core/core/agents.py
+++ b/src/vaultspec_core/core/agents.py
@@ -320,6 +320,26 @@ _TOML_TABLE_HEADER_RE = re.compile(r"^\s*\[")
 _AGENTS_TABLE_RE = re.compile(
     r'^\s*\[agents\.(?:"(?P<quoted>[^"]+)"|(?P<bare>[^\]]+))\]\s*$'
 )
+# A TOML key-value assignment regex (matches key = value,
+# where key can be quoted or bare)
+_TOML_KEY_ASSIGNMENT_RE = re.compile(
+    r"^\s*(?:\"(?P<quoted_d>[^\"]+)\"|'(?P<quoted_s>[^']+)'|(?P<bare>[^=\s#]+))\s*="
+)
+
+
+def _is_agent_key_assignment(line: str, names: set[str]) -> bool:
+    """Return True if line is a key assignment for a name in *names*."""
+    match = _TOML_KEY_ASSIGNMENT_RE.match(line)
+    if match is None:
+        return False
+    quoted_d = match.group("quoted_d")
+    if quoted_d is not None:
+        return quoted_d in names
+    quoted_s = match.group("quoted_s")
+    if quoted_s is not None:
+        return quoted_s in names
+    bare = match.group("bare")
+    return bare.strip() in names if bare else False
 
 
 def _agents_table_name(line: str) -> str | None:
@@ -405,6 +425,18 @@ def _strip_agent_tables_in_segment(lines: list[str], names: set[str]) -> list[st
             while index < total:
                 inner = lines[index]
                 if state is None and _TOML_TABLE_HEADER_RE.match(inner):
+                    break
+                state = _advance_multiline_state(inner, state)
+                index += 1
+            continue
+        if state is None and _is_agent_key_assignment(line, names):
+            index += 1
+            while index < total:
+                inner = lines[index]
+                if state is None and (
+                    _TOML_TABLE_HEADER_RE.match(inner)
+                    or _TOML_KEY_ASSIGNMENT_RE.match(inner)
+                ):
                     break
                 state = _advance_multiline_state(inner, state)
                 index += 1
@@ -495,6 +527,23 @@ def _sync_codex_agents(
     existing = _sanitize_legacy_codex_agents(raw_existing, managed_names)
 
     abs_path = str(path).replace("\\", "/")
+
+    # Issue 149: Prune obsolete agents directory if prune is True
+    if prune:
+        agents_dir = path.parent / "agents"
+        if agents_dir.is_dir():
+            for child in sorted(agents_dir.iterdir()):
+                if child.is_file():
+                    child_abs = str(child).replace("\\", "/")
+                    result.items.append((child_abs, "[DELETE]"))
+                    if not dry_run:
+                        child.unlink()
+                    result.pruned += 1
+            if not dry_run:
+                import contextlib
+
+                with contextlib.suppress(OSError):
+                    agents_dir.rmdir()
 
     if not body:
         if prune and existed:

--- a/src/vaultspec_core/tests/cli/test_sync_incremental.py
+++ b/src/vaultspec_core/tests/cli/test_sync_incremental.py
@@ -327,3 +327,43 @@ class TestIncrementalAgents:
         assert '[agents."vaultspec-worker"]' not in codex_cfg.read_text(
             encoding="utf-8"
         )
+
+    def test_prune_obsolete_codex_agents_directory(self, synthetic_project):
+        obsolete_dir = synthetic_project / ".codex" / "agents"
+        obsolete_dir.mkdir(parents=True, exist_ok=True)
+        legacy_file = obsolete_dir / "vaultspec-adr-researcher.toml"
+        legacy_file.write_text("some content", encoding="utf-8")
+
+        assert legacy_file.exists()
+        assert obsolete_dir.exists()
+
+        agents_sync(prune=True)
+
+        assert not legacy_file.exists()
+        assert not obsolete_dir.exists()
+
+    def test_strip_unmanaged_duplicate_agent_keys(self, synthetic_project):
+        codex_cfg = synthetic_project / ".codex" / "config.toml"
+        initial_toml = """[agents]
+vaultspec-worker = "legacy-value"
+other-config = 123
+
+# <vaultspec type="agents">
+# </vaultspec>
+"""
+        codex_cfg.write_text(initial_toml, encoding="utf-8")
+
+        agents_dir = synthetic_project / ".vaultspec" / "rules" / "agents"
+        agents_dir.mkdir(parents=True, exist_ok=True)
+        agent_path = agents_dir / "vaultspec-worker.md"
+        agent_path.write_text(
+            "---\ndescription: worker\n---\n\n# Worker\n\nv1",
+            encoding="utf-8",
+        )
+
+        agents_sync()
+
+        content = codex_cfg.read_text(encoding="utf-8")
+        assert 'vaultspec-worker = "legacy-value"' not in content
+        assert "other-config = 123" in content
+        assert '[agents."vaultspec-worker"]' in content

--- a/src/vaultspec_core/tests/plan/test_e2e.py
+++ b/src/vaultspec_core/tests/plan/test_e2e.py
@@ -472,3 +472,50 @@ def test_cli_stable_insertion_uses_alpha_suffixes_for_waves_and_phases(
     assert "P01a" in reparsed.retired_phase_ids
     assert "W01a" in reparsed.retired_wave_ids
     assert "S03" in reparsed.retired_step_ids
+
+
+def test_unexpected_retirement_check_direct(tmp_path) -> None:
+    """Verify that unexpected retirement check raises PlanCommandError.
+
+    Tests calling _save_plan_or_dry_run directly.
+    """
+    from vaultspec_core.cli.plan_cmd import _save_plan_or_dry_run
+    from vaultspec_core.plan.commands._errors import PlanCommandError
+    from vaultspec_core.plan.parser import parse_plan
+
+    original_text = """---
+tags:
+  - '#plan'
+  - '#test'
+date: '2026-06-05'
+tier: L1
+related: []
+---
+
+# `test` plan
+
+- [ ] `S01` - work; `src/a.py`.
+"""
+    plan_path = tmp_path / "test-plan.md"
+    plan_path.write_text(original_text, encoding="utf-8")
+
+    plan = parse_plan(original_text)
+    # Simulate a mutation that retires S01 (adds S01 to retired_step_ids)
+    plan.retired_step_ids.add("S01")
+    # And removes S01 from steps
+    plan.steps = []
+
+    # If we don't pass S01 in expected_retired, it should raise PlanCommandError
+    with pytest.raises(PlanCommandError) as exc_info:
+        _save_plan_or_dry_run(
+            path=plan_path,
+            plan=plan,
+            original_text=original_text,
+            dry_run=False,
+            canonicalise=False,
+            success_msg="Mutated plan",
+            expected_retired=set(),
+        )
+
+    assert "unexpected retirement of active plan items" in str(exc_info.value)
+    assert "S01" in str(exc_info.value)


### PR DESCRIPTION
Addresses and resolves Issue #149 and Issue #150.

### Overview of Changes

#### 1. Plan Serializer Unexpected Retirements Validation (Fixes #150)
- **Problem:** When sequential plan mutations are performed, visible phases or steps could be silently retired (moved to the retired ledger block) because of serializer constraints or layout conflicts.
- **Solution:** 
  - Added validation in \_save_plan_or_dry_run\ under \src/vaultspec_core/cli/plan_cmd.py\ to compare retired sets (\etired_step_ids | retired_phase_ids | retired_wave_ids\) before and after the mutation. Any new retirement not matching the targeted \expected_retired\ set raises a \PlanCommandError\ and aborts the mutation.
  - Updated destructive command handlers (\step remove\, \phase remove\, \wave remove\, and \	ier demote\) to pass their expected retired sets.
  - Added a direct unit/integration test \	est_unexpected_retirement_check_direct\ in \src/vaultspec_core/tests/plan/test_e2e.py\ verifying that unexpected retirements correctly trigger the error and abort.

#### 2. Obsolete Codex Agents Pruning and Configuration Sanitization (Fixes #149)
- **Problem:** Obsolete \.codex/agents/*.toml\ individual role definitions triggers load warnings. Additionally, duplicate unmanaged agent tables and key assignments outside the managed tag blocks in \.codex/config.toml\ cause parse crashes.
- **Solution:**
  - Updated \_sync_codex_agents\ in \src/vaultspec_core/core/agents.py\ to prune files in \.codex/agents/\ and remove the directory itself when \prune=True\.
  - Refactored \_strip_agent_tables_in_segment\ to strip both \[agents.name]\ tables and unmanaged \
ame = ...\ key assignments under \[agents]\ tables that lie outside the managed tag block in \.codex/config.toml\.
  - Added tests \	est_prune_obsolete_codex_agents_directory\ and \	est_strip_unmanaged_duplicate_agent_keys\ in \src/vaultspec_core/tests/cli/test_sync_incremental.py\ to verify the pruning and key stripping.