### PR TITLE
fix(diagnosis): single comparator for install/sync/doctor parity

### DIFF
--- a/.vault/adr/2026-06-28-diagnosis-surface-parity-adr.md
+++ b/.vault/adr/2026-06-28-diagnosis-surface-parity-adr.md
@@ -1,0 +1,88 @@
+---
+tags:
+  - '#adr'
+  - '#diagnosis-surface-parity'
+date: '2026-06-28'
+modified: '2026-06-28'
+related:
+  - "[[2026-06-28-diagnosis-surface-parity-audit]]"
+  - "[[2026-03-27-cli-ambiguous-states-resolver-adr]]"
+  - '[[2026-06-28-diagnosis-surface-parity-research]]'
+---
+
+# `diagnosis-surface-parity` adr: `single comparator for provider artifact parity` | (**status:** `accepted`)
+
+## Problem Statement
+
+The audit found that `install`, `sync`, and `spec doctor` each decide independently
+whether a provider artifact matches its source, and the copies have drifted: the doctor's
+`collect_content_integrity` compares filenames only and reports clean files that `sync`
+will rewrite, the snapshot lifecycle has no owner for orphan pruning, the MCP writer and
+the doctor's foreign-file detector disagree on what may live in a provider directory, and
+`install --dry-run` previews at a coarser granularity than `sync`. The ambiguous-states
+resolver ADR already specified the intended design - content integrity reuses the sync
+infrastructure and SHA-256 compares expected against actual, with a `DIVERGED` signal for
+content mismatch - so this is not a new architecture but a restoration of conformance plus
+a stated rule against future re-divergence.
+
+## Considerations
+
+The same question - "is this provider file in sync with its source" - is answered today
+by `apply_file_sync` (content-exact, canonical), `check_outdated` (content-exact),
+`list_modified_builtins` (content-exact), and `collect_content_integrity` (name-only, the
+outlier). The canonical comparator already exists and is correct; the defect is that one
+surface bypasses it. The fix must not introduce a fifth comparator; it must route the
+doctor through the existing one.
+
+## Considered options
+
+- **Route every parity decision through one comparator (chosen).** The doctor computes
+  expected rendered content via the same sync rendering path and compares it to the
+  destination, emitting `DIVERGED` on mismatch. One body of code owns the decision; the
+  three surfaces become views over it. Restores conformance to the resolver ADR.
+
+- **Patch the doctor's name-only check to also read content, independently.** Rejected:
+  adds a second content comparator that can itself drift from `apply_file_sync`, which is
+  the exact defect being fixed.
+
+- **Make `sync` looser to match the doctor (name-only).** Rejected: would hide real
+  content drift and defeats the purpose of sync.
+
+## Constraints
+
+No new dependencies. The change is confined to the diagnosis collectors, the snapshot
+module, the MCP/host-native registry, and the install dry-run renderer; it relies on the
+existing, stable sync rendering path (`apply_file_sync` and the resource collectors), so
+there is no frontier risk. Tests must follow the project's zero-mock standard and assert
+against a real workspace rather than patched comparators.
+
+## Implementation
+
+Content integrity is rebuilt as a thin view over the sync renderer: for each managed
+provider file the collector obtains the expected rendered text from the shared rendering
+path and compares it (hash or bytes) to the on-disk destination, reporting `CLEAN`,
+`DIVERGED` (content differs), or `STALE`/orphan (no source). Orphan-snapshot pruning gets
+a single owner in the snapshot module, invoked so that retiring a builtin returns
+`builtin_version` to clean. The set of files that legitimately live in a provider
+directory becomes one registry shared by the MCP writer and the doctor's foreign-file
+detector, extended to cover `mcp_config.json` and its lock sibling. The install dry-run
+preview is brought to per-file granularity so it matches sync. The redeclared add/update
+classifications (codex agents, MCP sync) are folded back onto the canonical comparator or
+a single extracted helper.
+
+## Rationale
+
+The resolver ADR already chose content-exact comparison reusing sync; the audit shows the
+implementation regressed to name-only. Re-deriving the same decision in multiple places is
+the documented root cause of the contradictions, so the durable fix is one comparator with
+the surfaces as views, not better-synchronised copies.
+
+## Consequences
+
+The doctor will begin reporting content drift it previously hid (the `DIVERGED` signal
+goes live), which may surface latent staleness in existing workspaces - correct, but
+louder. Pruning orphan snapshots changes `builtin_version` from a permanent error to a
+recoverable state. Centralising the provider-file registry and the comparator reduces the
+surface area where drift can reappear, and gives the codebase-wide sweep a concrete
+pattern to search for. The risk is incomplete consolidation: if any surface keeps a
+private copy of the decision, the contradiction returns, so the sweep is the safeguard.

--- a/.vault/audit/2026-06-28-diagnosis-surface-parity-audit.md
+++ b/.vault/audit/2026-06-28-diagnosis-surface-parity-audit.md
@@ -1,0 +1,120 @@
+---
+tags:
+  - '#audit'
+  - '#diagnosis-surface-parity'
+date: '2026-06-28'
+modified: '2026-06-28'
+related:
+  - "[[2026-03-27-cli-ambiguous-states-resolver-adr]]"
+  - "[[2026-02-24-vault-doctor-suite-adr]]"
+---
+
+# `diagnosis-surface-parity` audit: `diagnosis surface parity: install/sync/doctor drift`
+
+## Scope
+
+Triggered by a concrete contradiction: `spec doctor` reports the provider copy of
+`vaultspec-rag.builtin.md` as clean while `sync` reports the same file as needing an
+update, and `spec doctor` reports `builtins error deleted` plus `antigravity mixed` on a
+freshly reinstalled workspace. The audit covers the three CLI surfaces that each decide,
+independently, whether a provider artifact is in sync with its source - `install`,
+`sync`, and `spec doctor` (the `core/diagnosis` collectors) - plus the snapshot
+lifecycle in `core/revert.py` and the template resolver in `vaultcore/hydration.py`. The
+governing decision is the ambiguous-states resolver ADR, which already specified the
+intended design; the finding is that the implementation drifted from it.
+
+The audit is a worked instance of a broader concern: where the same decision is made by
+more than one body of code, the copies drift. The codebase-wide sweep for that pattern is
+tracked separately in the sibling plan.
+
+## Findings
+
+### content-integrity-name-only | critical | doctor compares filenames, sync compares content, so they contradict
+
+`collect_content_integrity` in `src/vaultspec_core/core/diagnosis/collectors.py` decides
+a provider rule file is clean when its basename is present in both the source directory
+(`.vaultspec/rules`) and the destination provider directory, and stale only when the
+basename is absent from the source. It never reads or compares file content. `sync`
+routes every file through `apply_file_sync` in `src/vaultspec_core/core/sync.py`, which
+compares the full rendered text byte-for-byte and reports `[UPDATE]` on any difference.
+Because both read the same source directory but apply different comparison semantics,
+they disagree whenever content drifts without the filename changing - exactly the
+`vaultspec-rag.builtin.md` case. This directly violates the ambiguous-states resolver
+ADR, which specified that content integrity reuse the sync infrastructure and SHA-256
+compare the expected transformed output against the actual destination file. The ADR even
+defined a `DIVERGED` content signal for "file differs from expected content"; the shipped
+collector never emits it, so `DIVERGED` is a dead state and content drift is structurally
+invisible to the doctor.
+
+### orphan-snapshots-never-pruned | high | builtin_version reports DELETED forever after a builtin is removed from source
+
+`snapshot_builtins` in `src/vaultspec_core/core/revert.py` copies every live
+`.builtin.md` under `.vaultspec/` into `.vaultspec/_snapshots/` at install time but never
+removes a snapshot whose source builtin has since been deleted. `list_modified_builtins`
+walks the snapshot tree and reports any snapshot with no live counterpart as `missing`,
+which `collect_builtin_version_state` maps to `BuiltinVersionSignal.DELETED`. After the
+codify phase was removed from the firmware, the six promoted codify-era rules survive only
+as orphan snapshots, so the doctor reports `builtins error deleted` permanently with no
+in-workspace remedy. No surface owns orphan-snapshot pruning - not install, not sync, not
+uninstall.
+
+### mcp-config-foreign-to-doctor | medium | install writes a provider file its own doctor flags as foreign
+
+`mcp_sync` writes `mcp_config.json` (and a `.lock` sibling) into provider directories
+such as `.agents/`. `collect_provider_dir_state` classifies any provider-directory child
+that is not a known managed path and not in `_HOST_NATIVE_FILES` as foreign, returning
+`MIXED`. `mcp_config.json` and `*.lock` are absent from `_HOST_NATIVE_FILES`, so the
+diagnosis flags a directory that the framework itself populated. The writer
+(`core/mcps.py`) and the checker (`core/diagnosis/collectors.py`) hold two unsynchronised
+notions of what files legitimately live in a provider directory.
+
+### install-dry-run-granularity | medium | install --dry-run previews provider artifacts at directory granularity while sync previews per file
+
+`install --dry-run` renders provider targets through `_scaffold_provider`, which emits one
+entry per provider directory (for example `claude (rules) = .claude/rules`), because the
+install scaffold creates directories and defers file seeding. `sync --dry-run` renders
+through `apply_file_sync`, which emits one entry per file. The two previews of overlapping
+work therefore disagree in resolution, and the install preview understates blast radius:
+an operator reading it cannot see which individual files will be added or updated.
+
+### action-classification-redeclared | medium | codex agents and MCP sync re-implement the add/update decision instead of using apply_file_sync
+
+`apply_file_sync` is documented as "the single place the add/update/unchanged decision is
+made," yet `_sync_codex_agents` recomputes `[UPDATE]`/`[ADD]` inline and `mcp_sync` uses
+its own JSON-merge-and-write loop with no per-file content comparison at all. These are
+two more copies of the sync decision that can drift from the canonical one, the same class
+of defect as the doctor's name-only check.
+
+### template-resolver-version-skew | low | a stale global binary silently shadows the editable source and fails template lookup
+
+`vault add audit` failed with "No template found for type 'audit'" when invoked as the
+bare `vaultspec-core` on `PATH` (a stale 0.1.34 global install) while the editable source
+is 0.1.35. This is environment skew rather than a source defect, but it is the same
+failure mode at the tooling layer: two resolvable copies of the program, the older one
+shadowing the newer, producing a result that contradicts the source of truth. The
+canonical invocation in this workspace is `uv run --no-sync vaultspec-core`.
+
+## Recommendations
+
+- Restore `collect_content_integrity` to the ambiguous-states resolver ADR: compute the
+  expected rendered content through the shared sync renderer and compare it (hash or
+  bytes) against the destination, emitting `DIVERGED` on content mismatch. The doctor and
+  `sync` must answer "is this file in sync" through one comparator, not two.
+
+- Give orphan-snapshot pruning a single owner so `builtin_version` can return to a clean
+  state after a builtin is retired, and so the snapshot tree tracks the live builtin set.
+
+- Centralise the "what may legitimately live in a provider directory" registry so the MCP
+  writer and the doctor's foreign-file detector read from one list; add `mcp_config.json`
+  and its lock sibling.
+
+- Unify the dry-run preview so `install` and `sync` describe provider work at the same
+  per-file granularity.
+
+- Fold the redeclared add/update classifications (codex agents, MCP sync) back onto
+  `apply_file_sync`, or extract one shared decision helper, so the canonical comparator is
+  the only one.
+
+- Treat each of the above as an instance of one root pattern - the same decision made by
+  divergent code - and run the codebase-wide drift and centralisation sweep tracked in the
+  sibling plan to find the rest before they surface as contradictions.

--- a/.vault/index/codebase-drift-sweep.index.md
+++ b/.vault/index/codebase-drift-sweep.index.md
@@ -1,0 +1,20 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#codebase-drift-sweep'
+date: '2026-06-28'
+modified: '2026-06-28'
+related:
+  - '[[2026-06-28-codebase-drift-sweep-plan]]'
+---
+
+# `codebase-drift-sweep` feature index
+
+Auto-generated index of all documents tagged with `#codebase-drift-sweep`.
+
+## Documents
+
+### plan
+
+- `2026-06-28-codebase-drift-sweep-plan` - `codebase-drift-sweep` plan

--- a/.vault/index/diagnosis-surface-parity.index.md
+++ b/.vault/index/diagnosis-surface-parity.index.md
@@ -1,0 +1,35 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#diagnosis-surface-parity'
+date: '2026-06-28'
+modified: '2026-06-28'
+related:
+  - '[[2026-06-28-diagnosis-surface-parity-adr]]'
+  - '[[2026-06-28-diagnosis-surface-parity-audit]]'
+  - '[[2026-06-28-diagnosis-surface-parity-plan]]'
+  - '[[2026-06-28-diagnosis-surface-parity-research]]'
+---
+
+# `diagnosis-surface-parity` feature index
+
+Auto-generated index of all documents tagged with `#diagnosis-surface-parity`.
+
+## Documents
+
+### adr
+
+- `2026-06-28-diagnosis-surface-parity-adr` - `diagnosis-surface-parity` adr: `single comparator for provider artifact parity` | (**status:** `accepted`)
+
+### audit
+
+- `2026-06-28-diagnosis-surface-parity-audit` - `diagnosis-surface-parity` audit: `diagnosis surface parity: install/sync/doctor drift`
+
+### plan
+
+- `2026-06-28-diagnosis-surface-parity-plan` - `diagnosis-surface-parity` plan
+
+### research
+
+- `2026-06-28-diagnosis-surface-parity-research` - `diagnosis-surface-parity` research: `mapping the install/sync/doctor parity surfaces`

--- a/.vault/plan/2026-06-28-codebase-drift-sweep-plan.md
+++ b/.vault/plan/2026-06-28-codebase-drift-sweep-plan.md
@@ -1,0 +1,67 @@
+---
+tags:
+  - '#plan'
+  - '#codebase-drift-sweep'
+date: '2026-06-28'
+modified: '2026-06-28'
+tier: L2
+related:
+  - '[[2026-06-28-diagnosis-surface-parity-audit]]'
+  - '[[2026-06-28-diagnosis-surface-parity-adr]]'
+---
+
+# `codebase-drift-sweep` plan
+
+## Description
+
+A codebase-wide hunt for the root pattern the diagnosis-surface-parity audit exposed: the
+same decision made by divergent bodies of code, which drift into contradiction. Each phase
+sweeps one class of that pattern with RAG-led, rg-confirmed discovery, records findings,
+and collapses confirmed duplications onto one source of truth.
+
+## Steps
+
+### Phase `P01` - Decision-logic duplication
+
+RAG and rg sweep for the add/update/freshness/comparison decision re-implemented outside the canonical apply_file_sync (codex agent sync and MCP sync are the seed instances from the audit), then fold each onto the canonical comparator.
+
+- [ ] `P01.S01` - Sweep for content and freshness comparisons re-implemented outside apply_file_sync and record each site; `src/vaultspec_core/core/`.
+- [ ] `P01.S02` - Fold confirmed duplications onto the canonical comparator or one shared helper, with tests; `src/vaultspec_core/core/sync.py`.
+
+### Phase `P02` - Source-of-truth registry duplication
+
+Hunt for registries and resolvers maintained in more than one place (host-native file lists, provider-file sets, path resolution, template-name maps) where a writer and a checker can disagree.
+
+- [ ] `P02.S03` - Sweep for registries and resolvers maintained in more than one place and record each writer-checker pair; `src/vaultspec_core/core/`.
+- [ ] `P02.S04` - Collapse each confirmed duplicate registry to one source of truth, with tests; `src/vaultspec_core/core/`.
+
+### Phase `P03` - Lifecycle ownership gaps
+
+Find artefacts created but never pruned or reconciled (the orphan-snapshot class): snapshots, manifests, generated provider files, lock files, caches, each needing a single prune or reconcile owner.
+
+- [ ] `P03.S05` - Sweep for created-but-never-reconciled artefacts and record each lifecycle gap with its missing owner; `src/vaultspec_core/core/`.
+- [ ] `P03.S06` - Assign each confirmed gap a single prune or reconcile owner, with tests; `src/vaultspec_core/core/`.
+
+### Phase `P04` - Preview vs apply parity
+
+Audit every destructive verb for dry-run and apply granularity and outcome parity (install versus sync was the seed); a preview that understates or misreports the apply is a finding.
+
+- [ ] `P04.S07` - Audit every destructive verb for dry-run and apply parity and record mismatches; `src/vaultspec_core/cli/`.
+- [ ] `P04.S08` - Bring confirmed previews to apply-faithful granularity, with tests; `src/vaultspec_core/cli/`.
+
+### Phase `P05` - Version and tooling shadowing
+
+Sweep for shadowing where two resolvable copies disagree: stale global binary versus editable source, deployed template mirror versus package source, generated reference versus live surface.
+
+- [ ] `P05.S09` - Sweep for shadowing between resolvable copies and record each; `src/vaultspec_core/`.
+- [ ] `P05.S10` - Document the canonical invocation and add cheap drift guards where warranted, with tests; `src/vaultspec_core/`.
+
+## Parallelization
+
+The five phases are independent sweeps and may run concurrently; the collapse step within
+each phase depends only on that phase's discovery step.
+
+## Verification
+
+Each collapse lands with tests and leaves spec doctor, the lint suite, and the unit gate
+green.

--- a/.vault/plan/2026-06-28-diagnosis-surface-parity-plan.md
+++ b/.vault/plan/2026-06-28-diagnosis-surface-parity-plan.md
@@ -1,0 +1,65 @@
+---
+tags:
+  - '#plan'
+  - '#diagnosis-surface-parity'
+date: '2026-06-28'
+modified: '2026-06-28'
+tier: L2
+related:
+  - '[[2026-06-28-diagnosis-surface-parity-adr]]'
+  - '[[2026-06-28-diagnosis-surface-parity-audit]]'
+  - '[[2026-06-28-diagnosis-surface-parity-research]]'
+---
+
+<!-- RETIRED: P05, S12, S13 -->
+
+# `diagnosis-surface-parity` plan
+
+## Description
+
+Restore single-comparator parity across install, sync, and spec doctor per the sibling
+ADR. Each phase fixes one instance of the same root pattern - one decision made by
+divergent code - surfaced in the sibling audit.
+
+## Steps
+
+### Phase `P01` - Single comparator for content integrity
+
+Rebuild collect_content_integrity as a view over the canonical sync renderer: compare expected rendered content to the destination and emit DIVERGED on mismatch, restoring conformance to the ambiguous-states resolver ADR.
+
+- [x] `P01.S01` - Extract a shared expected-content renderer the collector can call without writing, reusing the apply_file_sync rendering path; `src/vaultspec_core/core/sync.py`.
+- [x] `P01.S02` - Rebuild collect_content_integrity to compare rendered expected content to destination, emitting DIVERGED on mismatch and CLEAN on match; `src/vaultspec_core/core/diagnosis/collectors.py`.
+- [x] `P01.S03` - Wire DIVERGED through the doctor presentation and exit-code mapping so content drift is reported; `src/vaultspec_core/cli/spec_cmd.py`.
+- [x] `P01.S04` - Add a real-workspace test asserting doctor and sync agree on a content-drifted provider file; `src/vaultspec_core/tests/cli/`.
+
+### Phase `P02` - Orphan-snapshot pruning owner
+
+Give orphan-snapshot pruning a single owner in the snapshot module so retiring a builtin returns builtin_version to clean and the snapshot tree tracks the live builtin set.
+
+- [x] `P02.S05` - Add prune_orphan_snapshots to the snapshot module removing snapshots whose live builtin no longer exists; `src/vaultspec_core/core/revert.py`.
+- [x] `P02.S06` - Invoke orphan pruning from the install snapshot refresh path so builtin_version recovers; `src/vaultspec_core/core/commands.py`.
+- [x] `P02.S07` - Add a test retiring a builtin and asserting builtin_version returns to clean after prune; `src/vaultspec_core/tests/cli/`.
+
+### Phase `P03` - Centralise provider-file registry
+
+Make one registry the shared source of truth for files that may live in a provider directory, read by both the MCP writer and the doctor foreign-file detector; cover mcp_config.json and its lock sibling.
+
+- [x] `P03.S08` - Read the shared ToolConfig mcp_config_file in the foreign-file detector and accept lock byproducts; `src/vaultspec_core/core/diagnosis/collectors.py`.
+- [x] `P03.S09` - Add a test asserting a freshly synced antigravity provider dir is COMPLETE not MIXED; `src/vaultspec_core/tests/cli/`.
+
+### Phase `P04` - Per-file install dry-run granularity
+
+Bring install --dry-run to the same per-file granularity as sync so the preview no longer understates provider blast radius.
+
+- [x] `P04.S10` - Render install --dry-run provider work per file via the sync sources instead of per directory; `src/vaultspec_core/core/commands.py`.
+- [x] `P04.S11` - Add a test asserting install --dry-run lists individual provider files; `src/vaultspec_core/tests/cli/`.
+
+## Parallelization
+
+P01 through P04 are independent; each is self-contained with its own real-workspace test
+and was executed in sequence.
+
+## Verification
+
+Full unit gate green (1558 passed), spec doctor clean, lint suite and vault check all
+green.

--- a/.vault/research/2026-06-28-diagnosis-surface-parity-research.md
+++ b/.vault/research/2026-06-28-diagnosis-surface-parity-research.md
@@ -1,0 +1,45 @@
+---
+tags:
+  - '#research'
+  - '#diagnosis-surface-parity'
+date: '2026-06-28'
+modified: '2026-06-28'
+related: []
+---
+
+# `diagnosis-surface-parity` research: `mapping the install/sync/doctor parity surfaces`
+
+A RAG-led, rg-confirmed sweep of every surface that decides whether a provider artifact
+matches its source, undertaken to root-cause an observed contradiction between `spec doctor` and `sync`. The question driving it: how many independent bodies of code answer
+"is this provider file in sync with its source", and where do they disagree.
+
+## Findings
+
+### One canonical comparator, three divergent readers
+
+The add/update/unchanged decision has a single documented home: `apply_file_sync` in
+`src/vaultspec_core/core/sync.py`, which compares the full rendered content byte-for-byte.
+Two further surfaces compare content correctly through their own readers - `check_outdated`
+in `builtins/__init__.py` and `list_modified_builtins` in `core/revert.py` - but the
+doctor's `collect_content_integrity` in `core/diagnosis/collectors.py` was the outlier:
+it compared filenames only and never read content. That is the direct cause of the
+`spec doctor` says CLEAN / `sync` says UPDATE contradiction on `vaultspec-rag.builtin.md`.
+
+### The intended design already existed
+
+The ambiguous-states resolver ADR specified that content integrity reuse the sync
+infrastructure and SHA-256 compare expected transformed output against the actual
+destination, and the `ContentSignal` enum already carries a `DIVERGED` value for "file
+differs from expected content". The shipped collector never emitted `DIVERGED`, so the
+state was dead and content drift was structurally invisible. The fix is a restoration of
+the ADR, not a new design: route the doctor through `apply_file_sync` in dry-run.
+
+### The same pattern recurs
+
+The sweep surfaced sibling instances of one root pattern - the same decision made by
+divergent code: orphan snapshots that no surface prunes (so `builtin_version` reports
+`DELETED` forever); a provider-file registry split between the MCP writer (`core/mcps.py`)
+and the doctor's foreign-file detector; an `install --dry-run` preview rendered at
+directory granularity while `sync --dry-run` renders per file; and the add/update decision
+re-implemented inline by codex agent sync and MCP sync. Each is detailed in the sibling
+audit; the codebase-wide hunt for the remainder is tracked in the sweep plan.

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -169,7 +169,8 @@ def _scaffold_provider(
         Deduplicated list of ``(relative_path, label)`` tuples, one per
         directory or file created (or that would be created).
     """
-    cfg = _t.get_context().tool_configs.get(tool)
+    ctx = _t.get_context()
+    cfg = ctx.tool_configs.get(tool)
     if cfg is None:
         return []
 
@@ -183,20 +184,46 @@ def _scaffold_provider(
             seen_rels.add(rel)
             created.append((rel, f"{label} ({sublabel})"))
 
+    def _add_dir_or_files(
+        dest_dir: Path, sublabel: str, src_dir: Path | None, *, is_skill: bool = False
+    ) -> None:
+        # The dry-run preview lists the individual files sync would deploy, so it
+        # matches the per-file granularity of ``sync --dry-run`` instead of
+        # understating provider work as a single directory line. Real install
+        # only needs the directory created; file content is deployed by the
+        # subsequent sync pass. Sources are read read-only (no flattening side
+        # effect). When sources are absent (a true fresh install before the
+        # builtins are seeded) the directory line is the honest preview.
+        names: list[str] = []
+        if dry_run and src_dir is not None and src_dir.is_dir():
+            if is_skill:
+                names = sorted(
+                    p.name
+                    for p in src_dir.iterdir()
+                    if p.is_dir() and (p / "SKILL.md").exists()
+                )
+            else:
+                names = sorted(p.name for p in src_dir.glob("*.md"))
+        if names:
+            for name in names:
+                _add(_rel(target, dest_dir / name), sublabel)
+        else:
+            _add(_rel(target, dest_dir), sublabel)
+
     if ProviderCapability.RULES in caps and cfg.rules_dir:
         if not dry_run:
             ensure_dir(cfg.rules_dir)
-        _add(_rel(target, cfg.rules_dir), "rules")
+        _add_dir_or_files(cfg.rules_dir, "rules", ctx.rules_src_dir)
 
     if ProviderCapability.SKILLS in caps and cfg.skills_dir:
         if not dry_run:
             ensure_dir(cfg.skills_dir)
-        _add(_rel(target, cfg.skills_dir), "skills")
+        _add_dir_or_files(cfg.skills_dir, "skills", ctx.skills_src_dir, is_skill=True)
 
     if ProviderCapability.AGENTS in caps and cfg.agents_dir:
         if not dry_run:
             ensure_dir(cfg.agents_dir)
-        _add(_rel(target, cfg.agents_dir), "agents")
+        _add_dir_or_files(cfg.agents_dir, "agents", ctx.agents_src_dir)
 
     if ProviderCapability.WORKFLOWS in caps and cfg.workflows_dir:
         if not dry_run:

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -228,6 +228,12 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
         known_paths.add(cfg.native_config_file)
     if cfg.system_file is not None:
         known_paths.add(cfg.system_file)
+    # The provider-native MCP config (e.g. Antigravity's .agents/mcp_config.json)
+    # is written by mcp_sync. Read the same ToolConfig field the writer uses so
+    # the doctor and the writer share one notion of what legitimately lives in a
+    # provider directory, rather than maintaining a divergent hardcoded list.
+    if cfg.mcp_config_file is not None:
+        known_paths.add(cfg.mcp_config_file)
 
     all_present = True
     for d in content_dirs:
@@ -262,6 +268,10 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
         # Host-tool-native files (e.g. Claude Code's settings.local.json) are
         # benign and must not classify the directory as MIXED (issue #122).
         if child.is_file() and _is_host_native(tool_value, child.name):
+            continue
+        # Advisory-lock byproducts (e.g. mcp_config.json.lock) are local runtime
+        # artefacts the framework itself writes; they are not foreign content.
+        if child.is_file() and child.name.endswith(".lock"):
             continue
         # If we reach here, the child is not a known resource
         has_foreign = True
@@ -521,8 +531,11 @@ def collect_content_integrity(tool_value: str) -> dict[str, ContentSignal]:
         :class:`~vaultspec_core.core.diagnosis.signals.ContentSignal`.
     """
     from ..enums import Tool
+    from ..helpers import collect_md_resources
+    from ..rules import transform_rule
+    from ..sync import apply_file_sync
     from ..system import SYSTEM_BUILTIN_RULE
-    from ..types import get_context
+    from ..types import SyncResult, get_context
 
     tool = Tool(tool_value)
     result: dict[str, ContentSignal] = {}
@@ -539,36 +552,51 @@ def collect_content_integrity(tool_value: str) -> dict[str, ContentSignal]:
     dest_dir = cfg.rules_dir
     source_dir = ctx.rules_src_dir
 
-    # Provider rule directories are flat: nesting is not supported and sync
-    # sanitizes it (custom rules authored under ``rules/project/`` are
-    # flattened into the provider root, the ``project/`` prefix stripped). So
-    # the destination is globbed flat. The source is globbed recursively only
-    # to discover those project-authored sources by basename - the same
-    # basename the flattened destination carries - so a custom project rule is
-    # matched against its flat deployment and reported clean, not stale (#153).
+    # Content integrity is decided by the same comparator sync uses, not by
+    # filename presence. The ambiguous-states resolver ADR specified that this
+    # collector reuse the sync infrastructure and compare expected transformed
+    # output against the actual destination; a prior name-only implementation
+    # drifted from that, reporting a content-drifted file as CLEAN while sync
+    # would rewrite it. We render each managed rule through the same
+    # ``transform_rule`` the sync engine applies, then route it through
+    # ``apply_file_sync`` in dry-run mode (no write) so the doctor's verdict and
+    # sync's verdict come from one decision. Content drift now surfaces as
+    # DIVERGED instead of a false CLEAN.
+    #
+    # Source rules are globbed read-only and reduced to their flat basename -
+    # the same name the flat provider deployment carries. The recursive glob in
+    # ``collect_md_resources`` discovers any project-authored source one level
+    # down (#153) without the flattening side effect of ``collect_rules`` (the
+    # doctor must not mutate the source tree).
+    expected: dict[str, str] = {}
+    if source_dir.is_dir():
+        raw_sources = collect_md_resources(source_dir)
+        for key, (_src_path, meta, body) in raw_sources.items():
+            name = key.replace("\\", "/").rsplit("/", 1)[-1]
+            expected[name] = transform_rule(tool, name, meta, body)
+
     dest_files: set[str] = set()
     if dest_dir.is_dir():
         dest_files = {f.name for f in dest_dir.glob("*.md")}
 
-    # Collect files from source (recursive: project-authored rules live one
-    # level down, but only their basename matters for the flat comparison).
-    source_files: set[str] = set()
-    if source_dir.is_dir():
-        source_files = {f.name for f in source_dir.glob("**/*.md")}
+    # Files with a source: dry-run the canonical comparator and map its action.
+    # [UNCHANGED] -> CLEAN, [UPDATE] -> DIVERGED, [ADD] (dest absent) -> MISSING.
+    for name, content in expected.items():
+        probe = SyncResult()
+        action = apply_file_sync(probe, dest_dir / name, content, dry_run=True)
+        if action == "[UNCHANGED]":
+            result[name] = ContentSignal.CLEAN
+        elif action == "[ADD]":
+            result[name] = ContentSignal.MISSING
+        else:  # [UPDATE]
+            result[name] = ContentSignal.DIVERGED
 
-    # Files in both
-    for name in dest_files & source_files:
-        result[name] = ContentSignal.CLEAN
-
-    # Files only in destination
-    for name in dest_files - source_files:
+    # Files only in destination: an orphan with no source (e.g. a retired
+    # builtin's leftover deployment). The synthesized system rule has no source.
+    for name in dest_files - set(expected):
         if name == SYSTEM_BUILTIN_RULE:
             continue  # Synthesized by system_sync(), not sourced
         result[name] = ContentSignal.STALE
-
-    # Files only in source
-    for name in source_files - dest_files:
-        result[name] = ContentSignal.MISSING
 
     return result
 

--- a/src/vaultspec_core/core/revert.py
+++ b/src/vaultspec_core/core/revert.py
@@ -65,7 +65,59 @@ def snapshot_builtins(vaultspec_dir: Path) -> int:
         count += 1
         logger.debug("Snapshotted %s", rel)
 
+    # A snapshot refresh is copy-current plus prune-orphans: a builtin retired
+    # from the framework must not leave a snapshot behind, or list_modified_builtins
+    # reports it ``missing`` forever and builtin_version stays DELETED.
+    prune_orphan_snapshots(vaultspec_dir)
+
     return count
+
+
+def prune_orphan_snapshots(vaultspec_dir: Path) -> int:
+    """Remove snapshots whose live builtin no longer exists under *vaultspec_dir*.
+
+    When a builtin is retired from the framework its install-time snapshot is
+    left behind. That makes :func:`list_modified_builtins` report the snapshot as
+    ``missing`` and :func:`collect_builtin_version_state` return ``DELETED``
+    permanently, with no in-workspace remedy. Pruning the orphan snapshot
+    restores a clean version state and keeps the snapshot tree tracking the live
+    builtin set. Now-empty snapshot subdirectories are removed afterwards.
+
+    Args:
+        vaultspec_dir: The ``.vaultspec`` directory.
+
+    Returns:
+        Number of orphan snapshot files removed.
+    """
+    snapshot_dir = vaultspec_dir / _SNAPSHOT_DIR
+    if not snapshot_dir.exists():
+        return 0
+
+    removed = 0
+    for snapshot in snapshot_dir.rglob(f"*{_BUILTIN_SUFFIX}"):
+        rel = snapshot.relative_to(snapshot_dir)
+        if (vaultspec_dir / rel).exists():
+            continue
+        try:
+            snapshot.unlink()
+            removed += 1
+            logger.debug("Pruned orphan snapshot %s", rel)
+        except OSError as exc:
+            logger.warning("Failed to prune orphan snapshot %s: %s", rel, exc)
+
+    # Remove now-empty snapshot subdirectories, deepest first.
+    for directory in sorted(
+        (p for p in snapshot_dir.rglob("*") if p.is_dir()),
+        key=lambda p: len(p.parts),
+        reverse=True,
+    ):
+        try:
+            if not any(directory.iterdir()):
+                directory.rmdir()
+        except OSError:
+            pass
+
+    return removed
 
 
 def get_snapshot_content(

--- a/src/vaultspec_core/tests/cli/test_collectors.py
+++ b/src/vaultspec_core/tests/cli/test_collectors.py
@@ -293,6 +293,40 @@ class TestProviderDirState:
             == ProviderDirSignal.MISSING
         )
 
+    def test_provider_native_mcp_config_is_not_mixed(
+        self, synthetic_project: Path
+    ) -> None:
+        """A provider-native mcp_config.json (and its .lock) is not foreign.
+
+        The MCP writer deploys mcp_config.json into providers such as
+        Antigravity's .agents/ dir; the doctor must read the same ToolConfig
+        field the writer uses instead of flagging the framework's own artefact
+        as MIXED.
+        """
+        from vaultspec_core.core.types import get_context
+
+        ctx = get_context()
+        tool = next(
+            (
+                t
+                for t, cfg in ctx.tool_configs.items()
+                if cfg.mcp_config_file is not None
+            ),
+            None,
+        )
+        assert tool is not None, "expected a provider with a native MCP config"
+        mcp_path = ctx.tool_configs[tool].mcp_config_file
+        assert mcp_path is not None
+
+        baseline = collect_provider_dir_state(synthetic_project, tool.value)
+        mcp_path.parent.mkdir(parents=True, exist_ok=True)
+        mcp_path.write_text('{"mcpServers": {}}\n', encoding="utf-8")
+        (mcp_path.parent / f"{mcp_path.name}.lock").write_text("", encoding="utf-8")
+
+        after = collect_provider_dir_state(synthetic_project, tool.value)
+        assert after != ProviderDirSignal.MIXED
+        assert after == baseline
+
 
 # ---------------------------------------------------------------------------
 # collect_builtin_version_state
@@ -338,6 +372,34 @@ class TestBuiltinVersionState:
         # No corresponding file in rules/
 
         assert collect_builtin_version_state(tmp_path) == BuiltinVersionSignal.DELETED
+
+    def test_prune_orphan_snapshots_recovers_from_deleted(self, tmp_path: Path) -> None:
+        """Pruning an orphan snapshot returns builtin_version from DELETED to clean.
+
+        A builtin retired from the framework leaves its snapshot behind, which
+        pins builtin_version at DELETED forever. prune_orphan_snapshots removes
+        the snapshot whose live builtin is gone, restoring a clean state.
+        """
+        from vaultspec_core.core.revert import prune_orphan_snapshots
+
+        vs = tmp_path / ".vaultspec"
+        snap = vs / "_snapshots" / "rules"
+        snap.mkdir(parents=True)
+        rules = vs / "rules"
+        rules.mkdir(parents=True)
+
+        # A live builtin (kept) and an orphan snapshot (retired builtin).
+        (snap / "live.builtin.md").write_text("content", encoding="utf-8")
+        (rules / "live.builtin.md").write_text("content", encoding="utf-8")
+        (snap / "retired.builtin.md").write_text("gone", encoding="utf-8")
+
+        assert collect_builtin_version_state(tmp_path) == BuiltinVersionSignal.DELETED
+
+        removed = prune_orphan_snapshots(vs)
+        assert removed == 1
+        assert not (snap / "retired.builtin.md").exists()
+        assert (snap / "live.builtin.md").exists()
+        assert collect_builtin_version_state(tmp_path) == BuiltinVersionSignal.CURRENT
 
 
 # ---------------------------------------------------------------------------
@@ -480,6 +542,7 @@ class TestContentIntegrity:
         deployment and report CLEAN, rather than flagging the source as
         STALE/MISSING because the destination has no ``project/`` subdir.
         """
+        from vaultspec_core.core.rules import rules_sync
         from vaultspec_core.core.types import get_context
 
         ctx = get_context()
@@ -491,13 +554,48 @@ class TestContentIntegrity:
         src_rule.parent.mkdir(parents=True, exist_ok=True)
         src_rule.write_text("# custom rule\n", encoding="utf-8")
 
-        # Destination: flattened into the provider rules root (what sync emits).
-        dest_rule = cfg.rules_dir / "custom-rule.md"
-        dest_rule.parent.mkdir(parents=True, exist_ok=True)
-        dest_rule.write_text("# custom rule\n", encoding="utf-8")
+        # Deploy through the real sync path (which flattens the nesting and
+        # writes the transformed content) rather than hand-writing raw bytes:
+        # content integrity now compares rendered content, so the destination
+        # must hold what sync actually emits to read CLEAN.
+        rules_sync()
 
         result = collect_content_integrity("claude")
         assert result["custom-rule.md"] == ContentSignal.CLEAN
+
+    def test_content_drift_reports_diverged_and_agrees_with_sync(
+        self, synthetic_project: Path
+    ) -> None:
+        """A content-drifted deployed rule reads DIVERGED, and sync would update it.
+
+        Regression for the install/sync/doctor disagreement: the prior
+        name-only check reported a content-drifted file as CLEAN while sync
+        would rewrite it. The collector now routes through the same comparator
+        sync uses, so the two surfaces agree.
+        """
+        from vaultspec_core.core.rules import rules_sync
+        from vaultspec_core.core.types import get_context
+
+        ctx = get_context()
+        cfg = ctx.tool_configs.get(Tool.CLAUDE)
+        assert cfg is not None and cfg.rules_dir is not None
+
+        # A real, synced builtin rule whose deployed copy we corrupt in place.
+        target = cfg.rules_dir / "vaultspec.builtin.md"
+        assert target.exists()
+        target.write_text("# drifted content not matching source\n", encoding="utf-8")
+
+        # Doctor: the file is DIVERGED, not a false CLEAN.
+        result = collect_content_integrity("claude")
+        assert result["vaultspec.builtin.md"] == ContentSignal.DIVERGED
+
+        # Sync: claude's copy of the same file is queued for [UPDATE]. The two
+        # surfaces agree. (Other providers share the basename but were not
+        # drifted, so match on the exact claude destination path.)
+        sync_result = rules_sync(dry_run=True)
+        target_str = str(target).replace("\\", "/")
+        claude_actions = [a for p, a in sync_result.items if p == target_str]
+        assert claude_actions == ["[UPDATE]"]
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaultspec_core/tests/cli/test_install.py
+++ b/src/vaultspec_core/tests/cli/test_install.py
@@ -55,6 +55,21 @@ class TestInstallDryRun:
         assert result.exit_code == 0
         assert len(result.output.strip()) > 0
 
+    def test_dry_run_lists_individual_provider_files(self, synthetic_project, runner):
+        """On an installed workspace, the preview lists provider files, not just dirs.
+
+        Regression for the sparse install --dry-run output: provider work was
+        previewed at directory granularity (a single ``claude (rules)`` line)
+        while sync previewed per file. The preview now enumerates the files
+        sync would deploy, matching sync's granularity.
+        """
+        result = runner.invoke(
+            app, ["-t", str(synthetic_project), "install", "--force", "--dry-run"]
+        )
+        assert result.exit_code == 0, result.output
+        # An individual builtin rule file appears, not only the directory line.
+        assert "vaultspec-cli.builtin.md" in result.output
+
 
 class TestInstallPathSafety:
     def test_deep_nonexistent_path_rejected(self, tmp_path, runner):


### PR DESCRIPTION
## Why

`spec doctor` and `sync` disagreed: the doctor reported a content-drifted provider rule (`vaultspec-rag.builtin.md`) as **clean** while `sync` would rewrite it; the doctor also reported `builtins error deleted` and `antigravity mixed` on a freshly reinstalled workspace. Root cause: the same decision - "is this provider file in sync with its source" - is made by divergent bodies of code, and the copies drifted.

Grounded in `.vault/`: research, audit, and ADR (`diagnosis-surface-parity`). The ambiguous-states resolver ADR already specified the intended design; the doctor's check had regressed to a name-only comparison.

## What

- **Content integrity (root fix):** `collect_content_integrity` now renders each managed rule through `transform_rule` and routes it through `apply_file_sync` in dry-run, so doctor and sync share one comparator. The dormant `DIVERGED` signal goes live.
- **Orphan snapshots:** `prune_orphan_snapshots` gives the snapshot lifecycle an owner; retiring a builtin no longer pins `builtin_version` at `DELETED`.
- **Provider-file registry:** the foreign-file detector reads the same `ToolConfig.mcp_config_file` the MCP writer uses (and ignores `.lock` byproducts), so a framework-written `mcp_config.json` no longer marks antigravity `MIXED`.
- **Install dry-run:** previews provider work per file, matching `sync --dry-run`.

## Tests

Real-workspace, zero-mock tests for each fix. Full unit gate green (1558 passed), spec doctor / lint / vault check all clean.

## Follow-up

The codebase-wide hunt for the same drift/shadowing/centralisation pattern is tracked as a separate plan-tracked sweep (`codebase-drift-sweep`).