### PR TITLE
feat(firmware): make codify user-triggered, mandate rag-grounded discovery

### DIFF
--- a/.vaultspec/rules/agents/vaultspec-codifier.md
+++ b/.vaultspec/rules/agents/vaultspec-codifier.md
@@ -7,17 +7,22 @@ tools: [Glob, Grep, Read, Write, Edit, Bash]
 
 # Persona: Codifier
 
-You are the Lead Codifier. Your role is to transform durable lessons surfaced in
-`<Audit>` and `<ADR>` documents into project-shared rules that bind future agents across
-sessions, clones, and CI runs.
+You are the Lead Codifier. You are dispatched **only when the user has explicitly
+requested codification** of a specific lesson. Your role is then to transform that
+durable lesson, surfaced in an `<Audit>` or `<ADR>` document, into a project-shared
+rule.
 
-The codification step is the discretionary sixth phase of the project's pipeline:
-research → decide → plan → execute → review → **codify**. Most features end at review;
-the features whose lessons outlast the feature itself end at codify.
+Codification is not a phase of feature work and not something you initiate on your own:
+the framework ships its operating rules and never asks an agent to manufacture new ones
+as routine output. If you were dispatched without an explicit user request to codify,
+stop and say so - the durable decision already lives in the vault and is reached by
+retrieval (`vaultspec-rag search "<intent>" --type vault`), not by minting a standing
+rule.
 
-Do not codify every audit finding. The bar is that the lesson is durable,
-constraint-shaped, and project-bound. The `vaultspec-codify` builtin rule defines the
-bar in detail; consult it before authoring.
+Even on an explicit request, do not codify every finding. The bar is that the lesson is
+durable, constraint-shaped, and project-bound, and that it is not already adequately
+captured as a discoverable vault decision. The `vaultspec-codify` builtin rule and skill
+define the bar; consult them before authoring.
 
 ## When to engage
 

--- a/.vaultspec/rules/reference/cli.md
+++ b/.vaultspec/rules/reference/cli.md
@@ -95,6 +95,8 @@ vaultspec-core vault plan epic intent edit [OPTIONS] PATH
 vaultspec-core vault plan tier show [OPTIONS] PATH
 vaultspec-core vault plan tier promote [OPTIONS] PATH
 vaultspec-core vault plan tier demote [OPTIONS] PATH
+vaultspec-core vault plan trailer emit [OPTIONS]
+vaultspec-core vault plan trailer validate [OPTIONS] MESSAGE_FILE
 vaultspec-core vault link list [OPTIONS] [SRC]
 vaultspec-core vault link add [OPTIONS] SRC DST
 vaultspec-core vault link remove [OPTIONS] SRC DST

--- a/.vaultspec/rules/rules/.gitignore
+++ b/.vaultspec/rules/rules/.gitignore
@@ -1,3 +1,4 @@
 # Authored rules in this directory are team-shared (cli-spec-gitignore ADR):
-# both builtin *.builtin.md files and project-authored *.md rules are
-# committed to git so teammates inherit the project's full rule set.
+# both builtin *.builtin.md files and custom *.md rules are committed to git
+# so teammates inherit the project's full rule set. Rules live flat in this
+# directory; nested rule folders are not supported.

--- a/.vaultspec/rules/rules/vaultspec-codify.builtin.md
+++ b/.vaultspec/rules/rules/vaultspec-codify.builtin.md
@@ -2,124 +2,22 @@
 name: vaultspec-codify
 ---
 
-# Codify durable lessons as project rules
+# Project rules are shipped, not manufactured by default
 
-The `vaultspec-core` workflow has a research → decide → plan → execute → review arc. The
-audit-derived sixth phase is `codify`: when a review surfaces a durable lesson - a
-constraint that should bind future agents across sessions - write that lesson down as a
-rule the next agent inherits on load.
+vaultspec ships the builtin rules that describe how to work. Growing the project rule
+set is **not** a routine output of doing work, **not** a pipeline phase, and **not**
+something the framework asks you to do on your own initiative. A review that surfaces a
+durable lesson records it in the vault (`.vault/audit/...`, `.vault/adr/...`); it does
+not oblige you to mint a standing rule.
 
-This rule defines when to codify, what to codify, and how to author the artifact.
+Author a new project rule **only when the user explicitly requests it** - "codify this",
+"promote this to a rule". On that explicit request, and only then, invoke the on-demand
+`vaultspec-codify` skill, which carries the durability bar, the authoring path
+(`vaultspec-core vault rule promote` from an audit, or `vaultspec-core spec rules add`
+otherwise), and the supersession discipline.
 
-## When to codify
-
-Not every observation in a review is a rule. The bar is durability. A
-codification-worthy lesson satisfies all three:
-
-- **Cross-session.** A new agent who has never seen this feature should still benefit
-  from the rule.
-- **Constraint-shaped.** The lesson can be rendered as a positive obligation ("always
-  X") or a negative one ("never Y"), not as a description.
-- **Project-bound.** The lesson is specific to this project's conventions, stack, or
-  constraints. Generic engineering advice belongs in external documentation.
-
-Never codify on the first encounter with a constraint. A lesson qualifies only after it
-has held across at least one full execution cycle; the first encounter is an audit
-finding, not yet a rule.
-
-Examples that codify well: "harbor-notes runtime data lives under `~/.harbor-notes/`;
-never under `$TMPDIR`", "every destructive verb must accept `--dry-run`", "step records
-use the canonical filename schema". Examples that do not: "we considered library X,
-picked library Y" (that is an ADR), "the deploy failed last week" (that is an audit
-finding without a durable lesson).
-
-## What to codify
-
-The rule body names the constraint precisely. Three sections, in order:
-
-- **Rule.** One sentence stating the obligation. Imperative voice. No backstory.
-- **Why.** Two or three sentences naming the constraint's origin - the audit document or
-  ADR that surfaced the lesson, the failure mode it prevents.
-- **How.** Concrete worked examples of the rule applied and the rule violated.
-
-Keep the rule short. A rule longer than its own justifying audit finding has lost the
-plot. If the rule needs more than a page, it is actually a reference document; produce
-`.vault/reference/yyyy-mm-dd-{feature}-reference.md` instead.
-
-## How to author
-
-A codification produces a file under `.vaultspec/rules/rules/` that captures the rule.
-Two canonical authoring paths exist:
-
-- **Promote from an audit** (preferred when the lesson originates in an audit document):
-  `vaultspec-core vault rule promote --from <audit-stem> --as <rule-name>` reads the
-  audit, scaffolds the rule file, and records the audit stem in the rule's
-  `derived_from:` frontmatter. The author then refines the scaffolded body into the
-  three-section shape above.
-
-- **Author directly** (when the lesson originates in an ADR or outside the vault):
-  `vaultspec-core spec rules add <rule-name>` scaffolds an empty rule file; the author
-  fills the three sections and names the source document by stem in backticks in the
-  **Why** section.
-
-In both paths, `<rule-name>` is the kebab-case slug naming the rule's subject (e.g.,
-`harbor-notes-runtime-data`, `destructive-verbs-need-dry-run`).
-
-The CLI places authored project rules in the same directory as the framework's builtin
-rules (`.vaultspec/rules/rules/`). Project-authored rules are distinguished from
-builtins by name convention: builtins use the `*.builtin.md` suffix; authored rules do
-not.
-
-## How to find an existing rule
-
-Before authoring a new rule, check whether one already covers the intent.
-`vaultspec-core spec rules list` enumerates all project-shared rules.
-`vaultspec-core spec rules show <name>` prints any single rule. If an existing rule
-partially covers the intent, edit it via the standard CRUD path
-(`vaultspec-core spec rules edit <name>`) rather than producing a near-duplicate;
-partial rules are worse than complete ones because they fragment the discipline.
-
-## Where the rule lives, and why
-
-Project-authored rules live under `.vaultspec/rules/rules/` alongside the framework's
-builtin rules. The framework's install policy is for that directory to be tracked by git
-so the rule reaches every teammate on clone.
-
-A rule that exists only on one developer's machine is not a codification; it is a
-personal note. The whole point of writing the rule down is that the next agent inherits
-it on the next session, on the next teammate's clone, on the next CI run.
-
-## When a rule itself becomes wrong
-
-Rules age. A rule that captured a constraint last quarter may no longer hold this
-quarter. Two paths:
-
-- **Edit in place** when the constraint has shifted at the margins. The rule's name
-  stays; the body changes.
-- **Supersede** when the constraint has changed at the center. Author a new rule with a
-  new name and add a `## Status` section to both rule bodies: the prior rule's Status
-  names the successor's slug, and the new rule's Status names the rule it supersedes.
-  Once teammates are aware, remove the prior rule via
-  `vaultspec-core spec rules remove <name>`.
-
-A rule should never be silently deleted. The rule's removal is itself a project-level
-event; record it.
-
-## Audit-driven codification
-
-The framework supports an audit-first codification flow. The sequence:
-
-- A review at the end of a feature surfaces lessons in
-  `.vault/audit/yyyy-mm-dd-{feature}-audit.md`.
-- One audit can produce zero, one, or many rules - most produce zero (the lesson is
-  feature-specific), some produce one, and a rare audit (the kind that surfaces a
-  framework-wide pattern) produces several.
-- Each qualifying finding is promoted with
-  `vaultspec-core vault rule promote --from <audit-stem> --as <rule-name>`; the promoted
-  rule carries the audit stem in its `derived_from:` frontmatter, and the rule's **Why**
-  section names the finding in prose.
-
-Audit-driven codification is the natural follow-on to the `review` phase. The pipeline
-reads as research → decide → plan → execute → review → codify, with codify as the
-discretionary sixth step. Most features end at review; the features whose lessons
-outlast the feature itself end at codify.
+Absent an explicit request, do not codify. The durable decision already lives in the
+vault, and the next agent reaches it by retrieval -
+`vaultspec-rag search "<intent>" --type vault` - rather than by inheriting a restated
+copy in always-on context. Prefer discovering the decision over duplicating it as a
+rule.

--- a/.vaultspec/rules/skills/vaultspec-adr/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-adr/SKILL.md
@@ -17,6 +17,13 @@ Use this skill:
 
 ## Required steps
 
+- **Ground the decision in existing intent first.** Before drafting, retrieve the prior
+  decisions that bind this area: `vaultspec-rag search "<intent>" --type vault` surfaces
+  related ADRs, audits, and research (architect on top of them, and supersede explicitly
+  rather than silently contradicting), and `vaultspec-rag search "<intent>" --type code`
+  shows the implementation sites the decision will touch. Fall back to
+  `vaultspec-core vault list` and grep when `vaultspec-rag` is not installed.
+
 - **Read and use the template** at `.vaultspec/rules/templates/adr.md`; its embedded
   hint blocks govern the body structure.
 

--- a/.vaultspec/rules/skills/vaultspec-code-research/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-code-research/SKILL.md
@@ -21,6 +21,13 @@ explicitly requires direct code referencing.
 
 ## Required steps
 
+- **Ground in existing intent first.** Before the code deep dive, retrieve what the
+  project already decided and built: `vaultspec-rag search "<intent>" --type vault`
+  surfaces the ADRs, audits, and references that bind this area, and
+  `vaultspec-rag search "<intent>" --type code` locates the semantically matching
+  implementation sites to anchor the audit. Fall back to `vaultspec-core vault list` and
+  grep when `vaultspec-rag` is not installed.
+
 - **Read and use the template** at `.vaultspec/rules/templates/reference.md`; its
   embedded hint blocks govern the body structure.
 

--- a/.vaultspec/rules/skills/vaultspec-codify/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-codify/SKILL.md
@@ -5,18 +5,28 @@ description: Promote a durable lesson from an audit or ADR into a shared project
 
 # Rule authoring skill (vaultspec-codify)
 
-Use this skill:
+Engage this skill **only when the user explicitly requests codification** - "codify
+this", "promote this to a rule". The framework never triggers it on its own initiative;
+saving a project rule is a user decision, not a routine output of doing work. If no
+explicit request was made, do not engage; the durable decision belongs in the vault and
+is reached by retrieval (`vaultspec-rag search "<intent>" --type vault`).
 
-- After a `vaultspec-code-review` session, a `vaultspec-execute` run, or an `<Audit>`
-  document surfaces a lesson that must bind future agents across sessions.
+Once the user has asked, use this skill when:
 
-- When the lesson is constraint-shaped (renderable as "always X" or "never Y") and
+- A `vaultspec-code-review` session, a `vaultspec-execute` run, or an `<Audit>` document
+  surfaced the lesson the user wants bound across sessions.
+
+- The lesson is constraint-shaped (renderable as "always X" or "never Y") and
   project-bound (specific to this project's conventions, not generic engineering
   advice).
 
-- When no existing rule already covers the intent.
+- No existing rule already covers the intent, and - confirmed first by
+  `vaultspec-rag search "<intent>" --type vault` - the constraint is not already
+  adequately captured as a discoverable vault decision.
 
 Do NOT use this skill:
+
+- Without an explicit user request to codify.
 
 - On the first encounter with a constraint. Wait until the constraint has held across at
   least one full execution cycle.

--- a/.vaultspec/rules/skills/vaultspec-research/SKILL.md
+++ b/.vaultspec/rules/skills/vaultspec-research/SKILL.md
@@ -18,6 +18,14 @@ research and brainstorming."
 
 ## Required steps
 
+- **Ground in existing intent first.** Before exploring options, retrieve what the
+  project already decided: `vaultspec-rag search "<intent>" --type vault` surfaces the
+  ADRs, audits, and prior research that bind this area, and
+  `vaultspec-rag search "<intent>" --type code` locates the implementation sites that
+  match semantically. Read the records this surfaces and check for overlap before adding
+  new findings. Fall back to `vaultspec-core vault list` and grep when `vaultspec-rag`
+  is not installed.
+
 - **Read and use the template** at `.vaultspec/rules/templates/research.md`; its
   embedded hint blocks govern the body structure.
 

--- a/.vaultspec/rules/system/03-vaultspec.md
+++ b/.vaultspec/rules/system/03-vaultspec.md
@@ -20,29 +20,38 @@ before invoking any pipeline skill. Read the in-flight plans it names, then ente
 pipeline at the right phase: resume an in-flight plan via `vaultspec-execute`, or start
 fresh at Research.
 
+**Ground in existing intent.** Before researching or implementing a feature, retrieve
+what the project already decided rather than reconstructing it from these always-on
+rules. Run `vaultspec-rag search "<intent>" --type vault` first: the project's
+architecture intent - its ADRs, audits, and decisions - is semantically indexed, and
+`--type vault` surfaces the records that already bind the area you are about to touch.
+Follow with `vaultspec-rag search "<intent>" --type code` to locate the implementation
+sites that match semantically. When `vaultspec-rag` is not installed, fall back to
+`vaultspec-core vault list` and grep. Retrieval is the grounding step; prefer it over
+re-deriving intent from memory or prose.
+
 All significant work must follow this pipeline:
 
-| Phase        | Skill                   | Artifact                   | Requires                                        |
-| ------------ | ----------------------- | -------------------------- | ----------------------------------------------- |
-| 1a Research  | vaultspec-research      | .vault/research/...        | -                                               |
-| 1b Reference | vaultspec-code-research | .vault/reference/...       | -                                               |
-| 2 Specify    | vaultspec-adr           | .vault/adr/...             | Research artifact                               |
-| 3 Plan       | vaultspec-write         | .vault/plan/...            | ADR artifact                                    |
-| 4 Execute    | vaultspec-execute       | .vault/exec/.../steps      | Approved plan                                   |
-| 5 Verify     | vaultspec-code-review   | .vault/audit/...           | Completed step(s)                               |
-| 6 Codify     | vaultspec-codify        | .vaultspec/rules/rules/... | Review surfacing a durable cross-session lesson |
+| Phase        | Skill                   | Artifact              | Requires          |
+| ------------ | ----------------------- | --------------------- | ----------------- |
+| 1a Research  | vaultspec-research      | .vault/research/...   | -                 |
+| 1b Reference | vaultspec-code-research | .vault/reference/...  | -                 |
+| 2 Specify    | vaultspec-adr           | .vault/adr/...        | Research artifact |
+| 3 Plan       | vaultspec-write         | .vault/plan/...       | ADR artifact      |
+| 4 Execute    | vaultspec-execute       | .vault/exec/.../steps | Approved plan     |
+| 5 Verify     | vaultspec-code-review   | .vault/audit/...      | Completed step(s) |
 
 Phases 1a and 1b are parallel entry points: Research explores the problem space,
 Reference grounds the work in existing source code. A feature needs at least one of the
 two; complex features benefit from both.
 
-Phase 6 (Codify) is **discretionary**: most features end at Verify. Only when a Verify
-pass surfaces a lesson that satisfies the three durability criteria (cross-session,
-constraint-shaped, project-bound) does the work continue into Codify. The
-`vaultspec-codify` rule defines the criteria and the authoring path
-(`vaultspec-core vault rule promote`); the `vaultspec-codifier` agent persona enacts the
-discipline. A rule authored under Phase 6 binds future agents across sessions, clones,
-and CI runs.
+Saving a project rule is **not** a phase of this pipeline and **not** a routine output
+of doing work. The framework ships the builtin rules that describe how to work; it never
+asks you to manufacture new rules on your own initiative. Author a project rule only
+when the user **explicitly** requests it ("codify this", "promote this to a rule") -
+then, and only then, invoke the on-demand `vaultspec-codify` skill. Absent that explicit
+request, the durable decision belongs in the vault and is reached by retrieval
+(`vaultspec-rag search "<intent>" --type vault`), not restated as a standing rule.
 
 The pipeline scales with the work. Trivial, single-file fixes with no architectural
 weight may proceed directly with user approval; state explicitly that the pipeline is

--- a/.vaultspec/rules/templates/adr.md
+++ b/.vaultspec/rules/templates/adr.md
@@ -66,19 +66,18 @@ Do not add code; code references must be persisted in a separate `{reference}` d
 
 ## Codification candidates
 
-<!-- If this decision introduces a durable cross-session constraint
-that should bind future agents (an obligation, a prohibition, a
-discipline that survives this feature's lifecycle), name it here as
-a candidate for promotion into a project rule under
-`.vaultspec/rules/rules/` via the codify pipeline phase.
+<!-- Leave this section empty by default. Codification is not a
+routine output of an ADR: the framework ships its operating rules
+and never asks you to manufacture new ones. The durable decision
+this ADR records already lives in the vault and is reached by
+retrieval (`vaultspec-rag search "<intent>" --type vault`).
 
-Each candidate names the proposed rule slug (kebab-case, naming the
-constraint's subject) and a one-sentence statement of the rule.
-
-Not every ADR produces a codification candidate. Decisions that are
-local to one feature, or that describe rather than constrain, leave
-this section empty. An empty Codification candidates section is a
-positive signal, not a failure. -->
+Name a candidate here ONLY if the user has explicitly asked to
+codify a constraint from this decision. In that case give the
+proposed rule slug (kebab-case, naming the constraint's subject)
+and a one-sentence statement of the rule, and author it via the
+on-demand `vaultspec-codify` skill. An empty section is the
+expected, positive default. -->
 
 <!-- Example:
 

--- a/.vaultspec/rules/templates/audit.md
+++ b/.vaultspec/rules/templates/audit.md
@@ -43,21 +43,19 @@ related:
 
 ## Codification candidates
 
-<!-- Findings that satisfy the three durability criteria
-(cross-session, constraint-shaped, project-bound) and should be
-promoted into project-shared rules under `.vaultspec/rules/rules/`
-via `vaultspec-core vault rule promote --from <this-audit-stem>
---as <rule-name>`.
+<!-- Leave this section empty by default. An audit records its
+findings in the vault for discovery; it does not oblige you to mint
+standing rules. The framework ships its operating rules and never
+asks you to manufacture new ones as routine output.
 
-Each candidate names the finding it derives from, the proposed
-rule slug (kebab-case, naming the constraint's subject not the
-failure), and a one-sentence statement of the rule.
-
-Most audits produce zero codification candidates. Some produce one.
-Only the rare framework-wide-pattern audit produces several. If
-none of the findings above meet the bar, state that explicitly and
-move on -- an empty Codification candidates section is a positive
-signal, not a failure. -->
+Name a candidate here ONLY if the user has explicitly asked to
+codify a finding from this audit. In that case give the source
+finding, the proposed rule slug (kebab-case, naming the
+constraint's subject not the failure), and a one-sentence statement
+of the rule, then author it via the on-demand `vaultspec-codify`
+skill (`vaultspec-core vault rule promote --from <this-audit-stem>
+--as <rule-name>`). An empty section is the expected, positive
+default. -->
 
 <!-- Example:
 

--- a/src/vaultspec_core/builtins/agents/vaultspec-codifier.md
+++ b/src/vaultspec_core/builtins/agents/vaultspec-codifier.md
@@ -7,17 +7,22 @@ tools: [Glob, Grep, Read, Write, Edit, Bash]
 
 # Persona: Codifier
 
-You are the Lead Codifier. Your role is to transform durable lessons surfaced in
-`<Audit>` and `<ADR>` documents into project-shared rules that bind future agents across
-sessions, clones, and CI runs.
+You are the Lead Codifier. You are dispatched **only when the user has explicitly
+requested codification** of a specific lesson. Your role is then to transform that
+durable lesson, surfaced in an `<Audit>` or `<ADR>` document, into a project-shared
+rule.
 
-The codification step is the discretionary sixth phase of the project's pipeline:
-research → decide → plan → execute → review → **codify**. Most features end at review;
-the features whose lessons outlast the feature itself end at codify.
+Codification is not a phase of feature work and not something you initiate on your own:
+the framework ships its operating rules and never asks an agent to manufacture new ones
+as routine output. If you were dispatched without an explicit user request to codify,
+stop and say so - the durable decision already lives in the vault and is reached by
+retrieval (`vaultspec-rag search "<intent>" --type vault`), not by minting a standing
+rule.
 
-Do not codify every audit finding. The bar is that the lesson is durable,
-constraint-shaped, and project-bound. The `vaultspec-codify` builtin rule defines the
-bar in detail; consult it before authoring.
+Even on an explicit request, do not codify every finding. The bar is that the lesson is
+durable, constraint-shaped, and project-bound, and that it is not already adequately
+captured as a discoverable vault decision. The `vaultspec-codify` builtin rule and skill
+define the bar; consult them before authoring.
 
 ## When to engage
 

--- a/src/vaultspec_core/builtins/rules/vaultspec-codify.builtin.md
+++ b/src/vaultspec_core/builtins/rules/vaultspec-codify.builtin.md
@@ -2,124 +2,22 @@
 name: vaultspec-codify
 ---
 
-# Codify durable lessons as project rules
+# Project rules are shipped, not manufactured by default
 
-The `vaultspec-core` workflow has a research → decide → plan → execute → review arc. The
-audit-derived sixth phase is `codify`: when a review surfaces a durable lesson - a
-constraint that should bind future agents across sessions - write that lesson down as a
-rule the next agent inherits on load.
+vaultspec ships the builtin rules that describe how to work. Growing the project rule
+set is **not** a routine output of doing work, **not** a pipeline phase, and **not**
+something the framework asks you to do on your own initiative. A review that surfaces a
+durable lesson records it in the vault (`.vault/audit/...`, `.vault/adr/...`); it does
+not oblige you to mint a standing rule.
 
-This rule defines when to codify, what to codify, and how to author the artifact.
+Author a new project rule **only when the user explicitly requests it** - "codify this",
+"promote this to a rule". On that explicit request, and only then, invoke the on-demand
+`vaultspec-codify` skill, which carries the durability bar, the authoring path
+(`vaultspec-core vault rule promote` from an audit, or `vaultspec-core spec rules add`
+otherwise), and the supersession discipline.
 
-## When to codify
-
-Not every observation in a review is a rule. The bar is durability. A
-codification-worthy lesson satisfies all three:
-
-- **Cross-session.** A new agent who has never seen this feature should still benefit
-  from the rule.
-- **Constraint-shaped.** The lesson can be rendered as a positive obligation ("always
-  X") or a negative one ("never Y"), not as a description.
-- **Project-bound.** The lesson is specific to this project's conventions, stack, or
-  constraints. Generic engineering advice belongs in external documentation.
-
-Never codify on the first encounter with a constraint. A lesson qualifies only after it
-has held across at least one full execution cycle; the first encounter is an audit
-finding, not yet a rule.
-
-Examples that codify well: "harbor-notes runtime data lives under `~/.harbor-notes/`;
-never under `$TMPDIR`", "every destructive verb must accept `--dry-run`", "step records
-use the canonical filename schema". Examples that do not: "we considered library X,
-picked library Y" (that is an ADR), "the deploy failed last week" (that is an audit
-finding without a durable lesson).
-
-## What to codify
-
-The rule body names the constraint precisely. Three sections, in order:
-
-- **Rule.** One sentence stating the obligation. Imperative voice. No backstory.
-- **Why.** Two or three sentences naming the constraint's origin - the audit document or
-  ADR that surfaced the lesson, the failure mode it prevents.
-- **How.** Concrete worked examples of the rule applied and the rule violated.
-
-Keep the rule short. A rule longer than its own justifying audit finding has lost the
-plot. If the rule needs more than a page, it is actually a reference document; produce
-`.vault/reference/yyyy-mm-dd-{feature}-reference.md` instead.
-
-## How to author
-
-A codification produces a file under `.vaultspec/rules/rules/` that captures the rule.
-Two canonical authoring paths exist:
-
-- **Promote from an audit** (preferred when the lesson originates in an audit document):
-  `vaultspec-core vault rule promote --from <audit-stem> --as <rule-name>` reads the
-  audit, scaffolds the rule file, and records the audit stem in the rule's
-  `derived_from:` frontmatter. The author then refines the scaffolded body into the
-  three-section shape above.
-
-- **Author directly** (when the lesson originates in an ADR or outside the vault):
-  `vaultspec-core spec rules add <rule-name>` scaffolds an empty rule file; the author
-  fills the three sections and names the source document by stem in backticks in the
-  **Why** section.
-
-In both paths, `<rule-name>` is the kebab-case slug naming the rule's subject (e.g.,
-`harbor-notes-runtime-data`, `destructive-verbs-need-dry-run`).
-
-The CLI places authored project rules in the same directory as the framework's builtin
-rules (`.vaultspec/rules/rules/`). Project-authored rules are distinguished from
-builtins by name convention: builtins use the `*.builtin.md` suffix; authored rules do
-not.
-
-## How to find an existing rule
-
-Before authoring a new rule, check whether one already covers the intent.
-`vaultspec-core spec rules list` enumerates all project-shared rules.
-`vaultspec-core spec rules show <name>` prints any single rule. If an existing rule
-partially covers the intent, edit it via the standard CRUD path
-(`vaultspec-core spec rules edit <name>`) rather than producing a near-duplicate;
-partial rules are worse than complete ones because they fragment the discipline.
-
-## Where the rule lives, and why
-
-Project-authored rules live under `.vaultspec/rules/rules/` alongside the framework's
-builtin rules. The framework's install policy is for that directory to be tracked by git
-so the rule reaches every teammate on clone.
-
-A rule that exists only on one developer's machine is not a codification; it is a
-personal note. The whole point of writing the rule down is that the next agent inherits
-it on the next session, on the next teammate's clone, on the next CI run.
-
-## When a rule itself becomes wrong
-
-Rules age. A rule that captured a constraint last quarter may no longer hold this
-quarter. Two paths:
-
-- **Edit in place** when the constraint has shifted at the margins. The rule's name
-  stays; the body changes.
-- **Supersede** when the constraint has changed at the center. Author a new rule with a
-  new name and add a `## Status` section to both rule bodies: the prior rule's Status
-  names the successor's slug, and the new rule's Status names the rule it supersedes.
-  Once teammates are aware, remove the prior rule via
-  `vaultspec-core spec rules remove <name>`.
-
-A rule should never be silently deleted. The rule's removal is itself a project-level
-event; record it.
-
-## Audit-driven codification
-
-The framework supports an audit-first codification flow. The sequence:
-
-- A review at the end of a feature surfaces lessons in
-  `.vault/audit/yyyy-mm-dd-{feature}-audit.md`.
-- One audit can produce zero, one, or many rules - most produce zero (the lesson is
-  feature-specific), some produce one, and a rare audit (the kind that surfaces a
-  framework-wide pattern) produces several.
-- Each qualifying finding is promoted with
-  `vaultspec-core vault rule promote --from <audit-stem> --as <rule-name>`; the promoted
-  rule carries the audit stem in its `derived_from:` frontmatter, and the rule's **Why**
-  section names the finding in prose.
-
-Audit-driven codification is the natural follow-on to the `review` phase. The pipeline
-reads as research → decide → plan → execute → review → codify, with codify as the
-discretionary sixth step. Most features end at review; the features whose lessons
-outlast the feature itself end at codify.
+Absent an explicit request, do not codify. The durable decision already lives in the
+vault, and the next agent reaches it by retrieval -
+`vaultspec-rag search "<intent>" --type vault` - rather than by inheriting a restated
+copy in always-on context. Prefer discovering the decision over duplicating it as a
+rule.

--- a/src/vaultspec_core/builtins/skills/vaultspec-adr/SKILL.md
+++ b/src/vaultspec_core/builtins/skills/vaultspec-adr/SKILL.md
@@ -17,6 +17,13 @@ Use this skill:
 
 ## Required steps
 
+- **Ground the decision in existing intent first.** Before drafting, retrieve the prior
+  decisions that bind this area: `vaultspec-rag search "<intent>" --type vault` surfaces
+  related ADRs, audits, and research (architect on top of them, and supersede explicitly
+  rather than silently contradicting), and `vaultspec-rag search "<intent>" --type code`
+  shows the implementation sites the decision will touch. Fall back to
+  `vaultspec-core vault list` and grep when `vaultspec-rag` is not installed.
+
 - **Read and use the template** at `.vaultspec/rules/templates/adr.md`; its embedded
   hint blocks govern the body structure.
 

--- a/src/vaultspec_core/builtins/skills/vaultspec-code-research/SKILL.md
+++ b/src/vaultspec_core/builtins/skills/vaultspec-code-research/SKILL.md
@@ -21,6 +21,13 @@ explicitly requires direct code referencing.
 
 ## Required steps
 
+- **Ground in existing intent first.** Before the code deep dive, retrieve what the
+  project already decided and built: `vaultspec-rag search "<intent>" --type vault`
+  surfaces the ADRs, audits, and references that bind this area, and
+  `vaultspec-rag search "<intent>" --type code` locates the semantically matching
+  implementation sites to anchor the audit. Fall back to `vaultspec-core vault list` and
+  grep when `vaultspec-rag` is not installed.
+
 - **Read and use the template** at `.vaultspec/rules/templates/reference.md`; its
   embedded hint blocks govern the body structure.
 

--- a/src/vaultspec_core/builtins/skills/vaultspec-codify/SKILL.md
+++ b/src/vaultspec_core/builtins/skills/vaultspec-codify/SKILL.md
@@ -5,18 +5,28 @@ description: Promote a durable lesson from an audit or ADR into a shared project
 
 # Rule authoring skill (vaultspec-codify)
 
-Use this skill:
+Engage this skill **only when the user explicitly requests codification** - "codify
+this", "promote this to a rule". The framework never triggers it on its own initiative;
+saving a project rule is a user decision, not a routine output of doing work. If no
+explicit request was made, do not engage; the durable decision belongs in the vault and
+is reached by retrieval (`vaultspec-rag search "<intent>" --type vault`).
 
-- After a `vaultspec-code-review` session, a `vaultspec-execute` run, or an `<Audit>`
-  document surfaces a lesson that must bind future agents across sessions.
+Once the user has asked, use this skill when:
 
-- When the lesson is constraint-shaped (renderable as "always X" or "never Y") and
+- A `vaultspec-code-review` session, a `vaultspec-execute` run, or an `<Audit>` document
+  surfaced the lesson the user wants bound across sessions.
+
+- The lesson is constraint-shaped (renderable as "always X" or "never Y") and
   project-bound (specific to this project's conventions, not generic engineering
   advice).
 
-- When no existing rule already covers the intent.
+- No existing rule already covers the intent, and - confirmed first by
+  `vaultspec-rag search "<intent>" --type vault` - the constraint is not already
+  adequately captured as a discoverable vault decision.
 
 Do NOT use this skill:
+
+- Without an explicit user request to codify.
 
 - On the first encounter with a constraint. Wait until the constraint has held across at
   least one full execution cycle.

--- a/src/vaultspec_core/builtins/skills/vaultspec-research/SKILL.md
+++ b/src/vaultspec_core/builtins/skills/vaultspec-research/SKILL.md
@@ -18,6 +18,14 @@ research and brainstorming."
 
 ## Required steps
 
+- **Ground in existing intent first.** Before exploring options, retrieve what the
+  project already decided: `vaultspec-rag search "<intent>" --type vault` surfaces the
+  ADRs, audits, and prior research that bind this area, and
+  `vaultspec-rag search "<intent>" --type code` locates the implementation sites that
+  match semantically. Read the records this surfaces and check for overlap before adding
+  new findings. Fall back to `vaultspec-core vault list` and grep when `vaultspec-rag`
+  is not installed.
+
 - **Read and use the template** at `.vaultspec/rules/templates/research.md`; its
   embedded hint blocks govern the body structure.
 

--- a/src/vaultspec_core/builtins/system/03-vaultspec.md
+++ b/src/vaultspec_core/builtins/system/03-vaultspec.md
@@ -20,29 +20,38 @@ before invoking any pipeline skill. Read the in-flight plans it names, then ente
 pipeline at the right phase: resume an in-flight plan via `vaultspec-execute`, or start
 fresh at Research.
 
+**Ground in existing intent.** Before researching or implementing a feature, retrieve
+what the project already decided rather than reconstructing it from these always-on
+rules. Run `vaultspec-rag search "<intent>" --type vault` first: the project's
+architecture intent - its ADRs, audits, and decisions - is semantically indexed, and
+`--type vault` surfaces the records that already bind the area you are about to touch.
+Follow with `vaultspec-rag search "<intent>" --type code` to locate the implementation
+sites that match semantically. When `vaultspec-rag` is not installed, fall back to
+`vaultspec-core vault list` and grep. Retrieval is the grounding step; prefer it over
+re-deriving intent from memory or prose.
+
 All significant work must follow this pipeline:
 
-| Phase        | Skill                   | Artifact                   | Requires                                        |
-| ------------ | ----------------------- | -------------------------- | ----------------------------------------------- |
-| 1a Research  | vaultspec-research      | .vault/research/...        | -                                               |
-| 1b Reference | vaultspec-code-research | .vault/reference/...       | -                                               |
-| 2 Specify    | vaultspec-adr           | .vault/adr/...             | Research artifact                               |
-| 3 Plan       | vaultspec-write         | .vault/plan/...            | ADR artifact                                    |
-| 4 Execute    | vaultspec-execute       | .vault/exec/.../steps      | Approved plan                                   |
-| 5 Verify     | vaultspec-code-review   | .vault/audit/...           | Completed step(s)                               |
-| 6 Codify     | vaultspec-codify        | .vaultspec/rules/rules/... | Review surfacing a durable cross-session lesson |
+| Phase        | Skill                   | Artifact              | Requires          |
+| ------------ | ----------------------- | --------------------- | ----------------- |
+| 1a Research  | vaultspec-research      | .vault/research/...   | -                 |
+| 1b Reference | vaultspec-code-research | .vault/reference/...  | -                 |
+| 2 Specify    | vaultspec-adr           | .vault/adr/...        | Research artifact |
+| 3 Plan       | vaultspec-write         | .vault/plan/...       | ADR artifact      |
+| 4 Execute    | vaultspec-execute       | .vault/exec/.../steps | Approved plan     |
+| 5 Verify     | vaultspec-code-review   | .vault/audit/...      | Completed step(s) |
 
 Phases 1a and 1b are parallel entry points: Research explores the problem space,
 Reference grounds the work in existing source code. A feature needs at least one of the
 two; complex features benefit from both.
 
-Phase 6 (Codify) is **discretionary**: most features end at Verify. Only when a Verify
-pass surfaces a lesson that satisfies the three durability criteria (cross-session,
-constraint-shaped, project-bound) does the work continue into Codify. The
-`vaultspec-codify` rule defines the criteria and the authoring path
-(`vaultspec-core vault rule promote`); the `vaultspec-codifier` agent persona enacts the
-discipline. A rule authored under Phase 6 binds future agents across sessions, clones,
-and CI runs.
+Saving a project rule is **not** a phase of this pipeline and **not** a routine output
+of doing work. The framework ships the builtin rules that describe how to work; it never
+asks you to manufacture new rules on your own initiative. Author a project rule only
+when the user **explicitly** requests it ("codify this", "promote this to a rule") -
+then, and only then, invoke the on-demand `vaultspec-codify` skill. Absent that explicit
+request, the durable decision belongs in the vault and is reached by retrieval
+(`vaultspec-rag search "<intent>" --type vault`), not restated as a standing rule.
 
 The pipeline scales with the work. Trivial, single-file fixes with no architectural
 weight may proceed directly with user approval; state explicitly that the pipeline is

--- a/src/vaultspec_core/builtins/templates/adr.md
+++ b/src/vaultspec_core/builtins/templates/adr.md
@@ -66,19 +66,18 @@ Do not add code; code references must be persisted in a separate `{reference}` d
 
 ## Codification candidates
 
-<!-- If this decision introduces a durable cross-session constraint
-that should bind future agents (an obligation, a prohibition, a
-discipline that survives this feature's lifecycle), name it here as
-a candidate for promotion into a project rule under
-`.vaultspec/rules/rules/` via the codify pipeline phase.
+<!-- Leave this section empty by default. Codification is not a
+routine output of an ADR: the framework ships its operating rules
+and never asks you to manufacture new ones. The durable decision
+this ADR records already lives in the vault and is reached by
+retrieval (`vaultspec-rag search "<intent>" --type vault`).
 
-Each candidate names the proposed rule slug (kebab-case, naming the
-constraint's subject) and a one-sentence statement of the rule.
-
-Not every ADR produces a codification candidate. Decisions that are
-local to one feature, or that describe rather than constrain, leave
-this section empty. An empty Codification candidates section is a
-positive signal, not a failure. -->
+Name a candidate here ONLY if the user has explicitly asked to
+codify a constraint from this decision. In that case give the
+proposed rule slug (kebab-case, naming the constraint's subject)
+and a one-sentence statement of the rule, and author it via the
+on-demand `vaultspec-codify` skill. An empty section is the
+expected, positive default. -->
 
 <!-- Example:
 

--- a/src/vaultspec_core/builtins/templates/audit.md
+++ b/src/vaultspec_core/builtins/templates/audit.md
@@ -43,21 +43,19 @@ related:
 
 ## Codification candidates
 
-<!-- Findings that satisfy the three durability criteria
-(cross-session, constraint-shaped, project-bound) and should be
-promoted into project-shared rules under `.vaultspec/rules/rules/`
-via `vaultspec-core vault rule promote --from <this-audit-stem>
---as <rule-name>`.
+<!-- Leave this section empty by default. An audit records its
+findings in the vault for discovery; it does not oblige you to mint
+standing rules. The framework ships its operating rules and never
+asks you to manufacture new ones as routine output.
 
-Each candidate names the finding it derives from, the proposed
-rule slug (kebab-case, naming the constraint's subject not the
-failure), and a one-sentence statement of the rule.
-
-Most audits produce zero codification candidates. Some produce one.
-Only the rare framework-wide-pattern audit produces several. If
-none of the findings above meet the bar, state that explicitly and
-move on -- an empty Codification candidates section is a positive
-signal, not a failure. -->
+Name a candidate here ONLY if the user has explicitly asked to
+codify a finding from this audit. In that case give the source
+finding, the proposed rule slug (kebab-case, naming the
+constraint's subject not the failure), and a one-sentence statement
+of the rule, then author it via the on-demand `vaultspec-codify`
+skill (`vaultspec-core vault rule promote --from <this-audit-stem>
+--as <rule-name>`). An empty section is the expected, positive
+default. -->
 
 <!-- Example:
 


### PR DESCRIPTION
## Summary

Reframes the bundled always-on firmware so that **saving a project rule is an explicit, user-triggered action** rather than a mandated "sixth phase" of the pipeline, and adds a **RAG-grounded discovery step** to feature work.

Previously the always-on prose compelled agents to save durable dev steps as new project rules, growing permanent context without bound and duplicating the `.vault/` decision corpus. This change grounds feature work by retrieving existing architecture intent via `vaultspec-rag search --type vault` then `--type code`, and reserves rule-authoring for explicit user requests ("codify this").

## Changes

- **`system/03-vaultspec.md`** - add "Ground in existing intent" mandate (rag `--type vault` then `--type code`, with `vault list` + grep fallback); remove the Codify pipeline row and the Phase-6 paragraph - rule-saving is not a phase.
- **`rules/vaultspec-codify.builtin.md`** - collapse the ~125-line always-on how-to into a short guardrail ("rules are shipped, not manufactured by default").
- **`skills/vaultspec-codify` + `agents/vaultspec-codifier`** - gate on explicit user request; drop the "sixth phase" framing; discover-first via rag.
- **`skills/{research,code-research,adr}`** - add a discover-first `--type vault`/`code` grounding step.
- **`templates/{adr,audit}`** - Codification candidates sections default-empty and user-triggered; drop the "codify pipeline phase" misnomer.

The `.vaultspec/` managed mirror is regenerated by `vaultspec-core install --upgrade` (not hand-edited); it also refreshes the drifted CLI reference and the rules `.gitignore` comment.

## Verification

- `vaultspec-core spec reference generate --check` - in sync
- 682 unit tests pass; pre-commit hooks (markdown, vault doctor, provider artifacts) green
- Rebased onto `main` @ 0.1.33; no version/changelog noise
