### PR TITLE
feat(diagnosis): public observed_mcp_mode accessor for companion packages

### DIFF
--- a/src/vaultspec_core/core/diagnosis/__init__.py
+++ b/src/vaultspec_core/core/diagnosis/__init__.py
@@ -8,6 +8,7 @@ consumers can import directly from the package.
 from __future__ import annotations
 
 from ..resolver import ResolutionPlan, ResolutionStep, resolve
+from .collectors import observed_mcp_mode
 from .diagnosis import (
     PackageModeDiagnosis,
     ProviderDiagnosis,
@@ -52,5 +53,6 @@ __all__ = [
     "VersionFloorSignal",
     "WorkspaceDiagnosis",
     "diagnose",
+    "observed_mcp_mode",
     "resolve",
 ]

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -1025,3 +1025,22 @@ def collect_rename_integrity(target: Path) -> tuple[RenameIntegritySignal, int]:
     except Exception as exc:
         logger.warning("Rename integrity collector failed: %s", exc, exc_info=True)
         return RenameIntegritySignal.ERROR, 0
+
+
+def observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode | None:
+    """Public accessor for the deployed MCP entry's observed install mode.
+
+    Companion packages (vaultspec-rag's upgrade inference and mode-flip
+    detection) consume this observation; the private helper stays the
+    internal implementation.
+
+    Args:
+        target: Workspace root directory.
+        package: Distribution name whose server entry to read; ``None``
+            means ``vaultspec-core``.
+
+    Returns:
+        The :class:`~vaultspec_core.core.enums.InstallMode` the deployed
+        entry is shaped for, or ``None`` when unobservable.
+    """
+    return _observed_mcp_mode(target, package)


### PR DESCRIPTION
vaultspec-rag's upgrade inference and mode-flip detection consume the deployed MCP entry's observed mode. Its strict-typing CI gate (basedpyright, production scope) correctly refuses cross-package private imports, so the observation gets a public name - `observed_mcp_mode(target, package)` exported from `vaultspec_core.core.diagnosis` - while the private helper remains the implementation.

Flagged by the install-parity final review as the API-boundary follow-up; unblocks rag PR #223's strict-types gate. Collectors suite 99 passed; ruff/ty clean.