### PR TITLE
ci: bootstrap with `install --force` so Vault Audit survives tracked .vaultspec/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,12 +153,14 @@ jobs:
         run: just dev deps sync
 
       - name: Bootstrap framework
-        # The source repo no longer tracks .vaultspec/ (collapsed into the
-        # package source tree at src/vaultspec_core/builtins/). A fresh
-        # checkout has no .vaultspec/, so `vault check all` would fail with
-        # `vaultspec_dir does not exist`. Run install first to scaffold the
-        # workspace the same way any consumer would.
-        run: just prod install
+        # The source repo tracks .vaultspec/ framework config, but the install
+        # manifest (.vaultspec/providers.json) stays gitignored. A fresh
+        # checkout therefore has the framework dir without a manifest, which
+        # the diagnosis engine classifies as CORRUPTED. Run install with
+        # --force to repair/create the manifest from the tracked config and
+        # scaffold provider outputs, the way a consumer recovering a missing
+        # manifest would.
+        run: just prod install --force
 
       - name: Verify vault structure and links
         run: just prod vault check all


### PR DESCRIPTION
## Problem

Main's **Vault Audit** CI job has been failing since the #164 merge. All
lint/type/test jobs pass; only the `Bootstrap framework` step fails:

```
x Manifest is corrupted. Use --force to repair.
error: recipe `prod` failed on line 20 with exit code 1
```

## Root cause

Commit `f0bb84f` re-added `.vaultspec/` to git tracking ("track .vaultspec
framework config so the install is binding"), but the install manifest
`.vaultspec/providers.json` stays gitignored (`.gitignore`, vaultspec-managed
block). A fresh CI checkout therefore has the framework directory **without** a
manifest. The diagnosis collector (`collectors.py:101-116`) classifies that
state as `FrameworkSignal.CORRUPTED`, and the resolver
(`resolver.py:214-226`) makes bare `install` abort and demand `--force`.

The `Bootstrap framework` step's comment was also stale -- it still claimed the
repo "no longer tracks .vaultspec/".

## Fix

Run the Bootstrap step with `just prod install --force`. On the `CORRUPTED +
INSTALL + force` path the resolver appends `REPAIR_MANIFEST` and proceeds,
regenerating `providers.json` from the tracked config before `vault check all`.
The step comment is refreshed to match the now-tracked `.vaultspec/`.

Regression window: main CI was green through #163, red at #164 and #165.