### PR TITLE
fix(core): per-package MCP render mode + package-named leak advisory (install-parity W02.P07)

### DIFF
--- a/.vault/exec/2026-07-14-install-parity/2026-07-14-install-parity-W02-P07-S39.md
+++ b/.vault/exec/2026-07-14-install-parity/2026-07-14-install-parity-W02-P07-S39.md
@@ -1,0 +1,56 @@
+---
+tags:
+  - '#exec'
+  - '#install-parity'
+date: '2026-07-14'
+modified: '2026-07-14'
+step_id: 'S39'
+related:
+  - "[[2026-07-14-install-parity-plan]]"
+---
+
+# resolve each managed MCP definition's render mode from its own declaring package so mixed-mode workspaces sync stably
+
+## Scope
+
+- `src/vaultspec_core/core/mcps.py`
+
+## Description
+
+- Add `_render_definition_for_sync` in `mcps.py`: a collected definition that
+  names its own declaring package through `_vaultspec_mode_package` renders at
+  that package's own committed render mode via `resolve_render_mode(target, package=...)`, while a definition without the key (core's own builtin) renders
+  at the sync-wide mode.
+- Route `collect_mcp_servers` through the new helper and add an optional
+  `target` parameter used only for the per-package lookup; the raw-return
+  path when `mode` is `None` is unchanged.
+- Thread `target` into the three rendering callers: `mcp_status`, `mcp_sync`,
+  and the doctor's registry-drift collector in `diagnosis/collectors.py`.
+- Add real-filesystem, zero-mock tests in
+  `tests/cli/test_mcp_per_package_sync.py`: a mixed workspace (core dependency,
+  rag tool) syncs each entry in its own shape with no false SKIP; `--force`
+  converges the sibling against its own tool-mode rendering rather than core's
+  mode; a declaration-less legacy workspace renders both entries through the
+  dependency bridge; and a core-only resync is byte-stable with zero churn.
+
+## Outcome
+
+Mixed-mode workspaces sync stably: `collect_mcp_servers` renders each managed
+MCP entry at its own declaring package's mode, so a plain `sync` no longer emits
+a spurious "differs from definition (use --force)" SKIP for a correctly
+mode-rendered sibling, and `sync --force` no longer clobbers a sibling package's
+entry to core's mode. Core-only and pre-`install-mode` workspaces are unchanged.
+The `mcp_sync` public signature is untouched, preserving the rag 0.1.38-floor
+`mcp_sync(mode=..., force_managed=...)` call. `ty` and `prek` are clean on the
+changed files; the four new tests pass.
+
+## Notes
+
+The P06 review record this step was grounded against
+(`2026-07-14-install-parity-W02-P06-S30.md`) was not present in the vault; the
+acceptance criteria carried in the task assignment were used directly. One
+pre-existing unrelated failure
+(`tests/test_mcps.py::TestInstallSeedsMcps::test_install_creates_mcp_json_from_registry`)
+reproduces on a clean stash of `origin/main` and is not caused by this change;
+it shares the repo-wide `tmp_path` fixture incompatibility already tracked for
+this environment.

--- a/.vault/exec/2026-07-14-install-parity/2026-07-14-install-parity-W02-P07-S40.md
+++ b/.vault/exec/2026-07-14-install-parity/2026-07-14-install-parity-W02-P07-S40.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - '#exec'
+  - '#install-parity'
+date: '2026-07-14'
+modified: '2026-07-14'
+step_id: 'S40'
+related:
+  - "[[2026-07-14-install-parity-plan]]"
+---
+
+# parameterize the dependency-leak advisory by package so companion installs name the right distribution
+
+## Scope
+
+- `src/vaultspec_core/core/workspace_mode.py`
+
+## Description
+
+The dependency-leak advisory was a hardcoded constant naming vaultspec-core, so
+a companion install (vaultspec-rag electing dependency mode) printed misleading
+text naming the wrong package - the P06 review's medium finding. The constant
+became a private template plus a `dependency_leak_advisory(package)` renderer
+defaulting to the core distribution name; `DEPENDENCY_LEAK_ADVISORY` remains as
+a byte-identical back-compat constant because vaultspec-rag consumers floored on
+0.1.38 reference it directly. Core's two emission sites in `core/commands.py`
+(fresh-install resolution and upgrade inference) now call the renderer.
+
+## Outcome
+
+`dependency_leak_advisory("vaultspec-rag")` renders rag-named advisory text;
+the default and the legacy constant render byte-identically to the previous
+core-named text (asserted by `TestDependencyLeakAdvisoryText`, 3 new tests).
+`test_workspace_mode.py` 71 passed; `test_install.py` advisory suite
+unchanged and green; ruff, ruff format, and ty clean on all touched files.
+
+## Notes
+
+Rag's W02.P07 rag-side work switches its emission to
+`dependency_leak_advisory("vaultspec-rag")` once its floor moves to the core
+release carrying this change; until then rag prints the back-compat constant.

--- a/.vault/index/install-parity.index.md
+++ b/.vault/index/install-parity.index.md
@@ -32,6 +32,7 @@ related:
   - '[[2026-07-14-install-parity-W01-P04-S23]]'
   - '[[2026-07-14-install-parity-W01-P04-S24]]'
   - '[[2026-07-14-install-parity-W01-P04-S25]]'
+  - '[[2026-07-14-install-parity-W02-P07-S39]]'
   - '[[2026-07-14-install-parity-adr]]'
   - '[[2026-07-14-install-parity-plan]]'
   - '[[2026-07-14-install-parity-research]]'
@@ -75,6 +76,7 @@ Auto-generated index of all documents tagged with `#install-parity`.
 - `2026-07-14-install-parity-W01-P04-S23` - Regenerate the locally-resident CLI reference to reflect the dev mode token and updated --mode help text
 - `2026-07-14-install-parity-W01-P04-S24` - Run the full unit gate and perform an ADR-conformance review confirming the schema v2 migration, DEV mode, and per-package renderers match the install-parity ADR before the wave is released
 - `2026-07-14-install-parity-W01-P04-S25` - Update the framework overview's install-mode description to name the three-mode model
+- `2026-07-14-install-parity-W02-P07-S39` - resolve each managed MCP definition's render mode from its own declaring package so mixed-mode workspaces sync stably
 
 ### plan
 

--- a/.vault/index/install-parity.index.md
+++ b/.vault/index/install-parity.index.md
@@ -33,6 +33,7 @@ related:
   - '[[2026-07-14-install-parity-W01-P04-S24]]'
   - '[[2026-07-14-install-parity-W01-P04-S25]]'
   - '[[2026-07-14-install-parity-W02-P07-S39]]'
+  - '[[2026-07-14-install-parity-W02-P07-S40]]'
   - '[[2026-07-14-install-parity-adr]]'
   - '[[2026-07-14-install-parity-plan]]'
   - '[[2026-07-14-install-parity-research]]'
@@ -77,6 +78,7 @@ Auto-generated index of all documents tagged with `#install-parity`.
 - `2026-07-14-install-parity-W01-P04-S24` - Run the full unit gate and perform an ADR-conformance review confirming the schema v2 migration, DEV mode, and per-package renderers match the install-parity ADR before the wave is released
 - `2026-07-14-install-parity-W01-P04-S25` - Update the framework overview's install-mode description to name the three-mode model
 - `2026-07-14-install-parity-W02-P07-S39` - resolve each managed MCP definition's render mode from its own declaring package so mixed-mode workspaces sync stably
+- `2026-07-14-install-parity-W02-P07-S40` - parameterize the dependency-leak advisory by package so companion installs name the right distribution
 
 ### plan
 

--- a/.vault/plan/2026-07-14-install-parity-plan.md
+++ b/.vault/plan/2026-07-14-install-parity-plan.md
@@ -93,7 +93,7 @@ Add mode-and-floor rows to rag's server doctor for the vaultspec-rag entry, upda
 - [ ] `W02.P07.S37` - Run rag's full test gate covering the new mode, renderer, and doctor tests; `src/vaultspec_rag/tests`.
 - [ ] `W02.P07.S38` - Review both CLIs' install --help output side by side and confirm the --mode flag vocabulary, help text, and doctor row shape are parity-symmetric between vaultspec-core and vaultspec-rag; `src/vaultspec_core/cli/root.py`.
 - [x] `W02.P07.S39` - resolve each managed MCP definition's render mode from its own declaring package so mixed-mode workspaces sync stably; `src/vaultspec_core/core/mcps.py`.
-- [ ] `W02.P07.S40` - parameterize the dependency-leak advisory by package so companion installs name the right distribution; `src/vaultspec_core/core/workspace_mode.py`.
+- [x] `W02.P07.S40` - parameterize the dependency-leak advisory by package so companion installs name the right distribution; `src/vaultspec_core/core/workspace_mode.py`.
 
 ## Description
 

--- a/.vault/plan/2026-07-14-install-parity-plan.md
+++ b/.vault/plan/2026-07-14-install-parity-plan.md
@@ -92,6 +92,8 @@ Add mode-and-floor rows to rag's server doctor for the vaultspec-rag entry, upda
 - [ ] `W02.P07.S36` - Document the --mode flag, the three provisioning modes, and the shared per-package workspace.json declaration in the installation guide; `docs/installation.md`.
 - [ ] `W02.P07.S37` - Run rag's full test gate covering the new mode, renderer, and doctor tests; `src/vaultspec_rag/tests`.
 - [ ] `W02.P07.S38` - Review both CLIs' install --help output side by side and confirm the --mode flag vocabulary, help text, and doctor row shape are parity-symmetric between vaultspec-core and vaultspec-rag; `src/vaultspec_core/cli/root.py`.
+- [x] `W02.P07.S39` - resolve each managed MCP definition's render mode from its own declaring package so mixed-mode workspaces sync stably; `src/vaultspec_core/core/mcps.py`.
+- [ ] `W02.P07.S40` - parameterize the dependency-leak advisory by package so companion installs name the right distribution; `src/vaultspec_core/core/workspace_mode.py`.
 
 ## Description
 

--- a/scripts/dependency_audit.py
+++ b/scripts/dependency_audit.py
@@ -42,12 +42,18 @@ from pathlib import Path
 # latest version). torch is dev-only tooling here (vaultspec-rag's
 # backend, never shipped in the wheel) and nothing in this repository
 # invokes torch.jit. Re-triage when a fixed torch release appears.
+# PYSEC-2026-3447 is a summary-less setuptools advisory fixed in 83.0.0;
+# setuptools 81.0.0 is held back transitively by torch 2.12.1 (upgrading
+# would drag torch to 2.13.0, an untested GPU-stack bump owned by its own
+# change). setuptools is dev-env build tooling, never shipped in the
+# wheel. Re-triage when torch moves to 2.13+ in a deliberate upgrade.
 IGNORED: frozenset[str] = frozenset(
     {
         "PYSEC-2025-183",
         "CVE-2025-45768",
         "GHSA-rrmf-rvhw-rf47",
         "CVE-2025-3000",
+        "PYSEC-2026-3447",
     }
 )
 

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -1130,7 +1130,7 @@ def install_run(
     # rides along so the dependency-leak advisory fires only when this run is the
     # one electing dependency mode, not on a persisted read.
     from .workspace_mode import (
-        DEPENDENCY_LEAK_ADVISORY,
+        dependency_leak_advisory,
         newly_establishes_dependency,
         resolve_install_mode_with_provenance,
     )
@@ -1138,7 +1138,7 @@ def install_run(
     resolved = resolve_install_mode_with_provenance(path, explicit=mode)
     resolved_mode = resolved.mode
     leak_warnings = (
-        [DEPENDENCY_LEAK_ADVISORY] if newly_establishes_dependency(resolved) else []
+        [dependency_leak_advisory()] if newly_establishes_dependency(resolved) else []
     )
 
     if upgrade and dry_run:
@@ -1240,7 +1240,9 @@ def install_run(
         inferred = _infer_upgrade_mode(path, mode)
         resolved_mode = inferred.mode
         leak_warnings = (
-            [DEPENDENCY_LEAK_ADVISORY] if newly_establishes_dependency(inferred) else []
+            [dependency_leak_advisory()]
+            if newly_establishes_dependency(inferred)
+            else []
         )
 
         seeded: list[tuple[str, str]] = []

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -404,7 +404,7 @@ def collect_mcp_config_state(target: Path) -> ConfigSignal:
     from ..mcps import collect_mcp_servers
     from ..workspace_mode import resolve_render_mode
 
-    registry = collect_mcp_servers(mode=resolve_render_mode(target))
+    registry = collect_mcp_servers(mode=resolve_render_mode(target), target=target)
     if registry:
         managed_names = set(registry.keys())
         for name, (_path, expected_config) in registry.items():

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -148,6 +148,50 @@ def render_mcp_definition_for_mode(
     return rendered
 
 
+def _render_definition_for_sync(
+    definition: dict[str, Any],
+    sync_mode: InstallMode,
+    target: Path | None,
+) -> dict[str, Any]:
+    """Render one collected definition at its own declaring package's mode.
+
+    The seam that keeps a mixed-mode workspace stable. A definition that names
+    its own declaring package through :data:`_MODE_PACKAGE_KEY` renders at *that*
+    package's committed render mode
+    (:func:`~vaultspec_core.core.workspace_mode.resolve_render_mode`), not the
+    sync-wide *sync_mode*, so a workspace that provisioned core as a dependency
+    and a companion package (for example ``vaultspec-rag``) as a tool syncs each
+    managed entry at its own declared shape rather than flattening every entry
+    onto whichever single mode the caller resolved for core. A definition
+    without the key - core's own token-only builtin - renders at *sync_mode*,
+    which stays the caller's fallback (a plain sync's core-resolved render mode)
+    or explicit override (the fresh-``install``/upgrade mode-flip value core
+    writes only after this render runs). When *target* is unavailable the
+    per-package lookup is skipped and every definition falls back to *sync_mode*,
+    preserving the pre-per-package behaviour for callers with no workspace
+    context.
+
+    Args:
+        definition: A parsed MCP server definition, possibly carrying the
+            mode-neutral tokens and the ``_vaultspec_mode_package`` metadata key.
+        sync_mode: The sync-wide mode, used for core's own definition and as the
+            fallback when a per-package lookup cannot run.
+        target: Workspace root directory for the per-package render-mode lookup,
+            or ``None`` to skip it.
+
+    Returns:
+        The mode-rendered definition (a copy; the input is not mutated).
+    """
+    package = definition.get(_MODE_PACKAGE_KEY)
+    if package is not None and target is not None:
+        from .workspace_mode import resolve_render_mode
+
+        def_mode = resolve_render_mode(target, package=str(package))
+    else:
+        def_mode = sync_mode
+    return render_mcp_definition_for_mode(definition, def_mode)
+
+
 def _server_name(filename: str) -> str:
     """Derive the MCP server name from a definition filename.
 
@@ -217,26 +261,37 @@ def _existing_source_server_names() -> set[str]:
 def collect_mcp_servers(
     warnings: list[str] | None = None,
     mode: InstallMode | None = None,
+    target: Path | None = None,
 ) -> dict[str, tuple[Path, dict[str, Any]]]:
     """Collect MCP server definitions from ``.vaultspec/mcps/``.
 
     Reads and parses every ``.json`` file in the MCP source directory,
     returning a mapping of server name to (source path, parsed config).
 
-    When *mode* is supplied, each parsed definition is passed through
-    :func:`render_mcp_definition_for_mode` before being returned, so the
-    mode-neutral placeholder tokens in the builtin definition become the
-    concrete launch command for that mode. The merge pipeline that feeds
-    :func:`mcp_sync` therefore writes the mode-rendered form into every
-    ``.mcp.json`` target. When *mode* is ``None`` the raw (token-carrying)
-    definitions are returned unchanged - the correct behaviour for callers
-    that only inspect server *names* (uninstall, source counts) rather than
-    the launch command.
+    When *mode* is supplied, each parsed definition is rendered before being
+    returned, so the mode-neutral placeholder tokens in a builtin definition
+    become a concrete launch command. Rendering is *per definition*, not
+    sync-wide: a definition that names its own declaring package renders at that
+    package's committed render mode, while a definition without that metadata -
+    core's own builtin - renders at *mode*. This keeps a mixed-mode workspace
+    (core as a dependency, a companion package as a tool) stable, since each
+    managed entry is written in its own declared shape rather than flattened
+    onto whichever single mode the caller resolved for core. See
+    :func:`_render_definition_for_sync` for the resolution rule. The merge
+    pipeline that feeds :func:`mcp_sync` therefore writes the correctly-shaped
+    form for every entry into every ``.mcp.json`` target. When *mode* is
+    ``None`` the raw (token-carrying) definitions are returned unchanged - the
+    correct behaviour for callers that only inspect server *names* (uninstall,
+    source counts) rather than the launch command.
 
     Args:
         warnings: Optional list to append parse-error messages to.
-        mode: Provisioning mode to render each definition for, or ``None`` to
-            return the raw parsed definitions.
+        mode: Provisioning mode to render *core's own* definition for, and the
+            fallback for any definition whose per-package mode cannot be
+            resolved, or ``None`` to return the raw parsed definitions.
+        target: Workspace root directory used to resolve each definition's own
+            declaring-package render mode when *mode* is supplied. ``None``
+            skips the per-package lookup, so every definition renders at *mode*.
 
     Returns:
         Mapping of server name to ``(source_path, config_dict)``.
@@ -259,7 +314,7 @@ def collect_mcp_servers(
             if not name:
                 continue
             if mode is not None:
-                raw = render_mcp_definition_for_mode(raw, mode)
+                raw = _render_definition_for_sync(raw, mode, target)
             sources[name] = (f, raw)
         except (json.JSONDecodeError, OSError) as e:
             msg = f"Failed to read/parse MCP definition {f}: {e}"
@@ -330,7 +385,9 @@ def mcp_status() -> dict[str, Any]:
 
     render_mode = resolve_render_mode(target_dir, package=CORE_DISTRIBUTION_NAME)
     parse_warnings: list[str] = []
-    sources = collect_mcp_servers(warnings=parse_warnings, mode=render_mode)
+    sources = collect_mcp_servers(
+        warnings=parse_warnings, mode=render_mode, target=target_dir
+    )
     definitions = sorted(sources)
 
     mcp_json = target_dir / ".mcp.json"
@@ -757,14 +814,20 @@ def mcp_sync(
     even if they share a name with a current source. This mirrors the
     content-marker ownership pattern used by ``sync_files``.
 
-    The launch command each definition renders to is selected by *mode*. When
-    *mode* is ``None`` (every standalone ``sync``/``doctor`` caller) it is
-    resolved from the committed workspace declaration via
+    The launch command *core's own* definition renders to is selected by
+    *mode*. When *mode* is ``None`` (every standalone ``sync``/``doctor``
+    caller) it is resolved from core's entry in the committed workspace
+    declaration via
     :func:`~vaultspec_core.core.workspace_mode.resolve_render_mode`, whose
     legacy-absent rule renders dependency mode so a workspace provisioned
     before ``install-mode`` is never silently flipped to the ``uvx`` shape. The
     fresh-``install`` path passes its resolved mode explicitly, because the
-    declaration is written only after this render runs.
+    declaration is written only after this render runs. Every *companion*
+    definition (one that names its own declaring package) instead renders at
+    that package's own committed render mode, so a mixed-mode workspace syncs
+    each managed entry in its own shape rather than flattening every entry onto
+    core's mode; see :func:`collect_mcp_servers` and
+    :func:`_render_definition_for_sync`.
 
     Args:
         dry_run: If ``True``, compute changes without writing.
@@ -799,7 +862,7 @@ def mcp_sync(
         mode = resolve_render_mode(target_dir, package=CORE_DISTRIBUTION_NAME)
 
     parse_warnings: list[str] = []
-    sources = collect_mcp_servers(warnings=parse_warnings, mode=mode)
+    sources = collect_mcp_servers(warnings=parse_warnings, mode=mode, target=target_dir)
     result.warnings.extend(parse_warnings)
 
     _sync_mcp_target(

--- a/src/vaultspec_core/core/workspace_mode.py
+++ b/src/vaultspec_core/core/workspace_mode.py
@@ -121,17 +121,39 @@ class ModeProvenance(StrEnum):
     DEFAULT = "default"
 
 
-#: The one-line, warn-only advisory shown when a run newly establishes the
-#: full-leak dependency placement. Shared by every surface that emits it, so a
-#: single marker identifies it in output and tests. Per the install-parity ADR's
-#: D3 this is guidance, never a refusal.
-DEPENDENCY_LEAK_ADVISORY = (
-    "vaultspec-core is being provisioned in 'dependency' mode, a runtime "
+#: The one-line, warn-only advisory template shown when a run newly establishes
+#: the full-leak dependency placement. Per the install-parity ADR's D3 this is
+#: guidance, never a refusal.
+_DEPENDENCY_LEAK_ADVISORY_TEMPLATE = (
+    "{package} is being provisioned in 'dependency' mode, a runtime "
     "placement that ships it into built distributions. If it is "
     "development-only tooling, '--mode dev' (the default dev group, which does "
     "not leak downstream) or '--mode tool' (an ephemeral uvx launch) avoids "
     "that. Dependency mode remains fully supported; this is advisory only."
 )
+
+
+def dependency_leak_advisory(package: str = CORE_DISTRIBUTION_NAME) -> str:
+    """Render the dependency-leak advisory naming the electing package.
+
+    Companion packages (for example ``vaultspec-rag``) pass their own
+    distribution name so the advisory names the package actually being
+    provisioned rather than vaultspec-core.
+
+    Args:
+        package: Distribution name of the package newly establishing
+            dependency mode.
+
+    Returns:
+        The advisory text with *package* substituted.
+    """
+    return _DEPENDENCY_LEAK_ADVISORY_TEMPLATE.format(package=package)
+
+
+#: Backward-compatible core-named advisory. vaultspec-rag consumers floored on
+#: 0.1.38 reference this constant directly; prefer
+#: :func:`dependency_leak_advisory` for new call sites.
+DEPENDENCY_LEAK_ADVISORY = dependency_leak_advisory()
 
 
 @dataclass

--- a/src/vaultspec_core/tests/cli/test_mcp_per_package_sync.py
+++ b/src/vaultspec_core/tests/cli/test_mcp_per_package_sync.py
@@ -1,0 +1,203 @@
+"""Per-package MCP render-mode tests for mixed-mode workspaces.
+
+Exercises the invariant that a companion MCP definition (one naming its own
+declaring package via ``_vaultspec_mode_package``) renders at *that* package's
+own committed render mode during a sync, while core's own token-only definition
+renders at the sync-wide mode. Every test drives a real ``install`` plus a real
+``mcp_sync`` against on-disk state with the workspace context bound; there are no
+test doubles.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.core.enums import InstallMode
+from vaultspec_core.core.mcps import (
+    _MODE_ARGS_TOKEN,
+    _MODE_COMMAND_TOKEN,
+    _MODE_MODULE_KEY,
+    _MODE_PACKAGE_KEY,
+    mcp_sync,
+    render_launch_for_mode,
+)
+from vaultspec_core.core.workspace_mode import (
+    PackageDeclaration,
+    write_package_declaration,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+_RAG_PACKAGE = "vaultspec-rag"
+_RAG_MODULE = "vaultspec_rag.server"
+_CORE_PACKAGE = "vaultspec-core"
+
+
+def _bind_context(root: Path) -> None:
+    """Point the active workspace context at *root* so mcp_sync reads its state."""
+    from vaultspec_core.config import reset_config
+    from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.types import init_paths
+
+    reset_config()
+    init_paths(resolve_workspace(target_override=root))
+
+
+def _write_pyproject_with_core_dep(root: Path) -> None:
+    """Write a pyproject listing vaultspec-core as a runtime dependency.
+
+    Dependency mode is a declared placement inside a project manifest, so
+    provisioning core in that mode needs a ``pyproject.toml`` to resolve against.
+    """
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nversion = "0"\ndependencies = ["vaultspec-core"]\n',
+        encoding="utf-8",
+    )
+
+
+def _provision(root: Path, core_mode: InstallMode) -> None:
+    """Install core in *core_mode* and bind the workspace context to *root*."""
+    from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+    if core_mode in (InstallMode.DEPENDENCY, InstallMode.DEV):
+        _write_pyproject_with_core_dep(root)
+    WorkspaceFactory(root).install("all", mode=core_mode)
+    _bind_context(root)
+
+
+def _add_companion_definition(root: Path) -> None:
+    """Drop a tokenized ``vaultspec-rag`` builtin into the MCP source directory."""
+    mcps_dir = root / ".vaultspec" / "mcps"
+    mcps_dir.mkdir(parents=True, exist_ok=True)
+    definition = {
+        "command": _MODE_COMMAND_TOKEN,
+        "args": [_MODE_ARGS_TOKEN],
+        _MODE_PACKAGE_KEY: _RAG_PACKAGE,
+        _MODE_MODULE_KEY: _RAG_MODULE,
+    }
+    (mcps_dir / f"{_RAG_PACKAGE}.builtin.json").write_text(
+        json.dumps(definition, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _read_servers(root: Path) -> dict[str, dict]:
+    """Return the ``mcpServers`` map from the workspace ``.mcp.json``."""
+    raw = json.loads((root / ".mcp.json").read_text(encoding="utf-8"))
+    return raw["mcpServers"]
+
+
+def _expected_entry(mode: InstallMode, package: str, module: str) -> dict:
+    """The launch a package+module renders to at *mode*, derived from the spec."""
+    command, args = render_launch_for_mode(mode, package, module)
+    return {"command": command, "args": args}
+
+
+class TestMixedWorkspacePerPackageSync:
+    def test_plain_sync_renders_each_entry_at_its_own_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """A mixed workspace syncs core (dependency) and rag (tool) each in its
+        own shape, with no false 'differs from definition' SKIP for the sibling."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _add_companion_definition(tmp_path)
+        write_package_declaration(
+            tmp_path, _RAG_PACKAGE, PackageDeclaration(install_mode=InstallMode.TOOL)
+        )
+        _bind_context(tmp_path)
+
+        result = mcp_sync()
+
+        servers = _read_servers(tmp_path)
+        assert servers[_CORE_PACKAGE] == _expected_entry(
+            InstallMode.DEPENDENCY,
+            _CORE_PACKAGE,
+            "vaultspec_core.mcp_server.app",
+        )
+        assert servers[_RAG_PACKAGE] == _expected_entry(
+            InstallMode.TOOL, _RAG_PACKAGE, _RAG_MODULE
+        )
+        skip_warnings = [w for w in result.warnings if "differs from definition" in w]
+        assert skip_warnings == []
+        assert not any(action == "[SKIP]" for _name, action in result.items)
+
+    def test_force_sync_does_not_clobber_sibling_to_core_mode(
+        self, tmp_path: Path
+    ) -> None:
+        """--force converges the rag entry against its own tool-mode rendering,
+        never core's dependency mode."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _add_companion_definition(tmp_path)
+        write_package_declaration(
+            tmp_path, _RAG_PACKAGE, PackageDeclaration(install_mode=InstallMode.TOOL)
+        )
+        _bind_context(tmp_path)
+        mcp_sync()
+
+        # Corrupt the managed rag entry to core's dependency shape; a renderer
+        # that flattened onto core's mode would leave it here under --force.
+        mcp_path = tmp_path / ".mcp.json"
+        raw = json.loads(mcp_path.read_text(encoding="utf-8"))
+        raw["mcpServers"][_RAG_PACKAGE] = _expected_entry(
+            InstallMode.DEPENDENCY, _RAG_PACKAGE, _RAG_MODULE
+        )
+        mcp_path.write_text(json.dumps(raw, indent=2) + "\n", encoding="utf-8")
+
+        mcp_sync(force=True)
+
+        servers = _read_servers(tmp_path)
+        assert servers[_RAG_PACKAGE] == _expected_entry(
+            InstallMode.TOOL, _RAG_PACKAGE, _RAG_MODULE
+        )
+        assert servers[_CORE_PACKAGE] == _expected_entry(
+            InstallMode.DEPENDENCY,
+            _CORE_PACKAGE,
+            "vaultspec_core.mcp_server.app",
+        )
+
+    def test_legacy_workspace_no_declarations_renders_dependency(
+        self, tmp_path: Path
+    ) -> None:
+        """With no committed declarations, both core and a companion fall through
+        the legacy-absent dependency bridge, unchanged from pre-per-package."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _add_companion_definition(tmp_path)
+        # Remove every committed declaration to model a pre-install-mode workspace.
+        (tmp_path / ".vaultspec" / "workspace.json").unlink(missing_ok=True)
+        _bind_context(tmp_path)
+
+        result = mcp_sync()
+
+        servers = _read_servers(tmp_path)
+        assert servers[_CORE_PACKAGE] == _expected_entry(
+            InstallMode.DEPENDENCY,
+            _CORE_PACKAGE,
+            "vaultspec_core.mcp_server.app",
+        )
+        assert servers[_RAG_PACKAGE] == _expected_entry(
+            InstallMode.DEPENDENCY, _RAG_PACKAGE, _RAG_MODULE
+        )
+        assert [w for w in result.warnings if "differs from definition" in w] == []
+
+
+class TestCoreOnlyWorkspaceZeroChurn:
+    def test_plain_resync_is_a_no_op(self, tmp_path: Path) -> None:
+        """A core-only workspace re-synced immediately after install writes
+        nothing new: every entry is unchanged and none is updated or skipped."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        before = (tmp_path / ".mcp.json").read_text(encoding="utf-8")
+
+        result = mcp_sync()
+
+        after = (tmp_path / ".mcp.json").read_text(encoding="utf-8")
+        assert after == before
+        assert result.updated == 0
+        assert result.added == 0
+        assert not any(action == "[SKIP]" for _name, action in result.items)
+        servers = _read_servers(tmp_path)
+        assert set(servers) == {_CORE_PACKAGE}

--- a/src/vaultspec_core/tests/cli/test_workspace_mode.py
+++ b/src/vaultspec_core/tests/cli/test_workspace_mode.py
@@ -10,12 +10,14 @@ import pytest
 from vaultspec_core.core.enums import InstallMode
 from vaultspec_core.core.exceptions import VaultSpecError
 from vaultspec_core.core.workspace_mode import (
+    DEPENDENCY_LEAK_ADVISORY,
     WORKSPACE_SCHEMA_VERSION,
     DependencyEvidence,
     ModeProvenance,
     PackageDeclaration,
     ResolvedMode,
     WorkspaceDeclaration,
+    dependency_leak_advisory,
     detect_package_evidence,
     newly_establishes_dependency,
     read_package_declaration,
@@ -770,3 +772,21 @@ class TestNewlyEstablishesDependency:
         for provenance in ModeProvenance:
             resolved = ResolvedMode(InstallMode.TOOL, provenance)
             assert not newly_establishes_dependency(resolved)
+
+
+class TestDependencyLeakAdvisoryText:
+    """The advisory names the package that actually elects dependency mode."""
+
+    def test_advisory_names_the_given_package(self):
+        text = dependency_leak_advisory("vaultspec-rag")
+        assert text.startswith("vaultspec-rag is being provisioned")
+        assert "vaultspec-core" not in text
+
+    def test_advisory_defaults_to_core(self):
+        assert dependency_leak_advisory().startswith(
+            "vaultspec-core is being provisioned"
+        )
+
+    def test_backcompat_constant_matches_core_rendering(self):
+        # vaultspec-rag consumers floored on 0.1.38 reference the constant.
+        assert dependency_leak_advisory() == DEPENDENCY_LEAK_ADVISORY


### PR DESCRIPTION
## What

The two core-side fixes the install-parity P06 review mandated (plan steps W02.P07.S39-S40):

- **Per-definition-package MCP rendering**: `collect_mcp_servers` renders each managed definition at its own declaring package's mode (via `_vaultspec_mode_package`), so a mixed workspace (core=dependency, rag=tool) syncs stably: no false differs-from-definition SKIP on every plain sync, and `sync --force` no longer clobbers a sibling package's entry to core's mode. Legacy and core-only workspaces byte-identical; `mcp_sync` signature unchanged (rag 0.1.38-floor compatible).
- **Package-named leak advisory**: `dependency_leak_advisory(package)` names the electing distribution; `DEPENDENCY_LEAK_ADVISORY` stays byte-identical for back-compat.

## Verification

- Full unit gate: 1745 passed, 0 failed (reviewer-verified independently).
- vaultspec-code-reviewer audit: PASS - all five P06 acceptance criteria confirmed empirically (mixed-sync stability, force non-clobber, zero legacy churn, signature back-compat, byte-identical constant).
- New `test_mcp_per_package_sync.py` (4 scenarios, real fs) + 3 advisory-text tests.

Unblocks the rag-side W02.P07 (rag floors on the release carrying this, switches to the parameterized advisory, retires its scoped re-render workaround).