### PR TITLE
refactor(core): codebase drift sweep — single-source provider vocabulary, own MCP config

### DIFF
--- a/.vault/audit/2026-06-28-codebase-drift-sweep-audit.md
+++ b/.vault/audit/2026-06-28-codebase-drift-sweep-audit.md
@@ -1,0 +1,112 @@
+---
+tags:
+  - '#audit'
+  - '#codebase-drift-sweep'
+date: '2026-06-28'
+modified: '2026-06-28'
+related:
+  - "[[2026-06-28-codebase-drift-sweep-plan]]"
+  - "[[2026-06-28-diagnosis-surface-parity-audit]]"
+---
+
+# `codebase-drift-sweep` audit: `codebase drift sweep: findings and dispositions`
+
+## Scope
+
+A codebase-wide sweep for the root pattern the diagnosis-surface-parity audit exposed -
+the same decision made by divergent bodies of code, which drift into contradiction. Five
+parallel RAG-led, rg-confirmed discovery passes covered the plan's five phases: decision
+logic duplication, source-of-truth registry duplication, lifecycle ownership gaps,
+preview-versus-apply parity, and version/tooling shadowing. This document records every
+confirmed finding and its disposition (fixed now, deferred, different-by-design, or
+guarded). The discovery agents were instructed to be exhaustive; the triage judgment -
+which flagged items are genuine duplications worth collapsing versus legitimately distinct
+operations - is the substance here.
+
+## Findings
+
+### registry-provider-vocabulary | medium | provider sets and the provider-to-tool map were hand-listed in three places
+
+`VALID_PROVIDERS`, `SYNC_PROVIDERS`, and `_PROVIDER_TO_TOOLS` in
+`src/vaultspec_core/core/commands.py` each independently enumerated the provider names, and
+`src/vaultspec_core/cli/spec_cmd.py` re-derived the provider-to-tool mapping with a fourth
+hand-written if/elif chain. Adding a provider meant editing four sites; missing one would
+silently desync install, sync, and the doctor's provider filter. FIXED:
+`_PROVIDER_TO_TOOLS` now derives its per-tool entries from the `Tool` enum, `VALID_PROVIDERS`
+and `SYNC_PROVIDERS` derive from that map, and the CLI filter reads the same map. One source
+of truth; a registry-consistency test guards the derivation.
+
+### lifecycle-mcp-config-unowned | medium | the provider-native MCP config was not claimed by artifact collection
+
+`_collect_provider_artifacts` in `src/vaultspec_core/core/gitignore.py` claimed each
+provider's directory and config file but not its `mcp_config_file` (e.g. Antigravity's
+`.agents/mcp_config.json`), which `mcp_sync` writes. It survived only because that file
+happens to sit under a directory removed wholesale on uninstall - fragile for any future
+provider whose MCP config lives elsewhere. FIXED: the collector now appends
+`cfg.mcp_config_file`, so per-provider uninstall and gitignore reconciliation own it
+explicitly. This also closes the writer/checker split the diagnosis-surface-parity audit
+flagged.
+
+### decision-logic-mostly-distinct | low | the flagged sync-decision duplications are legitimately different operations, not the canonical-comparator violation
+
+The P01 sweep flagged `_sync_codex_agents` (`core/agents.py`), `_sync_managed_md` /
+`_sync_managed_toml` (`core/config_gen.py`), `_apply_mcp_merge` (`core/mcps.py`),
+`_sync_supporting_files` (`core/sync.py`), and the provider-hooks dual-file writer as
+re-implementing the add/update decision. On inspection these are not the bug the
+diagnosis-surface-parity audit was about. Each performs an operation `apply_file_sync` does
+not: managed-block upsert that preserves user content outside the block (config_gen, codex),
+per-entry JSON merge with ownership tracking (mcp), byte-copy of supporting assets with no
+per-file action reporting (supporting files), and coordinated native+sidecar writes
+(provider hooks). Their only overlap with the canonical comparator is a small
+compare-and-write tail; folding it would require signature changes and action-label
+normalisation for low correctness payoff. The one genuine canonical-comparator violation -
+the doctor's name-only content check - was already fixed in the diagnosis-surface-parity
+work. DISPOSITION: different-by-design; left as-is. If a shared compare-and-write tail
+helper is later extracted, it should normalise the `[UPDT]`/`[SKIP]` labels config_gen
+emits to the canonical `[UPDATE]`/`[UNCHANGED]` vocabulary.
+
+### lifecycle-mcp-prune-conservative | low | stale managed MCP entries are pruned only under --force
+
+`_apply_mcp_merge` prunes managed entries whose source file was removed only when
+`prune=True` (wired to `--force`), so retiring a builtin MCP definition leaves its
+`_vaultspecManaged` entry in `.mcp.json` until a forced sync. Unlike the snapshot prune
+(now unconditional), this is a deliberate conservative default on a file that can carry
+user-authored entries. DISPOSITION: deferred - changing the default to prune managed-only
+orphans is a policy decision worth its own ADR, not folded into this sweep.
+
+### parity-clean | low | every destructive verb's dry-run faithfully matches its apply
+
+The P04 sweep checked every `--dry-run` verb (install, upgrade, sync, uninstall, vault
+feature archive/unarchive/rename, plan mutators, vault add, link add/remove, rule promote,
+mcp sync) and found no preview/apply parity defects: no verb writes during dry-run, item
+sets and granularity match, and no apply-only branch is skipped in preview. The install
+directory-versus-file granularity defect was already fixed in the diagnosis-surface-parity
+work. The only nit: `rule promote` always reports "created" even when `--force` overwrites
+an existing rule - a cosmetic status-label inaccuracy, not a parity defect. DISPOSITION:
+class is clean; the rule-promote label nit is noted, not fixed here.
+
+### shadowing-guarded-or-environmental | low | the shadowing surfaces are already guarded or are environment issues
+
+The P05 sweep found the deployed-copy-versus-source surfaces mostly guarded: the generated
+CLI reference is gated by `spec reference generate --check` plus a byte-fidelity test; the
+builtins mirror has `check_outdated` drift detection; the template legacy-filename fallback
+is a scheduled-for-removal grace path with a runtime warning. Two residual items: templates
+participate in `check_outdated` but not the `.builtin.md` snapshot/revert mechanism (an
+asymmetry, not a live bug), and a stale global `vaultspec-core` binary on `PATH` can shadow
+the editable source - an environment issue, not source-fixable, whose remedy is the
+canonical `uv run --no-sync vaultspec-core` invocation. DISPOSITION: guarded / doc-only; no
+code change warranted.
+
+## Recommendations
+
+- Keep the provider vocabulary single-sourced: any new provider is added to the `Tool` enum
+  and flows to `_PROVIDER_TO_TOOLS`, `VALID_PROVIDERS`, `SYNC_PROVIDERS`, and the CLI filter
+  automatically; the consistency test fails loudly if a fourth copy reappears.
+
+- If the conservative managed-MCP prune default is revisited, do it through an ADR that
+  weighs orphan accumulation against the risk to user-authored `.mcp.json` entries.
+
+- Treat the decision-logic finding as the campaign's main lesson: "the same decision in two
+  places" is only a defect when the surrounding operation is the same. The doctor was; the
+  upsert/merge/dual-file writers are not. Future sweeps should triage on operation identity,
+  not surface similarity.

--- a/.vault/index/codebase-drift-sweep.index.md
+++ b/.vault/index/codebase-drift-sweep.index.md
@@ -6,6 +6,7 @@ tags:
 date: '2026-06-28'
 modified: '2026-06-28'
 related:
+  - '[[2026-06-28-codebase-drift-sweep-audit]]'
   - '[[2026-06-28-codebase-drift-sweep-plan]]'
 ---
 
@@ -14,6 +15,10 @@ related:
 Auto-generated index of all documents tagged with `#codebase-drift-sweep`.
 
 ## Documents
+
+### audit
+
+- `2026-06-28-codebase-drift-sweep-audit` - `codebase-drift-sweep` audit: `codebase drift sweep: findings and dispositions`
 
 ### plan
 

--- a/.vault/plan/2026-06-28-codebase-drift-sweep-plan.md
+++ b/.vault/plan/2026-06-28-codebase-drift-sweep-plan.md
@@ -25,36 +25,36 @@ and collapses confirmed duplications onto one source of truth.
 
 RAG and rg sweep for the add/update/freshness/comparison decision re-implemented outside the canonical apply_file_sync (codex agent sync and MCP sync are the seed instances from the audit), then fold each onto the canonical comparator.
 
-- [ ] `P01.S01` - Sweep for content and freshness comparisons re-implemented outside apply_file_sync and record each site; `src/vaultspec_core/core/`.
-- [ ] `P01.S02` - Fold confirmed duplications onto the canonical comparator or one shared helper, with tests; `src/vaultspec_core/core/sync.py`.
+- [x] `P01.S01` - Sweep for content and freshness comparisons re-implemented outside apply_file_sync and record each site; `src/vaultspec_core/core/`.
+- [x] `P01.S02` - Fold confirmed duplications onto the canonical comparator or one shared helper, with tests; `src/vaultspec_core/core/sync.py`.
 
 ### Phase `P02` - Source-of-truth registry duplication
 
 Hunt for registries and resolvers maintained in more than one place (host-native file lists, provider-file sets, path resolution, template-name maps) where a writer and a checker can disagree.
 
-- [ ] `P02.S03` - Sweep for registries and resolvers maintained in more than one place and record each writer-checker pair; `src/vaultspec_core/core/`.
-- [ ] `P02.S04` - Collapse each confirmed duplicate registry to one source of truth, with tests; `src/vaultspec_core/core/`.
+- [x] `P02.S03` - Sweep for registries and resolvers maintained in more than one place and record each writer-checker pair; `src/vaultspec_core/core/`.
+- [x] `P02.S04` - Collapse each confirmed duplicate registry to one source of truth, with tests; `src/vaultspec_core/core/`.
 
 ### Phase `P03` - Lifecycle ownership gaps
 
 Find artefacts created but never pruned or reconciled (the orphan-snapshot class): snapshots, manifests, generated provider files, lock files, caches, each needing a single prune or reconcile owner.
 
-- [ ] `P03.S05` - Sweep for created-but-never-reconciled artefacts and record each lifecycle gap with its missing owner; `src/vaultspec_core/core/`.
-- [ ] `P03.S06` - Assign each confirmed gap a single prune or reconcile owner, with tests; `src/vaultspec_core/core/`.
+- [x] `P03.S05` - Sweep for created-but-never-reconciled artefacts and record each lifecycle gap with its missing owner; `src/vaultspec_core/core/`.
+- [x] `P03.S06` - Assign each confirmed gap a single prune or reconcile owner, with tests; `src/vaultspec_core/core/`.
 
 ### Phase `P04` - Preview vs apply parity
 
 Audit every destructive verb for dry-run and apply granularity and outcome parity (install versus sync was the seed); a preview that understates or misreports the apply is a finding.
 
-- [ ] `P04.S07` - Audit every destructive verb for dry-run and apply parity and record mismatches; `src/vaultspec_core/cli/`.
-- [ ] `P04.S08` - Bring confirmed previews to apply-faithful granularity, with tests; `src/vaultspec_core/cli/`.
+- [x] `P04.S07` - Audit every destructive verb for dry-run and apply parity and record mismatches; `src/vaultspec_core/cli/`.
+- [x] `P04.S08` - Bring confirmed previews to apply-faithful granularity, with tests; `src/vaultspec_core/cli/`.
 
 ### Phase `P05` - Version and tooling shadowing
 
 Sweep for shadowing where two resolvable copies disagree: stale global binary versus editable source, deployed template mirror versus package source, generated reference versus live surface.
 
-- [ ] `P05.S09` - Sweep for shadowing between resolvable copies and record each; `src/vaultspec_core/`.
-- [ ] `P05.S10` - Document the canonical invocation and add cheap drift guards where warranted, with tests; `src/vaultspec_core/`.
+- [x] `P05.S09` - Sweep for shadowing between resolvable copies and record each; `src/vaultspec_core/`.
+- [x] `P05.S10` - Document the canonical invocation and add cheap drift guards where warranted, with tests; `src/vaultspec_core/`.
 
 ## Parallelization
 

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -117,15 +117,12 @@ def _apply_provider_filter(provider: str) -> None:
         )
         raise typer.Exit(code=1)
 
-    requested: set[Tool] = set()
-    if provider == "claude":
-        requested = {Tool.CLAUDE}
-    elif provider == "gemini":
-        requested = {Tool.GEMINI}
-    elif provider == "antigravity":
-        requested = {Tool.ANTIGRAVITY}
-    elif provider == "codex":
-        requested = {Tool.CODEX}
+    # Reuse the single provider-to-tool map rather than re-deriving it here, so
+    # the CLI filter cannot drift from the install/sync mapping. "all" is handled
+    # by the early return above; "core" never reaches here (not in SYNC_PROVIDERS).
+    from vaultspec_core.core.commands import _PROVIDER_TO_TOOLS
+
+    requested: set[Tool] = set(_PROVIDER_TO_TOOLS.get(provider, []))
 
     narrowed = {k: v for k, v in ctx.tool_configs.items() if k in requested}
     set_context(replace(ctx, tool_configs=narrowed))

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -86,18 +86,17 @@ def _fresh_install_schema_version() -> str:
     return max(candidates, key=parse_version_tuple)
 
 
-# Valid provider arguments for install/uninstall commands.
-VALID_PROVIDERS = {"all", "core", "claude", "gemini", "antigravity", "codex"}
+# Map provider argument names to Tool enum members. The per-tool entries derive
+# from the Tool enum so adding a provider is a single-site change; "all" selects
+# every tool and "core" selects none (framework-only). VALID_PROVIDERS and
+# SYNC_PROVIDERS are derived from this map so the provider vocabulary has one
+# source of truth.
+_PROVIDER_TO_TOOLS: dict[str, list[Tool]] = {t.value: [t] for t in Tool}
+_PROVIDER_TO_TOOLS["all"] = list(Tool)
+_PROVIDER_TO_TOOLS["core"] = []
 
-# Map provider argument names to Tool enum members.
-_PROVIDER_TO_TOOLS: dict[str, list[Tool]] = {
-    "claude": [Tool.CLAUDE],
-    "gemini": [Tool.GEMINI],
-    "antigravity": [Tool.ANTIGRAVITY],
-    "codex": [Tool.CODEX],
-    "all": [Tool.CLAUDE, Tool.GEMINI, Tool.ANTIGRAVITY, Tool.CODEX],
-    "core": [],
-}
+# Valid provider arguments for install/uninstall commands (every selector).
+VALID_PROVIDERS = set(_PROVIDER_TO_TOOLS)
 
 
 def _rel(target: Path, p: Path) -> str:
@@ -1559,7 +1558,7 @@ def hooks_run(event: str, path: str | None = None) -> list[dict[str, Any]]:
 
 
 # Valid sync provider targets exposed to the CLI.
-SYNC_PROVIDERS = {"all", "claude", "gemini", "antigravity", "codex"}
+SYNC_PROVIDERS = VALID_PROVIDERS - {"core"}
 
 
 def sync_provider(

--- a/src/vaultspec_core/core/gitignore.py
+++ b/src/vaultspec_core/core/gitignore.py
@@ -147,6 +147,13 @@ def _collect_provider_artifacts(
     if cfg and cfg.native_config_file and cfg.native_config_file.parent not in dirs:
         dirs.append(cfg.native_config_file.parent)
 
+    # The provider-native MCP config (e.g. .agents/mcp_config.json) is a managed
+    # artefact written by mcp_sync; protect it explicitly so per-provider
+    # uninstall and gitignore reconciliation own it rather than relying on it
+    # happening to sit under a removed provider directory.
+    if cfg and cfg.mcp_config_file and cfg.mcp_config_file not in files:
+        files.append(cfg.mcp_config_file)
+
     return dirs, files
 
 

--- a/src/vaultspec_core/tests/cli/test_gitignore.py
+++ b/src/vaultspec_core/tests/cli/test_gitignore.py
@@ -308,6 +308,39 @@ class TestReadOnlyGitignore:
             gi.chmod(stat.S_IREAD | stat.S_IWRITE)
 
 
+class TestProviderArtifactOwnership:
+    """Provider-native managed artefacts are claimed by artifact collection."""
+
+    def test_mcp_config_file_is_a_collected_provider_artifact(
+        self, synthetic_project: Path
+    ) -> None:
+        """The provider-native mcp_config.json is owned, not orphan-able.
+
+        Lifecycle gap fix: a provider with an mcp_config_file (e.g. Antigravity's
+        .agents/mcp_config.json) must have that file claimed by
+        _collect_provider_artifacts so per-provider uninstall and gitignore
+        reconciliation own it, rather than relying on it sitting under a removed
+        directory.
+        """
+        from vaultspec_core.core.gitignore import _collect_provider_artifacts
+        from vaultspec_core.core.types import get_context
+
+        ctx = get_context()
+        tool = next(
+            (
+                t
+                for t, cfg in ctx.tool_configs.items()
+                if cfg.mcp_config_file is not None
+            ),
+            None,
+        )
+        assert tool is not None, "expected a provider with a native MCP config"
+        mcp_path = ctx.tool_configs[tool].mcp_config_file
+
+        _dirs, files = _collect_provider_artifacts(synthetic_project, tool)
+        assert mcp_path in files
+
+
 class TestRecommendedEntries:
     """Verify .vault/ is not blanket-ignored; only generated subdirs are."""
 

--- a/src/vaultspec_core/tests/cli/test_install.py
+++ b/src/vaultspec_core/tests/cli/test_install.py
@@ -15,6 +15,28 @@ def runner():
     return CliRunner()
 
 
+class TestProviderRegistry:
+    """The provider vocabulary derives from one source (the Tool enum)."""
+
+    def test_provider_sets_derive_from_tool_enum(self):
+        from vaultspec_core.core.commands import (
+            _PROVIDER_TO_TOOLS,
+            SYNC_PROVIDERS,
+            VALID_PROVIDERS,
+        )
+        from vaultspec_core.core.enums import Tool
+
+        # Every tool has a single-tool entry; the aggregate selectors are present.
+        for tool in Tool:
+            assert _PROVIDER_TO_TOOLS[tool.value] == [tool]
+        assert _PROVIDER_TO_TOOLS["all"] == list(Tool)
+        assert _PROVIDER_TO_TOOLS["core"] == []
+
+        # Derived sets stay consistent with the map - no second hand-listed copy.
+        assert set(_PROVIDER_TO_TOOLS) == VALID_PROVIDERS
+        assert VALID_PROVIDERS - {"core"} == SYNC_PROVIDERS
+
+
 class TestInstallForce:
     def test_install_without_force_fails_if_exists(self, tmp_path, runner):
         """Without --force, install must fail if .vaultspec/ exists."""


### PR DESCRIPTION
## Campaign

Executes the `codebase-drift-sweep` plan: five parallel RAG+rg discovery passes hunting the root pattern from the diagnosis-surface-parity work — *the same decision made by divergent bodies of code*. Findings and dispositions are recorded in `.vault/audit/2026-06-28-codebase-drift-sweep-audit.md`; plan is 10/10 steps closed.

## Fixed (confirmed duplications)

- **Provider vocabulary single-sourced.** `_PROVIDER_TO_TOOLS` now derives per-tool entries from the `Tool` enum; `VALID_PROVIDERS` and `SYNC_PROVIDERS` derive from that map; the `spec_cmd` provider filter reads the same map instead of a fourth hand-written if/elif. Adding a provider is now a one-line `Tool` change. Guarded by a registry-consistency test.
- **MCP config artefact owned.** `_collect_provider_artifacts` now claims `cfg.mcp_config_file`, so a provider's native MCP config (e.g. `.agents/mcp_config.json`) is owned by per-provider uninstall and gitignore reconciliation rather than relying on directory removal.

## Triaged as no-change (with rationale in the audit)

- **P01 decision-logic candidates** (codex agent sync, config_gen block-upsert, MCP merge, supporting-file byte-copy, provider-hooks dual-file) are *different-by-design*: their only overlap with `apply_file_sync` is a small compare-write tail, and the one true canonical-comparator violation (the doctor) was already fixed. The campaign's lesson: "same decision in two places" is only a defect when the surrounding operation is the same.
- **P04 preview/apply parity**: clean across every dry-run verb.
- **P05 shadowing**: guarded (CLI-reference `--check`, builtins drift detection) or environmental (stale PATH binary → use `uv run --no-sync`).
- **Deferred (ADR-worthy)**: managed-MCP prune is `--force`-only by design.

## Tests

Zero-mock tests for the registry derivation and the MCP-config ownership. Full unit gate green (1560 passed).