### PR TITLE
chore(vault): close out shipped plans; docs: trailer hook example, framework.md MCP tools

### DIFF
--- a/.vault/plan/2026-06-13-commit-linkage-plan.md
+++ b/.vault/plan/2026-06-13-commit-linkage-plan.md
@@ -3,7 +3,7 @@ tags:
   - '#plan'
   - '#commit-linkage'
 date: '2026-06-13'
-modified: '2026-06-13'
+modified: '2026-07-13'
 tier: L1
 related:
   - '[[2026-06-13-commit-linkage-adr]]'
@@ -12,10 +12,10 @@ related:
 
 # `commit-linkage` plan
 
-- [ ] `S01` - add the trailer module with keys, value regexes, and pure parse, format, and validate helpers; `src/vaultspec_core/plan/trailer.py`.
-- [ ] `S02` - add vault plan trailer emit and validate verbs that always exit zero; `src/vaultspec_core/cli/plan_cmd.py`.
-- [ ] `S03` - document the opt-in commit-msg pre-commit hook and update the bundled reference and docs; `docs/CLI.md`.
-- [ ] `S04` - cover the trailer module and both verbs with tests including malformed-trailer exit-zero; `src/vaultspec_core/tests/plan/test_trailer.py`.
+- [x] `S01` - add the trailer module with keys, value regexes, and pure parse, format, and validate helpers; `src/vaultspec_core/plan/trailer.py`.
+- [x] `S02` - add vault plan trailer emit and validate verbs that always exit zero; `src/vaultspec_core/cli/plan_cmd.py`.
+- [x] `S03` - document the opt-in commit-msg pre-commit hook and update the bundled reference and docs; `docs/CLI.md`.
+- [x] `S04` - cover the trailer module and both verbs with tests including malformed-trailer exit-zero; `src/vaultspec_core/tests/plan/test_trailer.py`.
 
 ## Description
 

--- a/.vault/plan/2026-06-13-status-hardening-plan.md
+++ b/.vault/plan/2026-06-13-status-hardening-plan.md
@@ -3,7 +3,7 @@ tags:
   - '#plan'
   - '#status-hardening'
 date: '2026-06-13'
-modified: '2026-06-13'
+modified: '2026-07-13'
 tier: L3
 related:
   - '[[2026-06-13-status-hardening-adr]]'
@@ -49,16 +49,16 @@ facts the surfaces render, with no new storage or traversal (decisions H2, H3; p
 
 Compute per-wave / per-phase completion and the first-open-step cursor inside the existing pass and carry them through the rollup model.
 
-- [ ] `W01.P01.S01` - expose per-wave and per-phase step membership on the parsed plan model so container completion is derivable without a rescan; `src/vaultspec_core/plan/parser.py`.
-- [ ] `W01.P01.S02` - extend PlanStatus with waves_completed, phases_completed, and next_open_step, computed in collect_status during the batched pass; `src/vaultspec_core/plan/status.py`.
-- [ ] `W01.P01.S03` - add the new fields to status_to_json_dict as an additive contract change; `src/vaultspec_core/plan/status.py`.
-- [ ] `W01.P01.S04` - carry waves_completed, phases_completed, and next_open_step through PlanInFlight and populate them in \_plans_in_flight; `src/vaultspec_core/vaultcore/orientation.py`.
+- [x] `W01.P01.S01` - expose per-wave and per-phase step membership on the parsed plan model so container completion is derivable without a rescan; `src/vaultspec_core/plan/parser.py`.
+- [x] `W01.P01.S02` - extend PlanStatus with waves_completed, phases_completed, and next_open_step, computed in collect_status during the batched pass; `src/vaultspec_core/plan/status.py`.
+- [x] `W01.P01.S03` - add the new fields to status_to_json_dict as an additive contract change; `src/vaultspec_core/plan/status.py`.
+- [x] `W01.P01.S04` - carry waves_completed, phases_completed, and next_open_step through PlanInFlight and populate them in \_plans_in_flight; `src/vaultspec_core/vaultcore/orientation.py`.
 
 ### Phase `W01.P02` - enrichment core tests
 
 Lock the enrichment behaviour against real plans across tiers.
 
-- [ ] `W01.P02.S05` - add factory-based tests for waves_completed, phases_completed, and next_open_step across L1 to L4 plans, including a fully complete plan (next_open_step is None); `src/vaultspec_core/tests/plan/test_status.py`.
+- [x] `W01.P02.S05` - add factory-based tests for waves_completed, phases_completed, and next_open_step across L1 to L4 plans, including a fully complete plan (next_open_step is None); `src/vaultspec_core/tests/plan/test_status.py`.
 
 ## Wave `W02` - status surfaces
 
@@ -69,26 +69,26 @@ check-state and paths, and stop double-counting index documents (decisions H1, H
 
 Promote orientation to `vaultspec-core status` and remove the old nesting.
 
-- [ ] `W02.P03.S06` - register the top-level status [TARGET] command delegating to the orientation core (rollup with no target, grounding trace with a target), with --limit / --since / --json / --no-hints; `src/vaultspec_core/cli/root.py`.
-- [ ] `W02.P03.S07` - remove the vault status command and its registration; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `W02.P03.S06` - register the top-level status [TARGET] command delegating to the orientation core (rollup with no target, grounding trace with a target), with --limit / --since / --json / --no-hints; `src/vaultspec_core/cli/root.py`.
+- [x] `W02.P03.S07` - remove the vault status command and its registration; `src/vaultspec_core/cli/vault_cmd.py`.
 
 ### Phase `W02.P04` - clean plan-line renderer and rollup
 
 Render the one reused clean no-glyph plan line and the recently-completed bucket.
 
-- [ ] `W02.P04.S08` - add a single shared clean plan-line renderer (column-aligned, no glyphs): feature, tier, W c/T, P c/T, k/N steps, percent, next display-path; with the condensed tier k/N percent tail variant; `src/vaultspec_core/cli/rendering.py`.
-- [ ] `W02.P04.S09` - render plans-in-flight rows with the full plan line and active-features rows with the condensed tail; `src/vaultspec_core/cli/vault_cmd.py`.
-- [ ] `W02.P04.S10` - add a recently-completed section (plans at 100% within the recency window, most recent first) and annotate the in-flight section with its open-step criterion; `src/vaultspec_core/vaultcore/orientation.py`.
-- [ ] `W02.P04.S11` - add rollup rendering tests covering the plan line, active-features tail, and recently-completed bucket; `src/vaultspec_core/tests/cli/test_vault_status.py`.
+- [x] `W02.P04.S08` - add a single shared clean plan-line renderer (column-aligned, no glyphs): feature, tier, W c/T, P c/T, k/N steps, percent, next display-path, with the condensed tier k/N percent tail variant; `src/vaultspec_core/cli/rendering.py`.
+- [x] `W02.P04.S09` - render plans-in-flight rows with the full plan line and active-features rows with the condensed tail; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `W02.P04.S10` - add a recently-completed section (plans at 100% within the recency window, most recent first) and annotate the in-flight section with its open-step criterion; `src/vaultspec_core/vaultcore/orientation.py`.
+- [x] `W02.P04.S11` - add rollup rendering tests covering the plan line, active-features tail, and recently-completed bucket; `src/vaultspec_core/tests/cli/test_vault_status.py`.
 
 ### Phase `W02.P05` - targeted trace
 
 Make the trace self-sufficient: check-state, cursor, real paths, no index double-count.
 
-- [ ] `W02.P05.S12` - render the clean plan line as the trace header and show each step row with [x]/[ ] check-state and a cursor on the first open step; `src/vaultspec_core/cli/vault_cmd.py`.
-- [ ] `W02.P05.S13` - add a --paths human mode and a path field beside every stem in the trace JSON (step record paths, summaries, grounding docs), sourced from existing graph nodes without leaking the graph; `src/vaultspec_core/vaultcore/orientation.py`.
-- [ ] `W02.P05.S14` - exclude index documents from the recent-documents grouping, grounding grouping, and any document-count summary so a feature's docs are never double-counted; `src/vaultspec_core/vaultcore/orientation.py`.
-- [ ] `W02.P05.S15` - add trace tests for check-state, the open-step cursor, --paths / JSON paths, and index exclusion; `src/vaultspec_core/tests/cli/test_vault_status.py`.
+- [x] `W02.P05.S12` - render the clean plan line as the trace header and show each step row with [x]/[ ] check-state and a cursor on the first open step; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `W02.P05.S13` - add a --paths human mode and a path field beside every stem in the trace JSON (step record paths, summaries, grounding docs), sourced from existing graph nodes without leaking the graph; `src/vaultspec_core/vaultcore/orientation.py`.
+- [x] `W02.P05.S14` - exclude index documents from the recent-documents grouping, grounding grouping, and any document-count summary so a feature's docs are never double-counted; `src/vaultspec_core/vaultcore/orientation.py`.
+- [x] `W02.P05.S15` - add trace tests for check-state, the open-step cursor, --paths / JSON paths, and index exclusion; `src/vaultspec_core/tests/cli/test_vault_status.py`.
 
 ## Wave `W03` - target resolution and recency hygiene
 
@@ -99,24 +99,24 @@ with a clean error, and bound recency output noise (decisions H6, H9).
 
 One resolver, the orientation verb's near-match error contract.
 
-- [ ] `W03.P06.S16` - add a shared plan-target resolver accepting a literal path, stem, stem.md, feature name, or #feature tag and resolving a handle to the feature's single plan, raising the orientation near-match error (never a raw traceback) on failure; `src/vaultspec_core/cli/_target.py`.
-- [ ] `W03.P06.S17` - add resolver tests for every accepted form plus ambiguous and unknown inputs and their near-match messages; `src/vaultspec_core/tests/cli/test_plan_target.py`.
+- [x] `W03.P06.S16` - add a shared plan-target resolver accepting a literal path, stem, stem.md, feature name, or #feature tag and resolving a handle to the feature's single plan, raising the orientation near-match error (never a raw traceback) on failure; `src/vaultspec_core/cli/_target.py`.
+- [x] `W03.P06.S17` - add resolver tests for every accepted form plus ambiguous and unknown inputs and their near-match messages; `src/vaultspec_core/tests/cli/test_plan_target.py`.
 
 ### Phase `W03.P07` - wire plan commands to the resolver
 
 End the asymmetry: every `vault plan` command accepts what the orientation verb accepts.
 
-- [ ] `W03.P07.S18` - resolve the PATH argument of vault plan status and vault plan check through the shared resolver; `src/vaultspec_core/cli/plan_cmd.py`.
-- [ ] `W03.P07.S19` - resolve the PATH argument of vault plan query through the shared resolver and add a --target option; `src/vaultspec_core/cli/plan_cmd.py`.
-- [ ] `W03.P07.S20` - resolve vault plan step / phase / wave / tier / epic targets and convert resolution failures into the user-facing error contract instead of a swallowed traceback; `src/vaultspec_core/cli/plan_cmd.py`.
-- [ ] `W03.P07.S21` - add tests asserting every vault plan command accepts stem and feature-handle targets and rejects unknown ones cleanly; `src/vaultspec_core/tests/cli/test_plan_target.py`.
+- [x] `W03.P07.S18` - resolve the PATH argument of vault plan status and vault plan check through the shared resolver; `src/vaultspec_core/cli/plan_cmd.py`.
+- [x] `W03.P07.S19` - resolve the PATH argument of vault plan query through the shared resolver and add a --target option; `src/vaultspec_core/cli/plan_cmd.py`.
+- [x] `W03.P07.S20` - resolve vault plan step / phase / wave / tier / epic targets and convert resolution failures into the user-facing error contract instead of a swallowed traceback; `src/vaultspec_core/cli/plan_cmd.py`.
+- [x] `W03.P07.S21` - add tests asserting every vault plan command accepts stem and feature-handle targets and rejects unknown ones cleanly; `src/vaultspec_core/tests/cli/test_plan_target.py`.
 
 ### Phase `W03.P08` - recency hygiene
 
 Make `--limit` honest and stop exec from flooding the view.
 
-- [ ] `W03.P08.S22` - apply --limit uniformly to every document-type group, collapse the exec group to one line per feature by default, and add a --verbose-exec flag to restore per-record rows; `src/vaultspec_core/vaultcore/orientation.py`.
-- [ ] `W03.P08.S23` - add recency tests for the uniform cap, exec collapse, --verbose-exec, and the --since window; `src/vaultspec_core/tests/cli/test_vault_status.py`.
+- [x] `W03.P08.S22` - apply --limit uniformly to every document-type group, collapse the exec group to one line per feature by default, and add a --verbose-exec flag to restore per-record rows; `src/vaultspec_core/vaultcore/orientation.py`.
+- [x] `W03.P08.S23` - add recency tests for the uniform cap, exec collapse, --verbose-exec, and the --since window; `src/vaultspec_core/tests/cli/test_vault_status.py`.
 
 ## Wave `W04` - firmware, reference, secondary gaps, and verification
 
@@ -127,21 +127,21 @@ secondary gaps, and verify the whole surface (decisions H10, H11; firmware-refer
 
 Land the verb's firmware mandate and reference in the same change that ships it.
 
-- [ ] `W04.P09.S24` - rewrite the orient-first mandate to name `vaultspec-core status` and its targeted form; `src/vaultspec_core/builtins/system/03-vaultspec.md`.
-- [ ] `W04.P09.S25` - rewrite the zeroth-move prose and the command table row to the top-level status verb; `src/vaultspec_core/builtins/rules/vaultspec-cli.builtin.md`.
-- [ ] `W04.P09.S26` - regenerate the CLI-owned reference so the status signature and section reflect the top-level verb; `src/vaultspec_core/builtins/reference/cli.md`.
+- [x] `W04.P09.S24` - rewrite the orient-first mandate to name `vaultspec-core status` and its targeted form; `src/vaultspec_core/builtins/system/03-vaultspec.md`.
+- [x] `W04.P09.S25` - rewrite the zeroth-move prose and the command table row to the top-level status verb; `src/vaultspec_core/builtins/rules/vaultspec-cli.builtin.md`.
+- [x] `W04.P09.S26` - regenerate the CLI-owned reference so the status signature and section reflect the top-level verb; `src/vaultspec_core/builtins/reference/cli.md`.
 
 ### Phase `W04.P10` - secondary gaps
 
 Close the testimonial's secondary findings (F7).
 
-- [ ] `W04.P10.S27` - emit a graceful error naming the missing .vaultspec/ directory and suggesting --target or the nearest vault instead of a bare failure; `src/vaultspec_core/cli/_target.py`.
-- [ ] `W04.P10.S28` - add a latest_activity column (human and JSON) and a --stale-days filter to vault feature list; `src/vaultspec_core/cli/vault_cmd.py`.
-- [ ] `W04.P10.S29` - append a !n flag to the plan line when exec_missing_ids is non-empty so checked-but-ungrounded steps are distinct from open steps; `src/vaultspec_core/cli/rendering.py`.
+- [x] `W04.P10.S27` - emit a graceful error naming the missing .vaultspec/ directory and suggesting --target or the nearest vault instead of a bare failure; `src/vaultspec_core/cli/_target.py`.
+- [x] `W04.P10.S28` - add a latest_activity column (human and JSON) and a --stale-days filter to vault feature list; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `W04.P10.S29` - append a !n flag to the plan line when exec_missing_ids is non-empty so checked-but-ungrounded steps are distinct from open steps; `src/vaultspec_core/cli/rendering.py`.
 
 ### Phase `W04.P11` - verification
 
 Migrate the suite to the new verb and prove the surface green.
 
-- [ ] `W04.P11.S30` - migrate all tests and fixtures referencing vault status to the top-level status verb and add a firmware-reference-parity assertion for the verb name; `src/vaultspec_core/tests`.
-- [ ] `W04.P11.S31` - run the full test suite, ty, and prek to green and smoke-test status rollup, targeted trace, and plan-handle resolution end to end; repository root.
+- [x] `W04.P11.S30` - migrate all tests and fixtures referencing vault status to the top-level status verb and add a firmware-reference-parity assertion for the verb name; `src/vaultspec_core/tests`.
+- [x] `W04.P11.S31` - run the full test suite, ty, and prek to green and smoke-test status rollup, targeted trace, and plan-handle resolution end to end; `repository root`.

--- a/.vault/plan/2026-06-13-vault-graph-ref-plan.md
+++ b/.vault/plan/2026-06-13-vault-graph-ref-plan.md
@@ -3,7 +3,7 @@ tags:
   - '#plan'
   - '#vault-graph-ref'
 date: '2026-06-13'
-modified: '2026-06-13'
+modified: '2026-07-13'
 tier: L1
 related:
   - '[[2026-06-13-vault-graph-ref-adr]]'
@@ -12,10 +12,10 @@ related:
 
 # `vault-graph-ref` plan
 
-- [ ] `S01` - add a git blob corpus reader enumerating and reading vault blobs at a ref via subprocess git; `src/vaultspec_core/graph/refscan.py`.
-- [ ] `S02` - add a VaultGraph ref-construction path with cache disabled, migrations skipped, doc-type from the tree path; `src/vaultspec_core/graph/api.py`.
-- [ ] `S03` - add --ref to the graph verb with typed errors and add the ref envelope key; `src/vaultspec_core/cli/vault_cmd.py`.
-- [ ] `S04` - cover the ref path with real-git tests and update the bundled reference and docs; `src/vaultspec_core/tests/cli/test_graph_ref.py`.
+- [x] `S01` - add a git blob corpus reader enumerating and reading vault blobs at a ref via subprocess git; `src/vaultspec_core/graph/refscan.py`.
+- [x] `S02` - add a VaultGraph ref-construction path with cache disabled, migrations skipped, doc-type from the tree path; `src/vaultspec_core/graph/api.py`.
+- [x] `S03` - add --ref to the graph verb with typed errors and add the ref envelope key; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `S04` - cover the ref path with real-git tests and update the bundled reference and docs; `src/vaultspec_core/tests/cli/test_graph_ref.py`.
 
 ## Description
 

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -548,6 +548,13 @@ Tier commands: `tier show`, `tier promote`, `tier demote`. The `promote` command
 `--phase-title`, `--phase-intent`, `--wave-title`, `--wave-intent`, `--epic-intent` for
 synthesized containers. The `demote` command takes `--force`.
 
+Trailer commands: `trailer emit` (takes exactly one of `--step` or `--feature`; prints a
+well-formed `Vaultspec-Step` or `Vaultspec-Feature` commit-linkage trailer line),
+`trailer validate MESSAGE_FILE` (reports malformed trailers in a commit-message file and
+always exits `0`, so it is safe as an opt-in `commit-msg`-stage pre-commit hook). The
+trailer convention is advisory enrichment only: absence or malformation never blocks a
+commit or fails a core command.
+
 ## Spec commands
 
 Signature: `vaultspec-core spec [OPTIONS] COMMAND [ARGS]...`. Framework resource

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1430,6 +1430,56 @@ to a hidden `<!-- RETIRED: ... -->` ledger embedded in the plan body. `next_avai
 consults this ledger so retired identifiers are never reused, even across
 `parse / serialize` round-trips invoked by `--fix`.
 
+#### Trailer commands
+
+- `emit` - Print a well-formed `Vaultspec-Step` or `Vaultspec-Feature` commit-linkage
+  trailer line. Takes exactly one of `--step` (a Step or Phase display path, e.g.
+  `W01.P02.S06` or `P02`) or `--feature` (a kebab-case feature tag, leading `#`
+  optional).
+- `validate` - Validate the commit-linkage trailers found in a commit-message file.
+  Always exits `0`.
+
+The commit-linkage trailer is an opt-in, advisory convention (per the accepted
+`commit-linkage` ADR): a malformed or absent trailer never blocks a commit and never
+fails a core command. `validate` reports each malformed trailer to stderr and always
+exits `0`, which makes it safe to wire up as a `commit-msg`-stage pre-commit hook. Teams
+that want the check add a local hook entry to their `.pre-commit-config.yaml`; teams
+that do not are unaffected:
+
+```yaml
+- repo: local
+  hooks:
+    - id: vaultspec-plan-trailer
+      name: Validate vaultspec commit-linkage trailers
+      language: system
+      stages: [commit-msg]
+      entry: uv run --no-sync vaultspec-core vault plan trailer validate
+```
+
+At the `commit-msg` stage, pre-commit passes the path to the commit-message file (for
+example `.git/COMMIT_EDITMSG`) as the hook's positional argument, which lines up with
+`validate`'s `MESSAGE_FILE` argument - no extra flag is needed.
+
+##### Examples
+
+- **Emit a Step trailer for a commit template**:
+
+  ```bash
+  vaultspec-core vault plan trailer emit --step P02.S06
+  ```
+
+- **Emit a feature trailer**:
+
+  ```bash
+  vaultspec-core vault plan trailer emit --feature commit-linkage
+  ```
+
+- **Validate a commit message file directly**:
+
+  ```bash
+  vaultspec-core vault plan trailer validate .git/COMMIT_EDITMSG
+  ```
+
 ## Spec commands
 
 Group command: `vaultspec-core spec [OPTIONS] COMMAND [ARGS]...`

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -154,9 +154,11 @@ vaultspec-core sync                       # writes .claude/, .gemini/, .codex/, 
 and `vaultspec-core vault graph --feature search-api` visualizes a feature. The CLI
 maintains each document's `modified:` and `date:` stamps; never hand-edit them.
 
-**Connect MCP clients.** `install` scaffolds an `.mcp.json` exposing vault discovery and
-authoring to Model Context Protocol (MCP) clients over stdio. Verify it with
-`vaultspec-core spec mcps status --json`; see the [MCP reference](./MCP.md).
+**Connect MCP clients.** `install` scaffolds an `.mcp.json` exposing the workflow to
+Model Context Protocol (MCP) clients over stdio: nine tools covering orientation,
+discovery, scaffolding, prose edits, checks, and plan progress, plus a gateway to the
+rest of the CLI. Verify the configuration with `vaultspec-core spec mcps status --json`;
+see the [MCP reference](./MCP.md).
 
 ## Related documentation
 

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -548,6 +548,13 @@ Tier commands: `tier show`, `tier promote`, `tier demote`. The `promote` command
 `--phase-title`, `--phase-intent`, `--wave-title`, `--wave-intent`, `--epic-intent` for
 synthesized containers. The `demote` command takes `--force`.
 
+Trailer commands: `trailer emit` (takes exactly one of `--step` or `--feature`; prints a
+well-formed `Vaultspec-Step` or `Vaultspec-Feature` commit-linkage trailer line),
+`trailer validate MESSAGE_FILE` (reports malformed trailers in a commit-message file and
+always exits `0`, so it is safe as an opt-in `commit-msg`-stage pre-commit hook). The
+trailer convention is advisory enrichment only: absence or malformation never blocks a
+commit or fails a core command.
+
 ## Spec commands
 
 Signature: `vaultspec-core spec [OPTIONS] COMMAND [ARGS]...`. Framework resource


### PR DESCRIPTION
## What

- **Plan bookkeeping closeout**: relevance assessment of the three stale in-flight plans (all 2026-06-13, 0 progress) found the work already merged without pipeline bookkeeping - vault-graph-ref (all 4 steps shipped in dc984ffd), status-hardening (all 31 steps shipped via PR #164), commit-linkage S01/S02/S04 (dc984ffd). All steps closed through `vault plan step check`; a mangled backtick in the status-hardening S08 row repaired via `plan step edit`. codebase-drift-sweep verified already complete (10/10, PR #187 + audit).
- **commit-linkage S03 (the one real remnant)**: the ADR's opt-in `commit-msg` pre-commit hook is now documented next to the trailer verbs in docs/CLI.md and the bundled reference (`spec reference generate --check` green).
- **framework.md**: MCP paragraph updated to the nine-tool server (same staleness class fixed in #192).

## Verification

- Unit gate: 1590 passed.
- All prek hooks green on commit (incl. Vault Doctor, CLI-reference generator check).
- `vaultspec-core status` now shows zero plans in flight.