### PR TITLE
fix(vault): match block indent and dedupe aliases in link add

### DIFF
--- a/src/vaultspec_core/vaultcore/related_surgery.py
+++ b/src/vaultspec_core/vaultcore/related_surgery.py
@@ -167,11 +167,15 @@ def remove_related_entries(path: Path, targets: list[str]) -> int:
 def append_related_entry(path: Path, wiki_link: str) -> bool:
     """Append a ``[[wiki_link]]`` entry to the ``related:`` YAML field.
 
-    Appends the entry as ``  - '[[stem]]'`` at the end of the existing
-    ``related:`` list block.  If no ``related:`` key exists, one is
-    inserted before the closing ``---`` fence.  If the entry already
-    exists (case-insensitive stem match) the file is left unchanged and
-    ``False`` is returned.
+    Appends the entry at the end of the existing ``related:`` list block,
+    reusing that block's own indentation so the append cannot introduce a
+    mixed-indent (strict-YAML-invalid) sequence; when there is no existing
+    block item to copy from the canonical two-space indent is used.  If no
+    ``related:`` key exists, one is inserted before the closing ``---``
+    fence.  If the entry already exists - matched case-insensitively on the
+    bare stem, so an aliased ``[[stem|Label]]`` entry dedupes a plain
+    ``[[stem]]`` append - the file is left unchanged and ``False`` is
+    returned.
 
     Only the ``related:`` frontmatter block is touched; body text is never
     modified.  CRLF line endings are preserved.
@@ -209,6 +213,7 @@ def append_related_entry(path: Path, wiki_link: str) -> bool:
     in_related = False
     related_idx: int | None = None
     last_related_item_idx: int | None = None
+    last_related_indent: str | None = None
     frontmatter_close_idx: int | None = None
     inline_value: str | None = None
 
@@ -239,12 +244,24 @@ def append_related_entry(path: Path, wiki_link: str) -> bool:
                 else:
                     m = _RELATED_ENTRY_RE.match(line)
                     if m:
-                        # Idempotency check
-                        if m.group(1).lower() == stem.lower():
+                        # Idempotency check on the bare stem: an aliased
+                        # existing entry (`[[foo|Foo]]`) must dedupe against a
+                        # plain `[[foo]]` append, so compare only the stem
+                        # left of any `|` alias pipe.
+                        existing_stem = m.group(1).split("|", 1)[0].strip()
+                        if existing_stem.lower() == stem.lower():
                             return False
                         last_related_item_idx = i
+                        last_related_indent = line[: len(line) - len(line.lstrip())]
 
-    new_entry = f"  - '[[{stem}]]'"
+    # Match the existing block's indentation so the appended item cannot
+    # introduce a mixed-indent block sequence - invalid under strict YAML yet
+    # silently tolerated by the vault's lenient line-stripping readers, which
+    # is how a bad append passes `check` while breaking a strict parser. When
+    # no block item exists to copy from (fresh key, empty list, inline
+    # normalisation) fall back to the canonical two-space indent.
+    indent = last_related_indent if last_related_indent is not None else "  "
+    new_entry = f"{indent}- '[[{stem}]]'"
 
     new_lines = list(lines)
 

--- a/src/vaultspec_core/vaultcore/tests/test_link_surgery.py
+++ b/src/vaultspec_core/vaultcore/tests/test_link_surgery.py
@@ -259,6 +259,43 @@ class TestAppendRelatedEntryLF:
         # Order must be preserved with the new entry LAST: [[x]], [[z]], [[y]]
         assert parsed["related"] == ["[[x]]", "[[z]]", "[[y]]"]
 
+    def test_append_matches_existing_block_indent(self, tmp_path):
+        """A new entry must reuse the block's indentation, not a fixed 2 spaces.
+
+        Appending a hardcoded 2-space item beneath a 4-space block produces a
+        mixed-indent sequence that strict YAML rejects while the vault's
+        lenient line-stripping readers silently accept it - the mis-indent
+        that broke `vault link add`.
+        """
+        doc = tmp_path / "doc.md"
+        _write_lf(doc, "---\nrelated:\n    - '[[a]]'\n---\nBody.\n")
+
+        appended = append_related_entry(doc, "[[b]]")
+
+        assert appended is True
+        text = doc.read_text(encoding="utf-8")
+        # The appended line carries the same 4-space indent as the existing one.
+        assert "\n    - '[[b]]'" in text
+        # Strict YAML - the parser the lenient readers mask - accepts it.
+        parsed = yaml.safe_load(text.split("---\n")[1])
+        assert parsed["related"] == ["[[a]]", "[[b]]"]
+
+    def test_append_aliased_stem_dedupes(self, tmp_path):
+        """A plain `[[foo]]` append must dedupe an aliased `[[foo|Foo]]` entry.
+
+        The idempotency guard compares the bare stem, so an aliased existing
+        entry is recognised and no duplicate line is written.
+        """
+        doc = tmp_path / "doc.md"
+        _write_lf(doc, "---\nrelated:\n  - '[[foo|Foo]]'\n---\nBody.\n")
+        original_bytes = doc.read_bytes()
+
+        appended = append_related_entry(doc, "[[foo]]")
+
+        assert appended is False
+        # No duplicate written - file is byte-identical.
+        assert doc.read_bytes() == original_bytes
+
     def test_idempotent_same_stem(self, tmp_path):
         doc = tmp_path / "doc.md"
         _write_lf(doc, "---\nrelated:\n  - '[[alpha]]'\n---\nBody.\n")


### PR DESCRIPTION
## Problem

`vaultspec-core vault link add` could append a **mis-indented duplicate** `related:` entry that broke strict YAML while `check` reported clean. Two independent defects in `append_related_entry` combined:

1. **Fixed indentation.** The new list item was hardcoded as `  - '[[stem]]'` (two spaces) and inserted regardless of the existing block's indentation. A 4-space (or tab) `related:` block got a 2-space item appended -> mixed-indent block sequence that strict YAML rejects.
2. **Alias-blind idempotency.** The duplicate guard compared the raw regex capture, so `[[foo|Foo]]` (captured as `foo|Foo`) never matched a plain `[[foo]]` append and a duplicate was written.

`check` stayed clean because the vault's readers are lenient by design: `parse_vault_metadata` strips every frontmatter line, and the frontmatter loader falls back to `_simple_yaml_load` on `YAMLError` - both ignore indentation. Only a strict parser sees the break.

## Fix

- Reuse the indentation captured from the last existing block item for the appended entry; fall back to the canonical two spaces only when there is no block item to copy (fresh key, empty list, inline-flow normalisation).
- Compare the bare stem (left of any `|` alias) in the idempotency check.

The fix deliberately does not rewrite files that were already strict-invalid before any append (tab-indented blocks, `-'[[x]]'` with no space after the dash) - it only stops the append from *introducing* invalidity into a valid block.

## Tests

Two regression tests in `test_link_surgery.py`:
- 4-space-block indent matching, asserted via strict `yaml.safe_load`
- aliased-stem dedup (byte-identical no-op)

Full vaultcore unit suite (479 tests) green; ruff + ty clean.