### PR TITLE
fix(core): force managed MCP entry on mode-flip upgrade; declare repo version floor

### DIFF
--- a/.vaultspec/workspace.json
+++ b/.vaultspec/workspace.json
@@ -1,4 +1,5 @@
 {
   "install_mode": "dependency",
+  "minimum_vaultspec_version": "0.1.37",
   "schema_version": "1.0"
 }

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -1221,6 +1221,22 @@ def install_run(
         # floor reconciliation still run once, later, via _persist_resolved_mode.
         _write_mode_declaration(path, resolved_mode)
 
+        # Detect a mode flip before the sync below re-renders any artifact.
+        # The pre-commit and declaration renderers rewrite unconditionally, but
+        # the MCP sync runs force-gated: a pre-existing MANAGED vaultspec-core
+        # entry still carrying the old mode's launch shape is skipped unless
+        # --force, which would leave the migration non-atomic across the three
+        # renderers until a later forced re-sync (mode-flip-force-asymmetry
+        # audit finding). Captured here against the still-old .mcp.json, this
+        # flags whether the deployed MCP launch shape disagrees with the mode
+        # this upgrade resolved to; the targeted force below closes the gap.
+        from .diagnosis.collectors import _observed_mcp_mode
+
+        observed_mcp_mode = _observed_mcp_mode(path)
+        mcp_mode_flipped = (
+            observed_mcp_mode is not None and observed_mcp_mode != resolved_mode
+        )
+
         sync_target = provider if provider not in ("all", "core") else "all"
         # `sync_provider` rejects `core` in its skip set (`allow_core=False`).
         # `install_run` accepts `core` because it skips the framework scaffold;
@@ -1234,6 +1250,23 @@ def install_run(
 
         if "precommit" not in skip:
             _scaffold_precommit(path, mode=resolved_mode)
+
+        # Close the mode-flip force-gate asymmetry: when the mode flipped, the
+        # force-gated MCP pass above skipped the stale managed vaultspec-core
+        # entry. Force just that one managed entry into the new mode's launch
+        # shape so all three renderers migrate atomically in this run. Scoped to
+        # the managed vaultspec-core entry only, so user-owned entries and the
+        # foreign-entry discipline are untouched. Skipped when --force already
+        # rewrote it, when the mode did not flip (preserving today's force-gated
+        # semantics for a same-mode divergent entry), or when mcp sync is
+        # skipped outright.
+        if mcp_mode_flipped and not force and "mcp" not in skip:
+            from .mcps import mcp_sync
+
+            mcp_sync(
+                mode=resolved_mode,
+                force_managed=frozenset({"vaultspec-core"}),
+            )
 
         # Update manifest timestamps and version
         import datetime

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -446,6 +446,7 @@ def _apply_mcp_merge(
     prune: bool,
     result: SyncResult,
     label: str,
+    force_managed: frozenset[str] = frozenset(),
 ) -> bool:
     """Merge *sources* into the *existing* MCP config dict in place.
 
@@ -455,6 +456,18 @@ def _apply_mcp_merge(
     and the ``_vaultspecManaged`` ownership sidecar) and records actions and
     warnings on *result*.
 
+    *force_managed* is a surgical, per-entry escalation of *force* scoped to
+    the named already-managed servers only. It exists for the ``install
+    --upgrade`` mode-flip case: when an upgrade flips the workspace's install
+    mode, the pre-commit and declaration renderers rewrite unconditionally but
+    an unforced MCP sync would skip a pre-existing managed ``vaultspec-core``
+    entry still carrying the old mode's launch shape, leaving the migration
+    non-atomic across the three renderers. Naming that entry in *force_managed*
+    updates it in the same run without escalating the whole sync to *force*.
+    Because it gates only the ``name in managed`` branch, a user-owned entry
+    that shares a name with a source is never adopted or overwritten by it, so
+    the foreign-entry discipline stays intact.
+
     Args:
         existing: Parsed target config; mutated in place.
         sources: Collected MCP definitions keyed by server name.
@@ -463,6 +476,9 @@ def _apply_mcp_merge(
         result: Accumulator for counters, items, and warnings.
         label: Human label for the target (e.g. ``".mcp.json"``) used in
             warning messages.
+        force_managed: Names of already-managed servers to overwrite when they
+            diverge from their source, even when *force* is ``False``. Ignored
+            for any name not currently in the managed set.
 
     Returns:
         ``True`` when *existing* was modified, else ``False``.
@@ -510,7 +526,7 @@ def _apply_mcp_merge(
             if servers[name] == config:
                 result.unchanged += 1
                 result.items.append((name, "[UNCHANGED]"))
-            elif force:
+            elif force or name in force_managed:
                 servers[name] = config
                 result.updated += 1
                 result.items.append((name, "[UPDATE]"))
@@ -592,6 +608,7 @@ def _sync_mcp_target(
     prune: bool,
     result: SyncResult,
     label: str,
+    force_managed: frozenset[str] = frozenset(),
 ) -> None:
     """Merge *sources* into a single MCP config file at *path*.
 
@@ -599,6 +616,9 @@ def _sync_mcp_target(
     :func:`_apply_mcp_merge`, and writes the result. When pruning empties
     the file and no user-defined top-level keys remain, the file is removed
     rather than left as an orphan ``{"mcpServers": {}}`` artefact.
+
+    *force_managed* is forwarded verbatim to :func:`_apply_mcp_merge`; see its
+    docstring for the narrowly-scoped mode-flip escalation it performs.
     """
     with advisory_lock(path):
         existing: dict[str, Any] = {}
@@ -611,7 +631,13 @@ def _sync_mcp_target(
                 result.warnings.append(f"Cannot parse existing {label}: {exc}")
 
         changed = _apply_mcp_merge(
-            existing, sources, force=force, prune=prune, result=result, label=label
+            existing,
+            sources,
+            force=force,
+            prune=prune,
+            result=result,
+            label=label,
+            force_managed=force_managed,
         )
 
         if changed and not dry_run:
@@ -645,6 +671,7 @@ def mcp_sync(
     force: bool = False,
     prune: bool = False,
     mode: InstallMode | None = None,
+    force_managed: frozenset[str] = frozenset(),
 ) -> SyncResult:
     """Sync MCP server definitions into every MCP config target.
 
@@ -678,6 +705,13 @@ def mcp_sync(
             been deleted. Mirrors ``rules_sync``/``agents_sync``.
         mode: Provisioning mode to render definitions for, or ``None`` to
             resolve it from the committed workspace declaration.
+        force_managed: Names of already-managed servers to overwrite when they
+            diverge from their source, even when *force* is ``False``. This is
+            the ``install --upgrade`` mode-flip seam: it lets the caller migrate
+            a specific managed entry (the ``vaultspec-core`` launch command) to
+            the newly-resolved mode's shape in the same run without escalating
+            the whole sync to *force*. Scoped to managed entries only, so
+            user-owned entries stay untouched.
 
     Returns:
         :class:`~vaultspec_core.core.types.SyncResult` with sync statistics.
@@ -708,6 +742,7 @@ def mcp_sync(
         prune=prune,
         result=result,
         label=".mcp.json",
+        force_managed=force_managed,
     )
 
     for tool_name, mcp_path in sorted(_provider_mcp_targets().items()):
@@ -725,6 +760,7 @@ def mcp_sync(
             prune=prune,
             result=sub,
             label=rel.replace("\\", "/"),
+            force_managed=force_managed,
         )
         result.merge(sub)
         result.per_tool[tool_name] = sub

--- a/src/vaultspec_core/tests/cli/test_install_mode_flip.py
+++ b/src/vaultspec_core/tests/cli/test_install_mode_flip.py
@@ -1,0 +1,164 @@
+"""Tests for the mode-flip MCP force-gate fix on ``install --upgrade``.
+
+These exercise the ``mode-flip-force-asymmetry`` audit finding: on an upgrade
+that flips the workspace's install mode, the pre-commit and declaration
+renderers rewrite unconditionally, but the MCP sync is force-gated and would
+leave a pre-existing managed ``vaultspec-core`` entry stranded in the old
+mode's launch shape until a later forced re-sync. The fix forces just that
+managed entry when a flip is detected, keeping the migration atomic across the
+three renderers while leaving same-mode divergence, foreign entries, and
+non-flip upgrades on their existing semantics.
+
+Every test drives a real ``install_run`` over a real filesystem through
+:class:`WorkspaceFactory`; there are no test doubles.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.core.diagnosis.collectors import collect_mode_mismatch_state
+from vaultspec_core.core.diagnosis.signals import ModeMismatchSignal
+from vaultspec_core.core.enums import InstallMode
+from vaultspec_core.core.mcps import _MODE_MCP_LAUNCH
+from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+_DEPENDENCY_COMMAND, _DEPENDENCY_ARGS = _MODE_MCP_LAUNCH[InstallMode.DEPENDENCY]
+_TOOL_COMMAND, _TOOL_ARGS = _MODE_MCP_LAUNCH[InstallMode.TOOL]
+
+
+def _write_pyproject_with_vaultspec(root: Path) -> None:
+    """Write a ``pyproject.toml`` listing ``vaultspec-core`` as a dependency."""
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nversion = "0"\ndependencies = ["vaultspec-core"]\n',
+        encoding="utf-8",
+    )
+
+
+def _read_mcp(root: Path) -> dict:
+    """Read the parsed ``.mcp.json`` for *root*."""
+    return json.loads((root / ".mcp.json").read_text(encoding="utf-8"))
+
+
+def _vaultspec_entry(root: Path) -> dict:
+    """Return the ``vaultspec-core`` server entry from ``.mcp.json``."""
+    return _read_mcp(root)["mcpServers"]["vaultspec-core"]
+
+
+def _make_legacy_flip_workspace(root: Path) -> None:
+    """Provision a dependency-mode workspace, then strip it to a legacy flip.
+
+    Installs real dependency-mode artifacts (a ``uv run`` MCP launch and hook
+    entries), then deletes both the committed mode declaration and the
+    ``pyproject.toml`` dependency evidence. A subsequent bare ``install
+    --upgrade`` therefore has no declaration to honor and no dependency
+    evidence to detect, so it infers tool mode against dependency-shaped
+    artifacts: the exact bare-upgrade mode flip the audit describes.
+    """
+    _write_pyproject_with_vaultspec(root)
+    WorkspaceFactory(root).install("all", mode=InstallMode.DEPENDENCY)
+    (root / ".vaultspec" / "workspace.json").unlink()
+    (root / "pyproject.toml").unlink()
+
+
+class TestModeFlipForcesManagedEntry:
+    def test_flip_upgrade_rewrites_stale_managed_entry_without_force(
+        self, tmp_path: Path
+    ) -> None:
+        """A bare mode-flip upgrade rewrites the stale managed MCP entry in the
+        same run without ``--force``, leaving the workspace mode-coherent.
+        """
+        _make_legacy_flip_workspace(tmp_path)
+
+        # Precondition: the deployed MCP launch is still the old dependency
+        # shape and disagrees with the tool mode the upgrade will infer.
+        before = _vaultspec_entry(tmp_path)
+        assert before["command"] == _DEPENDENCY_COMMAND
+        assert before["args"] == list(_DEPENDENCY_ARGS)
+
+        WorkspaceFactory(tmp_path).install("all", upgrade=True)
+
+        after = _vaultspec_entry(tmp_path)
+        assert after["command"] == _TOOL_COMMAND
+        assert after["args"] == list(_TOOL_ARGS)
+        # All three renderers migrated atomically: declaration, hooks, and the
+        # MCP launch now agree on tool mode.
+        assert collect_mode_mismatch_state(tmp_path) == ModeMismatchSignal.CLEAN
+
+    def test_same_mode_divergent_managed_entry_is_preserved_without_force(
+        self, tmp_path: Path
+    ) -> None:
+        """A managed entry that diverges but stays in the declared mode keeps
+        today's force-gated semantics on a non-flip upgrade: it is skipped and
+        preserved, not clobbered by the flip force path.
+        """
+        WorkspaceFactory(tmp_path).install("all", mode=InstallMode.TOOL)
+
+        # Diverge the managed entry without changing its mode shape: the
+        # command and args still name tool mode, so no flip is detected, but an
+        # extra field makes it differ from its rendered source definition.
+        mcp = _read_mcp(tmp_path)
+        mcp["mcpServers"]["vaultspec-core"]["env"] = {"HAND_ALTERED": "1"}
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(mcp, indent=2) + "\n", encoding="utf-8"
+        )
+
+        WorkspaceFactory(tmp_path).install("all", upgrade=True)
+
+        after = _vaultspec_entry(tmp_path)
+        # Force-gate untouched: the divergent managed entry survives verbatim.
+        assert after.get("env") == {"HAND_ALTERED": "1"}
+        assert after["command"] == _TOOL_COMMAND
+
+    def test_flip_upgrade_leaves_foreign_user_entry_untouched(
+        self, tmp_path: Path
+    ) -> None:
+        """The flip force is scoped to the managed ``vaultspec-core`` entry: a
+        user-owned MCP entry present during a flip upgrade is left byte-for-byte
+        intact while the managed entry migrates.
+        """
+        _make_legacy_flip_workspace(tmp_path)
+        WorkspaceFactory(tmp_path).add_user_mcp_servers()
+        foreign_before = _read_mcp(tmp_path)["mcpServers"]["my-custom-server"]
+
+        WorkspaceFactory(tmp_path).install("all", upgrade=True)
+
+        after = _read_mcp(tmp_path)
+        # Foreign entry untouched; managed entry migrated to the new mode.
+        assert after["mcpServers"]["my-custom-server"] == foreign_before
+        assert after["mcpServers"]["vaultspec-core"]["command"] == _TOOL_COMMAND
+
+    def test_non_flip_upgrade_takes_no_force_path(self, tmp_path: Path) -> None:
+        """A non-flip upgrade never engages the force path: a divergent
+        user-owned entry and the already-matching managed entry both survive an
+        upgrade unchanged.
+        """
+        WorkspaceFactory(tmp_path).install("all", mode=InstallMode.TOOL)
+
+        # A user-owned entry that intentionally diverges from what any managed
+        # source would render; it must be untouched by the upgrade.
+        mcp = _read_mcp(tmp_path)
+        mcp["mcpServers"]["my-custom-server"] = {
+            "command": "node",
+            "args": ["server.js"],
+            "env": {"DIVERGENT": "1"},
+        }
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(mcp, indent=2) + "\n", encoding="utf-8"
+        )
+        foreign_before = _read_mcp(tmp_path)["mcpServers"]["my-custom-server"]
+        managed_before = _vaultspec_entry(tmp_path)
+
+        WorkspaceFactory(tmp_path).install("all", upgrade=True)
+
+        after = _read_mcp(tmp_path)
+        assert after["mcpServers"]["my-custom-server"] == foreign_before
+        assert after["mcpServers"]["vaultspec-core"] == managed_before


### PR DESCRIPTION
## What

Closes both follow-ups the install-mode audit (`.vault/audit/2026-07-13-install-mode-audit.md`) tracked as open:

- **mode-flip-force-asymmetry (MEDIUM)**: on an `install --upgrade` that flips the workspace mode, the managed `.mcp.json` vaultspec-core entry now migrates in the same run without `--force`, via a narrowly-scoped `force_managed` parameter that provably cannot touch foreign/user-owned entries or the prune path. Non-flip upgrades, same-mode divergence, dry-run, and explicit `--force` behavior unchanged. 4 new WorkspaceFactory tests, independently reverified load-bearing (disabling the fix fails exactly the two flip assertions).
- **Version floor**: this repo's committed `.vaultspec/workspace.json` now declares `minimum_vaultspec_version: 0.1.37`, exercising the floor mechanism the feature shipped.

## Verification

- Full unit gate: 1656 passed, 0 failed.
- vaultspec-code-reviewer audit: PASS (scoping proven by control flow; ordering, dry-run isolation, and double-sync idempotence verified; floor pin diagnoses clean).
- `spec doctor` on this repo: all rows ok.