### PR TITLE
feat(vault): add set-body/set-frontmatter/edit verbs with blob-hash concurrency and conformance validation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -106,6 +106,9 @@ vaultspec-core uninstall [OPTIONS] [PROVIDER]
 vaultspec-core sync [OPTIONS] [PROVIDER]
 vaultspec-core doctor [OPTIONS]
 vaultspec-core status [OPTIONS] [TARGET]
+vaultspec-core vault set-body [OPTIONS] REF
+vaultspec-core vault set-frontmatter [OPTIONS] REF
+vaultspec-core vault edit [OPTIONS] REF
 vaultspec-core vault add [OPTIONS] DOC_TYPE
 vaultspec-core vault stats [OPTIONS]
 vaultspec-core vault list [OPTIONS] [DOC_TYPE]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,9 @@ target-version = "py313"
     "**/tests/**/*.py" = ["ARG"]
     # Core CLI modules use argparse/Path as runtime parameter types - no need to move to TYPE_CHECKING
     "src/vaultspec_core/core/*.py" = ["TC003"]
+    # The edit verbs declare Path-typed Typer options, which Typer introspects at
+    # runtime; Path must stay a runtime import, not move to a TYPE_CHECKING block.
+    "src/vaultspec_core/cli/edit_cmd.py" = ["TC003"]
     # Synthetic vault generator uses Path at runtime in dataclass fields and function args.
     "src/vaultspec_core/testing/synthetic.py" = ["TC003"]
     # Diagnosis dataclasses use Tool as runtime dict key and for JSON serialization.

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -43,6 +43,9 @@ vaultspec-core uninstall [OPTIONS] [PROVIDER]
 vaultspec-core sync [OPTIONS] [PROVIDER]
 vaultspec-core doctor [OPTIONS]
 vaultspec-core status [OPTIONS] [TARGET]
+vaultspec-core vault set-body [OPTIONS] REF
+vaultspec-core vault set-frontmatter [OPTIONS] REF
+vaultspec-core vault edit [OPTIONS] REF
 vaultspec-core vault add [OPTIONS] DOC_TYPE
 vaultspec-core vault stats [OPTIONS]
 vaultspec-core vault list [OPTIONS] [DOC_TYPE]

--- a/src/vaultspec_core/cli/edit_cmd.py
+++ b/src/vaultspec_core/cli/edit_cmd.py
@@ -413,7 +413,11 @@ def _read_body_channel(
         return None
 
     if body_stdin:
-        return sys.stdin.read()
+        # Normalize CRLF to LF identically to the --body-file branch below. The
+        # engine write channel always uses --body-stdin, so an un-normalized
+        # \r\n would flow into the LF-contract compose/validate/write path and
+        # corrupt CRLF files (\r\r\n) or leave stray \r\n in LF documents.
+        return sys.stdin.read().replace("\r\n", "\n")
 
     assert body_file is not None
     try:

--- a/src/vaultspec_core/cli/edit_cmd.py
+++ b/src/vaultspec_core/cli/edit_cmd.py
@@ -1,0 +1,1060 @@
+"""Typer wiring for the composed vault edit verbs.
+
+Registers three verbs on :data:`vaultspec_core.cli.vault_cmd.vault_app`:
+
+``vault set-body``
+    Replace only the body prose of a document, keeping its frontmatter
+    block byte-for-byte.
+
+``vault set-frontmatter``
+    Edit selected frontmatter fields (``date``, ``tags``, ``related``),
+    keeping the body byte-for-byte.
+
+``vault edit``
+    The single-round-trip "save": set the body and/or frontmatter in one
+    atomic write with one validation pass.  This is the verb the dashboard
+    engine's ``/ops`` body channel drives.
+
+Every verb composes existing core machinery and writes NO new validation
+logic: frontmatter conformance is :meth:`DocumentMetadata.validate`, and
+body/link conformance is the existing ``frontmatter`` / ``links`` /
+``body-links`` checkers run over an in-memory single-document snapshot of
+the *proposed* content - so the refuse-on-error decision is made strictly
+before any byte is persisted.  Optimistic concurrency is the git blob OID
+(:func:`git_blob_oid`) of the pre-write on-disk bytes, byte-compatible with
+the dashboard engine's hash.
+
+JSON envelopes (all via the shared :func:`json_envelope` helper):
+    ``vaultspec.vault.set-body.v1``
+    ``vaultspec.vault.set-frontmatter.v1``
+    ``vaultspec.vault.edit.v1``
+
+Canonical statuses: ``updated`` (content changed), ``unchanged`` (a no-op
+or a dry-run), ``failed`` (conflict, validation refusal, or write error).
+
+Exit codes:
+    0 - updated or unchanged
+    1 - resolution failure, blob-hash conflict, validation refusal, or
+        write error
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import datetime as _dt
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, cast
+
+import typer
+
+from vaultspec_core.cli._target import TargetOption, apply_target
+
+if TYPE_CHECKING:
+    import typer as _typer
+
+    from vaultspec_core.vaultcore.checks._base import CheckDiagnostic
+    from vaultspec_core.vaultcore.models import DocumentMetadata
+
+__all__ = ["register_edit_commands"]
+
+
+# ---------------------------------------------------------------------------
+# Shared resolution / validation / write machinery
+# ---------------------------------------------------------------------------
+
+
+class _EditError(Exception):
+    """A verb-level failure carrying a structured ``data`` payload.
+
+    Raised by the shared helpers to unwind to the verb entry point, which
+    renders the canonical failed envelope and exits non-zero.  The payload
+    is merged into ``data`` so the caller can attach ``conflict``,
+    ``refused``, ``checks``, or ``errors`` without each helper re-deriving
+    the envelope shape.
+    """
+
+    def __init__(self, message: str, data: dict[str, object]) -> None:
+        self.message = message
+        self.data = data
+        super().__init__(message)
+
+
+def _resolve_doc_path(ref: str, root_dir: Path) -> Path:
+    """Resolve a stem, filename, or path reference to an on-disk document.
+
+    Mirrors how ``vault add --related`` / ``vault link`` resolve a
+    reference - via :func:`resolve_related_inputs` - then maps the
+    canonical stem back to its backing file path.
+
+    Args:
+        ref: A document stem, filename (with or without ``.md``), absolute
+            or relative path, or ``[[wiki-link]]``.
+        root_dir: The project root whose ``.vault/`` holds the document.
+
+    Returns:
+        The absolute path to the backing document file.
+
+    Raises:
+        _EditError: When the reference resolves to no vault document.
+    """
+    from vaultspec_core.vaultcore.resolve import (
+        RelatedResolutionError,
+        resolve_related_inputs,
+    )
+    from vaultspec_core.vaultcore.scanner import scan_vault
+
+    try:
+        resolved = resolve_related_inputs([ref], root_dir)
+    except RelatedResolutionError as exc:
+        raise _EditError(
+            f"Cannot resolve document: '{ref}'",
+            {"path": ref},
+        ) from exc
+
+    if not resolved:
+        raise _EditError(f"Cannot resolve document: '{ref}'", {"path": ref})
+
+    stem = resolved[0][2:-2]  # strip [[ ]]
+    for doc_path in scan_vault(root_dir):
+        if doc_path.stem == stem:
+            return doc_path
+
+    raise _EditError(f"Resolved stem '{stem}' has no backing file", {"path": ref})
+
+
+def _split_document(text: str) -> tuple[str, str]:
+    """Split full document text into ``(frontmatter_block, body)``.
+
+    The frontmatter block retains its leading and trailing ``---`` fences
+    and the newline that follows the closing fence, so reassembling with
+    ``frontmatter_block + body`` reproduces the original bytes exactly.
+    A document with no frontmatter fence yields ``("", text)``.
+
+    Args:
+        text: Full document text with LF-normalised line endings.
+
+    Returns:
+        A two-tuple ``(frontmatter_block, body)``.
+    """
+    import re
+
+    match = re.match(r"^(﻿?---[ \t]*\n.*?\n---[ \t]*\n?)(.*)$", text, re.DOTALL)
+    if not match:
+        return "", text
+    return match.group(1), match.group(2)
+
+
+def _validate_proposed(doc_path: Path, root_dir: Path, new_text: str) -> list[dict]:
+    """Validate proposed full document text without writing it.
+
+    Builds a single-document snapshot keyed on *doc_path* from the parsed
+    *new_text* and runs the existing snapshot-consuming checkers
+    (``frontmatter``, ``links``, ``body-links``) over only that document,
+    so the conformance decision is made strictly pre-write.  No new
+    validation logic is authored here.
+
+    Args:
+        doc_path: The path the proposed content will be written to.
+        root_dir: Project root (used to relativise diagnostic paths).
+        new_text: The full proposed document text (frontmatter + body).
+
+    Returns:
+        The combined diagnostics as plain dicts (``path``, ``message``,
+        ``severity``, ``fixable``, ``fix_description``), ready to nest
+        under ``data.checks``.
+    """
+    from vaultspec_core.vaultcore.checks import (
+        check_body_links,
+        check_frontmatter,
+        check_links,
+    )
+    from vaultspec_core.vaultcore.parser import parse_vault_metadata
+
+    metadata, body = parse_vault_metadata(new_text)
+    snapshot = {doc_path: (metadata, body)}
+
+    results = [
+        check_frontmatter(root_dir, snapshot=snapshot, fix=False),
+        check_links(root_dir, snapshot=snapshot, fix=False),
+        check_body_links(root_dir, snapshot=snapshot),
+    ]
+
+    diagnostics: list[dict] = []
+    for result in results:
+        for diag in result.diagnostics:
+            diagnostics.append(_diag_to_dict(result.check_name, diag))
+    return diagnostics
+
+
+def _diag_to_dict(check_name: str, diag: CheckDiagnostic) -> dict:
+    """Render a :class:`CheckDiagnostic` as a JSON-safe dict.
+
+    Args:
+        check_name: The owning checker's name (e.g. ``"frontmatter"``).
+        diag: The diagnostic to render.
+
+    Returns:
+        A dict carrying the check name, relative path, message, severity,
+        and fix metadata.
+    """
+    payload = dataclasses.asdict(diag)
+    payload["check"] = check_name
+    payload["path"] = str(payload["path"]) if payload["path"] is not None else None
+    payload["severity"] = str(payload["severity"])
+    return payload
+
+
+def _has_error(diagnostics: list[dict]) -> bool:
+    """Return ``True`` when any diagnostic is ERROR severity.
+
+    Args:
+        diagnostics: Rendered diagnostics from :func:`_validate_proposed`.
+
+    Returns:
+        ``True`` if at least one diagnostic blocks the write.
+    """
+    return any(d["severity"] == "error" for d in diagnostics)
+
+
+def _enforce_blob_hash(doc_path: Path, expected: str | None) -> None:
+    """Enforce optimistic-concurrency against the pre-write on-disk bytes.
+
+    Args:
+        doc_path: The document whose current bytes are hashed.
+        expected: The blob OID the caller believes is current, or ``None``
+            to skip the check.
+
+    Raises:
+        _EditError: When *expected* is given and does not match the current
+            on-disk blob OID, carrying ``conflict``, ``expected``, and
+            ``actual`` in its payload.
+    """
+    from vaultspec_core.vaultcore.blob_hash import git_blob_oid
+
+    if expected is None:
+        return
+    actual = git_blob_oid(doc_path.read_bytes())
+    if actual != expected:
+        raise _EditError(
+            "Blob-hash conflict: document changed on disk since it was read",
+            {
+                "conflict": True,
+                "expected": expected,
+                "actual": actual,
+                "path": str(doc_path),
+            },
+        )
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter field surgery (preserves unknown keys and CRLF)
+# ---------------------------------------------------------------------------
+
+
+def _serialise_block_list(key: str, values: list[str]) -> list[str]:
+    """Render a YAML block list for *key* in the canonical vault style.
+
+    Args:
+        key: The frontmatter key (e.g. ``"tags"`` or ``"related"``).
+        values: The list items; each rendered as ``  - 'value'``.
+
+    Returns:
+        The rendered lines, ``key: []`` when *values* is empty.
+    """
+    if not values:
+        return [f"{key}: []"]
+    lines = [f"{key}:"]
+    lines.extend(f"  - '{v}'" for v in values)
+    return lines
+
+
+def _rewrite_frontmatter_field(
+    frontmatter_block: str,
+    key: str,
+    new_lines: list[str],
+) -> str:
+    """Replace (or insert) a single frontmatter *key*'s lines.
+
+    Operates only inside the leading ``---`` fence and touches only the
+    block belonging to *key*; every other key, comment, and unknown field
+    is preserved byte-for-byte.  When *key* is absent it is inserted
+    immediately before the closing fence.
+
+    Args:
+        frontmatter_block: The frontmatter, including both ``---`` fences.
+        key: The top-level key to rewrite (``date``, ``tags``, ``related``).
+        new_lines: The replacement lines for the key's block.
+
+    Returns:
+        The rewritten frontmatter block.
+    """
+    lines = frontmatter_block.split("\n")
+    out: list[str] = []
+    in_block = False
+    replaced = False
+    close_idx: int | None = None
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        if in_block:
+            # The key's block continues through indented list items only.
+            if line[:1] in (" ", "\t"):
+                continue
+            in_block = False
+
+        # Closing fence: remember its position for an insert-if-absent.
+        if stripped == "---" and i > 0 and close_idx is None and out:
+            close_idx = len(out)
+
+        if (
+            not in_block
+            and (stripped == f"{key}:" or stripped.startswith(f"{key}:"))
+            and not stripped.startswith("-")
+        ):
+            # Found the key line (block, inline, or empty form). Replace its
+            # whole block with the new rendering.
+            out.extend(new_lines)
+            replaced = True
+            in_block = True
+            close_idx = None
+            continue
+
+        out.append(line)
+
+    if not replaced:
+        # Insert before the closing fence (the last `---`).
+        insert_at = len(out) - 1
+        for j in range(len(out) - 1, -1, -1):
+            if out[j].strip() == "---":
+                insert_at = j
+                break
+        out[insert_at:insert_at] = new_lines
+
+    return "\n".join(out)
+
+
+def _apply_frontmatter_edits(
+    frontmatter_block: str,
+    *,
+    date: str | None,
+    tags: list[str] | None,
+    related: list[str] | None,
+) -> str:
+    """Apply the provided field edits to a frontmatter block.
+
+    Only the fields explicitly supplied (non-``None``) are rewritten; every
+    other key is preserved.  Returns the edited block (still fenced).
+
+    Args:
+        frontmatter_block: The frontmatter, including both ``---`` fences.
+        date: New ``date`` value, or ``None`` to leave unchanged.
+        tags: New ``tags`` list, or ``None`` to leave unchanged.
+        related: New ``related`` list of ``[[wiki-link]]`` strings, or
+            ``None`` to leave unchanged.
+
+    Returns:
+        The frontmatter block with the requested fields replaced.
+    """
+    block = frontmatter_block
+    if date is not None:
+        block = _rewrite_frontmatter_field(block, "date", [f"date: '{date}'"])
+    if tags is not None:
+        block = _rewrite_frontmatter_field(
+            block, "tags", _serialise_block_list("tags", tags)
+        )
+    if related is not None:
+        block = _rewrite_frontmatter_field(
+            block, "related", _serialise_block_list("related", related)
+        )
+    return block
+
+
+# ---------------------------------------------------------------------------
+# Body channel reading
+# ---------------------------------------------------------------------------
+
+
+def _read_body_channel(
+    body_file: Path | None,
+    body_stdin: bool,
+    *,
+    required: bool,
+) -> str | None:
+    """Read the new body text from the file or stdin channel.
+
+    Exactly one of *body_file* / *body_stdin* may be set.  Returns ``None``
+    when neither is supplied and *required* is ``False`` (the combined
+    ``edit`` verb permits a frontmatter-only edit).
+
+    Args:
+        body_file: Path to read the new body text from, or ``None``.
+        body_stdin: When ``True``, read the new body text from stdin.
+        required: When ``True``, a missing body channel is an error.
+
+    Returns:
+        The new body text, or ``None`` when no channel was supplied and the
+        body is optional.
+
+    Raises:
+        _EditError: When both channels are set, or a required channel is
+            absent, or the file cannot be read.
+    """
+    if body_file is not None and body_stdin:
+        raise _EditError("--body-file and --body-stdin are mutually exclusive", {})
+
+    if body_file is None and not body_stdin:
+        if required:
+            raise _EditError(
+                "A body channel is required: pass --body-file or --body-stdin", {}
+            )
+        return None
+
+    if body_stdin:
+        return sys.stdin.read()
+
+    assert body_file is not None
+    try:
+        raw = body_file.read_bytes().decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _EditError(f"Cannot read body file '{body_file}': {exc}", {}) from exc
+    return raw.replace("\r\n", "\n")
+
+
+# ---------------------------------------------------------------------------
+# Shared write core
+# ---------------------------------------------------------------------------
+
+
+def _compose_new_text(
+    doc_path: Path,
+    *,
+    new_body: str | None,
+    date: str | None,
+    tags: list[str] | None,
+    related: list[str] | None,
+) -> tuple[str, str]:
+    """Compose the proposed full document text from the on-disk original.
+
+    Reads the document CRLF-preservingly, applies the body and/or
+    frontmatter edits, and refreshes the ``modified:`` stamp.  Returns the
+    LF-normalised proposed text (for validation) and the source newline
+    convention (for the eventual write).
+
+    Args:
+        doc_path: The document to edit.
+        new_body: Replacement body text (LF-normalised), or ``None`` to keep.
+        date: New ``date`` value, or ``None`` to keep.
+        tags: New ``tags`` list, or ``None`` to keep.
+        related: New ``related`` list, or ``None`` to keep.
+
+    Returns:
+        A two-tuple ``(proposed_text_lf, source_newline)``.
+
+    Raises:
+        _EditError: When the document cannot be read.
+    """
+    from vaultspec_core.vaultcore.models import refresh_modified_stamp
+    from vaultspec_core.vaultcore.related_surgery import _read_preserve_newlines
+
+    try:
+        content, source_newline = _read_preserve_newlines(doc_path)
+    except (OSError, UnicodeDecodeError) as exc:
+        raise _EditError(f"Cannot read document '{doc_path}': {exc}", {}) from exc
+
+    frontmatter_block, body = _split_document(content)
+
+    if date is not None or tags is not None or related is not None:
+        frontmatter_block = _apply_frontmatter_edits(
+            frontmatter_block, date=date, tags=tags, related=related
+        )
+
+    if new_body is not None:
+        body = new_body
+
+    proposed = frontmatter_block + body
+    proposed = refresh_modified_stamp(proposed, _dt.date.today())
+    return proposed, source_newline
+
+
+def _execute_edit(
+    *,
+    command: str,
+    ref: str,
+    new_body: str | None,
+    date: str | None,
+    tags: list[str] | None,
+    related: list[str] | None,
+    expected_blob_hash: str | None,
+    run_checks: bool,
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    """Run the resolve -> validate -> concurrency -> write pipeline.
+
+    The single shared implementation behind all three verbs.  Renders the
+    canonical envelope and raises :class:`typer.Exit` with the right code.
+
+    Args:
+        command: Dotted command id for the envelope schema.
+        ref: The document reference (stem, filename, or path).
+        new_body: Replacement body text, or ``None`` for no body edit.
+        date: New ``date`` value, or ``None``.
+        tags: New ``tags`` list, or ``None``.
+        related: New ``related`` list (already resolved), or ``None``.
+        expected_blob_hash: Pre-write concurrency guard, or ``None``.
+        run_checks: Whether to run conformance checks before writing.
+        dry_run: When ``True``, do everything except the write.
+        json_output: When ``True``, emit the JSON envelope.
+    """
+    from vaultspec_core.core.types import get_context as _get_ctx
+
+    root_dir = _get_ctx().target_dir
+
+    try:
+        doc_path = _resolve_doc_path(ref, root_dir)
+
+        # Concurrency guard is enforced against the *current* on-disk bytes,
+        # before any mutation or even composition is trusted.
+        _enforce_blob_hash(doc_path, expected_blob_hash)
+
+        proposed_lf, source_newline = _compose_new_text(
+            doc_path,
+            new_body=new_body,
+            date=date,
+            tags=tags,
+            related=related,
+        )
+
+        # Frontmatter conformance is the model's own validator, run pre-write.
+        frontmatter_errors = _frontmatter_validate(proposed_lf)
+
+        checks: list[dict] = []
+        if run_checks:
+            checks = _validate_proposed(doc_path, root_dir, proposed_lf)
+
+        if frontmatter_errors or _has_error(checks):
+            data: dict[str, object] = {
+                "path": str(doc_path),
+                "refused": True,
+                "checks": checks,
+            }
+            if frontmatter_errors:
+                data["errors"] = frontmatter_errors
+            _emit(command, "failed", data, json_output=json_output)
+            raise typer.Exit(code=1)
+
+        original_bytes = doc_path.read_bytes()
+        proposed_bytes = (
+            proposed_lf
+            if source_newline == "\n"
+            else proposed_lf.replace("\n", source_newline)
+        ).encode("utf-8")
+
+        changed = proposed_bytes != original_bytes
+
+        if dry_run:
+            from vaultspec_core.vaultcore.blob_hash import git_blob_oid
+
+            _emit(
+                command,
+                "updated" if changed else "unchanged",
+                {
+                    "path": str(doc_path),
+                    "blob_hash": git_blob_oid(proposed_bytes),
+                    "checks": checks,
+                    "dry_run": True,
+                    "changed": changed,
+                },
+                json_output=json_output,
+            )
+            return
+
+        if changed:
+            _write_proposed(doc_path, proposed_lf, source_newline)
+            _invalidate_cache(root_dir)
+
+        from vaultspec_core.vaultcore.blob_hash import git_blob_oid
+
+        post_hash = git_blob_oid(doc_path.read_bytes())
+        _emit(
+            command,
+            "updated" if changed else "unchanged",
+            {"path": str(doc_path), "blob_hash": post_hash, "checks": checks},
+            json_output=json_output,
+        )
+    except _EditError as exc:
+        _emit(
+            command,
+            "failed",
+            {"message": exc.message, **exc.data},
+            json_output=json_output,
+        )
+        raise typer.Exit(code=1) from exc
+
+
+def _frontmatter_validate(proposed_lf: str) -> list[str]:
+    """Return :meth:`DocumentMetadata.validate` errors for proposed text.
+
+    Args:
+        proposed_lf: The proposed full document text (LF-normalised).
+
+    Returns:
+        The validator's violation strings (empty when conformant).
+    """
+    from vaultspec_core.vaultcore.parser import parse_vault_metadata
+
+    metadata: DocumentMetadata
+    metadata, _body = parse_vault_metadata(proposed_lf)
+    return metadata.validate()
+
+
+def _write_proposed(doc_path: Path, proposed_lf: str, source_newline: str) -> None:
+    """Atomically write proposed text, restoring the original on failure.
+
+    Args:
+        doc_path: The destination document.
+        proposed_lf: The proposed text (LF-normalised).
+        source_newline: The newline convention to restore on write.
+    """
+    from vaultspec_core.vaultcore.related_surgery import _atomic_write_restore
+
+    out = (
+        proposed_lf
+        if source_newline == "\n"
+        else proposed_lf.replace("\n", source_newline)
+    )
+    _atomic_write_restore(doc_path, out)
+
+
+def _invalidate_cache(root_dir: Path) -> None:
+    """Invalidate the graph cache after a mutating write.
+
+    Args:
+        root_dir: Project root whose graph cache is dropped.
+    """
+    from vaultspec_core.cli._cache_hook import invalidate_graph_cache
+
+    invalidate_graph_cache(root_dir)
+
+
+def _emit(
+    command: str,
+    status: str,
+    data: dict[str, object],
+    *,
+    json_output: bool,
+) -> None:
+    """Emit the canonical envelope (JSON) or a human-readable summary.
+
+    Args:
+        command: Dotted command id for the schema.
+        status: Canonical outcome word.
+        data: The verb payload.
+        json_output: When ``True`` emit JSON, else a Rich summary line.
+    """
+    from vaultspec_core.cli.rendering import json_envelope
+
+    if json_output:
+        typer.echo(
+            json.dumps(json_envelope(command, status, data), indent=2, default=str)
+        )
+        return
+
+    from vaultspec_core.console import get_console
+
+    console = get_console()
+    path = data.get("path", "")
+    if status == "failed":
+        message = data.get("message") or "refused"
+        console.print(f"[red]{message}[/red]")
+        if data.get("conflict"):
+            console.print(
+                f"[dim]expected {data.get('expected')}, "
+                f"on disk {data.get('actual')}[/dim]"
+            )
+        errors = data.get("errors")
+        if isinstance(errors, list):
+            for err in errors:
+                console.print(f"  [red]{err}[/red]")
+        checks = data.get("checks")
+        if isinstance(checks, list):
+            for raw in checks:
+                diag = cast("dict[str, object]", raw)
+                if diag.get("severity") == "error":
+                    console.print(f"  [red]{diag.get('message')}[/red]")
+        return
+
+    verb = "Would update" if data.get("dry_run") else "Updated"
+    if status == "unchanged":
+        verb = "Unchanged"
+    blob = data.get("blob_hash", "")
+    console.print(f"{verb}: {path}  [dim]{blob}[/dim]")
+
+
+# ---------------------------------------------------------------------------
+# Verb definitions
+# ---------------------------------------------------------------------------
+
+
+def _resolve_related_or_fail(related: list[str], root_dir: Path) -> list[str]:
+    """Resolve ``--related`` inputs to ``[[wiki-link]]`` strings.
+
+    Args:
+        related: Raw ``--related`` inputs.
+        root_dir: Project root for resolution.
+
+    Returns:
+        The resolved wiki-link strings.
+
+    Raises:
+        _EditError: When any input cannot be resolved.
+    """
+    from vaultspec_core.vaultcore.resolve import (
+        RelatedResolutionError,
+        resolve_related_inputs,
+    )
+
+    try:
+        return resolve_related_inputs(related, root_dir)
+    except RelatedResolutionError as exc:
+        raise _EditError(
+            f"Cannot resolve related document(s): {'; '.join(exc.failures)}",
+            {"errors": list(exc.failures)},
+        ) from exc
+
+
+def register_edit_commands(vault_app: _typer.Typer) -> None:
+    """Register ``set-body``, ``set-frontmatter``, and ``edit`` on *vault_app*.
+
+    Args:
+        vault_app: The ``vault`` command group to mount the verbs on.
+    """
+
+    @vault_app.command("set-body")
+    def cmd_set_body(  # pyright: ignore[reportUnusedFunction]
+        ref: Annotated[
+            str,
+            typer.Argument(
+                help=(
+                    "Document to edit. Accepts stem, filename, path, or [[wiki-link]]."
+                )
+            ),
+        ],
+        body_file: Annotated[
+            Path | None,
+            typer.Option(
+                "--body-file",
+                help="Read the new body text from this file.",
+                dir_okay=False,
+                file_okay=True,
+                resolve_path=True,
+            ),
+        ] = None,
+        body_stdin: Annotated[
+            bool,
+            typer.Option("--body-stdin", help="Read the new body text from stdin."),
+        ] = False,
+        expected_blob_hash: Annotated[
+            str | None,
+            typer.Option(
+                "--expected-blob-hash",
+                help="Refuse the write unless the on-disk blob OID matches.",
+            ),
+        ] = None,
+        check: Annotated[
+            bool,
+            typer.Option(
+                "--check/--no-check",
+                help="Run conformance checks before writing (default on).",
+            ),
+        ] = True,
+        dry_run: Annotated[
+            bool, typer.Option("--dry-run", help="Preview without writing.")
+        ] = False,
+        json_output: Annotated[
+            bool, typer.Option("--json", help="Output as JSON.")
+        ] = False,
+        target: TargetOption = None,
+    ) -> None:
+        """Replace only the body prose of a document, keeping its frontmatter.
+
+        The frontmatter block is preserved byte-for-byte; only the body
+        after the closing ``---`` fence is replaced.  The ``modified:``
+        stamp is refreshed.  With ``--check`` (default) the proposed
+        content is validated before writing and the write is refused if any
+        diagnostic is ERROR severity.
+        """
+        apply_target(target, json_output=json_output)
+        try:
+            new_body = _read_body_channel(body_file, body_stdin, required=True)
+        except _EditError as exc:
+            _emit(
+                "vault.set-body",
+                "failed",
+                {"message": exc.message, "path": ref, **exc.data},
+                json_output=json_output,
+            )
+            raise typer.Exit(code=1) from exc
+
+        _execute_edit(
+            command="vault.set-body",
+            ref=ref,
+            new_body=new_body,
+            date=None,
+            tags=None,
+            related=None,
+            expected_blob_hash=expected_blob_hash,
+            run_checks=check,
+            dry_run=dry_run,
+            json_output=json_output,
+        )
+
+    @vault_app.command("set-frontmatter")
+    def cmd_set_frontmatter(  # pyright: ignore[reportUnusedFunction]
+        ref: Annotated[
+            str,
+            typer.Argument(
+                help=(
+                    "Document to edit. Accepts stem, filename, path, or [[wiki-link]]."
+                )
+            ),
+        ],
+        date: Annotated[
+            str | None, typer.Option("--date", help="Set the date field (YYYY-MM-DD).")
+        ] = None,
+        tags: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--tags",
+                help="Set the tags list (repeatable; replaces the whole list).",
+            ),
+        ] = None,
+        related: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--related",
+                "-r",
+                help=(
+                    "Set the related list (repeatable; replaces the whole list). "
+                    "Each input is resolved to [[wiki-link]] form."
+                ),
+            ),
+        ] = None,
+        expected_blob_hash: Annotated[
+            str | None,
+            typer.Option(
+                "--expected-blob-hash",
+                help="Refuse the write unless the on-disk blob OID matches.",
+            ),
+        ] = None,
+        dry_run: Annotated[
+            bool, typer.Option("--dry-run", help="Preview without writing.")
+        ] = False,
+        json_output: Annotated[
+            bool, typer.Option("--json", help="Output as JSON.")
+        ] = False,
+        target: TargetOption = None,
+    ) -> None:
+        """Edit selected frontmatter fields, keeping the body byte-for-byte.
+
+        Only the provided fields (``--date`` / ``--tags`` / ``--related``)
+        are changed; every other key is preserved.  The proposed metadata
+        is validated with :meth:`DocumentMetadata.validate` BEFORE writing
+        and the write is refused on any violation.  The ``modified:`` stamp
+        is refreshed automatically.  There is no ``--title``: the title is
+        the body H1, not a frontmatter field.
+        """
+        apply_target(target, json_output=json_output)
+        from vaultspec_core.core.types import get_context as _get_ctx
+
+        if date is None and tags is None and related is None:
+            _emit(
+                "vault.set-frontmatter",
+                "failed",
+                {
+                    "message": (
+                        "Nothing to edit: pass at least one of "
+                        "--date, --tags, or --related."
+                    ),
+                    "path": ref,
+                },
+                json_output=json_output,
+            )
+            raise typer.Exit(code=1)
+
+        resolved_related: list[str] | None = None
+        if related is not None:
+            try:
+                resolved_related = _resolve_related_or_fail(
+                    related, _get_ctx().target_dir
+                )
+            except _EditError as exc:
+                _emit(
+                    "vault.set-frontmatter",
+                    "failed",
+                    {"message": exc.message, "path": ref, **exc.data},
+                    json_output=json_output,
+                )
+                raise typer.Exit(code=1) from exc
+
+        normalised_tags = (
+            [t if t.startswith("#") else f"#{t}" for t in tags]
+            if tags is not None
+            else None
+        )
+
+        _execute_edit(
+            command="vault.set-frontmatter",
+            ref=ref,
+            new_body=None,
+            date=date,
+            tags=normalised_tags,
+            related=resolved_related,
+            expected_blob_hash=expected_blob_hash,
+            run_checks=True,
+            dry_run=dry_run,
+            json_output=json_output,
+        )
+
+    @vault_app.command("edit")
+    def cmd_edit(  # pyright: ignore[reportUnusedFunction]
+        ref: Annotated[
+            str,
+            typer.Argument(
+                help=(
+                    "Document to edit. Accepts stem, filename, path, or [[wiki-link]]."
+                )
+            ),
+        ],
+        body_file: Annotated[
+            Path | None,
+            typer.Option(
+                "--body-file",
+                help="Read the new body text from this file.",
+                dir_okay=False,
+                file_okay=True,
+                resolve_path=True,
+            ),
+        ] = None,
+        body_stdin: Annotated[
+            bool,
+            typer.Option("--body-stdin", help="Read the new body text from stdin."),
+        ] = False,
+        date: Annotated[
+            str | None, typer.Option("--date", help="Set the date field (YYYY-MM-DD).")
+        ] = None,
+        tags: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--tags",
+                help="Set the tags list (repeatable; replaces the whole list).",
+            ),
+        ] = None,
+        related: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--related",
+                "-r",
+                help=(
+                    "Set the related list (repeatable; replaces the whole list). "
+                    "Each input is resolved to [[wiki-link]] form."
+                ),
+            ),
+        ] = None,
+        expected_blob_hash: Annotated[
+            str | None,
+            typer.Option(
+                "--expected-blob-hash",
+                help="Refuse the write unless the on-disk blob OID matches.",
+            ),
+        ] = None,
+        check: Annotated[
+            bool,
+            typer.Option(
+                "--check/--no-check",
+                help="Run conformance checks before writing (default on).",
+            ),
+        ] = True,
+        dry_run: Annotated[
+            bool, typer.Option("--dry-run", help="Preview without writing.")
+        ] = False,
+        json_output: Annotated[
+            bool, typer.Option("--json", help="Output as JSON.")
+        ] = False,
+        target: TargetOption = None,
+    ) -> None:
+        """Set body and/or frontmatter in one atomic write (single round-trip).
+
+        The dashboard "save": the body channel (``--body-file`` /
+        ``--body-stdin``) and the frontmatter flags are applied together in
+        ONE atomic write with ONE validation pass (frontmatter validate +
+        conformance checks), the same refuse-on-error and the same
+        blob-hash concurrency guard as the single-field verbs.  At least one
+        edit (a body channel or a frontmatter flag) must be supplied.
+        """
+        apply_target(target, json_output=json_output)
+        from vaultspec_core.core.types import get_context as _get_ctx
+
+        try:
+            new_body = _read_body_channel(body_file, body_stdin, required=False)
+        except _EditError as exc:
+            _emit(
+                "vault.edit",
+                "failed",
+                {"message": exc.message, "path": ref, **exc.data},
+                json_output=json_output,
+            )
+            raise typer.Exit(code=1) from exc
+
+        if new_body is None and date is None and tags is None and related is None:
+            _emit(
+                "vault.edit",
+                "failed",
+                {
+                    "message": (
+                        "Nothing to edit: pass a body channel "
+                        "(--body-file/--body-stdin) and/or a frontmatter flag "
+                        "(--date/--tags/--related)."
+                    ),
+                    "path": ref,
+                },
+                json_output=json_output,
+            )
+            raise typer.Exit(code=1)
+
+        resolved_related: list[str] | None = None
+        if related is not None:
+            try:
+                resolved_related = _resolve_related_or_fail(
+                    related, _get_ctx().target_dir
+                )
+            except _EditError as exc:
+                _emit(
+                    "vault.edit",
+                    "failed",
+                    {"message": exc.message, "path": ref, **exc.data},
+                    json_output=json_output,
+                )
+                raise typer.Exit(code=1) from exc
+
+        normalised_tags = (
+            [t if t.startswith("#") else f"#{t}" for t in tags]
+            if tags is not None
+            else None
+        )
+
+        _execute_edit(
+            command="vault.edit",
+            ref=ref,
+            new_body=new_body,
+            date=date,
+            tags=normalised_tags,
+            related=resolved_related,
+            expected_blob_hash=expected_blob_hash,
+            run_checks=check,
+            dry_run=dry_run,
+            json_output=json_output,
+        )

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -67,6 +67,10 @@ from vaultspec_core.cli.link_cmd import link_app  # noqa: E402
 
 vault_app.add_typer(link_app, name="link")
 
+from vaultspec_core.cli.edit_cmd import register_edit_commands  # noqa: E402
+
+register_edit_commands(vault_app)
+
 
 # ---- vault add ---------------------------------------------------------------
 

--- a/src/vaultspec_core/tests/cli/test_vault_edit.py
+++ b/src/vaultspec_core/tests/cli/test_vault_edit.py
@@ -1,0 +1,545 @@
+"""CLI tests for the composed vault edit verbs.
+
+Exercises ``vault set-body``, ``vault set-frontmatter``, and ``vault edit``
+through the real Typer CliRunner against on-disk vault fixtures (no mocks).
+
+Coverage:
+    - blob_hash: git-blob-OID parity for known byte vectors
+    - set-body: success (updated + post-write blob_hash), refuse-on-error
+      (invalid frontmatter blocks the write, file unchanged), blob-hash
+      conflict (stale expected hash refuses, file unchanged), --dry-run
+      writes nothing
+    - set-frontmatter: validate-then-write (good edit lands), refuse on bad
+      tags (file unchanged)
+    - edit: combined atomic body+frontmatter write
+    - exit codes: 0 updated/unchanged, 1 conflict/refusal/resolution failure
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.cli import app
+from vaultspec_core.vaultcore.blob_hash import git_blob_oid
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+pytestmark = [pytest.mark.unit]
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+_VALID_ADR = (
+    "---\n"
+    "tags:\n"
+    "  - '#adr'\n"
+    "  - '#test-feat'\n"
+    "date: '2026-01-01'\n"
+    "modified: '2026-01-01'\n"
+    "related: []\n"
+    "---\n"
+    "\n# Demo ADR\n\nOriginal body.\n"
+)
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Build a minimal installed vault with one valid ADR.
+
+    Returns the project root holding ``.vault/adr/2026-01-01-alpha-adr.md``
+    and an installed ``.vaultspec/`` framework so the workspace resolves.
+    """
+    root = tmp_path / "project"
+    root.mkdir()
+    adr_dir = root / ".vault" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "2026-01-01-alpha-adr.md").write_text(_VALID_ADR, encoding="utf-8")
+    (adr_dir / "2026-01-01-beta-adr.md").write_text(
+        _VALID_ADR.replace("# Demo ADR", "# Beta ADR"), encoding="utf-8"
+    )
+
+    from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.commands import install_run
+    from vaultspec_core.core.types import init_paths
+
+    install_run(path=root, provider="all", upgrade=False, dry_run=False, force=True)
+    layout = resolve_workspace(target_override=root)
+    init_paths(layout)
+    return root
+
+
+def _doc(root: Path) -> Path:
+    """Return the path to the primary fixture ADR."""
+    return root / ".vault" / "adr" / "2026-01-01-alpha-adr.md"
+
+
+def _run(runner, *args: str, target: Path, stdin: str | None = None) -> Result:
+    """Invoke the CLI with ``--target`` and optional stdin."""
+    return runner.invoke(app, ["--target", str(target), *args], input=stdin)
+
+
+def _envelope(result: Result) -> dict:
+    """Parse the JSON envelope from a CLI result, asserting it is present."""
+    return json.loads(result.output)
+
+
+# ---------------------------------------------------------------------------
+# blob_hash parity
+# ---------------------------------------------------------------------------
+
+
+class TestBlobHashParity:
+    def test_empty_blob_known_vector(self):
+        # The git blob OID of the empty string is a fixed, well-known value.
+        assert git_blob_oid(b"") == "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391"
+
+    def test_hello_blob_known_vector(self):
+        # `printf 'hello\n' | git hash-object --stdin` => ce0136...
+        assert git_blob_oid(b"hello\n") == "ce013625030ba8dba906f756967f9e9ca394464a"
+
+    def test_matches_header_construction(self):
+        # The hash is sha1("blob <len>\0<data>"); reconstruct independently.
+        import hashlib
+
+        data = b"some document bytes\nwith two lines\n"
+        expected = hashlib.sha1(
+            b"blob " + str(len(data)).encode() + b"\0" + data,
+            usedforsecurity=False,
+        ).hexdigest()
+        assert git_blob_oid(data) == expected
+
+
+# ---------------------------------------------------------------------------
+# set-body
+# ---------------------------------------------------------------------------
+
+
+class TestSetBody:
+    def test_success_returns_updated_and_post_hash(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        body_file = tmp_path / "newbody.md"
+        body_file.write_text("\n# Demo ADR\n\nReplaced body.\n", encoding="utf-8")
+
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        env = _envelope(result)
+        assert env["schema"] == "vaultspec.vault.set-body.v1"
+        assert env["status"] == "updated"
+
+        # The returned blob_hash matches the actual on-disk bytes post-write.
+        on_disk = _doc(root).read_bytes()
+        assert env["data"]["blob_hash"] == git_blob_oid(on_disk)
+        assert b"Replaced body." in on_disk
+        # Frontmatter survived byte-for-byte (still carries the original tags).
+        assert b"#test-feat" in on_disk
+
+    def test_stdin_channel(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-stdin",
+            "--json",
+            target=root,
+            stdin="\n# Demo ADR\n\nFrom stdin.\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert _envelope(result)["status"] == "updated"
+        assert b"From stdin." in _doc(root).read_bytes()
+
+    def test_refuse_on_error_leaves_file_unchanged(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        # Corrupt the fixture's frontmatter so the proposed content is invalid
+        # (a single tag fails the >=2-tag rule). The body replacement is fine,
+        # but the document as a whole is non-conformant and must be refused.
+        bad = (
+            "---\n"
+            "tags:\n"
+            "  - '#adr'\n"
+            "date: '2026-01-01'\n"
+            "modified: '2026-01-01'\n"
+            "related: []\n"
+            "---\n"
+            "\n# Bad ADR\n"
+        )
+        _doc(root).write_text(bad, encoding="utf-8")
+        before = _doc(root).read_bytes()
+
+        body_file = tmp_path / "b.md"
+        body_file.write_text("\n# Bad ADR\n\nNew body.\n", encoding="utf-8")
+
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        env = _envelope(result)
+        assert env["status"] == "failed"
+        assert env["data"]["refused"] is True
+        assert any(d["severity"] == "error" for d in env["data"]["checks"])
+        # The file is untouched.
+        assert _doc(root).read_bytes() == before
+
+    def test_no_check_allows_warning_but_still_blocks_error(self, runner, tmp_path):
+        # --no-check skips the snapshot checkers, but the frontmatter model
+        # validator still runs and an ERROR still refuses the write.
+        root = _make_vault(tmp_path)
+        bad = (
+            "---\n"
+            "tags:\n"
+            "  - '#adr'\n"
+            "date: '2026-01-01'\n"
+            "modified: '2026-01-01'\n"
+            "related: []\n"
+            "---\n"
+            "\n# Bad ADR\n"
+        )
+        _doc(root).write_text(bad, encoding="utf-8")
+        before = _doc(root).read_bytes()
+        body_file = tmp_path / "b.md"
+        body_file.write_text("\n# Bad ADR\n\nNew body.\n", encoding="utf-8")
+
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--no-check",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        assert _envelope(result)["data"]["refused"] is True
+        assert _doc(root).read_bytes() == before
+
+    def test_blob_hash_conflict_refuses(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        before = _doc(root).read_bytes()
+        body_file = tmp_path / "b.md"
+        body_file.write_text("\n# Demo ADR\n\nNope.\n", encoding="utf-8")
+
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--expected-blob-hash",
+            "deadbeef" * 5,
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        env = _envelope(result)
+        assert env["status"] == "failed"
+        assert env["data"]["conflict"] is True
+        assert env["data"]["expected"] == "deadbeef" * 5
+        assert env["data"]["actual"] == git_blob_oid(before)
+        # No write occurred.
+        assert _doc(root).read_bytes() == before
+
+    def test_blob_hash_match_allows_write(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        current = git_blob_oid(_doc(root).read_bytes())
+        body_file = tmp_path / "b.md"
+        body_file.write_text("\n# Demo ADR\n\nMatched.\n", encoding="utf-8")
+
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--expected-blob-hash",
+            current,
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _envelope(result)["status"] == "updated"
+        assert b"Matched." in _doc(root).read_bytes()
+
+    def test_dry_run_writes_nothing(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        before = _doc(root).read_bytes()
+        body_file = tmp_path / "b.md"
+        body_file.write_text("\n# Demo ADR\n\nDry run only.\n", encoding="utf-8")
+
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--dry-run",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        env = _envelope(result)
+        assert env["data"]["dry_run"] is True
+        assert env["data"]["changed"] is True
+        # File is unchanged on disk.
+        assert _doc(root).read_bytes() == before
+        # The previewed blob_hash equals what a real write would produce.
+        result2 = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--json",
+            target=root,
+        )
+        assert env["data"]["blob_hash"] == _envelope(result2)["data"]["blob_hash"]
+
+    def test_unresolvable_ref_fails(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        body_file = tmp_path / "b.md"
+        body_file.write_text("body\n", encoding="utf-8")
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "no-such-document",
+            "--body-file",
+            str(body_file),
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        assert _envelope(result)["status"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# set-frontmatter
+# ---------------------------------------------------------------------------
+
+
+class TestSetFrontmatter:
+    def test_set_date_validates_then_writes(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "set-frontmatter",
+            "2026-01-01-alpha-adr",
+            "--date",
+            "2026-02-02",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _envelope(result)["status"] == "updated"
+        text = _doc(root).read_text(encoding="utf-8")
+        assert "date: '2026-02-02'" in text
+        # The body survived the frontmatter edit byte-for-byte.
+        assert "Original body." in text
+
+    def test_set_related_resolves_and_writes(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "set-frontmatter",
+            "2026-01-01-alpha-adr",
+            "--related",
+            "2026-01-01-beta-adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        text = _doc(root).read_text(encoding="utf-8")
+        assert "[[2026-01-01-beta-adr]]" in text
+
+    def test_refuse_on_bad_tags(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        before = _doc(root).read_bytes()
+        # A single tag fails the >=2-tag and one-feature-tag rules.
+        result = _run(
+            runner,
+            "vault",
+            "set-frontmatter",
+            "2026-01-01-alpha-adr",
+            "--tags",
+            "#adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        env = _envelope(result)
+        assert env["status"] == "failed"
+        assert env["data"]["errors"]
+        assert _doc(root).read_bytes() == before
+
+    def test_nothing_to_edit_fails(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "set-frontmatter",
+            "2026-01-01-alpha-adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        assert _envelope(result)["status"] == "failed"
+
+    def test_dry_run_writes_nothing(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        before = _doc(root).read_bytes()
+        result = _run(
+            runner,
+            "vault",
+            "set-frontmatter",
+            "2026-01-01-alpha-adr",
+            "--date",
+            "2026-03-03",
+            "--dry-run",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _envelope(result)["data"]["dry_run"] is True
+        assert _doc(root).read_bytes() == before
+
+
+# ---------------------------------------------------------------------------
+# edit (combined)
+# ---------------------------------------------------------------------------
+
+
+class TestEdit:
+    def test_combined_atomic_write(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        body_file = tmp_path / "b.md"
+        body_file.write_text("\n# Demo ADR\n\nCombined body.\n", encoding="utf-8")
+
+        result = _run(
+            runner,
+            "vault",
+            "edit",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--date",
+            "2026-04-04",
+            "--related",
+            "2026-01-01-beta-adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        env = _envelope(result)
+        assert env["schema"] == "vaultspec.vault.edit.v1"
+        assert env["status"] == "updated"
+
+        text = _doc(root).read_text(encoding="utf-8")
+        # All three edits landed in one write.
+        assert "Combined body." in text
+        assert "date: '2026-04-04'" in text
+        assert "[[2026-01-01-beta-adr]]" in text
+        assert env["data"]["blob_hash"] == git_blob_oid(_doc(root).read_bytes())
+
+    def test_frontmatter_only_edit(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "edit",
+            "2026-01-01-alpha-adr",
+            "--date",
+            "2026-05-05",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _envelope(result)["status"] == "updated"
+        text = _doc(root).read_text(encoding="utf-8")
+        assert "date: '2026-05-05'" in text
+        assert "Original body." in text
+
+    def test_nothing_to_edit_fails(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "edit",
+            "2026-01-01-alpha-adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        assert _envelope(result)["status"] == "failed"
+
+    def test_dry_run_writes_nothing(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        before = _doc(root).read_bytes()
+        body_file = tmp_path / "b.md"
+        body_file.write_text("\n# Demo ADR\n\nDry combined.\n", encoding="utf-8")
+        result = _run(
+            runner,
+            "vault",
+            "edit",
+            "2026-01-01-alpha-adr",
+            "--body-file",
+            str(body_file),
+            "--date",
+            "2026-06-06",
+            "--dry-run",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _envelope(result)["data"]["dry_run"] is True
+        assert _doc(root).read_bytes() == before
+
+    def test_conflict_refuses_combined(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        before = _doc(root).read_bytes()
+        result = _run(
+            runner,
+            "vault",
+            "edit",
+            "2026-01-01-alpha-adr",
+            "--date",
+            "2026-07-07",
+            "--expected-blob-hash",
+            "0" * 40,
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1, result.output
+        env = _envelope(result)
+        assert env["data"]["conflict"] is True
+        assert _doc(root).read_bytes() == before

--- a/src/vaultspec_core/tests/cli/test_vault_edit.py
+++ b/src/vaultspec_core/tests/cli/test_vault_edit.py
@@ -165,6 +165,32 @@ class TestSetBody:
         assert _envelope(result)["status"] == "updated"
         assert b"From stdin." in _doc(root).read_bytes()
 
+    def test_stdin_channel_normalizes_crlf(self, runner, tmp_path):
+        # The engine write channel always uses --body-stdin; a CRLF draft must be
+        # normalized to LF identically to --body-file, never persisted as \r\n
+        # (which on an LF document is stray-CR corruption, and on a CRLF file
+        # would become \r\r\n in the source-newline restore).
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "set-body",
+            "2026-01-01-alpha-adr",
+            "--body-stdin",
+            "--json",
+            target=root,
+            stdin="\r\n# Demo ADR\r\n\r\nCRLF from stdin.\r\n",
+        )
+        assert result.exit_code == 0, result.output
+        assert _envelope(result)["status"] == "updated"
+        on_disk = _doc(root).read_bytes()
+        assert b"CRLF from stdin." in on_disk
+        # The stdin body is normalized to LF before compose/validate/write, then
+        # restored to the SOURCE newline once. No double-CR (\r\r\n) corruption —
+        # the exact failure that an un-normalized stdin \r\n produces when the
+        # write path re-applies a CRLF source newline.
+        assert b"\r\r" not in on_disk
+
     def test_refuse_on_error_leaves_file_unchanged(self, runner, tmp_path):
         root = _make_vault(tmp_path)
         # Corrupt the fixture's frontmatter so the proposed content is invalid

--- a/src/vaultspec_core/vaultcore/blob_hash.py
+++ b/src/vaultspec_core/vaultcore/blob_hash.py
@@ -1,0 +1,38 @@
+"""Git blob object-id computation, byte-compatible with ``git hash-object``.
+
+A vault document's identity on the wire is the git SHA-1 *blob* object id
+of its raw bytes - the same value ``git hash-object`` prints and the same
+value the dashboard engine derives over a file's bytes for optimistic
+concurrency.  The hash is computed purely with :mod:`hashlib`; no ``git``
+subprocess is spawned, so the helper works in an unindexed worktree and
+on hosts without a git binary.
+
+The git blob object is the bytes ``b"blob <len>\\0<data>"`` hashed with
+SHA-1, where ``<len>`` is the decimal byte length of the payload.  This is
+git's loose-object header convention; the empty blob therefore hashes to
+the well-known ``e69de29bb2d1d6434b8b29ae775ad8c2e48c5391``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+__all__ = ["git_blob_oid"]
+
+
+def git_blob_oid(data: bytes) -> str:
+    """Return the git SHA-1 blob object id of *data*.
+
+    Byte-for-byte equivalent to ``git hash-object`` (and to the dashboard
+    engine's gix blob OID) over the same payload.
+
+    Args:
+        data: The raw file bytes to hash.  Callers that hold document text
+            must encode it (UTF-8) before calling so the hash matches the
+            on-disk bytes.
+
+    Returns:
+        The 40-character lowercase hexadecimal SHA-1 blob object id.
+    """
+    header = b"blob " + str(len(data)).encode("ascii") + b"\0"
+    return hashlib.sha1(header + data, usedforsecurity=False).hexdigest()


### PR DESCRIPTION
Closes #167.

Adds three composed `vault` edit verbs for the vaultspec-dashboard document editor backend, all built from existing core machinery (no new validation logic):

- `vault set-body REF [--body-file | --body-stdin] [--expected-blob-hash] [--check/--no-check] [--dry-run] [--json]`
- `vault set-frontmatter REF [--date] [--tags ...] [--related ...] [--expected-blob-hash] [--dry-run] [--json]`
- `vault edit REF` — combined single-round-trip atomic save (body + frontmatter)

**Conformance:** validates before writing and **refuses to persist** any doc with an ERROR-severity diagnostic; WARNING/INFO are returned, not blocking. Diagnostics use the existing `CheckDiagnostic` shape so consumers can mark-invalid + offer autofix.

**Optimistic concurrency:** `--expected-blob-hash` computes the **git SHA-1 blob OID** (`hashlib`, CRLF/LF-preserving) — byte-matching `git hash-object` and the dashboard engine's reader — and refuses on a stale hash (exit 1, `data.conflict`) with no write. Success returns the post-write OID.

**Envelope:** all output via `json_envelope` (`{schema,status,data}`); success `status ∈ {updated,unchanged}`, refusal/conflict `status="failed"` + non-zero exit.

**Gate:** ruff + ty clean; 21 new tests in `tests/cli/test_vault_edit.py`; full unit suite 1245 passed; CLI-reference generator in sync.

Engine integration: drive via `--body-stdin` + `--expected-blob-hash`; `edit` is the single-call save.