### PR TITLE
fix(vault): accept reference and audit documents as ADR grounding

### DIFF
--- a/src/vaultspec_core/tests/cli/test_check_adr_grounding.py
+++ b/src/vaultspec_core/tests/cli/test_check_adr_grounding.py
@@ -1,0 +1,138 @@
+"""Schema check: ADR grounding accepts the sanctioned document types.
+
+The documentation hierarchy sanctions research, reference, and audit
+documents as ADR grounding, so `check_schema` must accept any one of the
+three and error only when none is linked. All tests run against real
+on-disk vault fixtures (no mocks).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.graph.api import VaultGraph
+from vaultspec_core.vaultcore.checks.references import check_schema
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+_FEATURE = "grounding-feat"
+
+
+def _write_doc(
+    root: Path,
+    doc_type: str,
+    stem: str,
+    *,
+    related: list[str] | None = None,
+) -> None:
+    doc_dir = root / ".vault" / doc_type
+    doc_dir.mkdir(parents=True, exist_ok=True)
+    related_yaml = (
+        "related: []\n"
+        if not related
+        else "related:\n" + "".join(f"  - '[[{r}]]'\n" for r in related)
+    )
+    (doc_dir / f"{stem}.md").write_text(
+        "---\n"
+        "tags:\n"
+        f"  - '#{doc_type}'\n"
+        f"  - '#{_FEATURE}'\n"
+        "date: '2026-07-14'\n"
+        f"{related_yaml}"
+        "---\n"
+        f"\n# {stem}\n",
+        encoding="utf-8",
+    )
+
+
+def _adr_diagnostics(root: Path) -> list[str]:
+    result = check_schema(root, graph=VaultGraph(root))
+    return [
+        d.message
+        for d in result.diagnostics
+        if "ADR has no grounding references" in d.message
+    ]
+
+
+class TestAdrGroundingAcceptance:
+    """Any sanctioned grounding type satisfies the ADR schema check."""
+
+    def test_research_grounding_passes(self, tmp_path: Path):
+        _write_doc(tmp_path, "research", "2026-07-14-grounding-feat-research")
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-07-14-grounding-feat-adr",
+            related=["2026-07-14-grounding-feat-research"],
+        )
+        assert _adr_diagnostics(tmp_path) == []
+
+    def test_reference_grounding_passes(self, tmp_path: Path):
+        _write_doc(tmp_path, "reference", "2026-07-14-grounding-feat-reference")
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-07-14-grounding-feat-adr",
+            related=["2026-07-14-grounding-feat-reference"],
+        )
+        assert _adr_diagnostics(tmp_path) == []
+
+    def test_audit_grounding_passes(self, tmp_path: Path):
+        _write_doc(tmp_path, "audit", "2026-07-14-grounding-feat-audit")
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-07-14-grounding-feat-adr",
+            related=["2026-07-14-grounding-feat-audit"],
+        )
+        assert _adr_diagnostics(tmp_path) == []
+
+    def test_ungrounded_adr_errors(self, tmp_path: Path):
+        _write_doc(tmp_path, "adr", "2026-07-14-grounding-feat-adr")
+        messages = _adr_diagnostics(tmp_path)
+        assert len(messages) == 1
+        assert "research, reference, or audit" in messages[0]
+
+    def test_plan_link_alone_does_not_ground(self, tmp_path: Path):
+        _write_doc(tmp_path, "plan", "2026-07-14-grounding-feat-plan")
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-07-14-grounding-feat-adr",
+            related=["2026-07-14-grounding-feat-plan"],
+        )
+        assert len(_adr_diagnostics(tmp_path)) == 1
+
+
+class TestAdrGroundingFix:
+    """The fix path links the best available grounding candidate."""
+
+    def test_fix_prefers_research(self, tmp_path: Path):
+        _write_doc(tmp_path, "research", "2026-07-14-grounding-feat-research")
+        _write_doc(tmp_path, "audit", "2026-07-14-grounding-feat-audit")
+        _write_doc(tmp_path, "adr", "2026-07-14-grounding-feat-adr")
+
+        result = check_schema(tmp_path, graph=VaultGraph(tmp_path), fix=True)
+
+        assert result.fixed_count == 1
+        adr = (
+            tmp_path / ".vault" / "adr" / "2026-07-14-grounding-feat-adr.md"
+        ).read_text(encoding="utf-8")
+        assert "[[2026-07-14-grounding-feat-research]]" in adr
+
+    def test_fix_falls_back_to_audit(self, tmp_path: Path):
+        _write_doc(tmp_path, "audit", "2026-07-14-grounding-feat-audit")
+        _write_doc(tmp_path, "adr", "2026-07-14-grounding-feat-adr")
+
+        result = check_schema(tmp_path, graph=VaultGraph(tmp_path), fix=True)
+
+        assert result.fixed_count == 1
+        adr = (
+            tmp_path / ".vault" / "adr" / "2026-07-14-grounding-feat-adr.md"
+        ).read_text(encoding="utf-8")
+        assert "[[2026-07-14-grounding-feat-audit]]" in adr

--- a/src/vaultspec_core/vaultcore/checks/references.py
+++ b/src/vaultspec_core/vaultcore/checks/references.py
@@ -2,7 +2,8 @@
 
 Two checks in one module:
 - references: feature docs that should reference each other but don't
-- schema: ADRs must reference research, plans must reference ADRs
+- schema: ADRs must reference grounding (research/reference/audit);
+  plans must reference ADRs
 
 Both support ``--fix`` to auto-add ``related:`` links in frontmatter.
 """
@@ -225,7 +226,8 @@ def check_schema(
 
     Rules enforced:
 
-    - ADR must reference at least one research document (ERROR).
+    - ADR must reference at least one grounding document - research,
+      reference, or audit (ERROR).
     - Plan must reference at least one ADR (ERROR).
     - Plan should reference research documents (WARNING).
 
@@ -287,13 +289,28 @@ def check_schema(
         feat_name = feat_tags[0].lstrip("#") if feat_tags else None
 
         if node.doc_type == DocType.ADR:
-            if "research" not in linked_types:
-                msg = "ADR has no references to research documents"
+            # The documentation hierarchy sanctions research, reference, and
+            # audit documents as ADR grounding; any one of them satisfies the
+            # check.
+            grounding_types = {"research", "reference", "audit"}
+            if not (linked_types & grounding_types):
+                msg = (
+                    "ADR has no grounding references "
+                    "(research, reference, or audit documents)"
+                )
                 if feat_name:
                     msg += f" (feature: {feat_name})"
 
                 if fix and feat_name:
-                    candidates = feat_type_index.get(feat_name, {}).get("research", [])
+                    by_type = feat_type_index.get(feat_name, {})
+                    candidates = next(
+                        (
+                            by_type[t]
+                            for t in ("research", "reference", "audit")
+                            if by_type.get(t)
+                        ),
+                        [],
+                    )
                     if candidates and _add_related_link(node.path, candidates[0].name):
                         result.fixed_count += 1
                         result.diagnostics.append(


### PR DESCRIPTION
The schema check errored unless an ADR linked a *research* document, but the documentation hierarchy explicitly sanctions research, reference, and audit documents as ADR grounding. An audit-grounded ADR in the vaultspec-rag workspace was flagged as a schema ERROR, blocking every commit there via the vault-fix hook.

- `check_schema` now accepts any sanctioned grounding type for ADRs; ungrounded ADRs still error.
- `--fix` links the best candidate in research > reference > audit order.
- 7 new real-fs unit tests (acceptance per type, ungrounded error, plan-link non-grounding, fix preference and fallback).
- Full gate: 1751 passed.

Unblocks the vaultspec-rag main-CI repair (rag consumes this via its next lock bump).