### PR TITLE
feat(vault): add rename verb for document file-rename with incoming-link rewrite

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,6 +109,7 @@ vaultspec-core status [OPTIONS] [TARGET]
 vaultspec-core vault set-body [OPTIONS] REF
 vaultspec-core vault set-frontmatter [OPTIONS] REF
 vaultspec-core vault edit [OPTIONS] REF
+vaultspec-core vault rename [OPTIONS] REF
 vaultspec-core vault add [OPTIONS] DOC_TYPE
 vaultspec-core vault stats [OPTIONS]
 vaultspec-core vault list [OPTIONS] [DOC_TYPE]

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -46,6 +46,7 @@ vaultspec-core status [OPTIONS] [TARGET]
 vaultspec-core vault set-body [OPTIONS] REF
 vaultspec-core vault set-frontmatter [OPTIONS] REF
 vaultspec-core vault edit [OPTIONS] REF
+vaultspec-core vault rename [OPTIONS] REF
 vaultspec-core vault add [OPTIONS] DOC_TYPE
 vaultspec-core vault stats [OPTIONS]
 vaultspec-core vault list [OPTIONS] [DOC_TYPE]

--- a/src/vaultspec_core/cli/edit_cmd.py
+++ b/src/vaultspec_core/cli/edit_cmd.py
@@ -57,7 +57,7 @@ if TYPE_CHECKING:
     from vaultspec_core.vaultcore.checks._base import CheckDiagnostic
     from vaultspec_core.vaultcore.models import DocumentMetadata
 
-__all__ = ["register_edit_commands"]
+__all__ = ["register_edit_commands", "register_rename_command"]
 
 
 # ---------------------------------------------------------------------------
@@ -728,6 +728,287 @@ def _resolve_related_or_fail(related: list[str], root_dir: Path) -> list[str]:
             f"Cannot resolve related document(s): {'; '.join(exc.failures)}",
             {"errors": list(exc.failures)},
         ) from exc
+
+
+def _validate_target_stem(new_stem: str) -> None:
+    """Validate a rename target stem before any mutation (cursory pre-check).
+
+    The target is the new identity-bearing filename stem (without ``.md``). It
+    must be a bounded single-segment name - never a path, a flag, or empty - so
+    the rename cannot escape the document's directory or inject a CLI argument.
+
+    Args:
+        new_stem: The proposed new stem.
+
+    Raises:
+        _EditError: When the stem is empty, flag-shaped, ``.md``-suffixed, or
+            carries a path separator or parent-dir token.
+    """
+    import re
+
+    bad = (
+        not new_stem
+        or new_stem.startswith("-")
+        or "/" in new_stem
+        or "\\" in new_stem
+        or new_stem in {".", ".."}
+        or new_stem.endswith(".md")
+        or re.fullmatch(r"[A-Za-z0-9._-]+", new_stem) is None
+    )
+    if bad:
+        raise _EditError(
+            f"Invalid rename target stem '{new_stem}': must be a single-segment "
+            "name (letters, digits, '.', '-', '_'; no path separator, no leading "
+            "'-', no '.md' suffix)",
+            {"target": new_stem},
+        )
+
+
+def _find_incoming_refs(root_dir: Path, old_stem: str) -> list[Path]:
+    """Return documents whose outgoing links reference *old_stem*.
+
+    Built from the vault graph's outgoing-link index so the scan is the same
+    truth the rest of the toolchain sees.
+
+    Args:
+        root_dir: Project root.
+        old_stem: The stem being renamed away from.
+
+    Returns:
+        Backing paths of documents linking to *old_stem*.
+    """
+    from vaultspec_core.graph.api import VaultGraph
+
+    graph = VaultGraph(root_dir)
+    refs: list[Path] = []
+    for _name, node in graph.nodes.items():
+        if node.path is not None and old_stem in node.out_links:
+            refs.append(node.path)
+    return refs
+
+
+def _rewrite_incoming_related(refs: list[Path], old_stem: str, new_stem: str) -> int:
+    """Re-point each referencing doc's ``related:`` from *old_stem* to *new_stem*.
+
+    Each rewrite removes the old ``related:`` entry and appends the new
+    ``[[new_stem]]`` link, refreshing that doc's ``modified:`` stamp (both
+    helpers do so internally). A doc whose only reference was a body link (not a
+    ``related:`` entry) is left untouched.
+
+    Args:
+        refs: Documents referencing *old_stem* (from :func:`_find_incoming_refs`).
+        old_stem: The stem being renamed away from.
+        new_stem: The stem being renamed to.
+
+    Returns:
+        The number of documents actually rewritten.
+    """
+    from vaultspec_core.vaultcore.checks.references import _add_related_link
+    from vaultspec_core.vaultcore.related_surgery import remove_related_entries
+
+    rewritten = 0
+    for path in refs:
+        removed = remove_related_entries(path, [old_stem])
+        added = _add_related_link(path, new_stem)
+        if removed or added:
+            rewritten += 1
+    return rewritten
+
+
+def _execute_rename(
+    *,
+    ref: str,
+    new_stem: str,
+    expected_blob_hash: str | None,
+    run_checks: bool,
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    """Rename a document's identity-bearing file and re-point incoming links.
+
+    Cursory pre-checks (blob-hash concurrency, target-stem grammar, collision)
+    run BEFORE any mutation. Then incoming ``related:`` references are rewritten,
+    the file is physically renamed, and its ``modified:`` stamp refreshed. The
+    renamed document's post-rename conformance diagnostics ride the envelope.
+
+    Args:
+        ref: The document to rename (stem, filename, path, or wiki-link).
+        new_stem: The new identity-bearing stem (filename without ``.md``).
+        expected_blob_hash: Pre-rename concurrency guard, or ``None``.
+        run_checks: Whether to report conformance checks on the renamed doc.
+        dry_run: When ``True``, do everything except mutate.
+        json_output: When ``True``, emit the JSON envelope.
+    """
+    from vaultspec_core.core.types import get_context as _get_ctx
+    from vaultspec_core.vaultcore.blob_hash import git_blob_oid
+    from vaultspec_core.vaultcore.models import refresh_modified_stamp
+    from vaultspec_core.vaultcore.related_surgery import (
+        _atomic_write_restore,
+        _read_preserve_newlines,
+    )
+
+    command = "vault.rename"
+    root_dir = _get_ctx().target_dir
+
+    try:
+        old_path = _resolve_doc_path(ref, root_dir)
+        old_stem = old_path.stem
+
+        # Cursory pre-checks, before any mutation.
+        _enforce_blob_hash(old_path, expected_blob_hash)
+        _validate_target_stem(new_stem)
+
+        if new_stem == old_stem:
+            _emit(
+                command,
+                "unchanged",
+                {
+                    "old_path": str(old_path),
+                    "new_path": str(old_path),
+                    "new_node_id": f"doc:{old_stem}",
+                    "incoming_rewritten": 0,
+                    "checks": [],
+                },
+                json_output=json_output,
+            )
+            return
+
+        new_path = old_path.parent / f"{new_stem}.md"
+        if new_path.exists():
+            raise _EditError(
+                f"Rename target already exists: {new_path.name}",
+                {
+                    "old_path": str(old_path),
+                    "new_path": str(new_path),
+                    "collision": True,
+                },
+            )
+
+        old_blob = git_blob_oid(old_path.read_bytes())
+        refs = _find_incoming_refs(root_dir, old_stem)
+
+        if dry_run:
+            _emit(
+                command,
+                "updated",
+                {
+                    "old_path": str(old_path),
+                    "new_path": str(new_path),
+                    "old_blob_hash": old_blob,
+                    "new_node_id": f"doc:{new_stem}",
+                    "incoming_rewritten": len(refs),
+                    "dry_run": True,
+                },
+                json_output=json_output,
+            )
+            return
+
+        # Re-point incoming links, physically rename, then refresh modified.
+        rewritten = _rewrite_incoming_related(refs, old_stem, new_stem)
+        old_path.replace(new_path)
+        text_lf, newline = _read_preserve_newlines(new_path)
+        stamped = refresh_modified_stamp(text_lf, _dt.date.today())
+        if stamped != text_lf:
+            _atomic_write_restore(
+                new_path,
+                stamped if newline == "\n" else stamped.replace("\n", newline),
+            )
+
+        checks: list[dict] = []
+        if run_checks:
+            content_lf, _ = _read_preserve_newlines(new_path)
+            checks = _validate_proposed(new_path, root_dir, content_lf)
+
+        _invalidate_cache(root_dir)
+        new_blob = git_blob_oid(new_path.read_bytes())
+        _emit(
+            command,
+            "updated",
+            {
+                "old_path": str(old_path),
+                "new_path": str(new_path),
+                "old_blob_hash": old_blob,
+                "new_blob_hash": new_blob,
+                "new_node_id": f"doc:{new_stem}",
+                "incoming_rewritten": rewritten,
+                "checks": checks,
+            },
+            json_output=json_output,
+        )
+    except _EditError as exc:
+        _emit(
+            command,
+            "failed",
+            {"message": exc.message, **exc.data},
+            json_output=json_output,
+        )
+        raise typer.Exit(code=1) from exc
+
+
+def register_rename_command(vault_app: _typer.Typer) -> None:
+    """Register the ``rename`` verb on *vault_app*.
+
+    Args:
+        vault_app: The ``vault`` command group to mount the verb on.
+    """
+
+    @vault_app.command("rename")
+    def cmd_rename(  # pyright: ignore[reportUnusedFunction]
+        ref: Annotated[
+            str,
+            typer.Argument(
+                help=(
+                    "Document to rename. Accepts stem, filename, path, or "
+                    "[[wiki-link]]."
+                )
+            ),
+        ],
+        to: Annotated[
+            str,
+            typer.Option(
+                "--to",
+                help="New identity-bearing stem (filename without .md).",
+            ),
+        ],
+        expected_blob_hash: Annotated[
+            str | None,
+            typer.Option(
+                "--expected-blob-hash",
+                help="Refuse the rename unless the on-disk blob OID matches.",
+            ),
+        ] = None,
+        check: Annotated[
+            bool,
+            typer.Option(
+                "--check/--no-check",
+                help="Report conformance checks on the renamed doc (default on).",
+            ),
+        ] = True,
+        dry_run: Annotated[
+            bool, typer.Option("--dry-run", help="Preview without writing.")
+        ] = False,
+        json_output: Annotated[
+            bool, typer.Option("--json", help="Output as JSON.")
+        ] = False,
+        target: TargetOption = None,
+    ) -> None:
+        """Rename a document's file and re-point incoming related references.
+
+        Physically renames the document to ``<--to>.md`` in the same directory,
+        rewrites every other document's ``related: [[old-stem]]`` to the new
+        stem, and refreshes the ``modified:`` stamp. Cursory pre-checks (blob
+        hash, target grammar, collision) run before any mutation; the renamed
+        document's conformance diagnostics ride the envelope.
+        """
+        apply_target(target, json_output=json_output)
+        _execute_rename(
+            ref=ref,
+            new_stem=to,
+            expected_blob_hash=expected_blob_hash,
+            run_checks=check,
+            dry_run=dry_run,
+            json_output=json_output,
+        )
 
 
 def register_edit_commands(vault_app: _typer.Typer) -> None:

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -67,9 +67,13 @@ from vaultspec_core.cli.link_cmd import link_app  # noqa: E402
 
 vault_app.add_typer(link_app, name="link")
 
-from vaultspec_core.cli.edit_cmd import register_edit_commands  # noqa: E402
+from vaultspec_core.cli.edit_cmd import (  # noqa: E402
+    register_edit_commands,
+    register_rename_command,
+)
 
 register_edit_commands(vault_app)
+register_rename_command(vault_app)
 
 
 # ---- vault add ---------------------------------------------------------------

--- a/src/vaultspec_core/tests/cli/test_vault_rename.py
+++ b/src/vaultspec_core/tests/cli/test_vault_rename.py
@@ -1,0 +1,227 @@
+"""CLI tests for the vault rename verb.
+
+Exercises ``vault rename`` through the real Typer CliRunner against on-disk
+vault fixtures (no mocks).
+
+Coverage:
+    - rename: moves the file, removes the old, re-keys the node id
+    - incoming-link rewrite: a doc referencing the old stem in ``related:`` is
+      re-pointed to the new stem
+    - collision: refuses when the target already exists, leaves the source
+    - invalid target stem: refuses a path-separator / flag-shaped stem
+    - blob-hash concurrency: stale expected hash refuses; matching hash allows
+    - dry-run: writes nothing
+    - exit codes: 0 updated, 1 refusal/conflict
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.cli import app
+from vaultspec_core.vaultcore.blob_hash import git_blob_oid
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from click.testing import Result
+
+pytestmark = [pytest.mark.unit]
+
+
+_ALPHA = (
+    "---\n"
+    "tags:\n"
+    "  - '#adr'\n"
+    "  - '#test-feat'\n"
+    "date: '2026-01-01'\n"
+    "modified: '2026-01-01'\n"
+    "related: []\n"
+    "---\n"
+    "\n# Alpha ADR\n\nOriginal body.\n"
+)
+
+# Beta references alpha in ``related:`` so the incoming-link rewrite is exercised.
+_BETA = (
+    "---\n"
+    "tags:\n"
+    "  - '#adr'\n"
+    "  - '#test-feat'\n"
+    "date: '2026-01-01'\n"
+    "modified: '2026-01-01'\n"
+    "related:\n"
+    "  - '[[2026-01-01-alpha-adr]]'\n"
+    "---\n"
+    "\n# Beta ADR\n\nBeta body.\n"
+)
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Build a minimal installed vault: alpha (renamed) + beta (references alpha)."""
+    root = tmp_path / "project"
+    root.mkdir()
+    adr_dir = root / ".vault" / "adr"
+    adr_dir.mkdir(parents=True)
+    (adr_dir / "2026-01-01-alpha-adr.md").write_text(_ALPHA, encoding="utf-8")
+    (adr_dir / "2026-01-01-beta-adr.md").write_text(_BETA, encoding="utf-8")
+
+    from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.commands import install_run
+    from vaultspec_core.core.types import init_paths
+
+    install_run(path=root, provider="all", upgrade=False, dry_run=False, force=True)
+    layout = resolve_workspace(target_override=root)
+    init_paths(layout)
+    return root
+
+
+def _alpha(root: Path) -> Path:
+    return root / ".vault" / "adr" / "2026-01-01-alpha-adr.md"
+
+
+def _beta(root: Path) -> Path:
+    return root / ".vault" / "adr" / "2026-01-01-beta-adr.md"
+
+
+def _gamma(root: Path) -> Path:
+    return root / ".vault" / "adr" / "2026-01-01-gamma-adr.md"
+
+
+def _run(runner, *args: str, target: Path, stdin: str | None = None) -> Result:
+    return runner.invoke(app, ["--target", str(target), *args], input=stdin)
+
+
+def _env(result: Result) -> dict:
+    return json.loads(result.output)
+
+
+class TestVaultRename:
+    def test_moves_file_and_rekeys(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "rename",
+            "2026-01-01-alpha-adr",
+            "--to",
+            "2026-01-01-gamma-adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        env = _env(result)
+        assert env["status"] == "updated"
+        assert env["data"]["new_node_id"] == "doc:2026-01-01-gamma-adr"
+        assert _gamma(root).exists()
+        assert not _alpha(root).exists()
+
+    def test_rewrites_incoming_related(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "rename",
+            "2026-01-01-alpha-adr",
+            "--to",
+            "2026-01-01-gamma-adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _env(result)["data"]["incoming_rewritten"] >= 1
+        beta_text = _beta(root).read_text(encoding="utf-8")
+        assert "[[2026-01-01-gamma-adr]]" in beta_text
+        assert "[[2026-01-01-alpha-adr]]" not in beta_text
+
+    def test_collision_refuses_and_leaves_source(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        before = _alpha(root).read_text(encoding="utf-8")
+        result = _run(
+            runner,
+            "vault",
+            "rename",
+            "2026-01-01-alpha-adr",
+            "--to",
+            "2026-01-01-beta-adr",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1
+        env = _env(result)
+        assert env["status"] == "failed"
+        assert env["data"].get("collision") is True
+        assert _alpha(root).read_text(encoding="utf-8") == before
+
+    def test_invalid_target_stem_refuses(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "rename",
+            "2026-01-01-alpha-adr",
+            "--to",
+            "bad/stem",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1
+        assert _env(result)["status"] == "failed"
+        assert _alpha(root).exists()
+
+    def test_stale_blob_hash_refuses(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "rename",
+            "2026-01-01-alpha-adr",
+            "--to",
+            "2026-01-01-gamma-adr",
+            "--expected-blob-hash",
+            "0" * 40,
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 1
+        assert _env(result)["status"] == "failed"
+        assert _alpha(root).exists()
+        assert not _gamma(root).exists()
+
+    def test_matching_blob_hash_allows(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        good = git_blob_oid(_alpha(root).read_bytes())
+        result = _run(
+            runner,
+            "vault",
+            "rename",
+            "2026-01-01-alpha-adr",
+            "--to",
+            "2026-01-01-gamma-adr",
+            "--expected-blob-hash",
+            good,
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _gamma(root).exists()
+
+    def test_dry_run_writes_nothing(self, runner, tmp_path):
+        root = _make_vault(tmp_path)
+        result = _run(
+            runner,
+            "vault",
+            "rename",
+            "2026-01-01-alpha-adr",
+            "--to",
+            "2026-01-01-gamma-adr",
+            "--dry-run",
+            "--json",
+            target=root,
+        )
+        assert result.exit_code == 0, result.output
+        assert _env(result)["data"]["dry_run"] is True
+        assert _alpha(root).exists()
+        assert not _gamma(root).exists()


### PR DESCRIPTION
## Summary
Adds `vault rename <ref> --to <new-stem>`: renames a document's identity-bearing file and re-points every other document's `related: [[old-stem]]` to the new stem.

Pipeline (mirrors the existing edit verbs): resolve → cursory pre-checks (blob-hash concurrency, target-stem grammar, collision) → incoming-`related:` rewrite (VaultGraph out-links scan + `related_surgery` + `references._add_related_link`) → atomic file rename + `modified:` refresh → conformance checks → `vaultspec.vault.rename.v1` envelope (old/new path, old/new `blob_hash`, `new_node_id` `doc:<new-stem>`, `incoming_rewritten`, `checks`). Flags: `--to`, `--expected-blob-hash`, `--dry-run`, `--check/--no-check`, `--json`, `--target`.

This is the document-rename capability the dashboard editor needs (title-change → on-disk file rename with identity re-keying), brokered later through the engine `/ops` write channel.

## Tests
`tests/cli/test_vault_rename.py` — 7 cases, all passing: move+rekey, incoming-`related:` rewrite, collision refusal, invalid-stem refusal, stale/matching blob-hash, dry-run.

## Verification
Live-verified against a real vault document: dry-run + real rename moved the file and the engine watcher re-ingested the new node (old node gone). Full pre-commit gate green (ruff, ty, mdformat, pymarkdown, vault doctor, regenerated CLI reference, provider artifacts).