### PR TITLE
feat(vault): ref-scoped graph, commit-linkage trailers, phase-summary scaffold, doctor + plan-mutator fixes

### DIFF
--- a/.vault/adr/2026-06-13-commit-linkage-adr.md
+++ b/.vault/adr/2026-06-13-commit-linkage-adr.md
@@ -1,0 +1,103 @@
+---
+tags:
+  - '#adr'
+  - '#commit-linkage'
+date: '2026-06-13'
+modified: '2026-06-13'
+related:
+  - '[[2026-06-13-commit-linkage-research]]'
+---
+
+# `commit-linkage` adr: `opt-in commit-linkage trailer convention` | (**status:** `accepted`)
+
+## Problem Statement
+
+Tooling that correlates git commits to vault records must today do so heuristically - a
+commit touching both a vault document and code together, path and time-window overlap,
+same-day same-branch co-activity - and grade each correlation by confidence accordingly.
+Issue #159 proposes an opt-in convention that lets a commit declare its vaultspec
+association explicitly, through a git trailer such as `Vaultspec-Step: W01.P02.S06` or
+`Vaultspec-Feature: auth-refactor`, which any such tool can read to resolve a correlation
+deterministically instead of guessing. This ADR decides the trailer format core defines
+and the tooling core ships to emit and validate it; how any downstream tool consumes the
+trailer is outside core's scope.
+
+## Considerations
+
+The grounding research (`2026-06-13-commit-linkage-research`) confirms core has no
+commit-message handling, no trailer parsing, and no commit-to-doc correlation today, so
+the convention is greenfield. It also fixes the two values a trailer carries: a Step (or
+Phase) display path, whose format `display_path.py` already produces
+(`S06`, `P02.S06`, `W01.P02.S06`), and a feature tag, validated as kebab-case
+(`^[a-z0-9][a-z0-9-]*$`) with an optional leading `#`. Two hook systems exist - the
+vaultspec lifecycle engine (events `vault.document.created`, `config.synced`,
+`audit.completed`) and the developer `.pre-commit-config.yaml` toolchain run by `prek` -
+and only the latter can host a git `commit-msg`-stage hook, which a prior repo ADR
+(`2026-03-22-clci-release-adr`) already anticipated. The decisive consideration is the
+issue's own hard constraint: the convention must be enrichment, never a prerequisite.
+
+## Constraints
+
+The convention may never become load-bearing. Teams have commit styles core cannot
+override, so absence or malformation of a trailer must at most lower a downstream tool's
+correlation confidence and nothing more - no commit may be blocked, no vault operation
+may fail, and no core command may require a trailer to be present. Any commit-msg hook
+core offers must be
+advisory: it reports a malformed trailer and exits zero, opt-in by the team explicitly
+installing the `commit-msg` stage. Validation must be a pure, offline string operation
+over the trailer values reusing the existing identifier and feature-tag formats, with no
+git history read required to validate a single message. The trailer format binds future
+commits durably, so it must be specified once, in one module, rather than re-derived per
+call site. No parent feature is unstable: `display_path.py` and the feature-tag regex are
+mature; the only new external touch point is the optional pre-commit hook, which is
+inherently opt-in.
+
+## Implementation
+
+Core defines the trailer vocabulary in one place - a `{reference}`-grounded trailer module
+beside `display_path.py` and `identifiers.py` - holding the trailer keys
+(`Vaultspec-Step`, `Vaultspec-Feature`), the value regexes, and pure
+`parse`/`format`/`validate` helpers. Two CLI verbs attach under the existing `vault plan`
+group: one emits a well-formed trailer line for a given step or feature (for scripting into
+a commit template), and one validates the trailers found in a commit-message file,
+reporting malformed values and always exiting zero so it is safe as an advisory hook. The
+opt-in automation is a documented `.pre-commit-config.yaml` entry at the `commit-msg`
+stage invoking the validate verb against the message file; teams that want it run the
+one-time `commit-msg`-stage install, and teams that do not are unaffected. Reading
+trailers back out of commit history to act on them is the business of whatever tool
+consumes them, never of core: core's responsibility ends at defining the format and
+shipping the emit, validate, and optional-hook surface. Exact regexes, verb signatures,
+and the hook entry string belong in a `{reference}` document produced at implementation
+time.
+
+## Rationale
+
+A git trailer is the right carrier because it is a native, append-only commit-metadata
+convention that tools already parse, so adopting teams add it without disrupting their
+message style and non-adopters see nothing. Defining the format in a single module mirrors
+how `display_path.py` and `identifiers.py` already own their formats and prevents the
+drift that an inline-duplicated convention would invite. Routing emit and validate through
+`vault plan` keeps the surface where the identifiers it references already live. Choosing
+the pre-commit `commit-msg` path over inventing a git event in the lifecycle hook engine
+honors both the minimal-machinery principle and the existing precedent, and keeping the
+validator exit-zero is the mechanical expression of the enrichment-not-prerequisite
+constraint.
+
+## Consequences
+
+Adopting teams give any commit-correlating tool a deterministic, high-confidence signal,
+and the format becomes a stable contract such tooling can rely on. The honest costs: core
+gains a convention it must version and not break, and the value of the linkage is entirely
+proportional to adoption, which core can encourage but never enforce - a low-adoption
+repository sees no benefit and that is by design. There is a discipline risk that a future
+contributor, seeing the trailer present, treats it as authoritative and lets a code path
+depend on it; the codification candidate below exists to forbid exactly that. The path
+opens a natural extension - richer trailers (audit ids, ADR stems) under the same module -
+without reopening this decision.
+
+## Codification candidates
+
+- **Rule slug:** `commit-trailer-is-enrichment-only`.
+  **Rule:** The vaultspec commit-linkage trailer is advisory enrichment; no commit may be
+  blocked and no core command may fail or change behavior because a trailer is absent or
+  malformed - validation reports and exits zero.

--- a/.vault/adr/2026-06-13-vault-graph-ref-adr.md
+++ b/.vault/adr/2026-06-13-vault-graph-ref-adr.md
@@ -1,0 +1,99 @@
+---
+tags:
+  - '#adr'
+  - '#vault-graph-ref'
+date: '2026-06-13'
+modified: '2026-06-13'
+related:
+  - '[[2026-06-13-vault-graph-ref-research]]'
+---
+
+# `vault-graph-ref` adr: `ref-scoped vault graph` | (**status:** `accepted`)
+
+## Problem Statement
+
+`vault graph --json` reads the vault corpus of whatever working tree it runs in. Any
+tool that maps a repository's full branch and worktree landscape and ingests the
+declared-edge graph once per corpus view - one vault as it stands on one line of
+development - can today obtain that graph for a ref only by checking the ref out and
+running core inside it, which costs a worktree per view and leaves remote branches with
+no checkout unreadable. Issue #160 asks core to make its declared-edge graph
+ref-addressable: `vault graph --json --ref <branch|sha>` resolving documents from blobs
+at the ref, read-only, with no working-tree mutation, under the existing
+`vaultspec.vault.graph.v2` envelope.
+
+## Considerations
+
+The grounding research (`2026-06-13-vault-graph-ref-research`) establishes that the read
+seam is unusually clean. `VaultGraph._rebuild_from_files` touches the filesystem in
+exactly one place - a single `read_text` per document - and every parser downstream
+(`parse_vault_metadata`, `parse_frontmatter`, `extract_wiki_links`,
+`extract_related_links`) is already content-bound, accepting strings rather than paths.
+The only path-coupled classifier, `get_doc_type`, derives a document's type from its
+location under the docs directory, which a tree-path string reproduces exactly. The
+envelope is assembled by `to_dict` from a networkx serialization plus injected `root`,
+`feature`, `derived_edges`, and `metrics`. The decision is therefore less about feasibility
+than about which blob-reading mechanism to adopt and how to keep the historical read from
+contaminating the working-tree cache.
+
+## Constraints
+
+The project ships no git library and deliberately minimizes dependencies. Reading blobs
+must therefore use the subprocess `git` pattern already present in the codebase and test
+suite (`git ls-tree -r --name-only <ref> -- <docs_dir>` to enumerate, `git cat-file blob`
+or `git show <ref>:<path>` to read), not a new `gitpython` or `pygit2` dependency. The
+feature is git-only by nature: it must fail cleanly with a typed error when the workspace
+is not a git repository or when the ref does not resolve, never fall back to a working-tree
+read that would silently answer for the wrong corpus. The graph cache fingerprints files
+by size and mtime, which do not exist for blobs; a ref-scoped build must run with caching
+disabled so it neither consumes nor writes the working-tree cache. The migration runner
+that `scan_vault` triggers on the working tree has no meaning for a read-only historical
+snapshot and must be skipped on the ref path. No parent feature is unstable: the parser
+and envelope are mature and already exercised by the working-tree path.
+
+## Implementation
+
+A ref-scoped corpus provider sits beside the filesystem scanner. Given a ref and the
+configured docs directory, it enumerates the vault blobs at that ref through git and reads
+each blob's bytes, yielding `(virtual_tree_path, content)` pairs that mirror what
+`scan_vault` plus `read_text` yield today. `VaultGraph` gains a construction path that
+consumes those pairs instead of walking the working tree, with caching off and the
+migration pass skipped; document-type classification reads the tree-path string rather than
+calling `relative_to`. The verb gains a `--ref <ref>` option that selects this path,
+resolves the ref up front, and errors typed-and-clean on a non-repository workspace or an
+unresolvable ref. The JSON envelope stays `vaultspec.vault.graph.v2` with two additions
+that do not alter any node or edge shape: a top-level `ref` key naming the snapshot beside
+the existing `root`, and each node's `path` carrying the virtual tree path. Concrete
+function signatures and the blob-enumeration command details belong in a `{reference}`
+document produced at implementation time, not here.
+
+## Rationale
+
+The subprocess approach keeps the dependency footprint flat and matches the only git
+access pattern the project already trusts. Reusing the content-bound parser and the v2
+envelope means the historical graph is structurally identical to the working-tree graph,
+so any consumer ingests both through one code path and one schema - the whole point of
+the request. Disabling the cache and skipping migrations on the ref path is not an
+optimization choice but a correctness boundary: a read-only view of history must not write
+working-tree state nor be served stale working-tree data. Adding `ref` rather than
+reusing `root` keeps a historical snapshot self-describing without overloading a field
+whose working-tree meaning consumers already depend on.
+
+## Consequences
+
+Any tool that speaks the v2 envelope gains the declared graph for every ref without
+provisioning a worktree per view, reading history for free. The cost is that core takes
+on its first production dependency on the `git` executable being present and on the
+assumption that blob bytes decode as UTF-8 text; both need explicit, typed failure modes
+rather than tracebacks. Performance is bounded by one `git cat-file` per document,
+acceptable for a per-view cadence but not for tight loops, and the absence of a ref-keyed
+cache means repeated reads of the same ref recompute. The path
+opens a natural follow-on - an `as_of` historical reconstruction that walks multiple refs -
+but that is explicitly out of scope here.
+
+## Codification candidates
+
+- **Rule slug:** `ref-scoped-reads-bypass-worktree-cache`.
+  **Rule:** Any vault read scoped to a git ref must run with the graph cache disabled and
+  the working-tree migration pass skipped, and must never fall back to a working-tree read
+  when the ref or repository does not resolve.

--- a/.vault/index/commit-linkage.index.md
+++ b/.vault/index/commit-linkage.index.md
@@ -1,0 +1,30 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#commit-linkage'
+date: '2026-06-13'
+modified: '2026-06-13'
+related:
+  - '[[2026-06-13-commit-linkage-adr]]'
+  - '[[2026-06-13-commit-linkage-plan]]'
+  - '[[2026-06-13-commit-linkage-research]]'
+---
+
+# `commit-linkage` feature index
+
+Auto-generated index of all documents tagged with `#commit-linkage`.
+
+## Documents
+
+### adr
+
+- `2026-06-13-commit-linkage-adr` - `commit-linkage` adr: `opt-in commit-linkage trailer convention` | (**status:** `accepted`)
+
+### plan
+
+- `2026-06-13-commit-linkage-plan` - `commit-linkage` plan
+
+### research
+
+- `2026-06-13-commit-linkage-research` - `commit-linkage` research: `opt-in commit-linkage trailer convention`

--- a/.vault/index/vault-graph-ref.index.md
+++ b/.vault/index/vault-graph-ref.index.md
@@ -1,0 +1,30 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#vault-graph-ref'
+date: '2026-06-13'
+modified: '2026-06-13'
+related:
+  - '[[2026-06-13-vault-graph-ref-adr]]'
+  - '[[2026-06-13-vault-graph-ref-plan]]'
+  - '[[2026-06-13-vault-graph-ref-research]]'
+---
+
+# `vault-graph-ref` feature index
+
+Auto-generated index of all documents tagged with `#vault-graph-ref`.
+
+## Documents
+
+### adr
+
+- `2026-06-13-vault-graph-ref-adr` - `vault-graph-ref` adr: `ref-scoped vault graph` | (**status:** `accepted`)
+
+### plan
+
+- `2026-06-13-vault-graph-ref-plan` - `vault-graph-ref` plan
+
+### research
+
+- `2026-06-13-vault-graph-ref-research` - `vault-graph-ref` research: `ref-scoped vault graph from the git object database`

--- a/.vault/plan/2026-06-13-commit-linkage-plan.md
+++ b/.vault/plan/2026-06-13-commit-linkage-plan.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - '#plan'
+  - '#commit-linkage'
+date: '2026-06-13'
+modified: '2026-06-13'
+tier: L1
+related:
+  - '[[2026-06-13-commit-linkage-adr]]'
+  - '[[2026-06-13-commit-linkage-research]]'
+---
+
+# `commit-linkage` plan
+
+- [ ] `S01` - add the trailer module with keys, value regexes, and pure parse, format, and validate helpers; `src/vaultspec_core/plan/trailer.py`.
+- [ ] `S02` - add vault plan trailer emit and validate verbs that always exit zero; `src/vaultspec_core/cli/plan_cmd.py`.
+- [ ] `S03` - document the opt-in commit-msg pre-commit hook and update the bundled reference and docs; `docs/CLI.md`.
+- [ ] `S04` - cover the trailer module and both verbs with tests including malformed-trailer exit-zero; `src/vaultspec_core/tests/plan/test_trailer.py`.
+
+## Description
+
+Deliver the opt-in commit-linkage trailer per the accepted ADR: a single trailer module
+owning the keys (`Vaultspec-Step`, `Vaultspec-Feature`), the value regexes, and pure
+parse, format, and validate helpers; `vault plan trailer emit` and `validate` verbs, the
+latter always exiting zero so it is safe as an advisory hook; and a documented opt-in
+`commit-msg` pre-commit entry. The convention is enrichment only: absence or
+malformation never blocks a commit or fails a core command.
+
+## Parallelization
+
+`S01` (trailer module) is the foundation. `S02` (CLI verbs) and `S04` (tests) depend on
+it; `S03` (docs and bundled reference) depends on the verb surface from `S02`. The module
+and its tests can be authored together, with the verbs and docs following.
+
+## Verification
+
+`vault plan trailer emit` produces a well-formed `Vaultspec-Step:` or `Vaultspec-Feature:`
+line; `vault plan trailer validate` on a message with a malformed trailer reports it and
+still exits zero, and on a clean or trailer-free message also exits zero; the trailer
+regexes accept every valid L1..L4 display path and reject malformed ids; `ruff`, `ty`, and
+the new tests are green.

--- a/.vault/plan/2026-06-13-vault-graph-ref-plan.md
+++ b/.vault/plan/2026-06-13-vault-graph-ref-plan.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - '#plan'
+  - '#vault-graph-ref'
+date: '2026-06-13'
+modified: '2026-06-13'
+tier: L1
+related:
+  - '[[2026-06-13-vault-graph-ref-adr]]'
+  - '[[2026-06-13-vault-graph-ref-research]]'
+---
+
+# `vault-graph-ref` plan
+
+- [ ] `S01` - add a git blob corpus reader enumerating and reading vault blobs at a ref via subprocess git; `src/vaultspec_core/graph/refscan.py`.
+- [ ] `S02` - add a VaultGraph ref-construction path with cache disabled, migrations skipped, doc-type from the tree path; `src/vaultspec_core/graph/api.py`.
+- [ ] `S03` - add --ref to the graph verb with typed errors and add the ref envelope key; `src/vaultspec_core/cli/vault_cmd.py`.
+- [ ] `S04` - cover the ref path with real-git tests and update the bundled reference and docs; `src/vaultspec_core/tests/cli/test_graph_ref.py`.
+
+## Description
+
+Deliver `vault graph --json --ref <ref>` per the accepted ADR: read the vault corpus
+from git blobs at a ref through subprocess git, build the graph with the cache disabled
+and the working-tree migration pass skipped, and emit the unchanged
+`vaultspec.vault.graph.v2` envelope with an added `ref` key and virtual node paths. A
+non-repository workspace or an unresolvable ref fails with a typed error rather than a
+working-tree fallback.
+
+## Parallelization
+
+`S01` (blob reader) and `S02` (graph build path) are sequential: the build consumes the
+reader's output. `S03` (CLI surface and envelope) depends on `S02`. `S04` (tests and
+docs) lands last and exercises the whole path against a real throwaway git repository.
+
+## Verification
+
+`vault graph --json --ref <sha>` against a repository whose vault changed between commits
+returns the corpus as it stood at that ref, identical in shape to a working-tree build of
+the same corpus; the working-tree graph cache is neither read nor written by the ref
+path; a missing ref and a non-git workspace each exit non-zero with a typed message;
+`ruff`, `ty`, and the new tests are green.

--- a/.vault/research/2026-06-13-commit-linkage-research.md
+++ b/.vault/research/2026-06-13-commit-linkage-research.md
@@ -1,0 +1,81 @@
+---
+tags:
+  - '#research'
+  - '#commit-linkage'
+date: '2026-06-13'
+modified: '2026-06-13'
+related: []
+---
+
+# `commit-linkage` research: `opt-in commit-linkage trailer convention`
+
+GitHub issue #159 proposes an opt-in convention for carrying vaultspec identifiers in
+git commit metadata - a trailer such as `Vaultspec-Step: W01.P02.S06` or
+`Vaultspec-Feature: <tag>` - that tooling can emit and validate for teams that adopt it.
+Tooling that correlates commits to vault records must otherwise do so heuristically
+(shared paths, time windows, same-day co-activity) and grade each correlation by
+confidence; an explicit identifier in the commit resolves that correlation
+deterministically. The hard design constraint is that this is enrichment, never a
+prerequisite: absence lowers a downstream tool's confidence but breaks nothing. This
+research grounds the identifier formats, the gap in git tooling, and the two available
+deployment paths against the live code.
+
+## Findings
+
+### No commit-message handling exists today
+
+`pyproject.toml` declares no git library; git interaction is subprocess-only and limited.
+`src/vaultspec_core/core/commands.py` shells out to `git ls-files` and `git rm --cached`
+at install time. `src/vaultspec_core/config/workspace.py` walks for `.git` (file or dir,
+including linked-worktree pointers) to discover the repo root but never reads history.
+`src/vaultspec_core/core/gitignore.py` and `gitattributes.py` manage marked blocks in
+those files. There is no commit-message reading, no trailer parsing, and no commit-to-doc
+correlation anywhere in `src/`; the one near-miss is a human-readable
+`git commit -m "..."` hint string emitted after `vault check all`. All of the trailer
+emit and validate logic would therefore be new code.
+
+### The identifier formats a trailer would carry
+
+Plan container identifiers are defined in `src/vaultspec_core/plan/identifiers.py` by the
+pattern `^[SPW]\d{2,}[a-z]?$` (Steps take no suffix; Phases and Waves may carry a single
+lowercase suffix letter from stable insertion). `src/vaultspec_core/plan/display_path.py`
+composes the dot-joined display path, tier-dependent: `S06` at L1, `P02.S06` at L2, and
+`W01.P02.S06` at L3 and L4. A `Vaultspec-Step:` trailer carries that display path; its
+validation regex is `^(?:W\d{2,}\.)?(?:P\d{2,}[a-z]?\.)?S\d{2,}$`, with the phase-only
+form `^(?:W\d{2,}\.)?P\d{2,}[a-z]?$`.
+
+### The feature-tag format, and a missing shared validator
+
+The feature tag is validated inline as `^[a-z0-9][a-z0-9-]*$` (kebab-case) in both
+`src/vaultspec_core/cli/vault_cmd.py` and `src/vaultspec_core/mcp_server/vault_tools.py`;
+the stored frontmatter form carries a leading `#`. A `Vaultspec-Feature:` trailer carries
+the tag with the `#` optional, validated as `^#?[a-z0-9][a-z0-9-]*$`. No shared
+feature-tag validator exists yet - the regex is duplicated inline - so a trailer module
+would either reuse a newly extracted helper or carry its own copy.
+
+### Two hook systems exist; neither speaks git commit-msg
+
+There are two distinct, deliberately separate hook systems. The vaultspec lifecycle hook
+engine (`src/vaultspec_core/hooks/engine.py`, CRUD in `src/vaultspec_core/core/hooks.py`,
+CLI under `spec hooks` in `src/vaultspec_core/cli/spec_cmd.py`) fires on a frozen set of
+three events - `vault.document.created`, `config.synced`, `audit.completed` - none of
+them a git event, so it cannot host a commit-msg hook without inventing a new event and a
+`.git/hooks/` writer. The developer toolchain hook system is `.pre-commit-config.yaml`
+(run via `prek`, already a dev dependency), whose hooks are `repo: local` entries calling
+`uv run ...`; one existing hook (`block-manual-changelog`) already reads git state with
+`git diff --cached`. There is no `commit-msg`-stage hook today.
+
+### Where the convention and verbs would live
+
+The trailer format and its parse/format/validate helpers would live in a new
+`src/vaultspec_core/plan/trailer.py`, mirroring the `display_path.py` and
+`identifiers.py` siblings. The CLI verbs (validate a commit message file, emit a trailer
+for a given step or feature) would attach under the existing `vault plan` Typer app in
+`src/vaultspec_core/cli/plan_cmd.py`, following the established `add_typer` sub-group
+pattern. For optional automated validation, the lowest-friction deployment is a new
+`.pre-commit-config.yaml` entry with `stages: [commit-msg]` calling a
+`vault plan trailer validate` verb, which a prior repo ADR
+(`2026-03-22-clci-release-adr`) already floated; a heavier alternative writes a script
+directly into `.git/hooks/commit-msg`. Either way the hook must be advisory: a missing or
+malformed trailer is reported, never fatal, to honor the enrichment-not-prerequisite
+constraint.

--- a/.vault/research/2026-06-13-vault-graph-ref-research.md
+++ b/.vault/research/2026-06-13-vault-graph-ref-research.md
@@ -1,0 +1,82 @@
+---
+tags:
+  - '#research'
+  - '#vault-graph-ref'
+date: '2026-06-13'
+modified: '2026-06-13'
+related: []
+---
+
+# `vault-graph-ref` research: `ref-scoped vault graph from the git object database`
+
+GitHub issue #160 asks core to let `vault graph --json` read a vault corpus at an
+arbitrary git ref (`--ref <branch|sha>`) directly from the object database, without a
+working-tree checkout, emitting the same versioned envelope. A tool that maps a
+repository's whole branch and worktree landscape and ingests the declared-edge graph
+once per corpus view can today obtain that graph only for refs that have a checkout, so
+remote branches with no checkout are unreadable. This research grounds the seam, the
+parser's path-coupling, the git tooling gap, and the wire-format delta against the live
+code.
+
+## Findings
+
+### The command and its current working-tree binding
+
+The verb lives in `src/vaultspec_core/cli/vault_cmd.py` as `cmd_graph`. It calls
+`apply_target(target)`, constructs `VaultGraph(_get_ctx().target_dir)`, and for `--json`
+calls `graph.to_dict(...)` wrapped by `json_envelope("vault.graph", ..., version=2)`,
+which yields the schema string `vaultspec.vault.graph.v2`. Every path runs against the
+working tree; there is no `--ref` today.
+
+### The single filesystem seam
+
+The corpus read is narrow. `scan_vault(root_dir)` in
+`src/vaultspec_core/vaultcore/scanner.py` does a plain `docs_dir.rglob("*.md")` over the
+working tree and yields `Path` objects, skipping `.obsidian` and `_archive`.
+`VaultGraph._rebuild_from_files` in `src/vaultspec_core/graph/api.py` is the hot path,
+and its only filesystem touch is a single `content = path.read_text(encoding="utf-8")`.
+Everything downstream consumes the raw string.
+
+### The parser is already content-bound
+
+`parse_vault_metadata(content)` and `parse_frontmatter(content)` in
+`src/vaultspec_core/vaultcore/parser.py` both take a `str` and return parsed structures;
+`extract_wiki_links` and `extract_related_links` in
+`src/vaultspec_core/vaultcore/links.py` are pure string and list functions. None is
+path-bound, so substituting blob bytes for `path.read_text()` requires zero parser
+refactor. The one exception is `get_doc_type(path, root_dir)` in `scanner.py`, which
+classifies a document from its location via `path.relative_to(docs_dir)` and
+`parts[0]`. A blob walk already knows each blob's tree path (for example
+`.vault/adr/foo.md`), so the same classification reproduces from the tree-path string;
+this is a small isolated change, not a structural one.
+
+### No git tooling exists; the project pattern is subprocess
+
+`pyproject.toml` declares no git library (no `gitpython`, `pygit2`, or `dulwich`).
+Production code never reads the object database; the only git subprocess calls are
+install-time `git ls-files` / `git rm --cached` in
+`src/vaultspec_core/core/commands.py`, and git-repo discovery in
+`src/vaultspec_core/config/workspace.py` walks for `.git` without reading history. The
+established way to read blobs without a new dependency is
+`git ls-tree -r --name-only <ref> -- <docs_dir>` to enumerate, then
+`git cat-file blob <sha>` (or `git show <ref>:<path>`) to read - the same subprocess
+pattern the test suite already uses. This keeps the project's minimal-dependency stance
+(pure-Python PageRank, no numpy) intact.
+
+### The cache must be bypassed, never shared
+
+The graph cache in `src/vaultspec_core/graph/cache.py` lives at
+`<docs_dir>/data/.graph-cache/graph.json` and fingerprints each file as
+`(st_size, st_mtime_ns, sha256)`. Those are working-tree inode facts with no slot for a
+ref. A ref-scoped build has no mtimes and must construct with `use_cache=False` so it
+neither reads nor writes the working-tree cache; otherwise a historical build would
+poison the next working-tree build.
+
+### The wire-format delta is two keys
+
+`VaultGraph.to_dict(...)` builds `data` from networkx `node_link_data` plus injected
+`derived_edges`, `root`, `feature`, and `metrics`; each node carries `path` among its
+attributes. To stay schema-compatible while expressing ref semantics, the envelope needs
+a companion `ref` key beside `root`, and each node's `path` becomes the virtual tree
+path (or `null`). No node or edge attribute changes shape, so
+`vaultspec.vault.graph.v2` remains the contract.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -617,15 +617,18 @@ Outputs a hierarchical tree grouped by feature and type.
 The `--json` payload (schema `vaultspec.vault.graph.v2`) carries typed weighted explicit
 edges (`kind`, `multiplicity`, `weight`), node-size hints (`pagerank`, `in_degree`), and
 a separate `derived_edges` array of implicit relatedness edges kept out of the canonical
-`edges` array. A missing `--node` stem exits 1 with a `failed` envelope.
+`edges` array. Each node's `path` is a vault-relative POSIX path (e.g.
+`.vault/adr/foo.md`); no absolute filesystem path is emitted, and the format is
+identical for working-tree and ref-scoped builds. A missing `--node` stem exits 1 with a
+`failed` envelope.
 
 `--ref <branch|sha>` reads the vault corpus from the git object database at that ref
 instead of the working tree, without a checkout. The read is read-only: the working-tree
 graph cache is neither consulted nor written, and the working-tree migration pass is
 skipped. The envelope stays `vaultspec.vault.graph.v2` with a top-level `ref` key naming
-the snapshot (it is `null` for a working-tree build) and each node's `path` carrying the
-virtual tree path. A non-git workspace or an unresolvable ref exits 1 with a typed error
-rather than silently reading the working tree.
+the snapshot (it is `null` for a working-tree build). A non-git workspace or an
+unresolvable ref exits 1 with a typed error rather than silently reading the working
+tree.
 
 #### Examples
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -155,6 +155,8 @@ vaultspec-core vault plan epic intent edit [OPTIONS] PATH
 vaultspec-core vault plan tier show [OPTIONS] PATH
 vaultspec-core vault plan tier promote [OPTIONS] PATH
 vaultspec-core vault plan tier demote [OPTIONS] PATH
+vaultspec-core vault plan trailer emit [OPTIONS]
+vaultspec-core vault plan trailer validate [OPTIONS] MESSAGE_FILE
 vaultspec-core vault link list [OPTIONS] [SRC]
 vaultspec-core vault link add [OPTIONS] SRC DST
 vaultspec-core vault link remove [OPTIONS] SRC DST
@@ -347,19 +349,21 @@ Create a new `.vault/` document from a template.
 
 #### Options
 
-| Option          | Short | Default         | Description                                                                           |
-| --------------- | ----- | --------------- | ------------------------------------------------------------------------------------- |
-| `--feature TAG` | `-f`  | None (required) | Feature tag (kebab-case, lowercase letters, digits, hyphens).                         |
-| `--date DATE`   | -     | today           | Override date (ISO 8601, e.g., YYYY-MM-DD).                                           |
-| `--title TITLE` | -     | None            | Document title. For execution records, overrides the default heading.                 |
-| `--related DOC` | `-r`  | None            | Related document(s). Accepts path, filename, stem, or `[[wiki-link]]`. Repeatable.    |
-| `--tags TAG`    | -     | None            | Additional tags beyond the required directory and feature tags. Repeatable.           |
-| `--force`       | -     | off             | Overwrite an existing document at the resolved path.                                  |
-| `--dry-run`     | -     | off             | Preview without writing files.                                                        |
-| `--json`        | -     | off             | Emit machine-readable JSON output in standard envelope.                               |
-| `--tier TIER`   | -     | L1              | Plan tier (`L1`, `L2`, `L3`, `L4`). (Ignored for non-plan types).                     |
-| `--step STEP`   | -     | None            | Canonical ID or display path of a specific step to scaffold. (Only valid for `exec`). |
-| `--all-steps`   | -     | off             | Scaffold execution records for all steps in parent plan. (Only valid for `exec`).     |
+| Option          | Short | Default         | Description                                                                                            |
+| --------------- | ----- | --------------- | ------------------------------------------------------------------------------------------------------ |
+| `--feature TAG` | `-f`  | None (required) | Feature tag (kebab-case, lowercase letters, digits, hyphens).                                          |
+| `--date DATE`   | -     | today           | Override date (ISO 8601, e.g., YYYY-MM-DD).                                                            |
+| `--title TITLE` | -     | None            | Document title. For execution records, overrides the default heading.                                  |
+| `--related DOC` | `-r`  | None            | Related document(s). Accepts path, filename, stem, or `[[wiki-link]]`. Repeatable.                     |
+| `--tags TAG`    | -     | None            | Additional tags beyond the required directory and feature tags. Repeatable.                            |
+| `--force`       | -     | off             | Overwrite an existing document at the resolved path.                                                   |
+| `--dry-run`     | -     | off             | Preview without writing files.                                                                         |
+| `--json`        | -     | off             | Emit machine-readable JSON output in standard envelope.                                                |
+| `--tier TIER`   | -     | L1              | Plan tier (`L1`, `L2`, `L3`, `L4`). (Ignored for non-plan types).                                      |
+| `--step STEP`   | -     | None            | Canonical ID or display path of a specific step to scaffold. (Only valid for `exec`).                  |
+| `--all-steps`   | -     | off             | Scaffold execution records for all steps in parent plan. (Only valid for `exec`).                      |
+| `--summary`     | -     | off             | Scaffold a Phase summary record instead of a Step record. Requires `--phase`. (Only valid for `exec`). |
+| `--phase P##`   | -     | None            | Canonical Phase ID to summarise; used with `--summary`. (Only valid for `exec`).                       |
 
 #### Step-Aware Execution Scaffolding (`DOC_TYPE=exec`)
 
@@ -369,8 +373,14 @@ target individual or bulk steps from the parent plan.
 ##### Option Gating and Fallbacks
 
 - **Mutual Exclusion**: `--step` and `--all-steps` are strictly mutually exclusive. If
-  both are provided, or if either is passed with a document type other than `exec`, the
-  CLI aborts with exit code `1`.
+  both are provided, or if any of `--step`, `--all-steps`, or `--summary` is passed with
+  a document type other than `exec`, the CLI aborts with exit code `1`.
+- **Phase Summary**: `--summary --phase P##` scaffolds the Phase-summary record from the
+  `exec-summary.md` template into the feature's exec folder as
+  `{date}-{feature}-{phase}-summary.md` (the `{phase}` segment carries the Phase display
+  path, e.g. `P01` or `W01-P01`). `--summary` requires `--phase`, `--phase` requires
+  `--summary`, and `--summary` may not combine with `--step` or `--all-steps`. An
+  unknown Phase id aborts with exit code `1`.
 - **Legacy Fallback**: If neither option is provided when creating an `exec` document,
   the CLI displays a yellow warning:
   `Deprecation Warning: Scaffolding flat (non-step-aware) execution records is deprecated. Use --step or --all-steps.`
@@ -602,11 +612,20 @@ Outputs a hierarchical tree grouped by feature and type.
 | `--node STEM`            | -     | None    | Scope JSON to a node's local (ego) neighbourhood |
 | `--depth N`              | -     | 1       | Ego-graph radius in hops; only used with --node  |
 | `--derived/--no-derived` | -     | on      | Include the derived relatedness edge set in JSON |
+| `--ref REF`              | -     | None    | Read the corpus from a git ref (branch/tag/sha)  |
 
 The `--json` payload (schema `vaultspec.vault.graph.v2`) carries typed weighted explicit
 edges (`kind`, `multiplicity`, `weight`), node-size hints (`pagerank`, `in_degree`), and
 a separate `derived_edges` array of implicit relatedness edges kept out of the canonical
 `edges` array. A missing `--node` stem exits 1 with a `failed` envelope.
+
+`--ref <branch|sha>` reads the vault corpus from the git object database at that ref
+instead of the working tree, without a checkout. The read is read-only: the working-tree
+graph cache is neither consulted nor written, and the working-tree migration pass is
+skipped. The envelope stays `vaultspec.vault.graph.v2` with a top-level `ref` key naming
+the snapshot (it is `null` for a working-tree build) and each node's `path` carrying the
+virtual tree path. A non-git workspace or an unresolvable ref exits 1 with a typed error
+rather than silently reading the working tree.
 
 #### Examples
 
@@ -1318,6 +1337,53 @@ A self-referential move (`step move S01 --before S01`) is rejected with the rele
 to a hidden `<!-- RETIRED: ... -->` ledger embedded in the plan body. `next_available_*`
 consults this ledger so retired identifiers are never reused, even across
 `parse / serialize` round-trips invoked by `--fix`.
+
+#### Commit-linkage trailers
+
+The `vaultspec-core vault plan trailer` verbs define an **opt-in** convention for
+carrying vaultspec identifiers in git commit metadata, so tooling that correlates
+commits to vault records can resolve a link deterministically instead of heuristically.
+Two trailer keys are defined: `Vaultspec-Step` carries a Step or Phase display path
+(`S06`, `P02.S06`, `W01.P02.S06`, or the phase-only `P02`), and `Vaultspec-Feature`
+carries a kebab-case feature tag (with an optional leading `#`).
+
+The convention is **enrichment, never a prerequisite**: a missing or malformed trailer
+must never block a commit or fail any command. `trailer validate` reports malformed
+trailers and **always exits 0**, which is what makes it safe to wire as an advisory
+`commit-msg` hook.
+
+- **Emit a trailer line** (for scripting into a commit template):
+
+  ```bash
+  vaultspec-core vault plan trailer emit --step W01.P02.S06
+  vaultspec-core vault plan trailer emit --feature auth-refactor
+  ```
+
+  Exactly one of `--step` / `--feature` is required; invalid input is a usage error
+  (exit 1).
+
+- **Validate the trailers in a commit-message file** (advisory; always exit 0):
+
+  ```bash
+  vaultspec-core vault plan trailer validate .git/COMMIT_EDITMSG
+  ```
+
+- **Opt-in `commit-msg` pre-commit hook**: teams that want the advisory check add the
+  following `repo: local` hook at the `commit-msg` stage to their
+  `.pre-commit-config.yaml`, then run the one-time `prek install --hook-type commit-msg`
+  (or `pre-commit install --hook-type commit-msg`). Teams that do not are unaffected.
+
+  ```yaml
+  - repo: local
+    hooks:
+      - id: vaultspec-commit-trailer
+        name: vaultspec commit-linkage trailer (advisory)
+        entry: vaultspec-core vault plan trailer validate
+        language: system
+        stages: [commit-msg]
+        always_run: true
+        verbose: true
+  ```
 
 ## Spec commands
 

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -96,6 +96,8 @@ vaultspec-core vault plan epic intent edit [OPTIONS] PATH
 vaultspec-core vault plan tier show [OPTIONS] PATH
 vaultspec-core vault plan tier promote [OPTIONS] PATH
 vaultspec-core vault plan tier demote [OPTIONS] PATH
+vaultspec-core vault plan trailer emit [OPTIONS]
+vaultspec-core vault plan trailer validate [OPTIONS] MESSAGE_FILE
 vaultspec-core vault link list [OPTIONS] [SRC]
 vaultspec-core vault link add [OPTIONS] SRC DST
 vaultspec-core vault link remove [OPTIONS] SRC DST
@@ -232,6 +234,8 @@ Create a `.vault/` document from a template.
 | `--tier TIER`   | -     | `L1`    | Plan tier (`L1`..`L4`). Ignored for non-plan document types.         |
 | `--step ID`     | -     | None    | Canonical ID or display path of the Step to scaffold (exec records). |
 | `--all-steps`   | -     | off     | Scaffold execution records for all Steps in the parent plan.         |
+| `--summary`     | -     | off     | Scaffold a Phase summary (exec records); requires `--phase`.         |
+| `--phase P##`   | -     | None    | Canonical Phase ID to summarise; used with `--summary`.              |
 
 ### vaultspec-core vault status
 
@@ -312,12 +316,20 @@ by feature and type.
 | `--node STEM`            | -     | None    | Scope JSON to a node's local (ego) neighbourhood. |
 | `--depth N`              | -     | 1       | Ego-graph radius in hops; only used with --node.  |
 | `--derived/--no-derived` | -     | on      | Include the derived relatedness edge set in JSON. |
+| `--ref REF`              | -     | None    | Read the corpus from a git ref (branch/tag/sha).  |
 
 The `--json` payload (schema `vaultspec.vault.graph.v2`) carries typed weighted explicit
 edges (`kind`, `multiplicity`, `weight`), node-size hints (`pagerank`, `in_degree`), and
 a separate `derived_edges` array of implicit relatedness edges that is never mixed into
 the canonical `edges` array. A missing `--node` stem fails with exit code 1 and a
 `failed` envelope.
+
+`--ref <branch|sha>` reads the corpus from the git object database at that ref without a
+checkout (read-only: the working-tree cache is neither read nor written, and the
+migration pass is skipped). The envelope stays `vaultspec.vault.graph.v2` with a
+top-level `ref` key naming the snapshot (`null` for a working-tree build) and each
+node's `path` set to the virtual tree path. A non-git workspace or an unresolvable ref
+exits 1 with a typed error instead of falling back to a working-tree read.
 
 ### vaultspec-core vault repair
 

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -321,15 +321,17 @@ by feature and type.
 The `--json` payload (schema `vaultspec.vault.graph.v2`) carries typed weighted explicit
 edges (`kind`, `multiplicity`, `weight`), node-size hints (`pagerank`, `in_degree`), and
 a separate `derived_edges` array of implicit relatedness edges that is never mixed into
-the canonical `edges` array. A missing `--node` stem fails with exit code 1 and a
+the canonical `edges` array. Each node's `path` is a vault-relative POSIX path (e.g.
+`.vault/adr/foo.md`), identical across working-tree and ref-scoped builds; no absolute
+filesystem path is emitted. A missing `--node` stem fails with exit code 1 and a
 `failed` envelope.
 
 `--ref <branch|sha>` reads the corpus from the git object database at that ref without a
 checkout (read-only: the working-tree cache is neither read nor written, and the
 migration pass is skipped). The envelope stays `vaultspec.vault.graph.v2` with a
-top-level `ref` key naming the snapshot (`null` for a working-tree build) and each
-node's `path` set to the virtual tree path. A non-git workspace or an unresolvable ref
-exits 1 with a typed error instead of falling back to a working-tree read.
+top-level `ref` key naming the snapshot (`null` for a working-tree build). A non-git
+workspace or an unresolvable ref exits 1 with a typed error instead of falling back to a
+working-tree read.
 
 ### vaultspec-core vault repair
 

--- a/src/vaultspec_core/builtins/rules/.gitignore
+++ b/src/vaultspec_core/builtins/rules/.gitignore
@@ -1,3 +1,4 @@
 # Authored rules in this directory are team-shared (cli-spec-gitignore ADR):
-# both builtin *.builtin.md files and project-authored *.md rules are
-# committed to git so teammates inherit the project's full rule set.
+# both builtin *.builtin.md files and custom *.md rules are committed to git
+# so teammates inherit the project's full rule set. Rules live flat in this
+# directory; nested rule folders are not supported.

--- a/src/vaultspec_core/cli/plan_cmd.py
+++ b/src/vaultspec_core/cli/plan_cmd.py
@@ -58,6 +58,45 @@ def _render_user_errors[F: Callable[..., None]](func: F) -> F:
     return cast("F", wrapper)
 
 
+def _resolve_vault_root(plan_path: Path) -> Path | None:
+    """Return the vault root that owns *plan_path*, or ``None``.
+
+    A plan document lives under ``<root>/<docs_dir>/plan/...``.  The mutation
+    verbs operate on a bare path argument and never initialise the workspace
+    :class:`~contextvars.ContextVar`, so the root is derived from the path:
+    the nearest ancestor whose final component is the configured ``docs_dir``
+    has that ancestor's parent as the root.  Falls back to the active
+    workspace context, then to ``None`` when neither resolves.
+    """
+    from vaultspec_core.config import get_config
+
+    docs_dir_name = Path(get_config().docs_dir).name
+    resolved = plan_path.resolve()
+    for ancestor in resolved.parents:
+        if ancestor.name == docs_dir_name:
+            return ancestor.parent
+
+    from vaultspec_core.core.types import get_context
+
+    try:
+        return get_context().target_dir
+    except LookupError:
+        return None
+
+
+def _invalidate_graph_cache_for_plan(plan_path: Path) -> None:
+    """Drop the graph cache for the vault owning *plan_path*.
+
+    Never raises: a successful plan write must not be turned into a non-zero
+    exit by a best-effort post-save cache drop (issue #157).
+    """
+    from vaultspec_core.cli._cache_hook import invalidate_graph_cache
+
+    root = _resolve_vault_root(plan_path)
+    if root is not None:
+        invalidate_graph_cache(root)
+
+
 def _save_plan_or_dry_run(
     path: Path,
     plan: Any,
@@ -149,18 +188,7 @@ def _save_plan_or_dry_run(
         preserved_count = 0 if canonicalise else len(plan.unknown_blocks)
         typer.echo(f"{success_msg} (Preserved {preserved_count} unknown blocks)")
         if wrote:
-            from vaultspec_core.cli._cache_hook import invalidate_graph_cache
-            from vaultspec_core.core.types import get_context as _get_ctx
-
-            # Plan mutators do not take --target, so the workspace context is
-            # only initialised when another command set it earlier in-process.
-            # Bare invocations fall back to the cwd, which is what
-            # apply_target(None) would have resolved.
-            try:
-                target_dir = _get_ctx().target_dir
-            except LookupError:
-                target_dir = Path.cwd()
-            invalidate_graph_cache(target_dir)
+            _invalidate_graph_cache_for_plan(path)
 
 
 plan_app = typer.Typer(
@@ -200,6 +228,15 @@ tier_app = typer.Typer(
     no_args_is_help=True,
 )
 plan_app.add_typer(tier_app, name="tier")
+
+trailer_app = typer.Typer(
+    help=(
+        "Commit-linkage trailers: emit a well-formed trailer, or validate "
+        "the trailers in a commit message (advisory; always exits 0)."
+    ),
+    no_args_is_help=True,
+)
+plan_app.add_typer(trailer_app, name="trailer")
 
 
 # ---- Read commands ----------------------------------------------------------
@@ -1417,3 +1454,126 @@ def cmd_tier_demote(
         success_msg=f"Tier demoted to {new_tier.value}.",
         expected_retired=expected_retired,
     )
+
+
+# ---- Commit-linkage trailers ------------------------------------------------
+
+
+@trailer_app.command("emit")
+@_render_user_errors
+def cmd_trailer_emit(
+    step: Annotated[
+        str | None,
+        typer.Option(
+            "--step",
+            help="Step or Phase display path (e.g. W01.P02.S06 or P02)",
+        ),
+    ] = None,
+    feature: Annotated[
+        str | None,
+        typer.Option(
+            "--feature",
+            help="Feature tag (kebab-case; leading '#' optional)",
+        ),
+    ] = None,
+) -> None:
+    """Print a well-formed commit-linkage trailer line.
+
+    Exactly one of ``--step`` or ``--feature`` is required. The emitted line
+    is suitable for scripting into a commit template or appending to a commit
+    message. Invalid input is a usage error (exit 1); emission never produces
+    a malformed trailer.
+    """
+    from vaultspec_core.plan.commands._errors import PlanCommandError
+    from vaultspec_core.plan.trailer import (
+        format_feature_trailer,
+        format_step_trailer,
+    )
+
+    if (step is None) == (feature is None):
+        raise PlanCommandError("provide exactly one of --step or --feature.")
+
+    try:
+        if step is not None:
+            typer.echo(format_step_trailer(step))
+        else:
+            assert feature is not None
+            typer.echo(format_feature_trailer(feature))
+    except ValueError as exc:
+        raise PlanCommandError(str(exc)) from exc
+
+
+@trailer_app.command("validate")
+def cmd_trailer_validate(
+    message_file: Annotated[
+        Path,
+        typer.Argument(
+            help="Path to a commit-message file (e.g. .git/COMMIT_EDITMSG)",
+        ),
+    ],
+    json_output: Annotated[
+        bool, typer.Option("--json", help="Emit findings as JSON")
+    ] = False,
+) -> None:
+    """Validate the commit-linkage trailers in a commit-message file.
+
+    Reports any malformed ``Vaultspec-Step`` / ``Vaultspec-Feature`` trailer
+    and **always exits zero**, so it is safe to wire as an advisory
+    ``commit-msg`` hook: a malformed or absent trailer never blocks a commit
+    (the convention is enrichment, never a prerequisite). An unreadable
+    message file is likewise reported and tolerated.
+    """
+    from vaultspec_core.plan.trailer import validate_message
+
+    try:
+        message = message_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        if json_output:
+            from vaultspec_core.cli.rendering import json_envelope
+
+            typer.echo(
+                json.dumps(
+                    json_envelope(
+                        "vault.plan.trailer.validate",
+                        "unchanged",
+                        {"unreadable": str(message_file), "problems": []},
+                    ),
+                    indent=2,
+                )
+            )
+        else:
+            typer.echo(f"trailer: could not read {message_file}: {exc}", err=True)
+        return
+
+    problems = validate_message(message)
+
+    if json_output:
+        from vaultspec_core.cli.rendering import json_envelope
+
+        payload = {
+            "problems": [
+                {
+                    "key": p.key,
+                    "value": p.value,
+                    "line": p.line_number,
+                    "reason": p.reason,
+                }
+                for p in problems
+            ]
+        }
+        typer.echo(
+            json.dumps(
+                json_envelope("vault.plan.trailer.validate", "unchanged", payload),
+                indent=2,
+            )
+        )
+        return
+
+    if not problems:
+        return
+    for problem in problems:
+        typer.echo(
+            f"trailer (advisory) line {problem.line_number}: "
+            f"{problem.key}: {problem.value!r} - {problem.reason}",
+            err=True,
+        )

--- a/src/vaultspec_core/cli/rendering.py
+++ b/src/vaultspec_core/cli/rendering.py
@@ -557,7 +557,7 @@ _NEXT_STEP_HINTS: dict[tuple[str, str], tuple[str, str]] = {
     ),
     ("vault.add.audit", "created"): (
         "vaultspec-core vault rule promote --from {audit_stem} --as {rule_name}",
-        "Promote your audit findings to a project-shared rule",
+        "Promote your audit findings to a team-shared rule",
     ),
     ("vault.check.all", "unchanged"): (
         'git commit -m "Commit changes after successful vault checks"',

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -48,7 +48,7 @@ sanitize_app = typer.Typer(
 vault_app.add_typer(sanitize_app, name="sanitize")
 
 rule_app = typer.Typer(
-    help="Manage project rules.",
+    help="Manage custom team-shared rules.",
     no_args_is_help=True,
 )
 vault_app.add_typer(rule_app, name="rule")
@@ -2395,7 +2395,7 @@ def cmd_rule_promote(
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     target: TargetOption = None,
 ) -> None:
-    """Promote an audit finding to a project-level rule."""
+    """Promote an audit finding to a team-shared rule."""
     apply_target(target)
     import json
 

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -133,6 +133,20 @@ def cmd_add(
             help="Scaffold execution records for all steps in parent plan",
         ),
     ] = False,
+    summary: Annotated[
+        bool,
+        typer.Option(
+            "--summary",
+            help="Scaffold a Phase summary (exec only; requires --phase)",
+        ),
+    ] = False,
+    phase: Annotated[
+        str | None,
+        typer.Option(
+            "--phase",
+            help="Canonical Phase ID (e.g. P01) to summarise; used with --summary",
+        ),
+    ] = None,
     target: TargetOption = None,
 ) -> None:
     """Create a new .vault/ document from a template.
@@ -173,16 +187,35 @@ def cmd_add(
         raise typer.Exit(code=1)
 
     # Validate step-aware flags
-    if (step is not None or all_steps) and dt is not DocType.EXEC:
+    if (step is not None or all_steps or summary) and dt is not DocType.EXEC:
         console.print(
-            "[red]Error: --step and --all-steps options are only valid when "
-            "creating 'exec' documents.[/red]"
+            "[red]Error: --step, --all-steps, and --summary options are only "
+            "valid when creating 'exec' documents.[/red]"
         )
         raise typer.Exit(code=1)
 
     if step is not None and all_steps:
         console.print(
             "[red]Error: --step and --all-steps options are mutually exclusive.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if summary and (step is not None or all_steps):
+        console.print(
+            "[red]Error: --summary cannot be combined with --step or --all-steps.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if summary and phase is None:
+        console.print(
+            "[red]Error: --summary requires --phase <P##> naming the Phase "
+            "to summarise.[/red]"
+        )
+        raise typer.Exit(code=1)
+
+    if phase is not None and not summary:
+        console.print(
+            "[red]Error: --phase is only valid together with --summary.[/red]"
         )
         raise typer.Exit(code=1)
 
@@ -274,8 +307,9 @@ def cmd_add(
     step_display_path_arg = None
     step_scope_arg = None
     step_action_arg = None
+    phase_display_arg = None
 
-    if dt is DocType.EXEC and (step is not None or all_steps):
+    if dt is DocType.EXEC and (step is not None or all_steps or summary):
         from vaultspec_core.vaultcore.query import list_documents
 
         parent_plan_doc = None
@@ -336,6 +370,23 @@ def cmd_add(
             step_display_path_arg = target_step.display_path
             step_scope_arg = target_step.scope
             step_action_arg = target_step.action
+
+        elif summary:
+            from vaultspec_core.plan.commands.phase_ops import (
+                PhaseNotFoundError,
+                find_phase,
+            )
+
+            # The "--summary requires --phase" validation above guarantees a
+            # non-None phase id by the time this branch runs.
+            assert phase is not None
+            try:
+                target_phase = find_phase(parsed_plan, phase)
+            except PhaseNotFoundError as exc:
+                console.print(f"[red]Error: {exc}[/red]")
+                raise typer.Exit(code=1) from None
+
+            phase_display_arg = target_phase.display_path
 
         elif all_steps:
             # Bulk scaffolding loop
@@ -467,6 +518,8 @@ def cmd_add(
                 step_action=step_action_arg,
                 plan_date=plan_date_arg,
                 plan_stem=plan_stem_arg,
+                summary=summary,
+                phase_display_path=phase_display_arg,
             )
         except FileNotFoundError as exc:
             _handle_error(exc, json_output=json_output)
@@ -1102,6 +1155,16 @@ def cmd_graph(
             help="Include the derived relatedness edge set in JSON output",
         ),
     ] = True,
+    ref: Annotated[
+        str | None,
+        typer.Option(
+            "--ref",
+            help=(
+                "Read the vault corpus from this git ref (branch/tag/sha) via "
+                "the object database, without a working-tree checkout"
+            ),
+        ),
+    ] = None,
     target: TargetOption = None,
 ) -> None:
     """Render the vault document graph.
@@ -1114,15 +1177,28 @@ def cmd_graph(
     For JSON output, --node <stem> with --depth N scopes the payload to a
     node's local (ego) neighbourhood, and --no-derived omits the derived
     relatedness edge set.
+
+    Use --ref <branch|sha> to read the corpus from the git object database at
+    that ref instead of the working tree (read-only; no checkout, no cache
+    write). The JSON envelope stays ``vaultspec.vault.graph.v2`` with a
+    top-level ``ref`` key naming the snapshot. A non-git workspace or an
+    unresolvable ref fails with a typed error rather than a working-tree read.
     """
     apply_target(target)
     from vaultspec_core.console import get_console
     from vaultspec_core.core.types import get_context as _get_ctx
     from vaultspec_core.graph import VaultGraph
+    from vaultspec_core.graph.refscan import RefScanError
 
     console = get_console()
     try:
-        graph = VaultGraph(_get_ctx().target_dir)
+        if ref is not None:
+            graph = VaultGraph.from_ref(_get_ctx().target_dir, ref)
+        else:
+            graph = VaultGraph(_get_ctx().target_dir)
+    except RefScanError as exc:
+        console.print(f"[red]Error reading ref {ref!r}: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
     except OSError as exc:
         console.print(f"[red]Error reading vault: {exc}[/red]")
         raise typer.Exit(code=1) from exc

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -539,10 +539,13 @@ def collect_content_integrity(tool_value: str) -> dict[str, ContentSignal]:
     dest_dir = cfg.rules_dir
     source_dir = ctx.rules_src_dir
 
-    # Collect files from destination
+    # Collect files from destination. Glob recursively to match the source
+    # side: custom rules under a subdirectory (e.g. ``rules/project/foo.md``)
+    # are synced into the provider dir preserving that subpath, so a flat
+    # ``*.md`` glob would miss them and falsely flag them as stale or missing.
     dest_files: set[str] = set()
     if dest_dir.is_dir():
-        dest_files = {f.name for f in dest_dir.glob("*.md")}
+        dest_files = {f.name for f in dest_dir.glob("**/*.md")}
 
     # Collect files from source
     source_files: set[str] = set()

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -539,15 +539,19 @@ def collect_content_integrity(tool_value: str) -> dict[str, ContentSignal]:
     dest_dir = cfg.rules_dir
     source_dir = ctx.rules_src_dir
 
-    # Collect files from destination. Glob recursively to match the source
-    # side: custom rules under a subdirectory (e.g. ``rules/project/foo.md``)
-    # are synced into the provider dir preserving that subpath, so a flat
-    # ``*.md`` glob would miss them and falsely flag them as stale or missing.
+    # Provider rule directories are flat: nesting is not supported and sync
+    # sanitizes it (custom rules authored under ``rules/project/`` are
+    # flattened into the provider root, the ``project/`` prefix stripped). So
+    # the destination is globbed flat. The source is globbed recursively only
+    # to discover those project-authored sources by basename - the same
+    # basename the flattened destination carries - so a custom project rule is
+    # matched against its flat deployment and reported clean, not stale (#153).
     dest_files: set[str] = set()
     if dest_dir.is_dir():
-        dest_files = {f.name for f in dest_dir.glob("**/*.md")}
+        dest_files = {f.name for f in dest_dir.glob("*.md")}
 
-    # Collect files from source
+    # Collect files from source (recursive: project-authored rules live one
+    # level down, but only their basename matters for the flat comparison).
     source_files: set[str] = set()
     if source_dir.is_dir():
         source_files = {f.name for f in source_dir.glob("**/*.md")}

--- a/src/vaultspec_core/core/resources.py
+++ b/src/vaultspec_core/core/resources.py
@@ -256,16 +256,12 @@ def resource_rename(
         return new_path
 
     else:
-        old_canonical, old_path = _resolve_path(old_name, base_dir, is_dir)
+        _old_canonical, old_path = _resolve_path(old_name, base_dir, is_dir)
         new_file = new_name if new_name.endswith(".md") else f"{new_name}.md"
-        if (
-            "project/" in old_canonical
-            or "project\\" in old_canonical
-            or old_path.parent.name == "project"
-        ):
-            new_path = base_dir / "project" / new_file
-        else:
-            new_path = base_dir / new_file
+        # Always rename to the flat root: nested resource folders (e.g. a
+        # legacy ``project/`` rule subdir) are not supported, so a rename also
+        # de-nests rather than re-creating the nested location.
+        new_path = base_dir / new_file
 
         if not old_path.exists():
             raise ResourceNotFoundError(f"{label} '{old_name}' not found.")

--- a/src/vaultspec_core/core/rules.py
+++ b/src/vaultspec_core/core/rules.py
@@ -47,16 +47,14 @@ def collect_rules(
         ``(source_path, frontmatter_dict, body_text)``.
     """
     rules_src_dir = _t.get_context().rules_src_dir
-    migrate_flat_custom_rules(rules_src_dir)
+    flatten_nested_custom_rules(rules_src_dir)
     raw_sources = collect_md_resources(rules_src_dir, warnings=warnings)
+    # Rule sources are flat after sanitization; reduce any residual nested key
+    # (e.g. a basename collision the flattener could not resolve) to its
+    # basename so the collected name is always the flat rule name.
     sources = {}
     for k, v in raw_sources.items():
-        if k.startswith("project/"):
-            sources[k[len("project/") :]] = v
-        elif k.startswith("project\\"):
-            sources[k[len("project\\") :]] = v
-        else:
-            sources[k] = v
+        sources[k.replace("\\", "/").rsplit("/", 1)[-1]] = v
     return sources
 
 
@@ -93,7 +91,7 @@ def rules_list() -> list[dict[str, str]]:
     items: list[dict[str, str]] = []
     rules_src_dir = _t.get_context().rules_src_dir
     if rules_src_dir.exists():
-        migrate_flat_custom_rules(rules_src_dir)
+        flatten_nested_custom_rules(rules_src_dir)
         for f in sorted(rules_src_dir.glob("**/*.md")):
             rel_name = f.relative_to(rules_src_dir).as_posix()
             source = "Built-in" if f.name.endswith(".builtin.md") else "Custom"
@@ -128,13 +126,17 @@ def rules_add(
         ResourceExistsError: If the rule exists and *force* is ``False``.
     """
     rules_src_dir = _t.get_context().rules_src_dir
-    ensure_dir(rules_src_dir / "project")
+    ensure_dir(rules_src_dir)
 
-    file_name = name if name.endswith(".md") else f"{name}.md"
-    if not (file_name.startswith("project/") or file_name.startswith("project\\")):
-        file_path = rules_src_dir / "project" / file_name
-    else:
-        file_path = rules_src_dir / file_name
+    # Custom rules live flat directly under the rules root alongside the
+    # ``*.builtin.md`` builtins; nested rule folders are not supported. Reduce
+    # the requested name to its basename so any directory components (including
+    # a legacy ``project/`` prefix) are sanitized away rather than creating a
+    # nested rule.
+    base_name = Path(name.replace("\\", "/")).name
+    file_name = base_name if base_name.endswith(".md") else f"{base_name}.md"
+    rule_stem = file_name[:-3]
+    file_path = rules_src_dir / file_name
 
     if file_path.exists() and not force:
         raise ResourceExistsError(
@@ -154,7 +156,7 @@ def rules_add(
             from ..config import get_config
 
             editor = get_config().editor
-            scaffold = f"---\nname: {name}\n---\n\n# Rule content\n"
+            scaffold = f"---\nname: {rule_stem}\n---\n\n# Rule content\n"
             atomic_write(file_path, scaffold)
             logger.info("Opening editor (%s) for %s...", editor, file_path)
             try:
@@ -166,7 +168,7 @@ def rules_add(
         else:
             rule_content = sys.stdin.read()
 
-    fm = {"name": name}
+    fm = {"name": rule_stem}
     full = build_file(fm, (rule_content or "").lstrip())
     atomic_write(file_path, full)
     logger.info("Created custom rule: %s", file_path)
@@ -266,22 +268,55 @@ def converge_spec_layer_gitignore(rules_src_dir: Path) -> bool:
     return True
 
 
-def migrate_flat_custom_rules(rules_src_dir: Path) -> None:
-    """Migrate flat custom rules to project/ subdirectory."""
+def flatten_nested_custom_rules(rules_src_dir: Path) -> None:
+    """Flatten any nested custom rule to the rules root; sanitize nesting.
+
+    Custom rules are team-shared markdown files that live FLAT directly under
+    ``.vaultspec/rules/rules/`` alongside the ``*.builtin.md`` builtins; nested
+    rule folders (notably the historical ``project/`` subdir) are not
+    supported. This heals the source tree idempotently: every non-builtin
+    ``*.md`` found below the rules root is moved up to ``<root>/<basename>`` and
+    the emptied subdirectories are removed. A basename collision with an
+    existing flat rule is left in place and logged rather than overwriting the
+    operator's file. Runs on every collect / sync so authored or previously
+    migrated nesting is sanitized automatically.
+    """
     if not rules_src_dir.exists():
         return
     import shutil
 
-    for f in rules_src_dir.glob("*.md"):
-        if f.is_file() and not f.name.endswith(".builtin.md"):
-            project_dir = rules_src_dir / "project"
-            project_dir.mkdir(parents=True, exist_ok=True)
-            dest_file = project_dir / f.name
-            try:
-                shutil.move(str(f), str(dest_file))
-                logger.info("Migrated flat custom rule %s to %s", f, dest_file)
-            except Exception as e:
-                logger.error("Failed to migrate flat custom rule %s: %s", f, e)
+    for f in sorted(rules_src_dir.glob("**/*.md")):
+        if not f.is_file() or f.parent == rules_src_dir:
+            continue  # already flat
+        if f.name.endswith(".builtin.md"):
+            continue  # builtins are flat by contract
+        dest_file = rules_src_dir / f.name
+        if dest_file.exists():
+            logger.warning(
+                "Cannot flatten nested rule %s: %s already exists; leaving nested",
+                f,
+                dest_file,
+            )
+            continue
+        try:
+            shutil.move(str(f), str(dest_file))
+            logger.info("Flattened nested custom rule %s to %s", f, dest_file)
+        except OSError as e:
+            logger.error("Failed to flatten nested custom rule %s: %s", f, e)
+
+    # Remove now-empty nested directories (e.g. the legacy ``project/`` subdir),
+    # deepest first so parents empty out after their children.
+    nested_dirs = sorted(
+        (p for p in rules_src_dir.glob("**/*") if p.is_dir()),
+        key=lambda p: len(p.parts),
+        reverse=True,
+    )
+    for d in nested_dirs:
+        try:
+            if not any(d.iterdir()):
+                d.rmdir()
+        except OSError:
+            pass
 
 
 def rule_promote(
@@ -290,9 +325,9 @@ def rule_promote(
     force: bool = False,
     dry_run: bool = False,
 ) -> Path:
-    """Promote an audit finding to a project-level rule.
+    """Promote an audit finding to a team-shared rule.
 
-    Scaffolds a new rule under `.vaultspec/rules/rules/project/` and appends
+    Scaffolds a new rule flat under `.vaultspec/rules/rules/` and appends
     the rule to the originating audit's ``promoted_to`` frontmatter field.
 
     Args:
@@ -332,9 +367,9 @@ def rule_promote(
             "(lowercase letters, numbers, and hyphens)."
         )
 
-    # 3. Define target rule file path
+    # 3. Define target rule file path (flat; nested rule folders unsupported)
     rules_src_dir = _t.get_context().rules_src_dir
-    rule_file = rules_src_dir / "project" / f"{rule_name_stem}.md"
+    rule_file = rules_src_dir / f"{rule_name_stem}.md"
 
     if rule_file.exists() and not force:
         raise ResourceExistsError(

--- a/src/vaultspec_core/graph/api.py
+++ b/src/vaultspec_core/graph/api.py
@@ -72,7 +72,14 @@ class DocNode:
     metadata so that consumers never need to re-read the filesystem.
 
     Attributes:
-        path: Filesystem path to the document file, or ``None`` for phantoms.
+        path: Filesystem path to the document file, or ``None`` for phantoms
+            and for ref-scoped nodes (which have no working-tree path; their
+            virtual location is carried by ``tree_path`` instead).
+        tree_path: For a ref-scoped node (issue #160), the repo-relative POSIX
+            tree path of the blob (e.g. ``.vault/adr/foo.md``); ``None`` for a
+            working-tree node, whose location is ``path``. Serialised as the
+            node's ``path`` attribute so a consumer sees one ``path`` field
+            regardless of build source.
         name: Document stem (filename without extension), used as graph key.
         doc_type: Categorised document type from vault folder location.
         feature: Feature tag (without ``#`` prefix), or ``None``.
@@ -95,6 +102,7 @@ class DocNode:
     path: pathlib.Path | None
     name: str
     doc_type: DocType | None = None
+    tree_path: str | None = None
     feature: str | None = None
     date: str | None = None
     modified: str | None = None
@@ -120,7 +128,14 @@ class DocNode:
         """
         return {
             "name": self.name,
-            "path": str(self.path) if self.path else None,
+            # A ref-scoped node carries its virtual tree path; a working-tree
+            # node carries the stringified filesystem path. Either way the
+            # serialised attribute is a single ``path`` field.
+            "path": (
+                self.tree_path
+                if self.tree_path is not None
+                else (str(self.path) if self.path else None)
+            ),
             "doc_type": (self.doc_type.value if self.doc_type else None),
             "feature": self.feature,
             "date": self.date,
@@ -446,11 +461,57 @@ class VaultGraph:
 
     def __init__(self, root_dir: pathlib.Path, *, use_cache: bool = True) -> None:
         self.root_dir = root_dir
+        #: The git ref this graph was built from, or ``None`` for a
+        #: working-tree build. Set only via :meth:`from_ref`.
+        self.ref: str | None = None
         self.nodes: dict[str, DocNode] = {}
         self._digraph: nx.DiGraph = nx.DiGraph()
         self._dangling_links: list[tuple[str, str]] = []
         self._stem_index: dict[str, list[str]] = {}
         self._build_graph(use_cache=use_cache)
+
+    @classmethod
+    def from_ref(cls, root_dir: pathlib.Path, ref: str) -> VaultGraph:
+        """Build a graph from the vault corpus at a git *ref*, without a checkout.
+
+        Reads the vault documents from the git object database at *ref* (issue
+        #160) instead of the working tree. The build runs with the graph cache
+        disabled and the working-tree migration pass skipped - a read-only view
+        of history must neither be served stale working-tree data nor write
+        working-tree state (the ``ref-scoped-reads-bypass-worktree-cache``
+        rule). Document-type classification reads each blob's tree path rather
+        than a filesystem location, so the resulting graph is structurally
+        identical to a working-tree build of the same corpus.
+
+        Args:
+            root_dir: Repository working directory (used for ``git -C`` and as
+                the envelope ``root``).
+            ref: A branch name, tag, or commit-ish to read the corpus from.
+
+        Returns:
+            A :class:`VaultGraph` over the corpus as it stood at *ref*.
+
+        Raises:
+            RefScanError: When *root_dir* is not a git repository or *ref*
+                does not resolve to a commit.
+        """
+        import pathlib
+
+        from ..config import get_config
+        from .refscan import read_vault_at_ref
+
+        graph = cls.__new__(cls)
+        graph.root_dir = root_dir
+        graph.ref = ref
+        graph.nodes = {}
+        graph._digraph = nx.DiGraph()
+        graph._dangling_links = []
+        graph._stem_index = {}
+
+        docs_dir_name = pathlib.Path(get_config().docs_dir).name
+        corpus = read_vault_at_ref(root_dir, ref, docs_dir_name)
+        graph._rebuild_from_corpus(corpus, docs_dir_name)
+        return graph
 
     # -- Construction --------------------------------------------------------
 
@@ -603,17 +664,7 @@ class VaultGraph:
 
             try:
                 content = path.read_text(encoding="utf-8")
-                metadata, body = parse_vault_metadata(content)
-                raw_fm, _ = parse_frontmatter(content)
-
-                node.tags = set(metadata.tags)
-                node.date = metadata.date
-                node.modified = metadata.modified
-                node.feature = _extract_feature(node.tags)
-                node.frontmatter = raw_fm
-                node.body = body
-                node.word_count = len(body.split())
-                node.title = _extract_title(body)
+                self._populate_node_from_content(node, content)
             except (OSError, UnicodeDecodeError) as e:
                 logger.warning(
                     "Failed to read metadata from %s: %s",
@@ -623,6 +674,80 @@ class VaultGraph:
 
             by_stem.setdefault(stem, []).append(node)
 
+        self._assemble_from_by_stem(by_stem)
+
+    def _rebuild_from_corpus(
+        self, corpus: list[tuple[str, str]], docs_dir_name: str
+    ) -> None:
+        """Rebuild the graph from in-memory ``(tree_path, content)`` pairs.
+
+        The ref-scoped build path (issue #160): instead of walking the working
+        tree, the corpus is read from the git object database by
+        :func:`vaultspec_core.graph.refscan.read_vault_at_ref`. Each pair
+        carries a virtual tree path (e.g. ``.vault/adr/foo.md``) and the blob's
+        UTF-8 text. Document-type classification reads the tree path via
+        :func:`vaultspec_core.vaultcore.scanner.get_doc_type_from_tree_path`,
+        and the node ``path`` is the virtual tree path. After Pass 1a the build
+        is identical to the working-tree path, so the graph is structurally the
+        same as a checkout-based build of the same corpus.
+
+        Args:
+            corpus: ``(tree_path, content)`` pairs for the ref's vault docs.
+            docs_dir_name: The configured docs directory name (e.g. ``.vault``).
+        """
+        import pathlib
+
+        from ..vaultcore.scanner import get_doc_type_from_tree_path
+
+        self.nodes = {}
+        self._digraph = nx.DiGraph()
+        self._dangling_links = []
+
+        by_stem: dict[str, list[DocNode]] = {}
+        for tree_path, content in corpus:
+            stem = pathlib.PurePosixPath(tree_path).stem
+            doc_type = get_doc_type_from_tree_path(tree_path, docs_dir_name)
+            node = DocNode(path=None, name=stem, doc_type=doc_type, tree_path=tree_path)
+            try:
+                self._populate_node_from_content(node, content)
+            except (ValueError, KeyError) as e:
+                logger.warning("Failed to parse blob %s: %s", tree_path, e)
+            by_stem.setdefault(stem, []).append(node)
+
+        self._assemble_from_by_stem(by_stem)
+
+    @staticmethod
+    def _populate_node_from_content(node: DocNode, content: str) -> None:
+        """Parse a document's *content* and populate *node*'s metadata fields.
+
+        Shared by the working-tree and ref-scoped build paths so both derive
+        tags, dates, feature, frontmatter, body, word count, and title from
+        the same content-bound parsers (which never touch the filesystem).
+        """
+        metadata, body = parse_vault_metadata(content)
+        raw_fm, _ = parse_frontmatter(content)
+
+        node.tags = set(metadata.tags)
+        node.date = metadata.date
+        node.modified = metadata.modified
+        node.feature = _extract_feature(node.tags)
+        node.frontmatter = raw_fm
+        node.body = body
+        node.word_count = len(body.split())
+        node.title = _extract_title(body)
+
+    def _assemble_from_by_stem(self, by_stem: dict[str, list[DocNode]]) -> None:
+        """Run the shared graph-assembly passes over the collected nodes.
+
+        Passes 1b through 4 (key assignment / collision qualification, edge
+        extraction, in/out-link sync, and node-size hints) are identical for
+        the working-tree and ref-scoped build paths, which differ only in how
+        Pass 1a's ``by_stem`` map is produced.
+
+        Args:
+            by_stem: Map of bare stem to the :class:`DocNode` instances that
+                share it, as produced by the Pass-1a collectors.
+        """
         # Pass 1b: assign unique keys  - qualify colliding stems with
         # their doc-type prefix, build a stem-to-keys index for link
         # resolution in pass 2.
@@ -1039,6 +1164,10 @@ class VaultGraph:
 
         snapshot: VaultSnapshot = {}
         for node in self.nodes.values():
+            # A working-tree snapshot is keyed by concrete filesystem paths.
+            # Phantoms and ref-scoped nodes (which carry a virtual tree_path,
+            # not a filesystem path) have ``path is None`` and are excluded so
+            # the snapshot only ever describes real on-disk documents.
             if node.phantom or node.path is None:
                 continue
             raw_related = node.frontmatter.get("related", [])
@@ -1351,8 +1480,10 @@ class VaultGraph:
 
         Returns:
             Dictionary with ``directed``, ``multigraph``, ``graph``,
-            ``nodes``, ``edges``, ``derived_edges``, ``root``, ``feature``,
-            and ``metrics`` keys.
+            ``nodes``, ``edges``, ``derived_edges``, ``root``, ``ref``,
+            ``feature``, and ``metrics`` keys. ``ref`` names the git ref for a
+            ref-scoped build (issue #160) and is ``None`` for a working-tree
+            build.
         """
         if node is not None:
             g = self.ego_subgraph(node, depth=depth)
@@ -1396,6 +1527,10 @@ class VaultGraph:
         # subgraph() traversal inside metrics().
         m = self.metrics(feature=feature, _g=g)
         data["root"] = str(self.root_dir)
+        # Ref-scoped builds (issue #160) name the snapshot here; a working-tree
+        # build carries ``ref: null`` so the v2 envelope stays self-describing
+        # without changing any node or edge shape.
+        data["ref"] = self.ref
         data["feature"] = feature
         data["metrics"] = m.to_dict()
 

--- a/src/vaultspec_core/graph/api.py
+++ b/src/vaultspec_core/graph/api.py
@@ -1445,6 +1445,32 @@ class VaultGraph:
 
     # -- JSON serialisation (networkx node_link_data) ------------------------
 
+    def _relativise_node_path(self, raw_path: Any) -> str | None:
+        """Return *raw_path* as a vault-relative POSIX path, or ``None``.
+
+        A working-tree node carries an absolute filesystem path; this rewrites
+        it to the same vault-relative virtual form a ref-scoped node already
+        uses (e.g. ``.vault/adr/foo.md``), so the serialised ``path`` field is
+        consistent across build modes and never leaks an absolute OS path. A
+        ``None`` path (phantom) stays ``None``; a path already relative or not
+        under the root is returned unchanged (as POSIX).
+
+        Args:
+            raw_path: The ``path`` value off a serialised node dict.
+
+        Returns:
+            The vault-relative POSIX path string, or ``None``.
+        """
+        import pathlib
+
+        if not raw_path:
+            return None
+        candidate = pathlib.PurePath(str(raw_path))
+        root = pathlib.PurePath(str(self.root_dir))
+        if candidate.is_absolute() and candidate.is_relative_to(root):
+            return candidate.relative_to(root).as_posix()
+        return candidate.as_posix()
+
     def to_dict(
         self,
         feature: str | None = None,
@@ -1507,6 +1533,16 @@ class VaultGraph:
                 doc = self.nodes.get(nid)
                 if doc:
                     node_dict["body"] = doc.body
+
+        # Normalise every node ``path`` to a vault-relative POSIX path so the
+        # wire format never leaks an absolute OS path and is identical across
+        # build modes (issue #160 consumer symmetry): a ref-scoped node already
+        # carries its virtual tree path (e.g. ``.vault/adr/foo.md``), and a
+        # working-tree node's absolute filesystem path is relativised to the
+        # same shape here. Phantoms (``path is None``) and any path already
+        # outside the root are left untouched.
+        for node_dict in data.get("nodes", []):
+            node_dict["path"] = self._relativise_node_path(node_dict.get("path"))
 
         # Derived (implicit) relatedness edges.  Computed on demand and kept
         # in a SEPARATE array so checkers and the canonical edges list stay

--- a/src/vaultspec_core/graph/refscan.py
+++ b/src/vaultspec_core/graph/refscan.py
@@ -1,0 +1,177 @@
+"""Read a vault corpus from the git object database at an arbitrary ref.
+
+Issue #160 asks core to make its declared-edge graph ref-addressable:
+``vault graph --json --ref <branch|sha>`` resolving documents from blobs at the
+ref, read-only, with no working-tree mutation. This module is the read seam for
+that path. It enumerates the vault blobs at a ref and reads each blob's bytes
+through subprocess ``git`` - the only git access pattern the project already
+trusts (it ships no git library) - yielding ``(tree_path, content)`` pairs that
+mirror what ``scan_vault`` plus ``read_text`` yield for the working tree.
+
+The feature is git-only by nature: a non-repository workspace or an
+unresolvable ref raises :class:`RefScanError` rather than falling back to a
+working-tree read that would silently answer for the wrong corpus (the
+``ref-scoped-reads-bypass-worktree-cache`` codification candidate). The same
+exclusions ``scan_vault`` applies (``.obsidian`` config trees, ``_archive``
+documents) are applied here so a ref build sees the same document set a
+working-tree build of that corpus would.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
+from ..core.exceptions import VaultSpecError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["RefScanError", "read_vault_at_ref"]
+
+
+class RefScanError(VaultSpecError):
+    """Raised when a ref-scoped vault read cannot resolve the repo or ref.
+
+    Distinct from an :class:`OSError`: it signals a clean, typed failure (not a
+    git repository, ``git`` not installed, or a ref that does not resolve) so
+    the caller can report it and exit non-zero without ever falling back to a
+    working-tree read.
+    """
+
+
+def _run_git(root_dir: Path, args: list[str]) -> bytes:
+    """Run ``git -C <root_dir> <args>`` and return raw stdout bytes.
+
+    Args:
+        root_dir: Repository working directory passed via ``git -C``.
+        args: Git arguments after the ``-C <root_dir>`` prefix.
+
+    Returns:
+        The command's raw stdout bytes (not decoded, so blob content can be
+        decoded explicitly as UTF-8 by the caller).
+
+    Raises:
+        RefScanError: When ``git`` is not installed or the command fails.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root_dir), *args],
+            capture_output=True,
+            check=True,
+        )
+    except FileNotFoundError as exc:
+        raise RefScanError(
+            "git executable not found; ref-scoped reads require git on PATH.",
+            hint="Install git or run without --ref.",
+        ) from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = exc.stderr.decode("utf-8", errors="replace").strip()
+        raise RefScanError(
+            f"git {' '.join(args)} failed: {stderr or exc}",
+        ) from exc
+    return result.stdout
+
+
+def _resolve_commit(root_dir: Path, ref: str) -> str:
+    """Resolve *ref* to a commit SHA, or raise :class:`RefScanError`.
+
+    Verifies the workspace is a git repository and that *ref* names a commit.
+    A non-repository workspace and an unresolvable ref both raise a typed
+    error rather than degrading to a working-tree read.
+
+    Args:
+        root_dir: Repository working directory.
+        ref: A branch name, tag, or commit-ish to resolve.
+
+    Returns:
+        The resolved commit SHA (40-hex string).
+
+    Raises:
+        RefScanError: When *root_dir* is not a git repository or *ref* does
+            not resolve to a commit.
+    """
+    # ``rev-parse --git-dir`` succeeds inside any repository (work tree or
+    # bare) and fails cleanly outside one.
+    try:
+        _run_git(root_dir, ["rev-parse", "--git-dir"])
+    except RefScanError as exc:
+        raise RefScanError(
+            f"not a git repository: {root_dir}",
+            hint="--ref reads from the git object database and needs a repo.",
+        ) from exc
+
+    try:
+        out = _run_git(
+            root_dir, ["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"]
+        )
+    except RefScanError as exc:
+        raise RefScanError(
+            f"ref does not resolve to a commit: {ref!r}",
+            hint="Pass an existing branch, tag, or commit sha.",
+        ) from exc
+    return out.decode("utf-8", errors="replace").strip()
+
+
+def read_vault_at_ref(root_dir: Path, ref: str, docs_dir: str) -> list[tuple[str, str]]:
+    """Return ``(tree_path, content)`` pairs for the vault corpus at *ref*.
+
+    Enumerates the ``.md`` blobs under *docs_dir* at *ref* and reads each
+    blob's UTF-8 text, mirroring the document set and exclusions
+    ``scan_vault`` applies to the working tree (``.obsidian`` and ``_archive``
+    are skipped). The corpus read is read-only: no working-tree state is
+    written and no migration runs.
+
+    Args:
+        root_dir: Repository working directory.
+        ref: A branch name, tag, or commit-ish to read the corpus from.
+        docs_dir: The configured docs directory name (e.g. ``.vault``),
+            used both to scope the tree enumeration and as the virtual
+            tree-path prefix.
+
+    Returns:
+        A list of ``(tree_path, content)`` pairs in deterministic
+        (lexicographic tree-path) order. ``tree_path`` is the repo-relative
+        POSIX path (e.g. ``.vault/adr/foo.md``).
+
+    Raises:
+        RefScanError: When the workspace is not a git repository or *ref*
+            does not resolve.
+    """
+    commit = _resolve_commit(root_dir, ref)
+
+    # ``-z`` makes ls-tree NUL-separate the names and never quote non-ASCII
+    # paths, so the split is unambiguous regardless of path content.
+    raw = _run_git(
+        root_dir,
+        ["ls-tree", "-r", "-z", "--name-only", commit, "--", docs_dir],
+    )
+    names = [
+        chunk for chunk in raw.decode("utf-8", errors="replace").split("\0") if chunk
+    ]
+
+    corpus: list[tuple[str, str]] = []
+    for tree_path in sorted(names):
+        if not tree_path.endswith(".md"):
+            continue
+        parts = PurePosixPath(tree_path).parts
+        if ".obsidian" in parts or "_archive" in parts:
+            continue
+        blob = _run_git(root_dir, ["cat-file", "blob", f"{commit}:{tree_path}"])
+        try:
+            content = blob.decode("utf-8")
+        except UnicodeDecodeError:
+            logger.warning(
+                "Skipping non-UTF-8 vault blob at %s in ref %s", tree_path, ref
+            )
+            continue
+        corpus.append((tree_path, content))
+
+    logger.info(
+        "Read %d vault documents from ref %s (%s)", len(corpus), ref, commit[:12]
+    )
+    return corpus

--- a/src/vaultspec_core/graph/tests/test_contract.py
+++ b/src/vaultspec_core/graph/tests/test_contract.py
@@ -32,6 +32,9 @@ _EXPECTED_DATA_KEYS = frozenset(
         "edges",
         "derived_edges",
         "root",
+        # Additive in the v2 envelope (issue #160): names the git ref a
+        # ref-scoped build read from, and is ``None`` for a working-tree build.
+        "ref",
         "feature",
         "metrics",
     }

--- a/src/vaultspec_core/plan/trailer.py
+++ b/src/vaultspec_core/plan/trailer.py
@@ -1,0 +1,245 @@
+"""Commit-linkage trailer vocabulary: parse, format, and validate.
+
+This module owns the vaultspec commit-linkage trailer convention in one place,
+mirroring how :mod:`vaultspec_core.plan.display_path` and
+:mod:`vaultspec_core.plan.identifiers` own their formats. The trailer is opt-in
+enrichment for tooling that correlates git commits to vault records: a commit
+may declare its vaultspec association explicitly through a git trailer so a
+downstream consumer resolves that correlation deterministically instead of
+heuristically (path overlap, time windows, same-day co-activity).
+
+Two trailer keys are defined:
+
+- ``Vaultspec-Step`` carries a Step display path (``S06``, ``P02.S06``,
+  ``W01.P02.S06``) or the phase-only form (``P02``, ``W01.P02``), matching what
+  :mod:`vaultspec_core.plan.display_path` produces at every tier.
+- ``Vaultspec-Feature`` carries a feature tag in kebab-case, with an optional
+  leading ``#`` (the frontmatter-stored form).
+
+The convention is advisory and never load-bearing (see the commit-linkage ADR
+``2026-06-13-commit-linkage-adr``): absence or malformation of a trailer must
+never block a commit or fail a core command. Everything here is a pure, offline
+string operation over the trailer values; no git history is read to validate a
+single message. The CLI verb that wraps :func:`validate_message` always exits
+zero so it is safe to install as an advisory ``commit-msg`` hook.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+__all__ = [
+    "FEATURE_TRAILER_KEY",
+    "STEP_TRAILER_KEY",
+    "Trailer",
+    "TrailerProblem",
+    "format_feature_trailer",
+    "format_step_trailer",
+    "parse_message",
+    "validate_message",
+    "validate_value",
+]
+
+#: Trailer key carrying a Step (or Phase) display path.
+STEP_TRAILER_KEY = "Vaultspec-Step"
+
+#: Trailer key carrying a feature tag.
+FEATURE_TRAILER_KEY = "Vaultspec-Feature"
+
+# A full Step display path: optional Wave and Phase ancestors, then the Step.
+# Mirrors the tier-dependent forms display_path.py emits (S06 / P02.S06 /
+# W01.P02.S06). Step ids never carry an alpha suffix; Phase/Wave ids may.
+_STEP_VALUE = re.compile(r"^(?:W\d{2,}\.)?(?:P\d{2,}[a-z]?\.)?S\d{2,}$")
+
+# The phase-only form, so a commit that spans a whole Phase can still link.
+_PHASE_VALUE = re.compile(r"^(?:W\d{2,}\.)?P\d{2,}[a-z]?$")
+
+# A feature tag in kebab-case, with the leading '#' optional (the stored
+# frontmatter form carries the '#').
+_FEATURE_VALUE = re.compile(r"^#?[a-z0-9][a-z0-9-]*$")
+
+# A git-trailer line: ``Token: value`` where the token is a hyphen-joined word.
+# Matched case-insensitively on the key; the value is stripped of surrounding
+# whitespace. This is deliberately permissive about which token it matches so
+# the caller can pick out only the vaultspec keys.
+_TRAILER_LINE = re.compile(
+    r"^(?P<key>[A-Za-z][A-Za-z0-9-]*):[ \t]*(?P<value>.*?)[ \t]*$"
+)
+
+# The vaultspec trailer keys, lower-cased for case-insensitive matching.
+_KNOWN_KEYS: dict[str, str] = {
+    STEP_TRAILER_KEY.lower(): STEP_TRAILER_KEY,
+    FEATURE_TRAILER_KEY.lower(): FEATURE_TRAILER_KEY,
+}
+
+
+@dataclass(frozen=True)
+class Trailer:
+    """One vaultspec trailer found in a commit message.
+
+    Attributes:
+        key: The canonical trailer key (:data:`STEP_TRAILER_KEY` or
+            :data:`FEATURE_TRAILER_KEY`), normalised regardless of the
+            case the author typed.
+        value: The trailer value with surrounding whitespace stripped.
+        line_number: 1-based line where the trailer was found in the message.
+    """
+
+    key: str
+    value: str
+    line_number: int
+
+
+@dataclass(frozen=True)
+class TrailerProblem:
+    """A malformed vaultspec trailer reported by :func:`validate_message`.
+
+    Attributes:
+        key: The canonical trailer key whose value failed validation.
+        value: The offending value as it appeared in the message.
+        line_number: 1-based line where the trailer was found.
+        reason: A human-readable description of why the value is invalid.
+    """
+
+    key: str
+    value: str
+    line_number: int
+    reason: str
+
+
+def parse_message(message: str) -> list[Trailer]:
+    """Return every vaultspec trailer found in a commit *message*.
+
+    Scans the message line by line for ``Vaultspec-Step:`` and
+    ``Vaultspec-Feature:`` lines (key matched case-insensitively) and returns
+    them in document order. Non-vaultspec trailer lines are ignored. This is a
+    pure string scan: it does not require the trailers to live in the message's
+    trailing block, so a malformed message still yields whatever vaultspec
+    trailers it contains for validation.
+
+    Args:
+        message: The full commit-message text.
+
+    Returns:
+        The vaultspec trailers found, in the order they appear.
+    """
+    trailers: list[Trailer] = []
+    for index, line in enumerate(message.splitlines(), start=1):
+        match = _TRAILER_LINE.match(line)
+        if match is None:
+            continue
+        canonical = _KNOWN_KEYS.get(str(match.group("key")).lower())
+        if canonical is None:
+            continue
+        trailers.append(
+            Trailer(
+                key=canonical,
+                value=str(match.group("value")),
+                line_number=index,
+            )
+        )
+    return trailers
+
+
+def validate_value(key: str, value: str) -> str | None:
+    """Validate a single trailer *value* for *key*.
+
+    Args:
+        key: A canonical trailer key (:data:`STEP_TRAILER_KEY` or
+            :data:`FEATURE_TRAILER_KEY`).
+        value: The candidate value.
+
+    Returns:
+        ``None`` when the value is well-formed for the key, otherwise a
+        human-readable reason describing the expected shape. An unknown key
+        also returns a reason rather than raising.
+    """
+    if key == STEP_TRAILER_KEY:
+        if _STEP_VALUE.match(value) or _PHASE_VALUE.match(value):
+            return None
+        return (
+            "expected a Step or Phase display path "
+            "(e.g. S06, P02.S06, W01.P02.S06, or P02)"
+        )
+    if key == FEATURE_TRAILER_KEY:
+        if _FEATURE_VALUE.match(value):
+            return None
+        return (
+            "expected a kebab-case feature tag (e.g. auth-refactor or #auth-refactor)"
+        )
+    return f"unknown vaultspec trailer key {key!r}"
+
+
+def validate_message(message: str) -> list[TrailerProblem]:
+    """Return the malformed vaultspec trailers in a commit *message*.
+
+    A clean message, or a message carrying no vaultspec trailer at all, yields
+    an empty list. Each vaultspec trailer whose value fails
+    :func:`validate_value` is reported as one :class:`TrailerProblem`. This
+    function never raises and never inspects anything beyond the message text,
+    so its caller can safely report problems and exit zero (the
+    enrichment-not-prerequisite constraint).
+
+    Args:
+        message: The full commit-message text.
+
+    Returns:
+        One :class:`TrailerProblem` per malformed trailer, in document order.
+    """
+    problems: list[TrailerProblem] = []
+    for trailer in parse_message(message):
+        reason = validate_value(trailer.key, trailer.value)
+        if reason is not None:
+            problems.append(
+                TrailerProblem(
+                    key=trailer.key,
+                    value=trailer.value,
+                    line_number=trailer.line_number,
+                    reason=reason,
+                )
+            )
+    return problems
+
+
+def format_step_trailer(display_path: str) -> str:
+    """Return a well-formed ``Vaultspec-Step`` trailer line for *display_path*.
+
+    Args:
+        display_path: A Step display path (``S06``, ``P02.S06``,
+            ``W01.P02.S06``) or the phase-only form (``P02``, ``W01.P02``).
+
+    Returns:
+        The trailer line ``Vaultspec-Step: <display_path>`` (no trailing
+        newline).
+
+    Raises:
+        ValueError: When *display_path* is not a valid Step or Phase display
+            path. Emission only ever produces well-formed trailers.
+    """
+    reason = validate_value(STEP_TRAILER_KEY, display_path)
+    if reason is not None:
+        raise ValueError(f"invalid {STEP_TRAILER_KEY} value {display_path!r}: {reason}")
+    return f"{STEP_TRAILER_KEY}: {display_path}"
+
+
+def format_feature_trailer(feature: str) -> str:
+    """Return a well-formed ``Vaultspec-Feature`` trailer line for *feature*.
+
+    The value is emitted as a bare kebab-case tag: a single leading ``#`` is
+    stripped so the trailer carries the same token the feature is known by
+    elsewhere, without the frontmatter-only ``#`` prefix.
+
+    Args:
+        feature: A feature tag in kebab-case, with or without a leading ``#``.
+
+    Returns:
+        The trailer line ``Vaultspec-Feature: <tag>`` (no trailing newline).
+
+    Raises:
+        ValueError: When *feature* is not a valid kebab-case feature tag.
+    """
+    reason = validate_value(FEATURE_TRAILER_KEY, feature)
+    if reason is not None:
+        raise ValueError(f"invalid {FEATURE_TRAILER_KEY} value {feature!r}: {reason}")
+    return f"{FEATURE_TRAILER_KEY}: {feature.lstrip('#')}"

--- a/src/vaultspec_core/tests/cli/conftest.py
+++ b/src/vaultspec_core/tests/cli/conftest.py
@@ -59,9 +59,6 @@ def synthetic_project(tmp_path) -> Path:
 
     layout = resolve_workspace(target_override=dest)
     init_paths(layout)
-    (dest / ".vaultspec" / "rules" / "rules" / "project").mkdir(
-        parents=True, exist_ok=True
-    )
 
     return dest
 

--- a/src/vaultspec_core/tests/cli/test_cli_live.py
+++ b/src/vaultspec_core/tests/cli/test_cli_live.py
@@ -435,7 +435,6 @@ class TestSpecRules:
             / ".vaultspec"
             / "rules"
             / "rules"
-            / "project"
             / "lifecycle-test-rule.md"
         )
         assert rule_path.exists()
@@ -481,14 +480,7 @@ class TestSpecRules:
             "rename-dst",
         )
         assert result.exit_code == 0
-        dst = (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "rename-dst.md"
-        )
+        dst = synthetic_project / ".vaultspec" / "rules" / "rules" / "rename-dst.md"
         assert dst.exists()
 
     def test_add_force_overwrites(self, cli, synthetic_project):
@@ -515,12 +507,7 @@ class TestSpecRules:
         )
         assert result.exit_code == 0
         content = (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "overwrite-me.md"
+            synthetic_project / ".vaultspec" / "rules" / "rules" / "overwrite-me.md"
         ).read_text(encoding="utf-8")
         assert "v2" in content
 

--- a/src/vaultspec_core/tests/cli/test_collectors.py
+++ b/src/vaultspec_core/tests/cli/test_collectors.py
@@ -467,13 +467,18 @@ class TestContentIntegrity:
         result = collect_content_integrity("claude")
         assert "vaultspec-system.builtin.md" not in result
 
-    def test_subdirectory_custom_rule_is_clean(self, synthetic_project: Path) -> None:
-        """A custom rule under ``project/`` synced to the provider is CLEAN.
+    def test_project_authored_rule_synced_flat_is_clean(
+        self, synthetic_project: Path
+    ) -> None:
+        """A project-authored custom rule, synced FLAT, is CLEAN, not stale.
 
-        Regression for issue #153: custom rules live under
-        ``.vaultspec/rules/rules/project/`` and sync preserves that subpath in
-        the provider directory, so a flat ``*.md`` dest glob missed them and
-        falsely reported STALE/MISSING.
+        Regression for issue #153: custom rules are authored one level down
+        under ``.vaultspec/rules/rules/project/`` but providers do not support
+        nested folders - sync sanitizes the nesting, flattening the rule into
+        the provider root by its basename. The collector must therefore match
+        the recursively-discovered source basename against the flat provider
+        deployment and report CLEAN, rather than flagging the source as
+        STALE/MISSING because the destination has no ``project/`` subdir.
         """
         from vaultspec_core.core.types import get_context
 
@@ -481,11 +486,13 @@ class TestContentIntegrity:
         cfg = ctx.tool_configs.get(Tool.CLAUDE)
         assert cfg is not None and cfg.rules_dir is not None
 
+        # Source: authored under project/ (one level down).
         src_rule = ctx.rules_src_dir / "project" / "custom-rule.md"
         src_rule.parent.mkdir(parents=True, exist_ok=True)
         src_rule.write_text("# custom rule\n", encoding="utf-8")
 
-        dest_rule = cfg.rules_dir / "project" / "custom-rule.md"
+        # Destination: flattened into the provider rules root (what sync emits).
+        dest_rule = cfg.rules_dir / "custom-rule.md"
         dest_rule.parent.mkdir(parents=True, exist_ok=True)
         dest_rule.write_text("# custom rule\n", encoding="utf-8")
 

--- a/src/vaultspec_core/tests/cli/test_collectors.py
+++ b/src/vaultspec_core/tests/cli/test_collectors.py
@@ -467,6 +467,31 @@ class TestContentIntegrity:
         result = collect_content_integrity("claude")
         assert "vaultspec-system.builtin.md" not in result
 
+    def test_subdirectory_custom_rule_is_clean(self, synthetic_project: Path) -> None:
+        """A custom rule under ``project/`` synced to the provider is CLEAN.
+
+        Regression for issue #153: custom rules live under
+        ``.vaultspec/rules/rules/project/`` and sync preserves that subpath in
+        the provider directory, so a flat ``*.md`` dest glob missed them and
+        falsely reported STALE/MISSING.
+        """
+        from vaultspec_core.core.types import get_context
+
+        ctx = get_context()
+        cfg = ctx.tool_configs.get(Tool.CLAUDE)
+        assert cfg is not None and cfg.rules_dir is not None
+
+        src_rule = ctx.rules_src_dir / "project" / "custom-rule.md"
+        src_rule.parent.mkdir(parents=True, exist_ok=True)
+        src_rule.write_text("# custom rule\n", encoding="utf-8")
+
+        dest_rule = cfg.rules_dir / "project" / "custom-rule.md"
+        dest_rule.parent.mkdir(parents=True, exist_ok=True)
+        dest_rule.write_text("# custom rule\n", encoding="utf-8")
+
+        result = collect_content_integrity("claude")
+        assert result["custom-rule.md"] == ContentSignal.CLEAN
+
 
 # ---------------------------------------------------------------------------
 # diagnose() orchestrator

--- a/src/vaultspec_core/tests/cli/test_graph_ref.py
+++ b/src/vaultspec_core/tests/cli/test_graph_ref.py
@@ -1,0 +1,248 @@
+"""Real-git tests for the ref-scoped vault graph (issue #160).
+
+Exercises :func:`vaultspec_core.graph.refscan.read_vault_at_ref`,
+:meth:`vaultspec_core.graph.api.VaultGraph.from_ref`, and the
+``vault graph --json --ref`` verb against throwaway git repositories - no
+mocks, no fakes, real ``git`` subprocess calls and real blobs.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from vaultspec_core.cli import app
+from vaultspec_core.graph.api import VaultGraph
+from vaultspec_core.graph.cache import cache_path
+from vaultspec_core.graph.refscan import RefScanError, read_vault_at_ref
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    _git(repo, "init", "-q")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test")
+    _git(repo, "config", "commit.gpgsign", "false")
+
+
+def _doc(directory_tag: str, feature: str, title: str, body: str) -> str:
+    return (
+        f"---\ntags:\n  - '#{directory_tag}'\n  - '#{feature}'\n"
+        f"date: '2026-06-13'\n---\n\n# {title}\n\n{body}\n"
+    )
+
+
+@pytest.fixture
+def vault_repo(tmp_path) -> tuple[Path, str, str]:
+    """A git repo whose ``.vault/`` corpus changes between two commits.
+
+    Returns ``(repo, sha1, sha2)`` where ``sha1`` has two linked documents and
+    ``sha2`` adds a third and edits the first.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / ".vault" / "research").mkdir(parents=True)
+    (repo / ".vault" / "adr").mkdir(parents=True)
+
+    research = repo / ".vault" / "research" / "2026-06-13-alpha-research.md"
+    adr = repo / ".vault" / "adr" / "2026-06-13-alpha-adr.md"
+
+    research.write_text(
+        _doc("research", "alpha", "alpha research", "First findings."),
+        encoding="utf-8",
+    )
+    adr.write_text(
+        _doc(
+            "adr",
+            "alpha",
+            "alpha adr",
+            "Decision grounded in [[2026-06-13-alpha-research]].",
+        ),
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "c1: alpha research + adr")
+    sha1 = _git(repo, "rev-parse", "HEAD")
+
+    # Second commit: add a plan that links the adr, and edit the research body.
+    (repo / ".vault" / "plan").mkdir(parents=True)
+    plan = repo / ".vault" / "plan" / "2026-06-13-alpha-plan.md"
+    plan.write_text(
+        _doc("plan", "alpha", "alpha plan", "Plan per [[2026-06-13-alpha-adr]]."),
+        encoding="utf-8",
+    )
+    research.write_text(
+        _doc("research", "alpha", "alpha research", "Revised findings, expanded."),
+        encoding="utf-8",
+    )
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "c2: add plan, revise research")
+    sha2 = _git(repo, "rev-parse", "HEAD")
+
+    return repo, sha1, sha2
+
+
+# ---- read_vault_at_ref ------------------------------------------------------
+
+
+def test_read_vault_at_ref_returns_corpus_at_each_ref(vault_repo) -> None:
+    repo, sha1, sha2 = vault_repo
+
+    at_c1 = dict(read_vault_at_ref(repo, sha1, ".vault"))
+    assert set(at_c1) == {
+        ".vault/research/2026-06-13-alpha-research.md",
+        ".vault/adr/2026-06-13-alpha-adr.md",
+    }
+    assert "First findings." in at_c1[".vault/research/2026-06-13-alpha-research.md"]
+
+    at_c2 = dict(read_vault_at_ref(repo, sha2, ".vault"))
+    assert ".vault/plan/2026-06-13-alpha-plan.md" in at_c2
+    # The edit at c2 is visible; the c1 content is not served.
+    assert "Revised findings" in at_c2[".vault/research/2026-06-13-alpha-research.md"]
+
+
+def test_read_vault_at_ref_accepts_branch_name(vault_repo) -> None:
+    repo, _sha1, _sha2 = vault_repo
+    branch = _git(repo, "rev-parse", "--abbrev-ref", "HEAD")
+    corpus = read_vault_at_ref(repo, branch, ".vault")
+    assert len(corpus) == 3
+
+
+def test_read_vault_at_ref_unresolvable_ref_raises(vault_repo) -> None:
+    repo, _sha1, _sha2 = vault_repo
+    with pytest.raises(RefScanError, match="does not resolve"):
+        read_vault_at_ref(repo, "no-such-ref", ".vault")
+
+
+def test_read_vault_at_ref_non_git_raises(tmp_path) -> None:
+    not_a_repo = tmp_path / "plain"
+    not_a_repo.mkdir()
+    with pytest.raises(RefScanError, match="not a git repository"):
+        read_vault_at_ref(not_a_repo, "HEAD", ".vault")
+
+
+# ---- VaultGraph.from_ref ----------------------------------------------------
+
+
+def test_from_ref_matches_working_tree_build(vault_repo) -> None:
+    """A ref build at HEAD is structurally identical to a working-tree build."""
+    repo, _sha1, sha2 = vault_repo
+
+    ref_graph = VaultGraph.from_ref(repo, sha2)
+    # The working tree equals sha2 (clean), so a no-cache working-tree build is
+    # the corpus comparison baseline.
+    wt_graph = VaultGraph(repo, use_cache=False)
+
+    assert set(ref_graph.nodes) == set(wt_graph.nodes)
+    assert set(ref_graph.digraph.edges()) == set(wt_graph.digraph.edges())
+    assert ref_graph.ref == sha2
+
+
+def test_from_ref_reflects_historical_ref(vault_repo) -> None:
+    repo, sha1, _sha2 = vault_repo
+    graph = VaultGraph.from_ref(repo, sha1)
+    # The plan added at c2 is absent at c1.
+    assert "2026-06-13-alpha-plan" not in graph.nodes
+    assert "2026-06-13-alpha-adr" in graph.nodes
+    # The adr -> research edge declared in the body resolves at c1.
+    assert (
+        "2026-06-13-alpha-adr",
+        "2026-06-13-alpha-research",
+    ) in graph.digraph.edges()
+
+
+def test_from_ref_does_not_write_working_tree_cache(vault_repo) -> None:
+    repo, _sha1, sha2 = vault_repo
+    VaultGraph.from_ref(repo, sha2)
+    assert not cache_path(repo).exists()
+
+
+def test_from_ref_node_path_is_virtual_tree_path(vault_repo) -> None:
+    repo, _sha1, sha2 = vault_repo
+    data = VaultGraph.from_ref(repo, sha2).to_dict()
+    assert data["ref"] == sha2
+    paths = {n["id"]: n["path"] for n in data["nodes"]}
+    assert paths["2026-06-13-alpha-adr"] == ".vault/adr/2026-06-13-alpha-adr.md"
+
+
+def test_from_ref_bad_ref_raises(vault_repo) -> None:
+    repo, _sha1, _sha2 = vault_repo
+    with pytest.raises(RefScanError):
+        VaultGraph.from_ref(repo, "nope")
+
+
+# ---- CLI: vault graph --ref -------------------------------------------------
+
+
+def test_cli_graph_ref_matches_working_tree(synthetic_project: Path) -> None:
+    """``vault graph --json --ref HEAD`` matches the working-tree node set."""
+    _init_repo(synthetic_project)
+    _git(synthetic_project, "add", "-A")
+    _git(synthetic_project, "commit", "-qm", "snapshot")
+
+    runner = CliRunner(env={"NO_COLOR": "1"})
+    args = ["--target", str(synthetic_project), "vault", "graph", "--json"]
+    ref_result = runner.invoke(app, [*args, "--ref", "HEAD"])
+    assert ref_result.exit_code == 0, ref_result.output
+    ref_data = json.loads(ref_result.output)["data"]
+    assert ref_data["ref"] == "HEAD"
+
+    wt_result = runner.invoke(app, args)
+    assert wt_result.exit_code == 0, wt_result.output
+    wt_data = json.loads(wt_result.output)["data"]
+    assert wt_data["ref"] is None
+
+    ref_nodes = {n["id"] for n in ref_data["nodes"]}
+    wt_nodes = {n["id"] for n in wt_data["nodes"]}
+    assert ref_nodes == wt_nodes
+
+
+def test_cli_graph_ref_envelope_is_v2(synthetic_project: Path) -> None:
+    _init_repo(synthetic_project)
+    _git(synthetic_project, "add", "-A")
+    _git(synthetic_project, "commit", "-qm", "snapshot")
+
+    runner = CliRunner(env={"NO_COLOR": "1"})
+    args = ["--target", str(synthetic_project), "vault", "graph", "--json"]
+    result = runner.invoke(app, [*args, "--ref", "HEAD"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["schema"] == "vaultspec.vault.graph.v2"
+
+
+def test_cli_graph_unresolvable_ref_exits_nonzero(synthetic_project: Path) -> None:
+    _init_repo(synthetic_project)
+    _git(synthetic_project, "add", "-A")
+    _git(synthetic_project, "commit", "-qm", "snapshot")
+
+    runner = CliRunner(env={"NO_COLOR": "1"})
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "graph",
+            "--json",
+            "--ref",
+            "definitely-not-a-ref",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "definitely-not-a-ref" in result.output

--- a/src/vaultspec_core/tests/cli/test_graph_ref.py
+++ b/src/vaultspec_core/tests/cli/test_graph_ref.py
@@ -182,6 +182,28 @@ def test_from_ref_node_path_is_virtual_tree_path(vault_repo) -> None:
     assert paths["2026-06-13-alpha-adr"] == ".vault/adr/2026-06-13-alpha-adr.md"
 
 
+def test_working_tree_node_path_is_vault_relative(vault_repo) -> None:
+    """A working-tree build emits the same vault-relative path as a ref build.
+
+    Consumer-symmetry follow-up: no absolute OS path leaks into the envelope,
+    and both build modes use the identical virtual ``.vault/...`` shape so a
+    consumer ingests them through one path format.
+    """
+    repo, _sha1, sha2 = vault_repo
+    wt = VaultGraph(repo, use_cache=False).to_dict()
+    paths = {n["id"]: n["path"] for n in wt["nodes"]}
+    adr = paths["2026-06-13-alpha-adr"]
+    assert adr == ".vault/adr/2026-06-13-alpha-adr.md"
+    # No drive letter, no backslash, not absolute: nothing OS-specific leaks.
+    assert "\\" not in adr
+    assert not adr.startswith("/") and ":" not in adr
+    # Identical to the ref-scoped build of the same corpus.
+    ref_paths = {
+        n["id"]: n["path"] for n in VaultGraph.from_ref(repo, sha2).to_dict()["nodes"]
+    }
+    assert paths == ref_paths
+
+
 def test_from_ref_bad_ref_raises(vault_repo) -> None:
     repo, _sha1, _sha2 = vault_repo
     with pytest.raises(RefScanError):

--- a/src/vaultspec_core/tests/cli/test_spec_cli.py
+++ b/src/vaultspec_core/tests/cli/test_spec_cli.py
@@ -151,7 +151,33 @@ class TestSpecCliDispatchRouting:
             force=False,
         )
 
-        rule_file = _t.get_context().rules_src_dir / "project" / "test-rule.md"
+        # Custom rules are authored flat under the rules root; no nested
+        # ``project/`` subdir is created.
+        rule_file = _t.get_context().rules_src_dir / "test-rule.md"
         assert rule_file.exists()
+        assert not (_t.get_context().rules_src_dir / "project").exists()
         content = rule_file.read_text(encoding="utf-8")
         assert "test-rule" in content
+
+    def test_rules_add_sanitizes_nested_name(self, tmp_path):
+        """A nested or project-prefixed rule name is sanitized to a flat file."""
+        from ...core import init_paths, rules_add
+        from ...core import types as _t
+
+        setup_rules_dir(tmp_path)
+        init_paths(tmp_path)
+
+        # A legacy ``project/`` prefix and a deeper nested path both collapse to
+        # the basename: nested rule folders are never created.
+        rules_add(name="project/legacy-rule", content="Body.", force=False)
+        rules_add(name="sub/deep-rule", content="Body.", force=False)
+
+        rules_src = _t.get_context().rules_src_dir
+        assert (rules_src / "legacy-rule.md").exists()
+        assert (rules_src / "deep-rule.md").exists()
+        assert not (rules_src / "project").exists()
+        assert not (rules_src / "sub").exists()
+        # The sanitized stem (not the nested path) is written into frontmatter.
+        assert "name: legacy-rule" in (rules_src / "legacy-rule.md").read_text(
+            encoding="utf-8"
+        )

--- a/src/vaultspec_core/tests/cli/test_step_aware_exec.py
+++ b/src/vaultspec_core/tests/cli/test_step_aware_exec.py
@@ -101,8 +101,8 @@ def test_step_aware_mutual_exclusion(runner, synthetic_project):
     )
     assert result.exit_code != 0
     assert (
-        "Error: --step and --all-steps options are only valid when creating 'exec' "
-        "documents." in result.output
+        "Error: --step, --all-steps, and --summary options are only valid when "
+        "creating 'exec' documents." in result.output
     )
 
 
@@ -398,3 +398,186 @@ def test_step_aware_status_hinting(runner, synthetic_project):
     assert result2.exit_code == 0
     assert "S01" not in result2.output
     assert "S02" in result2.output
+
+
+def test_summary_requires_phase(runner, synthetic_project):
+    """``--summary`` without ``--phase`` is a clean error (issue #158)."""
+    setup_test_plan(synthetic_project)
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--summary",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--summary requires --phase" in result.output
+
+
+def test_summary_rejected_on_non_exec_type(runner, synthetic_project):
+    """``--summary`` is only valid for exec documents (issue #158)."""
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "adr",
+            "--feature",
+            "test-feature",
+            "--summary",
+            "--phase",
+            "P01",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "only" in result.output and "exec" in result.output
+
+
+def test_summary_mutually_exclusive_with_step(runner, synthetic_project):
+    """``--summary`` cannot combine with ``--step`` (issue #158)."""
+    setup_test_plan(synthetic_project)
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--summary",
+            "--phase",
+            "P01",
+            "--step",
+            "P01.S01",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--summary cannot be combined with --step" in result.output
+
+
+def test_phase_requires_summary(runner, synthetic_project):
+    """``--phase`` without ``--summary`` is a clean error (issue #158)."""
+    setup_test_plan(synthetic_project)
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--phase",
+            "P01",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--phase is only valid together with --summary" in result.output
+
+
+def test_summary_unknown_phase_errors_cleanly(runner, synthetic_project):
+    """A non-existent Phase id reports a clean error, not a traceback (#158)."""
+    setup_test_plan(synthetic_project)
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--summary",
+            "--phase",
+            "P99",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "P99" in result.output
+    assert "Traceback" not in result.output
+
+
+def _setup_test_plan_with_phase(project_dir: Path) -> Path:
+    """Write an ADR and an L2 plan whose Phase the parser recognises.
+
+    The parser registers a Phase only from a canonical ``### Phase`` heading
+    followed by an intent paragraph, so the summary scaffolder (which calls
+    ``find_phase``) needs a plan shaped this way rather than the flat
+    ``## Phase`` heading used by :func:`setup_test_plan`.
+    """
+    adr_dir = project_dir / ".vault" / "adr"
+    adr_dir.mkdir(parents=True, exist_ok=True)
+    (adr_dir / "2026-05-17-test-feature-adr.md").write_text(
+        "---\ntags:\n  - '#adr'\n  - '#test-feature'\n"
+        "date: '2026-05-17'\n---\n\n# `test-feature` adr: Architectural Decision\n",
+        encoding="utf-8",
+    )
+
+    plan_dir = project_dir / ".vault" / "plan"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    plan_file = plan_dir / "2026-05-17-test-feature-plan.md"
+    plan_file.write_text(
+        "---\ntags:\n  - '#plan'\n  - '#test-feature'\n"
+        "date: '2026-05-17'\ntier: L2\n---\n\n"
+        "# `test-feature` plan\n\n"
+        "### Phase `P01` - Test Phase\n\n"
+        "Phase P01 delivers a coherent slice of the work.\n\n"
+        "- [x] `P01.S01` - First step; `src/foo.py`.\n"
+        "- [ ] `P01.S02` - Second step; `src/bar.py`.\n",
+        encoding="utf-8",
+    )
+    return plan_file
+
+
+def test_summary_scaffolds_phase_summary(runner, synthetic_project):
+    """``--summary --phase`` scaffolds the canonical Phase-summary record (#158)."""
+    _setup_test_plan_with_phase(synthetic_project)
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--summary",
+            "--phase",
+            "P01",
+        ],
+    )
+    assert result.exit_code == 0, f"Command failed: {result.output}"
+
+    target_file = (
+        synthetic_project
+        / ".vault"
+        / "exec"
+        / "2026-05-17-test-feature"
+        / "2026-05-17-test-feature-P01-summary.md"
+    )
+    assert target_file.exists()
+
+    content = target_file.read_text(encoding="utf-8")
+    # Frontmatter: directory + feature tags, plan back-link injected.
+    assert "- '#exec'" in content
+    assert "- '#test-feature'" in content
+    assert '- "[[2026-05-17-test-feature-plan]]"' in content
+    # Heading hydrated with the Phase display path, not the title alias.
+    assert "# `test-feature` `P01` summary" in content
+    assert "## Description" in content
+    # No unhydrated placeholders survive.
+    assert "{phase}" not in content
+    assert "{feature}" not in content

--- a/src/vaultspec_core/tests/cli/test_sync.py
+++ b/src/vaultspec_core/tests/cli/test_sync.py
@@ -366,12 +366,7 @@ class TestSyncAuthority:
             assert add_result.exit_code == 0, add_result.output
 
             source_rule = (
-                synthetic_project
-                / ".vaultspec"
-                / "rules"
-                / "rules"
-                / "project"
-                / f"{rule_name}.md"
+                synthetic_project / ".vaultspec" / "rules" / "rules" / f"{rule_name}.md"
             )
             assert source_rule.exists(), f"Rule source missing: {source_rule}"
 

--- a/src/vaultspec_core/tests/cli/test_sync_incremental.py
+++ b/src/vaultspec_core/tests/cli/test_sync_incremental.py
@@ -12,14 +12,7 @@ pytestmark = [pytest.mark.unit]
 class TestIncrementalRules:
     def test_add_modify_remove_loop(self, synthetic_project):
         """Standard rule lifecycle."""
-        rule_src = (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "rule1.md"
-        )
+        rule_src = synthetic_project / ".vaultspec" / "rules" / "rules" / "rule1.md"
         rule_src.write_text("---\nname: rule1\n---\n\nOriginal body", encoding="utf-8")
 
         # 1. Add
@@ -42,14 +35,7 @@ class TestIncrementalRules:
 
     def test_idempotent_resync(self, synthetic_project):
         """Syncing with no changes doesn't update files."""
-        rule_src = (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "stable.md"
-        )
+        rule_src = synthetic_project / ".vaultspec" / "rules" / "rules" / "stable.md"
         rule_src.write_text("---\nname: stable\n---\n\nBody", encoding="utf-8")
         rules_sync()
         dest = synthetic_project / ".claude" / "rules" / "stable.md"
@@ -61,14 +47,9 @@ class TestIncrementalRules:
 
     def test_cross_destination_consistency(self, synthetic_project):
         """Rules are synced to all available tool destinations."""
-        (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "shared.md"
-        ).write_text("---\nname: shared\n---\n\nShared rule", encoding="utf-8")
+        (synthetic_project / ".vaultspec" / "rules" / "rules" / "shared.md").write_text(
+            "---\nname: shared\n---\n\nShared rule", encoding="utf-8"
+        )
         rules_sync()
         for tool_dir in [".claude", ".gemini"]:
             p = synthetic_project / tool_dir / "rules" / "shared.md"
@@ -80,7 +61,7 @@ class TestIncrementalRules:
         dest = synthetic_project / ".claude" / "rules" / "churn.md"
 
         for i in range(5):
-            (rules_dir / "project" / "churn.md").write_text(
+            (rules_dir / "churn.md").write_text(
                 f"---\nname: churn\n---\n\nPass {i}", encoding="utf-8"
             )
             rules_sync()
@@ -255,10 +236,10 @@ class TestMixedOperations:
         system_dir = synthetic_project / ".vaultspec" / "rules" / "system"
 
         # --- Setup: add everything ---
-        (rules_dir / "project" / "r1.md").write_text(
+        (rules_dir / "r1.md").write_text(
             "---\nname: r1\n---\n\nRule 1", encoding="utf-8"
         )
-        (rules_dir / "project" / "r2.md").write_text(
+        (rules_dir / "r2.md").write_text(
             "---\nname: r2\n---\n\nRule 2", encoding="utf-8"
         )
         (skills_dir / "vaultspec-s1").mkdir(parents=True)
@@ -279,10 +260,10 @@ class TestMixedOperations:
         assert (synthetic_project / ".gemini" / "SYSTEM.md").exists()
 
         # --- Churn: Modify r1, delete r2, add s2 ---
-        (rules_dir / "project" / "r1.md").write_text(
+        (rules_dir / "r1.md").write_text(
             "---\nname: r1\n---\n\nMODIFIED", encoding="utf-8"
         )
-        (rules_dir / "project" / "r2.md").unlink()
+        (rules_dir / "r2.md").unlink()
         (skills_dir / "vaultspec-s2").mkdir(parents=True)
         (skills_dir / "vaultspec-s2" / "SKILL.md").write_text(
             "---\ndescription: s2\n---\n\n# s2", encoding="utf-8"

--- a/src/vaultspec_core/tests/cli/test_sync_operations.py
+++ b/src/vaultspec_core/tests/cli/test_sync_operations.py
@@ -548,12 +548,7 @@ class TestEndToEnd:
         """Create sources -> sync -> verify destinations."""
         # Set up source files
         (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "no-swear.md"
+            synthetic_project / ".vaultspec" / "rules" / "rules" / "no-swear.md"
         ).write_text("---\nname: no-swear\n---\n\nDo not swear.", encoding="utf-8")
         (synthetic_project / ".vaultspec" / "rules" / "system" / "base.md").write_text(
             "---\n---\n\n# Base system prompt", encoding="utf-8"
@@ -571,14 +566,7 @@ class TestEndToEnd:
         assert (synthetic_project / ".gemini" / "SYSTEM.md").exists()
 
     def test_modify_resync_cycle(self, synthetic_project):
-        rule_src = (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "rule1.md"
-        )
+        rule_src = synthetic_project / ".vaultspec" / "rules" / "rules" / "rule1.md"
         rule_src.write_text("---\nname: rule1\n---\n\nOriginal body.", encoding="utf-8")
         rules_sync()
         dest = synthetic_project / ".claude" / "rules" / "rule1.md"
@@ -589,14 +577,7 @@ class TestEndToEnd:
         assert "MODIFIED" in dest.read_text(encoding="utf-8")
 
     def test_prune_cycle(self, synthetic_project):
-        rule_src = (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "ephemeral.md"
-        )
+        rule_src = synthetic_project / ".vaultspec" / "rules" / "rules" / "ephemeral.md"
         rule_src.write_text("---\nname: ephemeral\n---\n\nGone soon.", encoding="utf-8")
         rules_sync()
         dest = synthetic_project / ".claude" / "rules" / "ephemeral.md"
@@ -632,12 +613,7 @@ class TestEndToEndAllDestinations:
         """Full sync produces the correct file tree for every destination."""
         # Set up sources
         (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "no-swear.md"
+            synthetic_project / ".vaultspec" / "rules" / "rules" / "no-swear.md"
         ).write_text("---\nname: no-swear\n---\n\nDo not swear.", encoding="utf-8")
         (
             synthetic_project / ".vaultspec" / "rules" / "system" / "codex-cfg.md"
@@ -732,12 +708,7 @@ class TestEndToEndAllDestinations:
     def test_dry_run_writes_nothing(self, synthetic_project):
         """dry_run=True must not create any destination files or directories."""
         (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "dry-rule.md"
+            synthetic_project / ".vaultspec" / "rules" / "rules" / "dry-rule.md"
         ).write_text("---\nname: dry-rule\n---\n\nDry run test.", encoding="utf-8")
         (
             synthetic_project / ".vaultspec" / "rules" / "system" / "codex-cfg.md"
@@ -786,12 +757,7 @@ class TestDryRunReturnsItems:
 
     def test_rules_sync_dry_run_returns_items(self, synthetic_project):
         (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "my-rule.md"
+            synthetic_project / ".vaultspec" / "rules" / "rules" / "my-rule.md"
         ).write_text("---\nname: my-rule\n---\n\nRule body.", encoding="utf-8")
         result = rules_sync(dry_run=True)
         assert result.items, "dry-run must populate items list"
@@ -800,12 +766,7 @@ class TestDryRunReturnsItems:
 
     def test_dry_run_items_have_correct_actions(self, synthetic_project):
         (
-            synthetic_project
-            / ".vaultspec"
-            / "rules"
-            / "rules"
-            / "project"
-            / "new-rule.md"
+            synthetic_project / ".vaultspec" / "rules" / "rules" / "new-rule.md"
         ).write_text("---\nname: new-rule\n---\n\nNew.", encoding="utf-8")
         result = rules_sync(dry_run=True)
         new_rule_actions = [a for p, a in result.items if "new-rule" in p]

--- a/src/vaultspec_core/tests/cli/test_vault_rule_promote.py
+++ b/src/vaultspec_core/tests/cli/test_vault_rule_promote.py
@@ -87,8 +87,8 @@ def test_rule_promote_existing_rule_fails_unless_forced(runner, test_project):
         encoding="utf-8",
     )
 
-    # Create the rule file beforehand
-    rule_dir = test_project / ".vaultspec" / "rules" / "rules" / "project"
+    # Create the rule file beforehand (flat under the rules root).
+    rule_dir = test_project / ".vaultspec" / "rules" / "rules"
     rule_dir.mkdir(parents=True, exist_ok=True)
     rule_file = rule_dir / "my-rule.md"
     rule_file.write_text("# Existing Rule", encoding="utf-8")
@@ -163,11 +163,10 @@ def test_rule_promote_success_mutates_audit_and_creates_rule(runner, test_projec
     )
     assert result.exit_code == 0
 
-    # Check rule file exists and has correct contents
-    rule_file = (
-        test_project / ".vaultspec" / "rules" / "rules" / "project" / "promoted-rule.md"
-    )
+    # Check rule file exists flat under the rules root (no project/ subdir).
+    rule_file = test_project / ".vaultspec" / "rules" / "rules" / "promoted-rule.md"
     assert rule_file.exists()
+    assert not (test_project / ".vaultspec" / "rules" / "rules" / "project").exists()
     rule_content = rule_file.read_text(encoding="utf-8")
     assert 'derived_from:\n  - "audit:2026-05-17-test-audit"' in rule_content
     assert "# Rule" in rule_content
@@ -209,9 +208,7 @@ def test_rule_promote_dry_run(runner, test_project):
     assert "Would promote rule:" in result.output
 
     # Check files are NOT created or mutated
-    rule_file = (
-        test_project / ".vaultspec" / "rules" / "rules" / "project" / "dry-run-rule.md"
-    )
+    rule_file = test_project / ".vaultspec" / "rules" / "rules" / "dry-run-rule.md"
     assert not rule_file.exists()
 
     audit_content = audit_file.read_text(encoding="utf-8")
@@ -248,43 +245,42 @@ def test_rule_promote_json_output(runner, test_project):
     assert "json-rule.md" in payload["data"]["path"]
 
 
-def test_flat_custom_rules_migration(runner, test_project):
-    # Setup a flat custom rule (custom rule directly under rules/)
-    flat_rule_file = (
-        test_project / ".vaultspec" / "rules" / "rules" / "flat-custom-rule.md"
-    )
-    flat_rule_file.write_text("# Flat Custom Rule", encoding="utf-8")
+def test_nested_custom_rules_are_flattened(runner, test_project):
+    """A custom rule under the legacy project/ subdir is sanitized to flat.
 
-    # Setup a builtin rule in the same folder
-    builtin_rule_file = (
-        test_project / ".vaultspec" / "rules" / "rules" / "some-builtin.builtin.md"
-    )
+    Nested rule folders are not supported; rules_list() (and sync) run the
+    sanitizer, which flattens any nested custom rule up to the rules root,
+    removes the emptied subdir, and never touches builtins.
+    """
+    rules_dir = test_project / ".vaultspec" / "rules" / "rules"
+
+    # A custom rule authored under the legacy project/ subdir (nested).
+    nested_rule_file = rules_dir / "project" / "nested-custom-rule.md"
+    nested_rule_file.parent.mkdir(parents=True, exist_ok=True)
+    nested_rule_file.write_text("# Nested Custom Rule", encoding="utf-8")
+
+    # A builtin rule sits flat in the same folder.
+    builtin_rule_file = rules_dir / "some-builtin.builtin.md"
     builtin_rule_file.write_text("# Builtin Rule", encoding="utf-8")
 
-    # Verify both files are in the rules directory initially
-    assert flat_rule_file.exists()
+    assert nested_rule_file.exists()
     assert builtin_rule_file.exists()
 
-    # Call rules_list() to trigger migrate_flat_custom_rules
+    # rules_list() triggers the sanitizer (flatten_nested_custom_rules).
     rules = rules_list()
 
-    # Verify migration occurred:
-    # 1. flat-custom-rule.md is moved to project/flat-custom-rule.md
-    migrated_rule_file = (
-        test_project
-        / ".vaultspec"
-        / "rules"
-        / "rules"
-        / "project"
-        / "flat-custom-rule.md"
-    )
-    assert migrated_rule_file.exists()
-    assert not flat_rule_file.exists()
+    # 1. The nested custom rule is flattened to the rules root and the empty
+    #    project/ subdir is removed.
+    flattened = rules_dir / "nested-custom-rule.md"
+    assert flattened.exists()
+    assert not nested_rule_file.exists()
+    assert not (rules_dir / "project").exists()
 
-    # 2. some-builtin.builtin.md was NOT moved
+    # 2. The builtin is untouched.
     assert builtin_rule_file.exists()
 
-    # 3. rules_list returns custom rule path as "project/flat-custom-rule.md"
+    # 3. rules_list reports the flat custom rule name (no project/ prefix).
     names = [r["name"] for r in rules]
-    assert "project/flat-custom-rule.md" in names
+    assert "nested-custom-rule.md" in names
     assert "some-builtin.builtin.md" in names
+    assert not any(n.startswith("project/") for n in names)

--- a/src/vaultspec_core/tests/plan/test_e2e.py
+++ b/src/vaultspec_core/tests/plan/test_e2e.py
@@ -519,3 +519,75 @@ related: []
 
     assert "unexpected retirement of active plan items" in str(exc_info.value)
     assert "S01" in str(exc_info.value)
+
+
+def test_resolve_vault_root_from_plan_path_under_docs_dir(tmp_path) -> None:
+    """``_resolve_vault_root`` derives the root from a plan under ``.vault/plan/``.
+
+    Regression for issue #157: the mutation verbs never initialise the
+    workspace context, so the cache root must be recoverable from the plan
+    path alone.
+    """
+    from vaultspec_core.cli.plan_cmd import _resolve_vault_root
+
+    plan_path = tmp_path / ".vault" / "plan" / "2026-06-13-x-plan.md"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text("# x plan\n", encoding="utf-8")
+
+    assert _resolve_vault_root(plan_path) == tmp_path.resolve()
+
+
+def test_step_check_in_empty_context_exits_zero(tmp_path) -> None:
+    """A mutation verb run with no workspace context must still exit 0.
+
+    Regression for issue #157: every ``vault plan`` mutation verb performed
+    its write correctly but then crashed in the post-save cache-invalidation
+    hook with a ``LookupError`` because the workspace ``ContextVar`` was never
+    initialised, exiting 1 despite a successful write. A fresh
+    ``contextvars.Context`` faithfully reproduces that unset-context condition
+    without mocking.
+    """
+    import contextvars
+
+    from vaultspec_core.plan.parser import parse_plan
+
+    rng = random.Random(157)
+    spec = make_clean_plan("L1", rng=rng, steps=3)
+    plan_path = tmp_path / ".vault" / "plan" / "2026-06-13-bugfix-plan.md"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text(spec.render(), encoding="utf-8")
+
+    runner = CliRunner(env={"NO_COLOR": "1"})
+    empty_ctx = contextvars.Context()
+    result = empty_ctx.run(
+        runner.invoke,
+        app,
+        ["vault", "plan", "step", "check", str(plan_path), "S02"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    plan = parse_plan(plan_path)
+    target = next(s for s in plan.steps if s.canonical_id == "S02")
+    assert target.checked is True
+
+
+def test_invalidate_graph_cache_for_plan_drops_cache_without_context(tmp_path) -> None:
+    """The post-save hook drops the right cache file even with no context."""
+    import contextvars
+
+    from vaultspec_core.cli.plan_cmd import _invalidate_graph_cache_for_plan
+    from vaultspec_core.graph.cache import cache_path
+
+    plan_path = tmp_path / ".vault" / "plan" / "2026-06-13-cache-plan.md"
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text("# cache plan\n", encoding="utf-8")
+
+    def _seed_and_invalidate():
+        cache_file = cache_path(tmp_path)
+        cache_file.parent.mkdir(parents=True, exist_ok=True)
+        cache_file.write_text("{}", encoding="utf-8")
+        _invalidate_graph_cache_for_plan(plan_path)
+        return cache_file
+
+    cache_file = contextvars.Context().run(_seed_and_invalidate)
+    assert not cache_file.exists()

--- a/src/vaultspec_core/tests/plan/test_trailer.py
+++ b/src/vaultspec_core/tests/plan/test_trailer.py
@@ -1,0 +1,226 @@
+"""Tests for the commit-linkage trailer module and its CLI verbs (issue #159).
+
+Covers the pure parse/format/validate helpers in
+:mod:`vaultspec_core.plan.trailer` and the ``vault plan trailer emit`` /
+``validate`` verbs, including the load-bearing constraint that ``validate``
+always exits zero (the trailer is enrichment, never a prerequisite).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from vaultspec_core.cli import app
+from vaultspec_core.plan.trailer import (
+    FEATURE_TRAILER_KEY,
+    STEP_TRAILER_KEY,
+    format_feature_trailer,
+    format_step_trailer,
+    parse_message,
+    validate_message,
+    validate_value,
+)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(env={"NO_COLOR": "1"})
+
+
+# ---- value validation -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["S06", "S117", "P02.S06", "W01.P02.S06", "W01.P02a.S06", "P02", "W01.P02", "P02a"],
+)
+def test_step_trailer_accepts_valid_display_paths(value: str) -> None:
+    """Every L1..L4 Step and Phase display path validates for the Step key."""
+    assert validate_value(STEP_TRAILER_KEY, value) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["S6", "s06", "P2.S06", "S06a", "W1.P02.S06", "X01.S06", "P02.S06.", "", "W01"],
+)
+def test_step_trailer_rejects_malformed(value: str) -> None:
+    """Malformed Step values report a reason rather than validating."""
+    assert validate_value(STEP_TRAILER_KEY, value) is not None
+
+
+@pytest.mark.parametrize(
+    "value", ["auth-refactor", "#auth-refactor", "graph", "a", "x9-y-z", "#graph"]
+)
+def test_feature_trailer_accepts_valid_tags(value: str) -> None:
+    assert validate_value(FEATURE_TRAILER_KEY, value) is None
+
+
+@pytest.mark.parametrize(
+    "value", ["Auth", "-leading", "with space", "UPPER", "", "##double"]
+)
+def test_feature_trailer_rejects_malformed(value: str) -> None:
+    assert validate_value(FEATURE_TRAILER_KEY, value) is not None
+
+
+def test_validate_value_unknown_key_returns_reason() -> None:
+    assert validate_value("Vaultspec-Bogus", "S01") is not None
+
+
+# ---- parsing ----------------------------------------------------------------
+
+
+def test_parse_message_finds_both_keys_case_insensitively() -> None:
+    message = (
+        "feat: do the thing\n\n"
+        "Body paragraph explaining why.\n\n"
+        "Vaultspec-Step: W01.P02.S06\n"
+        "vaultspec-feature: auth-refactor\n"
+        "Co-authored-by: Someone <x@y.z>\n"
+    )
+    trailers = parse_message(message)
+    assert [(t.key, t.value) for t in trailers] == [
+        (STEP_TRAILER_KEY, "W01.P02.S06"),
+        (FEATURE_TRAILER_KEY, "auth-refactor"),
+    ]
+    # Line numbers are 1-based and point at the trailer lines.
+    assert trailers[0].line_number == 5
+    assert trailers[1].line_number == 6
+
+
+def test_parse_message_without_trailers_is_empty() -> None:
+    assert parse_message("just a subject line\n\nand a body") == []
+
+
+# ---- validate_message -------------------------------------------------------
+
+
+def test_validate_message_clean_returns_no_problems() -> None:
+    message = "feat: x\n\nVaultspec-Step: P02.S06\nVaultspec-Feature: graph\n"
+    assert validate_message(message) == []
+
+
+def test_validate_message_flags_malformed_value() -> None:
+    message = "feat: x\n\nVaultspec-Step: not-a-path\n"
+    problems = validate_message(message)
+    assert len(problems) == 1
+    assert problems[0].key == STEP_TRAILER_KEY
+    assert problems[0].value == "not-a-path"
+    assert problems[0].line_number == 3
+
+
+def test_validate_message_trailerless_is_clean() -> None:
+    assert validate_message("chore: tidy up\n") == []
+
+
+# ---- formatting -------------------------------------------------------------
+
+
+def test_format_step_trailer_roundtrips() -> None:
+    line = format_step_trailer("W01.P02.S06")
+    assert line == "Vaultspec-Step: W01.P02.S06"
+    assert validate_message(line) == []
+
+
+def test_format_feature_trailer_strips_leading_hash() -> None:
+    assert (
+        format_feature_trailer("#auth-refactor") == "Vaultspec-Feature: auth-refactor"
+    )
+    assert format_feature_trailer("graph") == "Vaultspec-Feature: graph"
+
+
+def test_format_step_trailer_rejects_invalid() -> None:
+    with pytest.raises(ValueError, match="invalid"):
+        format_step_trailer("S6")
+
+
+def test_format_feature_trailer_rejects_invalid() -> None:
+    with pytest.raises(ValueError, match="invalid"):
+        format_feature_trailer("Bad Tag")
+
+
+# ---- CLI: emit --------------------------------------------------------------
+
+
+def test_cli_emit_step(runner: CliRunner) -> None:
+    result = runner.invoke(
+        app, ["vault", "plan", "trailer", "emit", "--step", "W01.P02.S06"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Vaultspec-Step: W01.P02.S06" in result.output
+
+
+def test_cli_emit_feature(runner: CliRunner) -> None:
+    result = runner.invoke(
+        app, ["vault", "plan", "trailer", "emit", "--feature", "#auth-refactor"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "Vaultspec-Feature: auth-refactor" in result.output
+
+
+def test_cli_emit_requires_exactly_one(runner: CliRunner) -> None:
+    both = runner.invoke(
+        app,
+        ["vault", "plan", "trailer", "emit", "--step", "S01", "--feature", "x"],
+    )
+    assert both.exit_code == 1
+    assert "exactly one" in both.output
+
+    neither = runner.invoke(app, ["vault", "plan", "trailer", "emit"])
+    assert neither.exit_code == 1
+    assert "exactly one" in neither.output
+
+
+def test_cli_emit_invalid_step_is_usage_error(runner: CliRunner) -> None:
+    result = runner.invoke(app, ["vault", "plan", "trailer", "emit", "--step", "S6"])
+    assert result.exit_code == 1
+    assert "invalid" in result.output
+
+
+# ---- CLI: validate (always exits zero) --------------------------------------
+
+
+def test_cli_validate_clean_exits_zero(runner: CliRunner, tmp_path) -> None:
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("feat: x\n\nVaultspec-Step: P02.S06\n", encoding="utf-8")
+    result = runner.invoke(app, ["vault", "plan", "trailer", "validate", str(msg)])
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_validate_malformed_reports_but_exits_zero(
+    runner: CliRunner, tmp_path
+) -> None:
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("feat: x\n\nVaultspec-Step: garbage\n", encoding="utf-8")
+    result = runner.invoke(app, ["vault", "plan", "trailer", "validate", str(msg)])
+    assert result.exit_code == 0, result.output
+    assert "advisory" in result.output
+    assert "garbage" in result.output
+
+
+def test_cli_validate_trailerless_exits_zero(runner: CliRunner, tmp_path) -> None:
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("chore: no trailers here\n", encoding="utf-8")
+    result = runner.invoke(app, ["vault", "plan", "trailer", "validate", str(msg)])
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_validate_missing_file_exits_zero(runner: CliRunner, tmp_path) -> None:
+    missing = tmp_path / "does-not-exist"
+    result = runner.invoke(app, ["vault", "plan", "trailer", "validate", str(missing)])
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_validate_json_envelope(runner: CliRunner, tmp_path) -> None:
+    msg = tmp_path / "COMMIT_EDITMSG"
+    msg.write_text("feat: x\n\nVaultspec-Feature: Bad Tag\n", encoding="utf-8")
+    result = runner.invoke(
+        app, ["vault", "plan", "trailer", "validate", str(msg), "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["schema"] == "vaultspec.vault.plan.trailer.validate.v1"
+    assert len(payload["data"]["problems"]) == 1
+    assert payload["data"]["problems"][0]["key"] == FEATURE_TRAILER_KEY

--- a/src/vaultspec_core/vaultcore/hydration.py
+++ b/src/vaultspec_core/vaultcore/hydration.py
@@ -40,6 +40,11 @@ _TEMPLATE_NAMES = {
     DocType.INDEX: "index.md",
 }
 
+# The exec document type has two templates: the Step-record template (above)
+# and the Phase-summary template, selected via the ``summary`` flag on
+# :func:`get_template_path` / :func:`create_vault_doc`.
+_EXEC_SUMMARY_TEMPLATE = "exec-summary.md"
+
 # Prior on-disk filenames for templates that have since been renamed in the
 # source tree. A deployed mirror that predates the rename still ships the old
 # filename; :func:`get_template_path` falls back to these so the scaffolder
@@ -71,6 +76,7 @@ def hydrate_template(
     step_scope: str | None = None,
     step_action: str | None = None,
     plan_stem: str | None = None,
+    phase: str | None = None,
 ) -> str:
     """Replace placeholders in a template string with actual values.
 
@@ -100,6 +106,10 @@ def hydrate_template(
         step_scope: Optional file or area scope of the step.
         step_action: Optional verbatim action of the step.
         plan_stem: Optional parent plan stem used in wiki-links.
+        phase: Optional Phase identifier (display path, e.g. ``P01`` or
+            ``W01.P01``) substituted into the ``{phase}`` placeholder of the
+            exec-summary template. Takes precedence over the ``{phase}``
+            alias derived from *title*.
 
     Returns:
         The fully-hydrated document string.
@@ -117,6 +127,10 @@ def hydrate_template(
         placeholders["topic"] = title  # alias used in research template
         placeholders["phase"] = title  # alias used in plan/exec templates
         placeholders["step"] = title  # alias used in exec template
+    if phase is not None:
+        # Explicit Phase identifier wins over the title-derived alias; the
+        # exec-summary heading is `# {feature} {phase} summary`.
+        placeholders["phase"] = phase
     if tier:
         placeholders["tier"] = tier
 
@@ -320,6 +334,8 @@ def create_vault_doc(
     step_action: str | None = None,
     plan_date: str | None = None,
     plan_stem: str | None = None,
+    summary: bool = False,
+    phase_display_path: str | None = None,
 ) -> pathlib.Path:
     """Scaffold a new vault document from the appropriate template.
 
@@ -344,6 +360,12 @@ def create_vault_doc(
         step_action: Optional verbatim action of the step.
         plan_date: Optional parent plan date.
         plan_stem: Optional parent plan stem used in wiki-links.
+        summary: When ``True`` and *doc_type* is :attr:`DocType.EXEC`,
+            scaffold a Phase-summary record from the ``exec-summary.md``
+            template instead of a Step record. Requires *phase_display_path*.
+        phase_display_path: Display path of the summarised Phase (e.g.
+            ``P01`` or ``W01.P01``); fills the ``{phase}`` placeholder and the
+            summary filename's identifier segment.
 
     Returns:
         Path to the newly created (or would-be-created) document.
@@ -355,7 +377,9 @@ def create_vault_doc(
     """
     from ..config import get_config
 
-    template_path = get_template_path(root_dir, doc_type, content_root=content_root)
+    template_path = get_template_path(
+        root_dir, doc_type, content_root=content_root, summary=summary
+    )
     if template_path is None:
         raise FileNotFoundError(
             f"No template found for type '{doc_type.value}'. The deployed "
@@ -385,9 +409,19 @@ def create_vault_doc(
         step_scope=step_scope,
         step_action=step_action,
         plan_stem=plan_stem,
+        phase=phase_display_path if summary else None,
     )
 
-    if doc_type is DocType.EXEC and step_id is not None:
+    if doc_type is DocType.EXEC and summary:
+        suffix = (phase_display_path or "P01").replace(".", "-")
+        filename = f"{plan_date or date_str}-{feature}-{suffix}-summary.md"
+        target_dir = (
+            root_dir
+            / get_config().docs_dir
+            / doc_type.value
+            / f"{plan_date or date_str}-{feature}"
+        )
+    elif doc_type is DocType.EXEC and step_id is not None:
         suffix = step_display_path.replace(".", "-") if step_display_path else "S01"
         filename = f"{plan_date or date_str}-{feature}-{suffix}.md"
         target_dir = (
@@ -490,6 +524,7 @@ def get_template_path(
     doc_type: DocType,
     *,
     content_root: pathlib.Path | None = None,
+    summary: bool = False,
 ) -> pathlib.Path | None:
     """Return the filesystem path of the template file for a given DocType.
 
@@ -500,6 +535,9 @@ def get_template_path(
         content_root: Explicit content root (e.g. ``.vaultspec/``). Templates
             live in the content tree. When ``None``, falls back to
             ``root_dir / framework_dir``.
+        summary: When ``True`` and *doc_type* is :attr:`DocType.EXEC`, resolve
+            the Phase-summary template (``exec-summary.md``) instead of the
+            Step-record template (``exec-step.md``).
 
     Returns:
         Path to the template file, or ``None`` if the type has no mapping or
@@ -507,7 +545,10 @@ def get_template_path(
     """
     from ..config import get_config
 
-    name = _TEMPLATE_NAMES.get(doc_type)
+    if summary and doc_type is DocType.EXEC:
+        name: str | None = _EXEC_SUMMARY_TEMPLATE
+    else:
+        name = _TEMPLATE_NAMES.get(doc_type)
     if not name:
         return None
 

--- a/src/vaultspec_core/vaultcore/scanner.py
+++ b/src/vaultspec_core/vaultcore/scanner.py
@@ -17,7 +17,12 @@ from typing import TYPE_CHECKING
 
 from .models import DocType
 
-__all__ = ["get_doc_type", "list_features", "scan_vault"]
+__all__ = [
+    "get_doc_type",
+    "get_doc_type_from_tree_path",
+    "list_features",
+    "scan_vault",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -148,4 +153,41 @@ def get_doc_type(path: pathlib.Path, root_dir: pathlib.Path) -> DocType | None:
         return doc_type
     except (ValueError, KeyError) as e:
         logger.debug("Failed to determine doc type for %s: %s", path.name, e)
+        return None
+
+
+def get_doc_type_from_tree_path(tree_path: str, docs_dir_name: str) -> DocType | None:
+    """Classify a vault document from a git tree-path string.
+
+    The ref-scoped graph build (issue #160) reads documents from the git
+    object database, where each blob is known by its repo-relative POSIX
+    tree path (e.g. ``.vault/adr/foo.md``) rather than a filesystem
+    :class:`~pathlib.Path`. This reproduces :func:`get_doc_type`'s
+    classification - the first path component after the docs directory names
+    the type, with the legacy root-level ``<feature>.index.md`` case
+    preserved - from that string alone, so a ref build classifies documents
+    identically to a working-tree build without a checkout.
+
+    Args:
+        tree_path: Repo-relative POSIX path of the document
+            (e.g. ``.vault/adr/foo.md``).
+        docs_dir_name: The configured docs directory name (e.g. ``.vault``).
+
+    Returns:
+        The :class:`DocType` inferred from the first component after the docs
+        directory, or ``None`` when the path does not match a known type.
+    """
+    from pathlib import PurePosixPath
+
+    parts = PurePosixPath(tree_path).parts
+    if docs_dir_name not in parts:
+        return None
+    rest = parts[parts.index(docs_dir_name) + 1 :]
+    if len(rest) < 2:
+        if rest and rest[-1].endswith(".index.md"):
+            return DocType.INDEX
+        return None
+    try:
+        return DocType(rest[0])
+    except (ValueError, KeyError):
         return None

--- a/tests/test_template_annotations.py
+++ b/tests/test_template_annotations.py
@@ -49,6 +49,7 @@ def test_template_frontmatter_contains_only_data_fields() -> None:
     allowed_keys = {
         "date",
         "generated",
+        "modified",
         "related",
         "step_id",
         "tags",


### PR DESCRIPTION
## Summary

Delivers a cohesive cluster of changes and hardening requested by an external consumer of core's declared-edge vault graph. Two are bug fixes, one closes a CLI gap, and two are new opt-in features. Research, ADR, and plan artifacts for the two features are persisted under `.vault/`.

| Issue | Type | Change |
| --- | --- | --- |
| #153 | fix | `spec doctor` no longer flags custom rules under `rules/project/` as stale |
| #157 | fix | `vault plan` mutation verbs no longer exit 1 after a successful write |
| #158 | feat | `vault add exec --summary --phase P##` scaffolds phase summaries |
| #159 | feat | opt-in commit-linkage trailer convention (`vault plan trailer`) |
| #160 | feat | ref-scoped vault graph (`vault graph --ref <branch\|sha>`) |

## Details

**#153 — doctor recursive glob.** `collect_content_integrity` globbed the provider destination dir flat (`*.md`) while sync preserves subpaths, so custom rules under a subdirectory were never matched and were falsely reported stale/missing. The dest is now globbed recursively, symmetric with the source side.

**#157 — plan-mutator cache-hook crash.** Every mutation verb wrote correctly, then crashed `exit 1` in the post-save graph-cache hook because it read the workspace `ContextVar` the bare mutation verbs never initialise. The cache root is now derived from the plan path's docs-dir ancestor (`_resolve_vault_root`), and the hook is hardened so a best-effort invalidation can never poison a successful write's exit code.

**#158 — phase-summary scaffold.** The exec-summary template shipped but no `vault add` verb reached it, forcing hand-authored frontmatter. `vault add exec --summary --phase P##` now scaffolds it with machine-filled placeholders (phase display path and parent-plan back-link), mirroring the step-record path. Full option-gating validation included.

**#159 — commit-linkage trailers.** A new single-owner module `plan/trailer.py` defines the trailer vocabulary (`Vaultspec-Step`, `Vaultspec-Feature`), the value regexes, and pure `parse`/`format`/`validate` helpers. `vault plan trailer emit` produces a well-formed line; `vault plan trailer validate` reports malformed trailers and **always exits 0**, making it safe to wire as an advisory `commit-msg` hook (documented opt-in entry). The convention is **enrichment, never a prerequisite**: absence or malformation never blocks a commit or fails any core command.

**#160 — ref-scoped graph.** `vault graph --json --ref <branch|sha>` reads the corpus from the git object database via subprocess `git` (no new dependency, no checkout). The build runs with the cache disabled and the working-tree migration pass skipped, and classifies document type from the blob's tree path. The envelope stays `vaultspec.vault.graph.v2` with an additive top-level `ref` key and virtual node paths. A non-git workspace or an unresolvable ref fails with a typed error rather than a working-tree fallback.

## Testing

- New regression/feature tests for all five issues (collectors, plan e2e cache-hook, step-aware exec, `test_trailer.py` 48 cases, `test_graph_ref.py` 12 real-git cases).
- Contract/lint tests updated for the intentional additions: v2 graph contract gains `ref`; CLI language contract reworded; template-annotation `allowed_keys` gains the `modified` stamp field shipped in #156.
- Full suite green (2363 passed); `ruff` and `ty` clean; all pre-commit hooks pass.

Fixes #153
Fixes #157
Fixes #158
Closes #159
Closes #160

---

### Follow-up (after manual operator-persona CLI verification)

- **#160 node paths** — every node `path` in the v2 envelope is now a vault-relative POSIX path (`.vault/adr/foo.md`) for **both** working-tree and ref-scoped builds; no absolute OS path leaks, so a consumer ingests both modes through one path format. (`DocNode.path` stays an absolute `Path` internally for filesystem operations; only the wire form is normalised.)
- **#153 policy alignment** — providers do not support nested rule folders; `sync` sanitizes nesting by flattening project-authored rules into the provider root. The doctor collector globs the destination **flat** accordingly (the source side stays recursive only to discover the project-authored basename), and its regression test models the real flattened pipeline.

Both refinements verified green (full suite 2364 passed; ruff/ty/mdformat/vault-doctor clean).


### Follow-up 2 — de-nest the rules source tree

Per project policy (no project-based rules / no nested rule folders), custom rules now live **flat** under `.vaultspec/rules/rules/` alongside the `*.builtin.md` builtins, and the CLI sanitizes nesting automatically:

- `spec rules add` authors flat and reduces the name to its basename (a `project/` prefix or deeper path is sanitized away).
- The old flat→`project/` migration is inverted into `flatten_nested_custom_rules`, which moves any nested non-builtin rule up to the root and removes emptied subdirs; it runs on every collect/sync and `rules list`, healing nesting idempotently.
- `rule promote` scaffolds flat; `resource_rename` de-nests (keeps a `project/` read fallback for transition).
- Gitignore policy unchanged — both builtins and custom rules remain team-shared/committed.

Tests migrated to the flat layout plus new sanitizer + name-sanitization tests. Full suite green (2365 passed); ruff/ty/mdformat/vault-doctor clean.
