### PR TITLE
feat: add provider-native MCP enrollment

### DIFF
--- a/.vault/adr/2026-04-11-mcp-registry-adr.md
+++ b/.vault/adr/2026-04-11-mcp-registry-adr.md
@@ -1,16 +1,17 @@
 ---
 tags:
-  - '#adr'
-  - '#mcp-registry'
+  - "#adr"
+  - "#mcp-registry"
 date: '2026-04-11'
-modified: '2026-06-13'
 related:
-  - '[[2026-04-11-mcp-registry-research]]'
-  - '[[2026-03-28-mcp-installation-patterns-research]]'
-  - '[[2026-02-22-mcp-consolidation-adr]]'
+  - "[[2026-04-11-mcp-registry-research]]"
+  - "[[2026-03-28-mcp-installation-patterns-research]]"
+  - "[[2026-02-22-mcp-consolidation-adr]]"
+superseded_by: '2026-07-15-provider-mcp-enrollment-adr'
+modified: '2026-07-15'
 ---
 
-# `mcp-registry` adr: built-in MCP definitions with install/sync/uninstall lifecycle | (**status:** `accepted`)
+# `mcp-registry` adr: built-in MCP definitions with install/sync/uninstall lifecycle | (**status:** `superseded`)
 
 ## Problem Statement
 

--- a/.vault/adr/2026-07-15-provider-mcp-enrollment-adr.md
+++ b/.vault/adr/2026-07-15-provider-mcp-enrollment-adr.md
@@ -1,0 +1,121 @@
+---
+tags:
+  - "#adr"
+  - "#provider-mcp-enrollment"
+date: '2026-07-15'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-research]]"
+  - "[[2026-07-15-provider-mcp-enrollment-reference]]"
+  - "[[2026-04-11-mcp-registry-adr]]"
+supersedes:
+  - '2026-04-11-mcp-registry-adr'
+modified: '2026-07-15'
+---
+
+# `provider-mcp-enrollment` adr: typed provider-native MCP enrollment with explicit scopes | (**status:** `accepted`)
+
+## Problem Statement
+
+The accepted MCP registry decision incorrectly makes one JSON deployment target stand
+for every provider. Core consequently reports Codex healthy without configuring the
+surface Codex reads. A replacement decision must retain the canonical registry and
+package-mode renderer while making deployment, ownership, scope, status, migration,
+and uninstall native to each enrolled host.
+
+## Considerations
+
+- Host scope and schema facts are grounded in
+  `2026-07-15-provider-mcp-enrollment-research`.
+- Existing lifecycle insertion points and the companion-facing API are grounded in
+  `2026-07-15-provider-mcp-enrollment-reference`.
+- The source registry and mode-aware launch authority from
+  `2026-04-11-mcp-registry-adr` remain stable and reusable.
+- User and local configuration writes cross the workspace boundary and require an
+  explicit scope authorization.
+- Desired state and observed ownership must remain distinct so a sidecar cannot silently
+  become a second registry.
+
+## Considered options
+
+- Keep shared `.mcp.json` and add a Codex copy step: rejected because it preserves the
+  false provider abstraction, duplicates lifecycle behavior, and cannot model scopes.
+- Invoke each host's `mcp add/remove` commands: rejected as the primary writer because
+  Codex exposes no project-scope flag, host command defaults differ, and round-trip
+  preservation and dry-run would depend on external mutations.
+- Parse and reserialize whole native files: rejected because it destroys comments and
+  user formatting in shared TOML and expands the corruption blast radius.
+- Use typed targets with provider adapters, managed TOML blocks, and ownership sidecars:
+  selected because it gives one lifecycle contract while preserving native schemas and
+  user content.
+
+## Constraints
+
+- `.vaultspec/mcps/*.json` remains the only desired-state authority.
+- Dependency/dev and tool launch shapes continue through the existing mode renderer.
+- Canonical mode metadata separates declaring-package identity from an optional
+  tool-mode distribution spec; both are stripped before host rendering.
+- Provider-native files contain only host-supported configuration and comments.
+- Project is the default scope. User and Claude-local scopes require an explicit option;
+  Codex-local is invalid.
+- Fresh install must reconcile the selected providers even before their manifest write.
+- Dry-run writes no project, host, ownership, or manifest bytes.
+- Unforced sync never adopts a same-name entry without affirmative legacy ownership.
+- A provider-only operation never mutates another provider or scope.
+- Installation never launches an MCP process; hosts retain trust and approval control.
+
+## Implementation
+
+Introduce typed scope, target-format, target, normalized-definition, and ownership
+records above the deployment writers. Target resolution maps Claude project, local, and
+user scopes plus Codex project and user scopes to their native stores and rejects invalid
+combinations. Provider adapters render normalized stdio definitions to Claude JSON or
+Codex TOML and report unsupported fields.
+
+Project ownership is recorded under Vaultspec workspace state. Explicit user-scope
+ownership is recorded under Vaultspec user state. These records contain only target
+identity, managed names, and observed fingerprints. Codex project and user tables are
+also bounded by a comment-only managed block so unrelated TOML remains byte-stable.
+
+The JSON migration transfers legacy `_vaultspecManaged` evidence into ownership state
+and removes the non-host key. Entries without affirmative ownership remain external;
+force is the only adoption path. Prune and uninstall act exclusively on recorded
+ownership. Status aggregates selected native targets and is green only when every
+selected enrolled provider is synchronized.
+
+Keep `mcp_sync` as the public package-aware reconcile seam, extended with provider and
+scope. Preserve `mode` and `force_managed` so companion packages can use one canonical
+definition and one public call. Add matching provider/scope controls to status and
+uninstall and pass selected providers directly during fresh install. Root install,
+upgrade, sync, and uninstall default to project scope and never touch user state unless
+the operator explicitly requests it.
+
+Extend the single launch renderer with an optional tool distribution spec. The existing
+package metadata continues to select committed workspace mode; only tool mode substitutes
+the optional spec into `uvx --from`. Definition collection validates and strips the new
+metadata key before either provider adapter sees the definition.
+
+## Rationale
+
+Typed target adapters are the only option that satisfies both host contracts without
+forking the canonical registry or allowing provider-specific logic into companion
+packages. External ownership state is required by the host-valid-schema constraint,
+while the managed TOML block is required by the user-content round-trip constraint.
+The explicit scope matrix follows the consent boundary established by
+`2026-07-15-provider-mcp-enrollment-research`; the public seam follows the existing
+architecture mapped by `2026-07-15-provider-mcp-enrollment-reference`.
+
+## Consequences
+
+- Codex and Claude receive equivalent lifecycle semantics through different native
+  files, and status can no longer be green against an irrelevant file.
+- Claude's working project `.mcp.json` behavior remains intact while its Vaultspec-only
+  top-level key is retired.
+- Companion packages gain a stable provider/scope reconcile API and no longer need to
+  infer deployment format.
+- Ownership migration becomes conservative; some legacy same-name entries will require
+  one explicit force adoption rather than being claimed automatically.
+- User-scope support adds cross-workspace conflict and locking concerns that project-only
+  code did not have; acceptance must isolate configuration homes and exercise real host
+  CLIs.
+- `2026-04-11-mcp-registry-adr` is superseded because its provider-agnostic deployment
+  premise is replaced, while its canonical source-registry decision is carried forward.

--- a/.vault/audit/2026-07-15-provider-mcp-enrollment-audit.md
+++ b/.vault/audit/2026-07-15-provider-mcp-enrollment-audit.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - '#audit'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# `provider-mcp-enrollment` audit: `provider-native enrollment release review`
+
+## Scope
+
+This audit reviews the complete provider-native MCP enrollment feature against its accepted ADR and implementation plan. It covers typed provider and scope resolution, Claude and Antigravity JSON reconciliation, Codex TOML reconciliation, external ownership state, legacy marker migration, force adoption, prune and selective uninstall, install and sync lifecycle integration, CLI and gateway mutation boundaries, companion package launch rendering, operator guidance, and real Claude Code and Codex CLI acceptance.
+
+## Findings
+
+### install-syncresult-success | high | resolved: install reported success after native-store reconciliation errors
+
+The release review confirmed that the inherited install orchestration consumed MCP `SyncResult` items but did not inspect its errors. A malformed provider-native store could therefore prevent enrollment while the API returned an install result and the CLI exited successfully. The fix adds a single reconciliation-success boundary used by fresh install, fresh preview, upgrade preview, actual upgrade, and targeted mode migration. Any detailed or count-only reconciliation error now becomes a typed `VaultSpecError`, which the CLI renders with a non-zero exit. Real-file API and CLI regressions use a malformed Claude `.mcp.json` and prove that neither surface claims success.
+
+### claude-local-windows-key | medium | resolved: Windows path spelling did not match Claude's local project key
+
+Real Claude Code acceptance found that local enrollment used a backslash-form absolute path under `~/.claude.json`, while Claude keys the projects object with the forward-slash absolute spelling on Windows. The writer and empty-container cleanup now use the same resolved POSIX path form. Claude Code 2.1.210 recognizes the resulting local entry.
+
+### host-trust-and-approval | low | accepted: enrollment does not grant provider runtime authority
+
+Claude project enrollment is visible to the host while remaining pending until the host's approval flow completes. Codex project recognition requires its native project trust/config behavior. Status therefore remains configuration- and ownership-only and does not infer process health, approval, or connectivity. The CLI and operator guide state that boundary explicitly.
+
+### repository-wide-collection-layout | low | non-blocking pre-existing test-layout conflict
+
+The repository's CI-defined unit target is green. An additional all-roots collection attempt remains blocked independently of this feature by duplicate `test_normalize.py` module names under the default import mode; switching to importlib mode reaches an unrelated optional `statistic` package import. The feature's focused root suites and installed-host acceptance were run separately and are green.
+
+## Recommendations
+
+- Preserve the reconciliation-success boundary for any future install-time resource adapter; install must not turn an error-bearing `SyncResult` into success.
+- Keep provider runtime trust and approval outside Vaultspec status unless a future ADR introduces an explicit runtime-probe contract.
+- Resolve the repository-wide duplicate test-module and optional-package collection issues separately; they do not block the CI-defined gate or this release.
+
+**Verdict: PASS.** The release-blocking HIGH finding is fixed and covered through real API and CLI behavior. The full CI unit target passes 1,761 tests with 1,052 deliberately deselected. The focused provider-native suites, MCP gateway catalogue, generated references, Ruff, Ty, vault checks, and real Claude Code 2.1.210 and Codex CLI 0.144.4 acceptance are green. No unresolved CRITICAL or HIGH finding remains.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S01.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S01.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S01'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Define typed MCP scope, target, ownership, and tool-spec contracts
+
+## Scope
+
+- `src/vaultspec_core/core/enums.py and src/vaultspec_core/core/types.py`
+
+## Description
+
+- Define project, local, and user MCP scopes as a canonical enum.
+- Define JSON and TOML native target formats.
+- Add the immutable provider, scope, path, and format target contract.
+- Declare MCP capability for Claude, Antigravity, and Codex without claiming unverified Gemini support.
+
+## Outcome
+
+Core now has an additive typed boundary for provider-native MCP target resolution. Ruff and type checks pass. All 32 tests that did not require temporary paths passed, and the three capability contract tests passed with an explicit pytest base directory.
+
+## Notes
+
+The repository Windows temp compatibility shim calls pytest's numbering helper without its new required `register` argument. The affected tests pass unchanged when pytest receives `--basetemp`; this is pre-existing test infrastructure drift, not an S01 product failure.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S02.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S02.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S02'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Implement ownership state and provider-scope target resolution
+
+## Scope
+
+- `src/vaultspec_core/core/mcps.py`
+
+## Description
+
+- Resolve enrolled MCP-capable providers to verified native project, local, and user targets.
+- Reject Codex local and unsupported Antigravity broader-scope combinations.
+- Honor `CODEX_HOME` for explicit Codex user scope.
+- Add strict external ownership sidecar parsing and writing contracts.
+- Separate declaring package identity from the optional tool-mode distribution spec and strip all mode metadata before host output.
+
+## Outcome
+
+Production resolver checks selected Claude JSON and Codex TOML paths correctly, rejected Codex local, rendered RAG tool mode through `vaultspec-rag[mcp]`, and preserved dependency/dev `uv run`. Ruff and type checks pass. The existing MCP suite reached 52 passes; one current test expects dependency mode from an unspecified fresh install even though Core now defaults to tool mode.
+
+## Notes
+
+The stale fresh-install mode assertion is preserved for the dedicated test-update step rather than changing product behavior or weakening the test during this architecture step.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S03.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S03.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S03'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall
+
+## Scope
+
+- `src/vaultspec_core/core/mcps.py`
+
+## Description
+
+- Reconcile canonical stdio definitions into Claude project, local, and user JSON stores plus Codex project and user TOML stores.
+- Preserve unrelated Codex settings and comments through a comment-bounded managed block and surgical force adoption.
+- Move ownership names and observed fingerprints into external project or user state.
+- Migrate only affirmative legacy ownership and remove the unsupported host-schema marker.
+- Aggregate missing, drifted, stale, and external entries independently per provider.
+- Prune and uninstall only recorded managed entries with per-provider `SyncResult` outcomes.
+- Bootstrap explicit `target_dir` and `enrolled` calls without relying on ambient workspace context.
+
+## Outcome
+
+Real-file probes passed fresh native writes, idempotence, same-name collision preservation and explicit adoption, unrelated TOML byte preservation, affirmative legacy migration, conservative no-marker migration, source-safe prune, independent provider drift, provider-scoped uninstall, explicit Claude local scope, and standalone sync/status/uninstall without a preinitialized context. Ruff and type checks pass. A real fresh installation wrote Claude, Antigravity, and Codex project targets; Claude CLI recognized its project entry, while Codex correctly withheld the untrusted temporary project configuration.
+
+## Notes
+
+The existing JSON-only tests intentionally remain for the dedicated test-replacement step. Codex host acceptance must create an isolated trusted project in the dedicated acceptance step rather than weakening the host trust boundary.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S04.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P01-S04.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S04'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Export the stable package-aware companion reconcile API
+
+## Scope
+
+- `src/vaultspec_core/core/__init__.py`
+- `src/vaultspec_core/core/mcps.py`
+
+## Description
+
+- Export typed provider, scope, format, target, and install-mode contracts from the public Core package.
+- Export native target resolution, package-aware launch rendering, sync, status, and uninstall functions.
+- Preserve the single canonical definition renderer for Core and companion packages.
+
+## Outcome
+
+A consumer importing only `vaultspec_core.core` reconciled Claude and Codex in a fresh workspace without ambient context, inspected aggregate native status, resolved typed targets, verified package-aware launch rendering, and uninstalled both providers with per-tool outcomes. Ruff and type checks pass.
+
+## Notes
+
+`provider="all"` reads the persisted enrolled-provider manifest during ordinary lifecycle calls. Fresh pre-manifest callers pass the exact `enrolled` provider members explicitly, preventing accidental host selection.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P02-S05.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P02-S05.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S05'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Wire selected providers and project-default MCP scopes into install, upgrade, sync, and uninstall
+
+## Scope
+
+- `src/vaultspec_core/core/commands.py`
+- `src/vaultspec_core/core/mcps.py`
+
+## Description
+
+- Pass the exact fresh-install provider members into project-scope MCP reconciliation before manifest persistence.
+- Route all-provider sync through the committed manifest and provider-specific sync through only the requested MCP-capable host.
+- Remove recorded native MCP entries before provider directories, manifests, or ownership state are deleted.
+- Report native target paths and provider-specific uninstall errors through lifecycle results.
+- Treat any selected native MCP target as installed instead of using Claude's project file as a proxy.
+- Make install and MCP dry-runs lock-free so previews leave no project bytes.
+
+## Outcome
+
+Real lifecycle probes passed Codex-only, Claude-only, Gemini-only, and all-provider fresh installs; Claude-only sync left Codex drift untouched, Codex sync repaired only Codex, Claude uninstall preserved Codex, and full uninstall removed all native targets. Install and uninstall previews were byte-stable, and a fresh install preview left an otherwise empty target directory unchanged. Ruff and type checks pass. The existing command suite reached ten passes; two assertions still expect the superseded dependency-mode default, and one pre-existing result-count assertion omits the hooks pass.
+
+## Notes
+
+Project scope remains the lifecycle default. Broader host scopes are not reached by root install, sync, upgrade, or uninstall unless the dedicated MCP CLI explicitly requests them in the next step.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P02-S06.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P02-S06.md
@@ -1,0 +1,35 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S06'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Add provider-scope MCP controls and provider-native status output
+
+## Scope
+
+- `src/vaultspec_core/cli/spec_cmd.py`
+- `src/vaultspec_core/cli/root.py`
+- `src/vaultspec_core/core/mcps.py`
+- generated CLI reference regions
+
+## Description
+
+- Add provider and scope selection to MCP status and reconciliation.
+- Report aggregate and per-provider enrollment, ownership, drift, missing, and external state.
+- Add owned-entry uninstall with dry-run and explicit destructive confirmation.
+- Group structured reconciliation outcomes by native provider target.
+- Describe canonical definitions and provider-native enrollment consistently in live help and generated CLI reference copy.
+
+## Outcome
+
+The MCP CLI now manages Claude, Codex, and Antigravity native targets independently at supported project, local, or user scopes. Status is configuration-only and exposes per-provider health; sync supports force and owned-entry pruning; uninstall removes only recorded ownership. The root sync outcome collector includes the hooks pass and groups MCP outcomes per provider. Ruff and Ty pass, the generated CLI reference is synchronized, and real CLI probes verified project and isolated user-scope operations without dry-run writes.
+
+## Notes
+
+Gemini is intentionally absent from the MCP target list because it has no native MCP capability. Host trust, approval, and process availability remain provider-owned and are not inferred from enrollment status.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-S07.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-S07.md
@@ -1,0 +1,35 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S07'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests
+
+## Scope
+
+- `tests/test_mcps.py`
+- `tests/test_commands.py`
+- `src/vaultspec_core/tests/cli/test_sync.py`
+- `src/vaultspec_core/tests/cli/test_mcp_provider_files.py`
+
+## Description
+
+- Replace shared-file and inline-marker expectations with provider-native targets and external ownership records.
+- Exercise Claude and Antigravity JSON plus Codex TOML through real filesystem reconciliation.
+- Cover explicit public target enrollment, package-aware tool rendering, independent provider drift, force adoption, prune, migration, dry-run byte stability, and unsupported scope errors.
+- Prove selective companion uninstall preserves Core entries and exact Core ownership fingerprints.
+- Align fresh-install command and hook assertions with the tool-mode default and include the hooks sync pass in root result labels.
+
+## Outcome
+
+Seventy-one focused command and MCP tests pass, including five new multi-provider native-enrollment cases. Thirty-three broader CLI sync and provider-file tests pass, and twenty-three doctor tests pass. Ruff and Ty pass for every changed test file. The repository-wide collection remains independently blocked by duplicate `test_normalize.py` module names under default import mode; switching to importlib mode exposes an unrelated optional `statistic` package import failure.
+
+## Notes
+
+Tests use real source imports and real files. They do not use mocks, fakes, stubs, monkeypatching, skips, or expected-failure markers.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-S08.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-S08.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+step_id: 'S08'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Add isolated Codex and Claude CLI acceptance and update MCP operator guidance
+
+## Scope
+
+- `tests/cli/test_mcp_hosts.py and docs/MCP.md`
+
+## Description
+
+- Exercise project, user, and local enrollment through installed Claude Code and Codex CLI binaries with isolated host state.
+- Verify provider-owned Claude approval and Codex trust behavior without claiming runtime connectivity.
+- Reject unsupported Codex local scope without falling back to or mutating user configuration.
+- Correct Claude local project-key rendering for Windows paths.
+- Document canonical definitions, provider-native targets, ownership, scope support, force, prune, dry-run, uninstall, and the `vaultspec-rag[mcp]` tool spec.
+- Keep MCP mutation commands outside the MCP gateway catalogue.
+
+## Outcome
+
+Claude Code 2.1.210 and Codex CLI 0.144.4 passed all three real-host acceptance tests. Both hosts recognized isolated project and user enrollment. Claude recognized local enrollment after Core normalized its `~/.claude.json` project key to the host's forward-slash absolute-path convention; Codex local scope failed explicitly and left user configuration untouched. Claude reported its native pending-approval state for project enrollment, while the isolated Codex project used the host's trust configuration. The generated CLI reference, operator guide, Ruff, Ty, and MCP gateway catalogue tests pass.
+
+## Notes
+
+Enrollment status is deliberately configuration-only. Host approval, trust, executable availability, and server process health remain provider-owned runtime concerns.

--- a/.vault/index/provider-mcp-enrollment.index.md
+++ b/.vault/index/provider-mcp-enrollment.index.md
@@ -1,0 +1,59 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+related:
+  - '[[2026-07-15-provider-mcp-enrollment-P01-S01]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P01-S02]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P01-S03]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P01-S04]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P02-S05]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P02-S06]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P03-S07]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P03-S08]]'
+  - '[[2026-07-15-provider-mcp-enrollment-adr]]'
+  - '[[2026-07-15-provider-mcp-enrollment-audit]]'
+  - '[[2026-07-15-provider-mcp-enrollment-plan]]'
+  - '[[2026-07-15-provider-mcp-enrollment-reference]]'
+  - '[[2026-07-15-provider-mcp-enrollment-research]]'
+---
+
+# `provider-mcp-enrollment` feature index
+
+Auto-generated index of all documents tagged with `#provider-mcp-enrollment`.
+
+## Documents
+
+### adr
+
+- `2026-07-15-provider-mcp-enrollment-adr` - `provider-mcp-enrollment` adr: typed provider-native MCP enrollment with explicit scopes | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-15-provider-mcp-enrollment-audit` - `provider-mcp-enrollment` audit: `provider-native enrollment release review`
+
+### exec
+
+- `2026-07-15-provider-mcp-enrollment-P01-S01` - Define typed MCP scope, target, ownership, and tool-spec contracts
+- `2026-07-15-provider-mcp-enrollment-P01-S02` - Implement ownership state and provider-scope target resolution
+- `2026-07-15-provider-mcp-enrollment-P01-S03` - Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall
+- `2026-07-15-provider-mcp-enrollment-P01-S04` - Export the stable package-aware companion reconcile API
+- `2026-07-15-provider-mcp-enrollment-P02-S05` - Wire selected providers and project-default MCP scopes into install, upgrade, sync, and uninstall
+- `2026-07-15-provider-mcp-enrollment-P02-S06` - Add provider-scope MCP controls and provider-native status output
+- `2026-07-15-provider-mcp-enrollment-P03-S07` - Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests
+- `2026-07-15-provider-mcp-enrollment-P03-S08` - Add isolated Codex and Claude CLI acceptance and update MCP operator guidance
+
+### plan
+
+- `2026-07-15-provider-mcp-enrollment-plan` - `provider-mcp-enrollment` plan
+
+### reference
+
+- `2026-07-15-provider-mcp-enrollment-reference` - `provider-mcp-enrollment` reference: Core MCP registry and native host configuration surfaces
+
+### research
+
+- `2026-07-15-provider-mcp-enrollment-research` - `provider-mcp-enrollment` research: provider-native MCP enrollment scopes and ownership

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -42,7 +42,7 @@ Route install, upgrade, sync, status, prune, and uninstall through selected prov
 Verify migrations and real Codex and Claude recognition, then document the provider and scope contract for operators and companion packages.
 
 - [x] `P03.S07` - Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests; `tests/test_mcps.py and tests/test_commands.py`.
-- [ ] `P03.S08` - Add isolated Codex and Claude CLI acceptance and update MCP operator guidance; `tests/cli/test_mcp_hosts.py and docs/MCP.md`.
+- [x] `P03.S08` - Add isolated Codex and Claude CLI acceptance and update MCP operator guidance; `tests/cli/test_mcp_hosts.py and docs/MCP.md`.
 
 ## Parallelization
 

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -41,7 +41,7 @@ Route install, upgrade, sync, status, prune, and uninstall through selected prov
 
 Verify migrations and real Codex and Claude recognition, then document the provider and scope contract for operators and companion packages.
 
-- [ ] `P03.S07` - Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests; `tests/test_mcps.py and tests/test_commands.py`.
+- [x] `P03.S07` - Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests; `tests/test_mcps.py and tests/test_commands.py`.
 - [ ] `P03.S08` - Add isolated Codex and Claude CLI acceptance and update MCP operator guidance; `tests/cli/test_mcp_hosts.py and docs/MCP.md`.
 
 ## Parallelization

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -26,7 +26,7 @@ The accepted provider MCP enrollment ADR governs all three phases. Phase P01 rep
 Define normalized definitions, provider and scope targets, external ownership state, native renderers, and the stable companion reconcile boundary.
 
 - [x] `P01.S01` - Define typed MCP scope, target, ownership, and tool-spec contracts; `src/vaultspec_core/core/enums.py and src/vaultspec_core/core/types.py`.
-- [ ] `P01.S02` - Implement ownership state and provider-scope target resolution; `src/vaultspec_core/core/mcps.py`.
+- [x] `P01.S02` - Implement ownership state and provider-scope target resolution; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P01.S03` - Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P01.S04` - Export the stable package-aware companion reconcile API; `src/vaultspec_core/core/__init__.py and src/vaultspec_core/core/mcps.py`.
 

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -35,7 +35,7 @@ Define normalized definitions, provider and scope targets, external ownership st
 Route install, upgrade, sync, status, prune, and uninstall through selected provider-native targets with project-safe defaults.
 
 - [x] `P02.S05` - Wire selected providers and project-default MCP scopes into install, upgrade, sync, and uninstall; `src/vaultspec_core/core/commands.py`.
-- [ ] `P02.S06` - Add provider-scope MCP controls and provider-native status output; `src/vaultspec_core/cli/spec_cmd.py and src/vaultspec_core/cli/root.py`.
+- [x] `P02.S06` - Add provider-scope MCP controls and provider-native status output; `src/vaultspec_core/cli/spec_cmd.py and src/vaultspec_core/cli/root.py`.
 
 ### Phase `P03` - prove native hosts and publish guidance
 

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -27,7 +27,7 @@ Define normalized definitions, provider and scope targets, external ownership st
 
 - [x] `P01.S01` - Define typed MCP scope, target, ownership, and tool-spec contracts; `src/vaultspec_core/core/enums.py and src/vaultspec_core/core/types.py`.
 - [x] `P01.S02` - Implement ownership state and provider-scope target resolution; `src/vaultspec_core/core/mcps.py`.
-- [ ] `P01.S03` - Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall; `src/vaultspec_core/core/mcps.py`.
+- [x] `P01.S03` - Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P01.S04` - Export the stable package-aware companion reconcile API; `src/vaultspec_core/core/__init__.py and src/vaultspec_core/core/mcps.py`.
 
 ### Phase `P02` - integrate lifecycle and operator controls

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -34,7 +34,7 @@ Define normalized definitions, provider and scope targets, external ownership st
 
 Route install, upgrade, sync, status, prune, and uninstall through selected provider-native targets with project-safe defaults.
 
-- [ ] `P02.S05` - Wire selected providers and project-default MCP scopes into install, upgrade, sync, and uninstall; `src/vaultspec_core/core/commands.py`.
+- [x] `P02.S05` - Wire selected providers and project-default MCP scopes into install, upgrade, sync, and uninstall; `src/vaultspec_core/core/commands.py`.
 - [ ] `P02.S06` - Add provider-scope MCP controls and provider-native status output; `src/vaultspec_core/cli/spec_cmd.py and src/vaultspec_core/cli/root.py`.
 
 ### Phase `P03` - prove native hosts and publish guidance

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -25,7 +25,7 @@ The accepted provider MCP enrollment ADR governs all three phases. Phase P01 rep
 
 Define normalized definitions, provider and scope targets, external ownership state, native renderers, and the stable companion reconcile boundary.
 
-- [ ] `P01.S01` - Define typed MCP scope, target, ownership, and tool-spec contracts; `src/vaultspec_core/core/enums.py and src/vaultspec_core/core/types.py`.
+- [x] `P01.S01` - Define typed MCP scope, target, ownership, and tool-spec contracts; `src/vaultspec_core/core/enums.py and src/vaultspec_core/core/types.py`.
 - [ ] `P01.S02` - Implement ownership state and provider-scope target resolution; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P01.S03` - Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P01.S04` - Export the stable package-aware companion reconcile API; `src/vaultspec_core/core/__init__.py and src/vaultspec_core/core/mcps.py`.

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - '#plan'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+tier: L2
+related:
+  - '[[2026-07-15-provider-mcp-enrollment-adr]]'
+  - '[[2026-07-15-provider-mcp-enrollment-research]]'
+  - '[[2026-07-15-provider-mcp-enrollment-reference]]'
+---
+
+# `provider-mcp-enrollment` plan
+
+Deliver provider-native MCP enrollment for Claude and Codex with project-safe defaults, explicit broader scopes, ownership-safe migration, and one stable companion reconcile API.
+
+## Description
+
+The accepted provider MCP enrollment ADR governs all three phases. Phase P01 replaces the JSON-only deployment assumption with typed targets, external ownership, provider-native renderers, and the package-aware public seam. Phase P02 connects that engine to existing lifecycle and CLI surfaces without authorizing global writes by default. Phase P03 proves migration and recognition through real host CLIs and publishes the operator contract.
+
+## Steps
+
+### Phase `P01` - establish the typed enrollment engine
+
+Define normalized definitions, provider and scope targets, external ownership state, native renderers, and the stable companion reconcile boundary.
+
+- [ ] `P01.S01` - Define typed MCP scope, target, ownership, and tool-spec contracts; `src/vaultspec_core/core/enums.py and src/vaultspec_core/core/types.py`.
+- [ ] `P01.S02` - Implement ownership state and provider-scope target resolution; `src/vaultspec_core/core/mcps.py`.
+- [ ] `P01.S03` - Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall; `src/vaultspec_core/core/mcps.py`.
+- [ ] `P01.S04` - Export the stable package-aware companion reconcile API; `src/vaultspec_core/core/__init__.py and src/vaultspec_core/core/mcps.py`.
+
+### Phase `P02` - integrate lifecycle and operator controls
+
+Route install, upgrade, sync, status, prune, and uninstall through selected provider-native targets with project-safe defaults.
+
+- [ ] `P02.S05` - Wire selected providers and project-default MCP scopes into install, upgrade, sync, and uninstall; `src/vaultspec_core/core/commands.py`.
+- [ ] `P02.S06` - Add provider-scope MCP controls and provider-native status output; `src/vaultspec_core/cli/spec_cmd.py and src/vaultspec_core/cli/root.py`.
+
+### Phase `P03` - prove native hosts and publish guidance
+
+Verify migrations and real Codex and Claude recognition, then document the provider and scope contract for operators and companion packages.
+
+- [ ] `P03.S07` - Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests; `tests/test_mcps.py and tests/test_commands.py`.
+- [ ] `P03.S08` - Add isolated Codex and Claude CLI acceptance and update MCP operator guidance; `tests/cli/test_mcp_hosts.py and docs/MCP.md`.
+
+## Parallelization
+
+P01 is ordered because its contracts bind both native adapters. P02 follows P01 and its two steps are ordered so the CLI exposes only completed lifecycle semantics. In P03, engine regression tests and isolated host acceptance can be developed independently after P02; documentation follows verified behavior. Formal review and release gates follow all steps.
+
+## Verification
+
+- Focused Ruff, type, and pytest gates pass for every touched module.
+- Fresh Claude project install remains visible to `claude mcp get` through `.mcp.json`.
+- Fresh trusted Codex project install is visible to `codex mcp get` through `.codex/config.toml`.
+- Project dry-run, second sync, prune, provider uninstall, and full uninstall are byte-safe and ownership-safe.
+- Explicit local or user scope writes only the selected host scope in isolated homes; no default command writes user configuration.
+- Dependency/dev and tool definitions render through the declared package mode, including the optional RAG tool distribution spec.
+- Provider-native status reports missing, drifted, stale, and external entries without a false green.
+- The complete repository quality gate and formal Vaultspec code review pass before publication.

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -28,7 +28,7 @@ Define normalized definitions, provider and scope targets, external ownership st
 - [x] `P01.S01` - Define typed MCP scope, target, ownership, and tool-spec contracts; `src/vaultspec_core/core/enums.py and src/vaultspec_core/core/types.py`.
 - [x] `P01.S02` - Implement ownership state and provider-scope target resolution; `src/vaultspec_core/core/mcps.py`.
 - [x] `P01.S03` - Implement Claude JSON and Codex TOML reconciliation, status, prune, and uninstall; `src/vaultspec_core/core/mcps.py`.
-- [ ] `P01.S04` - Export the stable package-aware companion reconcile API; `src/vaultspec_core/core/__init__.py and src/vaultspec_core/core/mcps.py`.
+- [x] `P01.S04` - Export the stable package-aware companion reconcile API; `src/vaultspec_core/core/__init__.py and src/vaultspec_core/core/mcps.py`.
 
 ### Phase `P02` - integrate lifecycle and operator controls
 

--- a/.vault/reference/2026-07-15-provider-mcp-enrollment-reference.md
+++ b/.vault/reference/2026-07-15-provider-mcp-enrollment-reference.md
@@ -1,0 +1,137 @@
+---
+tags:
+  - '#reference'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+related:
+  - "[[2026-04-11-mcp-registry-adr]]"
+---
+
+# `provider-mcp-enrollment` reference: Core MCP registry and native host configuration surfaces
+
+This reference maps the current registry, install, status, configuration, and uninstall
+paths and defines the public boundary needed by companion packages. The audit covers
+the Core source, its real-behavior MCP tests, official Codex and Claude contracts, and
+the installed host CLIs.
+
+## Summary
+
+### Existing source and rendering flow
+
+`collect_mcp_servers` reads canonical JSON definitions and applies the package-aware
+mode renderer. `_apply_mcp_merge` and `_sync_mcp_target` then assume every destination
+is JSON with `mcpServers` and `_vaultspecManaged`. `mcp_sync` always targets root
+`.mcp.json` and adds provider-native JSON targets declared through `ToolConfig`.
+`mcp_status` inspects only root `.mcp.json`. `mcp_uninstall` repeats the JSON assumption.
+
+Fresh install calls `mcp_sync` before provider names are persisted to the manifest, so
+native target discovery through `installed_tool_configs` cannot see newly selected
+providers. Ordinary sync runs configuration before MCP reconciliation and can share a
+Codex TOML file safely only if MCP writes use their own managed block and one lock/write
+transaction. Provider-specific `spec mcps sync` currently validates the provider but
+does not pass it into `mcp_sync`.
+
+### Reusable Core seams
+
+`render_launch_for_mode` and `_render_definition_for_sync` already provide the correct
+package-mode behavior and should remain the single launch authority. They must accept an
+optional tool distribution spec independently of the declaring package: package remains
+the workspace-mode lookup identity, while tool mode renders `uvx --from <tool-spec>`.
+The metadata key `_vaultspec_mode_tool_spec` is stripped with the existing package and
+module metadata before any host output. The tag engine's
+comment-prefixed managed block supports byte-preserving Codex TOML ownership. The
+provider manifest supplies enrolled providers, but persistent MCP ownership is a
+separate concern and needs a dedicated sidecar because it is per provider, scope, and
+target.
+
+### Proposed stable public API
+
+The implementation should export these typed contracts from `vaultspec_core.core`:
+
+```python
+class McpScope(StrEnum):
+    PROJECT = "project"
+    LOCAL = "local"
+    USER = "user"
+
+@dataclass(frozen=True)
+class McpTarget:
+    provider: Tool
+    scope: McpScope
+    path: Path
+    format: McpTargetFormat
+
+def resolve_mcp_targets(
+    provider: Tool | str = "all",
+    *,
+    scope: McpScope = McpScope.PROJECT,
+    target_dir: Path | None = None,
+) -> tuple[McpTarget, ...]: ...
+
+def mcp_sync(
+    *,
+    provider: Tool | str = "all",
+    scope: McpScope = McpScope.PROJECT,
+    dry_run: bool = False,
+    force: bool = False,
+    prune: bool = False,
+    mode: InstallMode | None = None,
+    force_managed: frozenset[str] = frozenset(),
+) -> SyncResult: ...
+
+def mcp_status(
+    *,
+    provider: Tool | str = "all",
+    scope: McpScope = McpScope.PROJECT,
+) -> dict[str, object]: ...
+
+def mcp_uninstall(
+    target_dir: Path,
+    *,
+    provider: Tool | str = "all",
+    scope: McpScope = McpScope.PROJECT,
+    dry_run: bool = False,
+) -> SyncResult: ...
+```
+
+`mcp_sync` remains the provider-agnostic companion reconcile seam: RAG enrolls one
+canonical definition, records its package mode through existing workspace declaration
+logic, and invokes this public function with `force_managed={"vaultspec-rag"}` when a
+mode transition must update already-owned entries. It must never call adapter-private
+JSON or TOML functions. Its canonical definition keeps
+`_vaultspec_mode_package: "vaultspec-rag"` and adds
+`_vaultspec_mode_tool_spec: "vaultspec-rag[mcp]"`; dependency/dev render `uv run`, while
+tool mode renders `uvx --from vaultspec-rag[mcp]`.
+
+`SyncResult.per_tool` remains the result carrier for each provider. MCP status JSON must
+add `scope` and a `providers` map; every provider entry reports `target`, `format`,
+`configured`, `managed`, `external`, `missing`, `drifted`, `stale_managed`, and
+`warnings`. Aggregate status is green only when every selected enrolled provider's
+native target is synchronized.
+
+### Migration and lifecycle insertion points
+
+The JSON adapter migrates `_vaultspecManaged` to the sidecar under the same advisory
+lock before deleting the legacy key. Without legacy ownership, name equality never
+authorizes adoption. The TOML adapter owns only its comment-delimited MCP block and
+must detect same-name tables outside it. Force can adopt a conflicting entry by removing
+that complete table and rendering it in the managed block; default sync preserves it.
+
+Install must supply the freshly selected provider set directly or persist the manifest
+before MCP reconciliation. Upgrade passes resolved mode and the narrow
+`force_managed` set. Provider sync passes its provider argument. Provider uninstall
+removes only that provider/scope target; full uninstall defaults to all installed
+project targets. User/local targets are touched only by an explicit scope request.
+
+### Verification epicenters
+
+- `src/vaultspec_core/core/mcps.py`
+- `src/vaultspec_core/core/types.py`
+- `src/vaultspec_core/core/enums.py`
+- `src/vaultspec_core/core/config_gen.py`
+- `src/vaultspec_core/core/commands.py`
+- `src/vaultspec_core/core/manifest.py`
+- `src/vaultspec_core/cli/spec_cmd.py`
+- `tests/test_mcps.py`
+- `tests/test_commands.py`

--- a/.vault/research/2026-07-15-provider-mcp-enrollment-research.md
+++ b/.vault/research/2026-07-15-provider-mcp-enrollment-research.md
@@ -1,0 +1,113 @@
+---
+tags:
+  - '#research'
+  - '#provider-mcp-enrollment'
+date: '2026-07-15'
+modified: '2026-07-15'
+related:
+  - "[[2026-04-11-mcp-registry-adr]]"
+  - "[[2026-03-28-mcp-installation-patterns-research]]"
+---
+
+# `provider-mcp-enrollment` research: provider-native MCP enrollment scopes and ownership
+
+The MCP registry has one canonical desired-state source but its deployed state is not
+provider-agnostic. Claude Code consumes project MCPs from `.mcp.json`; Codex consumes
+them from trusted `.codex/config.toml`. The current shared-JSON assumption therefore
+produces a false-green Codex status. Current host contracts favor typed native targets,
+project scope as Vaultspec's safe default, explicit authorization for user or local
+scope, and ownership state outside host schemas.
+
+## Findings
+
+### Codex has project and user configuration layers, not a shared JSON registry
+
+Codex stores MCP tables as `[mcp_servers.<name>]` in `config.toml`. Its user layer is
+`$CODEX_HOME/config.toml`, defaulting to `~/.codex/config.toml`; a trusted repository
+may override it with `.codex/config.toml`. The installed `codex-cli@0.144.4` exposes
+`mcp add`, `get`, `list`, and `remove`, but no scope flag: `mcp add` is a user-config
+writer while project enrollment is a direct project-config operation. Official Codex
+configuration precedence places trusted project layers above user configuration.
+
+### Claude has three scopes with two physical configuration stores
+
+Claude Code `2.1.210` exposes `--scope local|user|project`, defaulting its own add
+command to local. Project scope is shared through the workspace `.mcp.json`. Local and
+user scope both live in `~/.claude.json`; local entries are nested under the current
+project path while user entries apply across projects. Project MCPs remain subject to
+workspace trust and per-server approval. Vaultspec's existing project `.mcp.json`
+output is therefore the correct Claude project target and must be preserved.
+
+### Vaultspec needs a stricter default than each host CLI
+
+An explicit workspace install already authorizes project-local scaffolding, matching
+the conclusion in `2026-03-28-mcp-installation-patterns-research`. It does not authorize
+writes to a user's cross-project configuration. Project must remain the default for
+install, sync, status, prune, and uninstall. Claude local and both hosts' user scope
+require an explicit scope option. Codex has no distinct local scope, so that matrix
+cell must fail rather than silently aliasing project or user scope.
+
+| Provider | Scope   | Native target                              | Vaultspec policy |
+| -------- | ------- | ------------------------------------------ | ---------------- |
+| Claude   | project | workspace `.mcp.json`                      | default          |
+| Claude   | local   | user `.claude.json`, current-project entry | explicit only    |
+| Claude   | user    | user `.claude.json`, cross-project entry   | explicit only    |
+| Codex    | project | trusted workspace `.codex/config.toml`     | default          |
+| Codex    | user    | `$CODEX_HOME/config.toml`                  | explicit only    |
+| Codex    | local   | unsupported                                | reject           |
+
+### Ownership metadata must not enter host schemas
+
+The current JSON merger writes `_vaultspecManaged` beside `mcpServers`. That key is
+Vaultspec state, not Claude's MCP schema, and cannot be translated into Codex TOML as a
+configuration key. Project ownership can live in a Vaultspec sidecar under
+`.vaultspec/`; explicitly requested user-scope ownership can live in user Vaultspec
+state. A Codex comment-delimited managed block additionally gives byte-preserving
+round-trip control without creating an interpreted key. Ownership records need only
+provider, scope, target identity, managed names, and observed fingerprints; desired
+configuration remains exclusively in `.vaultspec/mcps/*.json`.
+
+### Migration must prove ownership instead of inferring it from a name
+
+Legacy `_vaultspecManaged` is affirmative ownership evidence and can migrate to the
+sidecar before the invalid host key is removed. A same-name host entry without that
+evidence is user-owned, even when it currently equals a source definition. Default sync
+must preserve and report it; explicit force may adopt it. This is stricter than the
+current name-intersection migration and is necessary for safe uninstall and pruning.
+
+### One normalized definition can render to both native schemas
+
+The built-in Core and RAG definitions are stdio launches using `command`, `args`, and
+optional environment values. These fields translate directly to Claude JSON and Codex
+TOML while retaining Core's dependency/dev `uv run` and tool `uvx --from` rendering.
+Provider adapters should reject or report unsupported provider-specific fields rather
+than copying arbitrary JSON into every host. The normalized definition and target types
+belong above the JSON/TOML writers so companion packages call one public reconcile seam.
+
+Package mode identity and the tool-mode distribution requirement can differ. RAG owns
+mode state under package `vaultspec-rag`, but its MCP server dependencies are supplied
+by the optional `mcp` extra. Canonical definition metadata therefore needs a distinct
+optional tool distribution spec that renders only the `uvx --from` operand. Dependency
+and dev mode continue to resolve the module through the workspace's `uv run` environment.
+
+### Real host CLIs are the compatibility oracle
+
+Parser-only tests can reproduce the original false green. Isolated acceptance must run
+`claude mcp get/list` against project `.mcp.json` and `codex mcp get/list --json`
+against trusted project `.codex/config.toml`. User-scope acceptance must redirect host
+configuration homes to temporary directories so tests never mutate operator state.
+
+## Sources
+
+- https://developers.openai.com/codex/mcp/
+- https://developers.openai.com/codex/config-basic/
+- https://developers.openai.com/codex/config-advanced/
+- https://code.claude.com/docs/en/mcp
+- `codex-cli@0.144.4`
+- `claude-code@2.1.210`
+- `src/vaultspec_core/core/mcps.py:561`
+- `src/vaultspec_core/core/mcps.py:55`
+- `src/vaultspec_core/core/mcps.py:794`
+- `src/vaultspec_core/core/types.py:31`
+- `src/vaultspec_core/core/config_gen.py:329`
+- `src/vaultspec_core/core/commands.py:981`

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -109,7 +109,7 @@ full options.
 
 ### Top-level commands
 
-- `vaultspec-core install` - Deploy the vaultspec framework to the target directory.
+- `vaultspec-core install` - Install Vaultspec resources for the selected providers.
 - `vaultspec-core uninstall` - Remove the vaultspec framework from the target directory.
 - `vaultspec-core sync` - Sync rules, skills, agents, configs, system prompts, and MCPs.
 - `vaultspec-core doctor` - Diagnose overall workspace and vault health.
@@ -322,12 +322,14 @@ full options.
 
 #### Mcps
 
-- `vaultspec-core spec mcps list` - List all registered MCP server definitions.
-- `vaultspec-core spec mcps status` - Report focused MCP definition and .mcp.json sync
-  status.
-- `vaultspec-core spec mcps add` - Add a new custom MCP server definition.
-- `vaultspec-core spec mcps remove` - Remove an MCP server definition.
-- `vaultspec-core spec mcps sync` - Sync only MCP definitions to .mcp.json.
+- `vaultspec-core spec mcps list` - List canonical MCP server definitions.
+- `vaultspec-core spec mcps status` - Inspect provider-native MCP enrollment status.
+- `vaultspec-core spec mcps add` - Add or replace a canonical MCP server definition.
+- `vaultspec-core spec mcps remove` - Remove a canonical MCP server definition.
+- `vaultspec-core spec mcps sync` - Reconcile canonical definitions into provider-native
+  enrollment.
+- `vaultspec-core spec mcps uninstall` - Remove Vaultspec-owned provider-native MCP
+  enrollment.
 
 #### Reference
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1748,22 +1748,32 @@ ______________________________________________________________________
 vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...
 ```
 
-Manage MCP server definitions and the synced `.mcp.json` entries deployed for provider
-clients. MCP sync updates `.mcp.json`; use top-level `vaultspec-core sync` for a
-complete refresh across all provider-facing outputs.
+Manage canonical MCP server definitions in `.vaultspec/mcps/*.json` and reconcile them
+into provider-native enrollment files. Provider targets are `all`, `claude`,
+`antigravity`, and `codex`; scopes are `project`, `local`, and `user`. Unsupported
+provider/scope combinations fail instead of writing to a substitute location. Use
+top-level `vaultspec-core sync` for a complete refresh across all provider-facing
+outputs.
 
 #### Subcommands
 
 - `list` - List all registered MCP server definitions.
-- `status` (`--json`) - Validate MCP definitions against `.mcp.json`.
+- `status [PROVIDER]` (`--scope SCOPE`, `--json`, `--target PATH`) - Inspect enrollment
+  and ownership state without starting or probing MCP servers.
 - `add --name NAME [--config JSON] [--force]` - Add a new custom MCP server definition.
 - `remove NAME [--force]` - Remove an MCP server definition (`--force` skips
   confirmation).
-- `sync` (`--dry-run`, `--force`) - Sync MCP definitions to `.mcp.json`.
+- `sync [PROVIDER]` (`--scope SCOPE`, `--dry-run`, `--force`, `--prune`, `--json`,
+  `--target PATH`) - Reconcile canonical definitions into provider-native enrollment.
+- `uninstall [PROVIDER]` (`--scope SCOPE`, `--dry-run`, `--force`, `--json`,
+  `--target PATH`) - Remove only Vaultspec-owned provider-native enrollment.
 
 `vaultspec-core spec mcps status` exits `0` only when MCP config status is `ok`,
 otherwise `1`. It checks config health only and does not start or probe MCP server
-processes.
+processes. The default provider is `all` and the default scope is `project`. `--force`
+on `sync` explicitly adopts or replaces same-name external enrollment; `--prune` removes
+owned enrollment whose canonical source was deleted. `uninstall` preserves canonical
+definitions and externally owned host entries.
 
 #### Examples
 
@@ -1783,6 +1793,18 @@ processes.
 
   ```bash
   vaultspec-core spec mcps sync
+  ```
+
+- **Inspect Codex project enrollment**:
+
+  ```bash
+  vaultspec-core spec mcps status codex --scope project
+  ```
+
+- **Preview removal of Vaultspec-owned Claude user enrollment**:
+
+  ```bash
+  vaultspec-core spec mcps uninstall claude --scope user --dry-run
   ```
 
 - **Register a new custom MCP server definition**:

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -18,20 +18,21 @@ workspace behaves the same either way.
 
 ## Setup
 
-Run `vaultspec-core install` to scaffold `.mcp.json` in the workspace root.
-Configuration is part of the core install, not tied to any provider; skip it with
-`install --skip mcp` if you manage the file yourself.
+Vaultspec keeps provider-neutral MCP definitions in `.vaultspec/mcps/*.json`.
+Installation and `vaultspec-core spec mcps sync` render those definitions into each
+selected provider's native configuration:
 
-```json
-{
-  "mcpServers": {
-    "vaultspec-core": {
-      "command": "uv",
-      "args": ["run", "python", "-m", "vaultspec_core.mcp_server.app"]
-    }
-  }
-}
-```
+| Provider    | Project scope             | Broader scope                                                            |
+| ----------- | ------------------------- | ------------------------------------------------------------------------ |
+| Claude      | `.mcp.json`               | Local or user enrollment in `~/.claude.json`                             |
+| Codex       | `.codex/config.toml`      | User enrollment in `$CODEX_HOME/config.toml`; local scope is unsupported |
+| Antigravity | `.agents/mcp_config.json` | Broader scopes are unsupported                                           |
+
+Project scope is the safe default. Select user or local scope explicitly. Native host
+files contain only host-valid configuration; Vaultspec records project and local
+ownership in the workspace's `.vaultspec/mcp-ownership.json` and user ownership in
+`~/.vaultspec/mcp-ownership.json`, so unrelated host entries remain external. Use
+`install --skip mcp` if you manage enrollment yourself.
 
 The server resolves its workspace from the client's current working directory.
 Editor-integrated clients such as Claude Code and Cursor already set the working
@@ -46,36 +47,20 @@ Module invocation avoids the lock.
 
 ### Install modes
 
-`vaultspec-core install` writes one of two launch shapes for this entry, matching how
-the workspace runs the tooling. Three modes select between them. Tool mode is the
-default and launches the server with `uvx`, resolving vaultspec-core on demand without
-adding it to your project's dependency set:
+The canonical definition records the Vaultspec package and module. Vaultspec renders the
+launch command for the active install mode:
 
-```json
-{
-  "mcpServers": {
-    "vaultspec-core": {
-      "command": "uvx",
-      "args": ["--from", "vaultspec-core", "python", "-m", "vaultspec_core.mcp_server.app"]
-    }
-  }
-}
-```
+- Tool mode, the default, uses `uvx --from ...` without adding Vaultspec to the
+  project's dependencies. A companion may declare a dedicated tool requirement such as
+  `vaultspec-rag[mcp]`.
+- Dependency mode uses `uv run ...` against the project's environment and ships in built
+  distributions.
+- Development mode also uses `uv run ...`, but records a development-only placement that
+  does not ship in built distributions.
 
-Dependency mode is the `uv run` shape shown at the top of this section: it resolves
-vaultspec-core from your project's own environment. Install selects it automatically
-when your `pyproject.toml` already lists vaultspec-core, and you can pin any of the
-three modes with `install --mode tool`, `install --mode dependency`, or
-`install --mode dev`. Both shapes launch the server as a Python module for the same
-Windows-lock reason above, so neither one holds an executable open.
-
-Dev mode is for vaultspec-core placed in your project's default `dev` dependency group.
-It renders exactly like dependency mode - the same `uv run` shape - because `uv run`
-resolves the default dev group identically to a project dependency. The distinction is
-that dependency mode ships vaultspec-core in your project's built distributions, while
-dev mode does not. Choosing dev records that non-leaking placement so the doctor and a
-fresh clone can read it, rather than inferring a full runtime dependency from an
-identical launch command.
+Select a mode with `install --mode tool`, `install --mode dependency`, or
+`install --mode dev`. Vaultspec consumes the package, module, and optional tool
+requirement while rendering; that metadata never reaches native host configuration.
 
 The chosen mode is recorded per package in the workspace's committed `workspace.json`,
 which keys each provisioned package to its own mode and version floor. A workspace that
@@ -92,26 +77,18 @@ stable from then on.
 ### Point the server at a different workspace
 
 When the client's working directory isn't the workspace you want - for example in a
-standalone setup outside an editor - set `VAULTSPEC_TARGET_DIR` in the server's `env`
-block.
-
-```json
-{
-  "mcpServers": {
-    "vaultspec-core": {
-      "command": "uv",
-      "args": ["run", "python", "-m", "vaultspec_core.mcp_server.app"],
-      "env": { "VAULTSPEC_TARGET_DIR": "/path/to/workspace" }
-    }
-  }
-}
-```
+standalone setup outside an editor - set `VAULTSPEC_TARGET_DIR` in the canonical MCP
+definition's `env` map, then run `vaultspec-core spec mcps sync`. The provider adapter
+renders normalized `command`, `args`, and `env` fields into each selected native target.
 
 `VAULTSPEC_TARGET_DIR` is the environment equivalent of the CLI's `--target` flag.
 
 ### Your first call
 
-Restart or connect the MCP client so it picks up `.mcp.json`.
+Claude reads project enrollment from `.mcp.json`. Codex reads `.codex/config.toml` for a
+trusted project. Antigravity uses `.agents/mcp_config.json`. Reload or reconnect the
+provider as required by that host. Vaultspec writes enrollment only: it does not start
+the server, grant trust, or bypass provider approval.
 
 Call the `status` tool with no arguments. It returns a rollup report:
 `tool_schema_version`, the workspace's features with document counts and lifecycle
@@ -134,18 +111,22 @@ This is the only `VAULTSPEC_` variable the MCP server reads directly. See
 
 ## Verification
 
-Run `vaultspec-core spec mcps status --json` to check MCP configuration health. It
-validates the source definitions in `.vaultspec/mcps/` against `.mcp.json` without
-starting or probing any server process. The command exits 0 only when `status` is
-`"ok"`; any other status, including `missing_config`, `no_definitions`,
-`invalid_config`, or `no_context`, exits 1.
+```console
+vaultspec-core spec mcps status
+vaultspec-core spec mcps status codex --scope project
+vaultspec-core spec mcps status --json
+```
+
+Status reports aggregate and per-provider configuration health. It identifies managed,
+missing, drifted, stale managed, and external entries, plus warnings. It does not start
+or probe an MCP process. The command exits 0 only when aggregate status is `"ok"`.
 
 If status isn't `"ok"`, inspect the `missing`, `drifted`, `stale_managed`, and
-`warnings` fields in the output, run `vaultspec-core sync` to reconcile the definitions,
-then re-run the status check.
+`warnings` fields, run `vaultspec-core spec mcps sync` to reconcile enrollment, then
+re-run the status check. Project scope is the default; user or local enrollment must be
+requested explicitly, and unsupported provider/scope combinations fail.
 
-Run `vaultspec-core spec doctor --json` for a broader workspace diagnosis; it reports a
-missing or incomplete `.mcp.json` as one signal among the workspace's overall health.
+Run `vaultspec-core spec doctor --json` for a broader workspace diagnosis.
 
 ## Tools
 
@@ -177,9 +158,12 @@ synchronizing generated surfaces (`vaultspec-core sync`,
 so a connected host still asks you to confirm each one; the CLI skips that round-trip.
 
 Other operations have no MCP path at all. Regenerating a feature index runs through
-`vaultspec-core vault feature index`. Managing the MCP configuration itself runs through
-`vaultspec-core spec mcps add`, `remove`, and `sync`. Removing vaultspec from a
-workspace runs through `vaultspec-core uninstall`.
+`vaultspec-core vault feature index`. For MCP configuration, `list`, `add`, and `remove`
+inspect or mutate canonical definitions; `status` inspects native enrollment and
+ownership health; `sync` reconciles definitions into selected targets; and `uninstall`
+removes Vaultspec-owned enrollment while preserving canonical definitions and external
+host entries. Removing Vaultspec from a workspace runs through
+`vaultspec-core uninstall`.
 
 ### Terms
 
@@ -767,9 +751,9 @@ denylisted verbs from its results, and `invoke` rejects them before spawning. Th
 denylist covers:
 
 - `uninstall` - tears down the framework
-- `spec mcps add`, `spec mcps remove`, `spec mcps sync` - MCP registry mutation, owned
-  by the `spec mcps` lifecycle (the read-only `spec mcps list` and `spec mcps status`
-  stay available)
+- `spec mcps add`, `spec mcps remove`, `spec mcps sync`, and `spec mcps uninstall` - MCP
+  definition or enrollment mutation, owned by the `spec mcps` lifecycle (the read-only
+  `spec mcps list` and `spec mcps status` stay available)
 - `vault feature index` - index documents stay uncreatable through the MCP surface
 
 ## Logging

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -45,7 +45,7 @@ hand-edit between the markers.
 
 ### Top-level commands
 
-- `vaultspec-core install` - Deploy the vaultspec framework to the target directory.
+- `vaultspec-core install` - Install Vaultspec resources for the selected providers.
 - `vaultspec-core uninstall` - Remove the vaultspec framework from the target directory.
 - `vaultspec-core sync` - Sync rules, skills, agents, configs, system prompts, and MCPs.
 - `vaultspec-core doctor` - Diagnose overall workspace and vault health.
@@ -258,12 +258,14 @@ hand-edit between the markers.
 
 #### Mcps
 
-- `vaultspec-core spec mcps list` - List all registered MCP server definitions.
-- `vaultspec-core spec mcps status` - Report focused MCP definition and .mcp.json sync
-  status.
-- `vaultspec-core spec mcps add` - Add a new custom MCP server definition.
-- `vaultspec-core spec mcps remove` - Remove an MCP server definition.
-- `vaultspec-core spec mcps sync` - Sync only MCP definitions to .mcp.json.
+- `vaultspec-core spec mcps list` - List canonical MCP server definitions.
+- `vaultspec-core spec mcps status` - Inspect provider-native MCP enrollment status.
+- `vaultspec-core spec mcps add` - Add or replace a canonical MCP server definition.
+- `vaultspec-core spec mcps remove` - Remove a canonical MCP server definition.
+- `vaultspec-core spec mcps sync` - Reconcile canonical definitions into provider-native
+  enrollment.
+- `vaultspec-core spec mcps uninstall` - Remove Vaultspec-owned provider-native MCP
+  enrollment.
 
 #### Reference
 

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -608,15 +608,24 @@ enabled hooks; it takes `--path PATH`. Valid events: `vault.document.created`,
 
 ### vaultspec-core spec mcps
 
-Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage MCP server
-definitions and synced `.mcp.json` entries.
+Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage canonical
+definitions in `.vaultspec/mcps/*.json` and reconcile them into provider-native
+enrollment. Providers are `all`, `claude`, `antigravity`, and `codex`; scopes are
+`project`, `local`, and `user`. Unsupported provider/scope combinations fail.
 
-| Subcommand | Signature | Description | | ---------- |
---------------------------------------- | ----------------------------- | | `list` | - |
-List MCP server definitions. | | `status` | `[--json]` | Validate against `.mcp.json`. |
-| `add` | `--name NAME [--config JSON] [--force]` | Add a custom MCP definition. | |
-`remove` | `NAME [--force]` | Remove an MCP definition. | | `sync` |
-`[--dry-run] [--force]` | Sync definitions to config. |
+| Subcommand  | Signature                                                                             | Description                                                         |
+| ----------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `list`      | -                                                                                     | List canonical MCP server definitions.                              |
+| `status`    | `[PROVIDER] [--scope SCOPE] [--json] [--target PATH]`                                 | Inspect configuration and ownership state; does not probe runtimes. |
+| `add`       | `--name NAME [--config JSON] [--force]`                                               | Add or replace a canonical definition.                              |
+| `remove`    | `NAME [--force]`                                                                      | Remove a canonical definition.                                      |
+| `sync`      | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--prune] [--json] [--target PATH]` | Reconcile canonical definitions into native enrollment.             |
+| `uninstall` | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--json] [--target PATH]`           | Remove only Vaultspec-owned native enrollment.                      |
+
+The default provider is `all` and the default scope is `project`. `sync --force` adopts
+or replaces a same-name external entry; `sync --prune` removes owned enrollment whose
+canonical source was deleted. `uninstall` preserves canonical definitions and external
+host entries.
 
 ## Migration commands
 

--- a/src/vaultspec_core/cli/root.py
+++ b/src/vaultspec_core/cli/root.py
@@ -250,12 +250,12 @@ def cmd_install(
 ) -> None:
     """Install Vaultspec resources for the selected providers.
 
-    Scaffolds the workspace structure and syncs all managed resources. For
-    MCP-capable providers, installation reconciles canonical MCP definitions
-    into project-scope provider-native configuration. It does not start MCP
-    servers or grant provider trust.
+    Scaffolds the workspace structure and syncs all managed resources.
     Use --upgrade to update builtin rules without re-scaffolding.
     Use --skip to exclude components on retry (e.g. --skip core --skip claude).
+    For MCP-capable providers, installation reconciles canonical MCP definitions
+    into project-scope provider-native configuration. It does not start MCP
+    servers or grant provider trust.
     """
     from vaultspec_core.core.commands import install_run
     from vaultspec_core.core.exceptions import VaultSpecError

--- a/src/vaultspec_core/cli/root.py
+++ b/src/vaultspec_core/cli/root.py
@@ -248,9 +248,12 @@ def cmd_install(
         typer.Option("--no-hints", help="Suppress next-step advisory hints"),
     ] = False,
 ) -> None:
-    """Deploy the vaultspec framework to the target directory.
+    """Install Vaultspec resources for the selected providers.
 
-    Scaffolds the workspace structure and syncs all managed resources.
+    Scaffolds the workspace structure and syncs all managed resources. For
+    MCP-capable providers, installation reconciles canonical MCP definitions
+    into project-scope provider-native configuration. It does not start MCP
+    servers or grant provider trust.
     Use --upgrade to update builtin rules without re-scaffolding.
     Use --skip to exclude components on retry (e.g. --skip core --skip claude).
     """
@@ -805,17 +808,18 @@ def _collect_sync_outcomes(
 ) -> list[OutcomeItem]:
     """Flatten sync-pass results into per-provider-grouped outcomes.
 
-    Each resource pass carries per-provider results in ``per_tool``;
-    global passes (e.g. mcps) carry only the aggregate and are grouped
-    under their resource label. Shared by the text and ``--json``
-    renderings of both ``sync`` and ``sync --dry-run`` so the surfaces
-    cannot drift apart.
+    Each resource pass carries per-provider results in ``per_tool`` when its
+    output is host-specific; global passes use their resource label. Shared by
+    the text and ``--json`` renderings of both ``sync`` and ``sync --dry-run``
+    so the surfaces cannot drift apart.
     """
     from vaultspec_core.cli.rendering import sync_outcomes
 
     labels = ["rules", "skills", "agents", "system", "config"]
     if provider == "all" and "mcp" not in skip:
         labels.append("mcps")
+    if "hooks" not in skip:
+        labels.append("hooks")
     outcomes: list[OutcomeItem] = []
     # Results beyond the known positional resource passes (e.g. the trailing
     # structural-backfill pass, issue #133) are grouped per inferred provider so

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -30,7 +30,9 @@ from vaultspec_core.cli._target import TargetOption, apply_target
 logger = logging.getLogger(__name__)
 
 COMPLETE_SYNC_COMMAND = "vaultspec-core sync"
-PROVIDER_OUTPUTS = "AGENTS.md, CLAUDE.md, GEMINI.md, .codex/config.toml, .mcp.json"
+PROVIDER_OUTPUTS = (
+    "AGENTS.md, CLAUDE.md, GEMINI.md, native MCP configs, and provider directories"
+)
 
 
 def _print_complete_sync_notice(*, resource: str, mcp: bool = False) -> None:
@@ -42,7 +44,7 @@ def _print_complete_sync_notice(*, resource: str, mcp: bool = False) -> None:
     """
     from vaultspec_core.console import get_console
 
-    scope = ".mcp.json only" if mcp else f"{resource} resource files only"
+    scope = "native MCP targets only" if mcp else f"{resource} resource files only"
     get_console().print(
         f"[dim]Scoped sync: {scope}. Run [bold]{COMPLETE_SYNC_COMMAND}[/bold] "
         f"for the full provider refresh.[/dim]"
@@ -50,7 +52,12 @@ def _print_complete_sync_notice(*, resource: str, mcp: bool = False) -> None:
 
 
 def _emit_sync_result(
-    result: "SyncResult", *, label: str, dry_run: bool, json_output: bool
+    result: "SyncResult",
+    *,
+    label: str,
+    dry_run: bool,
+    json_output: bool,
+    command: str | None = None,
 ) -> None:
     """Render a sync pass through the canonical outcome renderer.
 
@@ -62,12 +69,17 @@ def _emit_sync_result(
     """
     from vaultspec_core.cli.rendering import emit_outcomes, sync_outcomes
 
-    outcomes = sync_outcomes(result)
+    outcomes = []
+    if result.per_tool:
+        for provider, provider_result in result.per_tool.items():
+            outcomes.extend(sync_outcomes(provider_result, group=provider))
+    else:
+        outcomes = sync_outcomes(result)
     title = f"{label} sync" + (" (dry run)" if dry_run else "")
     extra = {"warnings": result.warnings} if result.warnings else None
     code = emit_outcomes(
         outcomes,
-        command=f"spec.{label.lower()}.sync",
+        command=command or f"spec.{label.lower()}.sync",
         title=title,
         json_output=json_output,
         extra_json=extra,
@@ -1621,7 +1633,7 @@ def cmd_hooks_run(
 # =============================================================================
 
 mcps_app = make_app(
-    help="Manage MCP server definitions and synced .mcp.json entries.",
+    help="Manage canonical MCP definitions and provider-native enrollment.",
     no_args_is_help=True,
 )
 spec_app.add_typer(mcps_app, name="mcps")
@@ -1632,7 +1644,7 @@ def cmd_mcps_list(
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     target: TargetOption = None,
 ) -> None:
-    """List all registered MCP server definitions."""
+    """List canonical MCP server definitions."""
     apply_target(target)
     from vaultspec_core.core import mcp_list
 
@@ -1656,40 +1668,63 @@ def cmd_mcps_list(
 
 @mcps_app.command("status")
 def cmd_mcps_status(
+    provider: Annotated[
+        str,
+        typer.Argument(help="Provider target (all, claude, antigravity, codex)"),
+    ] = "all",
+    scope: Annotated[
+        str,
+        typer.Option(
+            "--scope",
+            help="Enrollment scope (project, local, user); default: project",
+        ),
+    ] = "project",
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     target: TargetOption = None,
 ) -> None:
-    """Report focused MCP definition and .mcp.json sync status."""
+    """Inspect provider-native MCP enrollment status."""
     apply_target(target)
+    _apply_provider_filter(provider)
     from vaultspec_core.core import mcp_status
 
-    status = mcp_status()
+    status = mcp_status(provider=provider, scope=scope)
 
     if json_output:
         _emit_json("spec.mcps.status", "unchanged", status)
         raise typer.Exit(0 if status["status"] == "ok" else 1)
 
-    from vaultspec_core.cli.rendering import Field, render_record
+    from vaultspec_core.cli.rendering import Column, render_listing
     from vaultspec_core.console import get_console
 
-    status_str = str(status["status"])
-    status_style = (
-        "green" if status_str == "ok" else ("yellow" if status_str == "warn" else "red")
-    )
-    fields: list[Field] = [
-        Field("status", status_str, style=status_style),
-        Field("config", str(status["config_path"])),
-        Field("definitions", ", ".join(status["definitions"]) or "none"),
-        Field("configured", ", ".join(status["configured"]) or "none"),
-        Field("managed", ", ".join(status["managed"]) or "none"),
+    rows = [
+        {
+            "provider": name,
+            "scope": data["scope"],
+            "status": data["status"],
+            "config": data["config_path"],
+            "managed": ", ".join(data["managed"]) or "none",
+            "missing": ", ".join(data["missing"]) or "none",
+            "drifted": ", ".join(data["drifted"]) or "none",
+            "external": ", ".join(data["external"]) or "none",
+        }
+        for name, data in status["providers"].items()
     ]
-    if status["missing"]:
-        fields.append(Field("missing", ", ".join(status["missing"])))
-    if status["drifted"]:
-        fields.append(Field("drifted", ", ".join(status["drifted"])))
-    if status["stale_managed"]:
-        fields.append(Field("stale managed", ", ".join(status["stale_managed"])))
-    render_record(fields, title="mcps status")
+    render_listing(
+        rows,
+        [
+            Column("provider"),
+            Column("scope"),
+            Column("status"),
+            Column("config"),
+            Column("managed"),
+            Column("missing"),
+            Column("drifted"),
+            Column("external"),
+        ],
+        title="mcps status",
+        summary=f"{status['status']}: {len(rows)} provider target(s)",
+        empty="no enrolled MCP-capable providers",
+    )
 
     console = get_console()
     for warning in status["warnings"]:
@@ -1708,7 +1743,7 @@ def cmd_mcps_add(
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     target: TargetOption = None,
 ) -> None:
-    """Add a new custom MCP server definition."""
+    """Add or replace a canonical MCP server definition."""
     apply_target(target)
     import json as json_mod
 
@@ -1743,7 +1778,7 @@ def cmd_mcps_remove(
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     target: TargetOption = None,
 ) -> None:
-    """Remove an MCP server definition."""
+    """Remove a canonical MCP server definition."""
     apply_target(target)
     from vaultspec_core.core import mcp_remove
     from vaultspec_core.core.exceptions import VaultSpecError
@@ -1768,28 +1803,95 @@ def cmd_mcps_remove(
 def cmd_mcps_sync(
     provider: Annotated[
         str,
-        typer.Argument(
-            help="Provider to sync (all, claude, gemini, antigravity, codex)"
-        ),
+        typer.Argument(help="Provider target (all, claude, antigravity, codex)"),
     ] = "all",
-    dry_run: Annotated[bool, typer.Option("--dry-run", help="Preview changes")] = False,
+    scope: Annotated[
+        str,
+        typer.Option(
+            "--scope",
+            help="Enrollment scope (project, local, user); default: project",
+        ),
+    ] = "project",
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview without writing files")
+    ] = False,
     force: Annotated[
         bool,
-        typer.Option("--force", help="Overwrite modified entries"),
+        typer.Option("--force", help="Adopt or overwrite same-name enrollment"),
+    ] = False,
+    prune: Annotated[
+        bool,
+        typer.Option("--prune", help="Remove owned enrollment with deleted sources"),
     ] = False,
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
     target: TargetOption = None,
 ) -> None:
-    """Sync only MCP definitions to .mcp.json."""
+    """Reconcile canonical definitions into provider-native enrollment."""
     apply_target(target)
     _apply_provider_filter(provider)
     from vaultspec_core.core import mcp_sync
 
-    result = mcp_sync(force=force, dry_run=dry_run)
+    result = mcp_sync(
+        provider=provider,
+        scope=scope,
+        force=force,
+        prune=prune,
+        dry_run=dry_run,
+    )
 
     if not json_output:
         _print_complete_sync_notice(resource="MCP", mcp=True)
     _emit_sync_result(result, label="MCPs", dry_run=dry_run, json_output=json_output)
+
+
+@mcps_app.command("uninstall")
+def cmd_mcps_uninstall(
+    provider: Annotated[
+        str,
+        typer.Argument(help="Provider target (all, claude, antigravity, codex)"),
+    ] = "all",
+    scope: Annotated[
+        str,
+        typer.Option(
+            "--scope",
+            help="Enrollment scope (project, local, user); default: project",
+        ),
+    ] = "project",
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview removals")
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option("--force", help="Required to remove owned host entries"),
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Remove Vaultspec-owned provider-native MCP enrollment."""
+    apply_target(target)
+    _apply_provider_filter(provider)
+    if not force and not dry_run:
+        typer.echo(
+            "Error: MCP uninstall is destructive. Pass --force or use --dry-run.",
+            err=True,
+        )
+        raise typer.Exit(code=1)
+
+    from vaultspec_core.core import get_context, mcp_uninstall
+
+    result = mcp_uninstall(
+        get_context().target_dir,
+        provider=provider,
+        scope=scope,
+        dry_run=dry_run,
+    )
+    _emit_sync_result(
+        result,
+        label="MCPs uninstall",
+        dry_run=dry_run,
+        json_output=json_output,
+        command="spec.mcps.uninstall",
+    )
 
 
 # =============================================================================

--- a/src/vaultspec_core/core/__init__.py
+++ b/src/vaultspec_core/core/__init__.py
@@ -17,6 +17,10 @@ from .agents import collect_agents as collect_agents
 from .agents import transform_agent as transform_agent
 from .config_gen import config_show as config_show
 from .config_gen import config_sync as config_sync
+from .enums import InstallMode as InstallMode
+from .enums import McpScope as McpScope
+from .enums import McpTargetFormat as McpTargetFormat
+from .enums import Tool as Tool
 from .exceptions import (
     EditorCancellationError as EditorCancellationError,
 )
@@ -72,6 +76,12 @@ from .mcps import mcp_list as mcp_list
 from .mcps import mcp_remove as mcp_remove
 from .mcps import mcp_status as mcp_status
 from .mcps import mcp_sync as mcp_sync
+from .mcps import mcp_uninstall as mcp_uninstall
+from .mcps import render_launch_for_mode as render_launch_for_mode
+from .mcps import (
+    render_mcp_definition_for_mode as render_mcp_definition_for_mode,
+)
+from .mcps import resolve_mcp_targets as resolve_mcp_targets
 from .resources import resource_edit as resource_edit
 from .resources import resource_remove as resource_remove
 from .resources import resource_rename as resource_rename
@@ -90,6 +100,7 @@ from .sync import sync_files as sync_files
 from .system import system_show as system_show
 from .system import system_sync as system_sync
 from .types import CONFIG_HEADER as CONFIG_HEADER
+from .types import McpTarget as McpTarget
 from .types import SyncResult as SyncResult
 from .types import ToolConfig as ToolConfig
 from .types import WorkspaceContext as WorkspaceContext

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -12,7 +12,7 @@ import contextvars
 import logging
 import shutil
 import subprocess
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from contextlib import nullcontext
 from dataclasses import replace
 from pathlib import Path
@@ -919,6 +919,24 @@ def _filter_tools(tools: list[Tool], skip: set[str]) -> list[Tool]:
     return [t for t in tools if t.value not in skip]
 
 
+def _require_reconciliation_success(
+    results: _t.SyncResult | Iterable[_t.SyncResult],
+    *,
+    operation: str,
+) -> None:
+    """Refuse to report install success after a failed reconciliation pass."""
+    passes = (results,) if isinstance(results, _t.SyncResult) else tuple(results)
+    errors = [message for result in passes for message in result.errors]
+    unreported = sum(result.errored for result in passes) - len(errors)
+    if unreported > 0:
+        errors.append(f"{unreported} reconciliation error(s) had no detail message.")
+    if errors:
+        raise VaultSpecError(
+            f"{operation} failed.",
+            hint=" ".join(errors),
+        )
+
+
 def init_run(
     force: bool = False,
     provider: str = "all",
@@ -994,6 +1012,10 @@ def init_run(
             mode=mode,
             target_dir=target,
             enrolled=selected,
+        )
+        _require_reconciliation_success(
+            mcp_result,
+            operation="MCP provider-native enrollment",
         )
         for mcp_target in resolve_mcp_targets(
             target_dir=target,
@@ -1170,9 +1192,14 @@ def install_run(
             sync_target = provider if provider not in ("all", "core") else "all"
             try:
                 sync_results = sync_provider(sync_target, dry_run=True, skip=skip)
-            except (VaultSpecError, OSError) as exc:
-                logger.debug("Upgrade dry-run provider preview skipped: %s", exc)
-                sync_results = []
+            except OSError as exc:
+                raise VaultSpecError(
+                    "Provider reconciliation preview failed.", hint=str(exc)
+                ) from exc
+            _require_reconciliation_success(
+                sync_results,
+                operation="Provider reconciliation preview",
+            )
             seen_preview = {rel for rel, _ in items}
             for sync_result in sync_results:
                 for rel, action in sync_result.items:
@@ -1217,6 +1244,10 @@ def install_run(
                 mode=resolved_mode,
                 target_dir=path,
                 enrolled=selected,
+            )
+            _require_reconciliation_success(
+                mcp_result,
+                operation="MCP provider-native enrollment preview",
             )
             for mcp_target in resolve_mcp_targets(
                 target_dir=path,
@@ -1329,7 +1360,11 @@ def install_run(
         # content. The pre-collapse hardcoded `force=True` was an asymmetry
         # against the fresh-install path and silently overwrote user content
         # on every upgrade. See PR #116 review thread r3260188496.
-        sync_provider(sync_target, force=force, skip=skip - {"core"})
+        sync_results = sync_provider(sync_target, force=force, skip=skip - {"core"})
+        _require_reconciliation_success(
+            sync_results,
+            operation="Provider reconciliation during upgrade",
+        )
 
         if "precommit" not in skip:
             _scaffold_precommit(path, mode=resolved_mode)
@@ -1346,9 +1381,13 @@ def install_run(
         if mcp_mode_flipped and not force and "mcp" not in skip:
             from .mcps import mcp_sync
 
-            mcp_sync(
+            mcp_result = mcp_sync(
                 mode=resolved_mode,
                 force_managed=frozenset({"vaultspec-core"}),
+            )
+            _require_reconciliation_success(
+                mcp_result,
+                operation="MCP mode-migration reconciliation",
             )
 
         # Update manifest timestamps and version

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -13,6 +13,7 @@ import logging
 import shutil
 import subprocess
 from collections.abc import Callable
+from contextlib import nullcontext
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -786,7 +787,7 @@ def _scaffold_precommit(
 
     config_file = target / ".pre-commit-config.yaml"
 
-    with advisory_lock(config_file):
+    with nullcontext() if dry_run else advisory_lock(config_file):
         if config_file.exists():
             try:
                 raw = config_file.read_text(encoding="utf-8")
@@ -986,11 +987,21 @@ def init_run(
         created.extend(_scaffold_provider(target, tool))
 
     if "mcp" not in skip:
-        from .mcps import mcp_sync
+        from .mcps import mcp_sync, resolve_mcp_targets
 
-        mcp_result = mcp_sync(mode=mode)
-        if mcp_result.items:
-            created.append((".mcp.json", "mcp"))
+        selected = tuple(tools)
+        mcp_result = mcp_sync(
+            mode=mode,
+            target_dir=target,
+            enrolled=selected,
+        )
+        for mcp_target in resolve_mcp_targets(
+            target_dir=target,
+            enrolled=selected,
+        ):
+            provider_result = mcp_result.per_tool.get(mcp_target.provider.value)
+            if provider_result and provider_result.items:
+                created.append((_rel(target, mcp_target.path), "mcp"))
     if "precommit" not in skip:
         created.extend(_scaffold_precommit(target, mode=mode))
 
@@ -1198,11 +1209,22 @@ def install_run(
         for tool in tools:
             manifest.extend(_scaffold_provider(path, tool, dry_run=True))
         if "mcp" not in skip:
-            from .mcps import mcp_sync
+            from .mcps import mcp_sync, resolve_mcp_targets
 
-            mcp_result = mcp_sync(dry_run=True, mode=resolved_mode)
-            if mcp_result.items:
-                manifest.append((".mcp.json", "mcp"))
+            selected = tuple(tools)
+            mcp_result = mcp_sync(
+                dry_run=True,
+                mode=resolved_mode,
+                target_dir=path,
+                enrolled=selected,
+            )
+            for mcp_target in resolve_mcp_targets(
+                target_dir=path,
+                enrolled=selected,
+            ):
+                provider_result = mcp_result.per_tool.get(mcp_target.provider.value)
+                if not skip_core or (provider_result and provider_result.items):
+                    manifest.append((_rel(path, mcp_target.path), "mcp"))
         if "precommit" not in skip:
             manifest.extend(_scaffold_precommit(path, dry_run=True, mode=resolved_mode))
 
@@ -1423,7 +1445,12 @@ def install_run(
 
     tools = _filter_tools(_PROVIDER_TO_TOOLS.get(provider, []), skip)
     provider_names = [t.value for t in tools]
-    has_mcp = (path / ".mcp.json").exists()
+    from .mcps import resolve_mcp_targets
+
+    has_mcp = any(
+        target.path.exists()
+        for target in resolve_mcp_targets(target_dir=path, enrolled=tuple(tools))
+    )
 
     # Manage gitignore block
     recommended = get_recommended_entries(path)
@@ -1622,15 +1649,31 @@ def uninstall_run(
             path / "AGENTS.md",
         ]
 
-        # Surgical .mcp.json cleanup BEFORE directory removal so the
-        # registry in .vaultspec/mcps/ is still readable.
-        mcp_path = path / ".mcp.json"
+        # Reconcile native MCP targets before provider directories and
+        # ownership state are removed.
         if "mcp" not in skip:
-            from .mcps import mcp_uninstall
+            from .mcps import mcp_uninstall, resolve_mcp_targets
 
-            uninstalled = mcp_uninstall(path, dry_run=dry_run)
-            if uninstalled:
-                removed.append((_rel(path, mcp_path), "mcp"))
+            active_ctx = _t.get_context()
+            mcp_tools = tuple(
+                tool
+                for tool, config in active_ctx.tool_configs.items()
+                if ProviderCapability.MCPS in config.capabilities
+                and tool.value not in skip
+            )
+            uninstalled = mcp_uninstall(
+                path,
+                dry_run=dry_run,
+                enrolled=mcp_tools,
+            )
+            errors.extend(uninstalled.errors)
+            for target in resolve_mcp_targets(
+                target_dir=path,
+                enrolled=mcp_tools,
+            ):
+                target_result = uninstalled.per_tool.get(target.provider.value)
+                if target_result and target_result.items:
+                    removed.append((_rel(path, target.path), "mcp"))
 
         for d in managed_dirs:
             owners = _dir_owners.get(d.name, [])
@@ -1741,6 +1784,31 @@ def uninstall_run(
     else:
         # Per-provider uninstall with shared directory protection
         tools = _filter_tools(_PROVIDER_TO_TOOLS.get(effective_provider, []), skip)
+        if "mcp" not in skip:
+            from .mcps import mcp_uninstall, resolve_mcp_targets
+
+            active_ctx = _t.get_context()
+            mcp_tools = tuple(
+                tool
+                for tool in tools
+                if ProviderCapability.MCPS in active_ctx.tool_configs[tool].capabilities
+            )
+            if mcp_tools:
+                uninstalled = mcp_uninstall(
+                    path,
+                    dry_run=dry_run,
+                    provider=effective_provider,
+                    enrolled=mcp_tools,
+                )
+                errors.extend(uninstalled.errors)
+                for target in resolve_mcp_targets(
+                    provider=effective_provider,
+                    target_dir=path,
+                    enrolled=mcp_tools,
+                ):
+                    target_result = uninstalled.per_tool.get(target.provider.value)
+                    if target_result and target_result.items:
+                        removed.append((_rel(path, target.path), "mcp"))
         for tool in tools:
             dirs, files = _collect_provider_artifacts(path, tool)
 
@@ -1996,7 +2064,11 @@ def sync_provider(
                     ensure_dir(directory)
         return result
 
-    def _run_all_syncs(*, include_mcp: bool = True) -> list[_t.SyncResult]:
+    def _run_all_syncs(
+        *,
+        include_mcp: bool = True,
+        mcp_provider: Tool | str = "all",
+    ) -> list[_t.SyncResult]:
         results: list[_t.SyncResult] = []
         sync_passes: list[tuple[Callable[[], _t.SyncResult], str]] = [
             (lambda: rules_sync(prune=force, dry_run=dry_run), "rules"),
@@ -2006,9 +2078,23 @@ def sync_provider(
             (lambda: config_sync(dry_run=dry_run, force=force), "config"),
         ]
         if include_mcp and "mcp" not in skip:
+            active_ctx = _t.get_context()
+            installed = read_manifest(active_ctx.target_dir)
+            enrolled = tuple(
+                tool
+                for tool in active_ctx.tool_configs
+                if tool.value in installed and tool.value not in (skip or set())
+            )
             sync_passes.append(
                 (
-                    lambda: _mcp_sync(dry_run=dry_run, force=force, prune=force),
+                    lambda: _mcp_sync(
+                        dry_run=dry_run,
+                        force=force,
+                        prune=force,
+                        provider=mcp_provider,
+                        target_dir=active_ctx.target_dir,
+                        enrolled=enrolled,
+                    ),
                     "mcps",
                 )
             )
@@ -2183,7 +2269,14 @@ def sync_provider(
     ) -> list[_t.SyncResult]:
         _t.set_context(replace(ctx, tool_configs=provider_configs))
         logger.info("Syncing provider: %s ...", provider)
-        results = _run_all_syncs(include_mcp=False)
+        include_mcp = any(
+            ProviderCapability.MCPS in config.capabilities
+            for config in provider_configs.values()
+        )
+        results = _run_all_syncs(
+            include_mcp=include_mcp,
+            mcp_provider=provider,
+        )
         if not dry_run:
             logger.info("Done.")
         return results

--- a/src/vaultspec_core/core/enums.py
+++ b/src/vaultspec_core/core/enums.py
@@ -196,6 +196,21 @@ class Tool(StrEnum):
     CODEX = "codex"
 
 
+class McpScope(StrEnum):
+    """Native host scope for an MCP server enrollment."""
+
+    PROJECT = "project"
+    LOCAL = "local"
+    USER = "user"
+
+
+class McpTargetFormat(StrEnum):
+    """Serialization format consumed by an MCP host target."""
+
+    JSON = "json"
+    TOML = "toml"
+
+
 class GeminiBuiltinTool(StrEnum):
     """Canonical Gemini CLI built-in tool identifiers.
 
@@ -234,6 +249,7 @@ class ProviderCapability(StrEnum):
     TEAMS = "teams"
     SCHEDULED_TASKS = "scheduled_tasks"
     WORKFLOWS = "workflows"
+    MCPS = "mcps"
 
 
 class Resource(StrEnum):

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -1,10 +1,9 @@
-"""Manage MCP server definitions for the vaultspec framework.
+"""Manage canonical MCP definitions and provider-native enrollment.
 
-This module handles MCP server definition collection, custom definition
-scaffolding, and the merge pipeline that syncs definitions into ``.mcp.json``.
-Unlike rules/skills/agents (which use Markdown sources and per-tool directory
-sync), MCP definitions are JSON files merged into a single provider-agnostic
-``.mcp.json`` file.
+Definitions in ``.vaultspec/mcps/*.json`` describe provider-neutral stdio
+servers. This module renders those definitions for each MCP-capable provider,
+reconciles project or explicit broader-scope targets, and records ownership
+outside host configuration so unrelated entries remain untouched.
 """
 
 from __future__ import annotations
@@ -43,7 +42,7 @@ logger = logging.getLogger(__name__)
 #: unambiguously. The seeded ``.vaultspec/mcps/`` copy carries these same bytes
 #: (keeping the ``BuiltinVersionSignal`` snapshot hash stable); substitution
 #: happens only here, downstream, and only the substituted concrete command is
-#: ever written into a workspace ``.mcp.json``.
+#: ever written into provider-native host configuration.
 _MODE_COMMAND_TOKEN = "@@VAULTSPEC_INSTALL_MODE_COMMAND@@"
 _MODE_ARGS_TOKEN = "@@VAULTSPEC_INSTALL_MODE_ARGS@@"
 
@@ -53,8 +52,8 @@ _MODE_ARGS_TOKEN = "@@VAULTSPEC_INSTALL_MODE_ARGS@@"
 #: and module below, keeping that file byte-identical - and present on a
 #: companion package's builtin so core's single sentinel-substitution renderer
 #: produces *that* package's ``uv run``/``uvx`` launch without a second renderer.
-#: They are consumed and stripped during substitution, so they never reach the
-#: written ``.mcp.json``.
+#: They are consumed and stripped during substitution, so they never reach
+#: provider-native host configuration.
 _MODE_PACKAGE_KEY = "_vaultspec_mode_package"
 _MODE_MODULE_KEY = "_vaultspec_mode_module"
 _MODE_TOOL_SPEC_KEY = "_vaultspec_mode_tool_spec"
@@ -143,8 +142,9 @@ def render_mcp_definition_for_mode(
     rather than falling off a two-key table. The distribution and module the
     launch targets come from the definition's own
     :data:`_MODE_PACKAGE_KEY`/:data:`_MODE_MODULE_KEY` metadata, defaulting to
-    core's package and module when absent; those keys are stripped during
-    substitution so they never reach the written ``.mcp.json``.
+    core's package and module when absent. Those keys and the optional
+    :data:`_MODE_TOOL_SPEC_KEY` are stripped during substitution so launch
+    metadata never reaches provider-native host configuration.
 
     Args:
         definition: A parsed MCP server definition (``command``/``args`` map).
@@ -455,7 +455,7 @@ def _existing_source_server_names() -> set[str]:
     must only be considered for orphan removal when its source file
     is *definitively absent*, not when parsing happened to fail this
     run. Otherwise a single typo in a managed definition would
-    silently delete the corresponding ``.mcp.json`` entry on the next
+    silently delete the corresponding provider-native enrollment on the next
     ``sync --force``, which is destructive and hard to recover from.
     """
     mcps_dir = _get_mcps_src_dir()
@@ -490,7 +490,7 @@ def collect_mcp_servers(
     onto whichever single mode the caller resolved for core. See
     :func:`_render_definition_for_sync` for the resolution rule. The merge
     pipeline that feeds :func:`mcp_sync` therefore writes the correctly-shaped
-    form for every entry into every ``.mcp.json`` target. When *mode* is
+    form for every entry into each provider-native target. When *mode* is
     ``None`` the raw (token-carrying) definitions are returned unchanged - the
     correct behaviour for callers that only inspect server *names* (uninstall,
     source counts) rather than the launch command.
@@ -569,7 +569,11 @@ def mcp_status(
     target_dir: Path | None = None,
     enrolled: Iterable[Tool] | None = None,
 ) -> dict[str, Any]:
-    """Return aggregate and per-provider native MCP enrollment status."""
+    """Return aggregate and per-provider enrollment health.
+
+    Status reports configuration and ownership state only; it does not start or
+    probe an MCP server.
+    """
     try:
         root = target_dir or _t.get_context().target_dir
     except LookupError:
@@ -1427,7 +1431,11 @@ def mcp_uninstall(
     enrolled: Iterable[Tool] | None = None,
     names: Iterable[str] | None = None,
 ) -> SyncResult:
-    """Remove only externally recorded Vaultspec-owned entries."""
+    """Remove recorded Vaultspec-owned enrollment from selected native targets.
+
+    When *names* is provided, only those owned server names are removed.
+    External host entries and canonical MCP definitions remain unchanged.
+    """
     result = SyncResult()
     selected_names = frozenset(names) if names is not None else None
     try:

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -11,14 +11,23 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
 from . import types as _t
-from .enums import InstallMode, render_mode
+from .enums import (
+    InstallMode,
+    McpScope,
+    McpTargetFormat,
+    ProviderCapability,
+    Tool,
+    render_mode,
+)
 from .exceptions import ResourceExistsError, ResourceNotFoundError, VaultSpecError
 from .helpers import advisory_lock, atomic_write, ensure_dir
-from .types import SyncResult
+from .types import McpTarget, SyncResult
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +52,7 @@ _MODE_ARGS_TOKEN = "@@VAULTSPEC_INSTALL_MODE_ARGS@@"
 #: written ``.mcp.json``.
 _MODE_PACKAGE_KEY = "_vaultspec_mode_package"
 _MODE_MODULE_KEY = "_vaultspec_mode_module"
+_MODE_TOOL_SPEC_KEY = "_vaultspec_mode_tool_spec"
 
 #: The distribution and module core's own MCP server launches through. Used as
 #: the substitution defaults when a definition omits the per-definition
@@ -52,7 +62,10 @@ _DEFAULT_MCP_MODULE = "vaultspec_core.mcp_server.app"
 
 
 def render_launch_for_mode(
-    mode: InstallMode, package: str, module: str
+    mode: InstallMode,
+    package: str,
+    module: str,
+    tool_spec: str | None = None,
 ) -> tuple[str, list[str]]:
     """Return the concrete ``(command, args)`` launch a package+module renders to.
 
@@ -76,15 +89,19 @@ def render_launch_for_mode(
 
     Args:
         mode: The provisioning mode whose launch to render.
-        package: Distribution name for the ``uvx --from`` tool-mode launch.
+        package: Distribution name used as the workspace-mode identity and as
+            the default ``uvx --from`` tool-mode requirement.
         module: Fully-qualified module the MCP server runs as ``python -m``.
+        tool_spec: Optional tool-mode distribution requirement, such as
+            ``"vaultspec-rag[mcp]"``. It affects only ``uvx --from``; package
+            remains the declaration and mode-resolution identity.
 
     Returns:
         The ``(command, args)`` pair for the rendered mode.
     """
     if render_mode(mode) is InstallMode.DEPENDENCY:
         return "uv", ["run", "python", "-m", module]
-    return "uvx", ["--from", package, "python", "-m", module]
+    return "uvx", ["--from", tool_spec or package, "python", "-m", module]
 
 
 #: Core's own concrete MCP-server launch per mode, derived from the generalized
@@ -134,13 +151,15 @@ def render_mcp_definition_for_mode(
         removed. The input is not mutated.
     """
     rendered = dict(definition)
+    package = str(rendered.pop(_MODE_PACKAGE_KEY, _DEFAULT_MCP_PACKAGE))
+    module = str(rendered.pop(_MODE_MODULE_KEY, _DEFAULT_MCP_MODULE))
+    raw_tool_spec = rendered.pop(_MODE_TOOL_SPEC_KEY, None)
+    tool_spec = str(raw_tool_spec) if raw_tool_spec is not None else None
     has_command_token = rendered.get("command") == _MODE_COMMAND_TOKEN
     has_args_token = rendered.get("args") == [_MODE_ARGS_TOKEN]
     if not (has_command_token or has_args_token):
         return rendered
-    package = str(rendered.pop(_MODE_PACKAGE_KEY, _DEFAULT_MCP_PACKAGE))
-    module = str(rendered.pop(_MODE_MODULE_KEY, _DEFAULT_MCP_MODULE))
-    command, args = render_launch_for_mode(mode, package, module)
+    command, args = render_launch_for_mode(mode, package, module, tool_spec)
     if has_command_token:
         rendered["command"] = command
     if has_args_token:
@@ -232,6 +251,179 @@ def _get_mcps_src_dir() -> Path | None:
         return _t.get_context().mcps_src_dir
     except LookupError:
         return None
+
+
+_OWNERSHIP_VERSION = 1
+_OWNERSHIP_FILENAME = "mcp-ownership.json"
+
+
+def _coerce_scope(scope: McpScope | str) -> McpScope:
+    try:
+        return scope if isinstance(scope, McpScope) else McpScope(scope)
+    except ValueError as exc:
+        choices = ", ".join(item.value for item in McpScope)
+        raise VaultSpecError(
+            f"Unsupported MCP scope: {scope}",
+            hint=f"Choose one of: {choices}.",
+        ) from exc
+
+
+def _selected_mcp_tools(
+    provider: Tool | str,
+    *,
+    enrolled: Iterable[Tool] | None,
+) -> tuple[Tool, ...]:
+    """Return selected MCP-capable providers in canonical tool order."""
+    ctx = _t.get_context()
+    if enrolled is None:
+        from .manifest import installed_tool_configs
+
+        available = installed_tool_configs()
+    else:
+        selected = set(enrolled)
+        available = {
+            tool: cfg for tool, cfg in ctx.tool_configs.items() if tool in selected
+        }
+
+    if provider == "all":
+        candidates = tuple(tool for tool in Tool if tool in available)
+    else:
+        try:
+            selected_tool = provider if isinstance(provider, Tool) else Tool(provider)
+        except ValueError as exc:
+            raise VaultSpecError(f"Unsupported MCP provider: {provider}") from exc
+        if selected_tool not in available:
+            raise VaultSpecError(
+                f"MCP provider '{selected_tool.value}' is not enrolled.",
+                hint="Install the provider or pass the freshly selected provider set.",
+            )
+        candidates = (selected_tool,)
+
+    supported: list[Tool] = []
+    for tool in candidates:
+        cfg = available[tool]
+        if ProviderCapability.MCPS in cfg.capabilities:
+            supported.append(tool)
+        elif provider != "all":
+            raise VaultSpecError(
+                f"Provider '{tool.value}' has no verified MCP target contract."
+            )
+    return tuple(supported)
+
+
+def _claude_user_config_path() -> Path:
+    """Return Claude Code's user/local MCP store."""
+    return Path.home() / ".claude.json"
+
+
+def _codex_user_config_path() -> Path:
+    """Return Codex's user MCP store, honoring ``CODEX_HOME``."""
+    configured = os.environ.get("CODEX_HOME")
+    home = Path(configured).expanduser() if configured else Path.home() / ".codex"
+    return home / "config.toml"
+
+
+def resolve_mcp_targets(
+    provider: Tool | str = "all",
+    *,
+    scope: McpScope | str = McpScope.PROJECT,
+    target_dir: Path | None = None,
+    enrolled: Iterable[Tool] | None = None,
+) -> tuple[McpTarget, ...]:
+    """Resolve selected providers to their native MCP configuration targets.
+
+    ``enrolled`` is the fresh-install seam: callers can supply the provider set
+    selected for the current install before the provider manifest is written.
+    Ordinary callers omit it and resolution uses the committed manifest.
+    """
+    ctx = _t.get_context()
+    root = target_dir or ctx.target_dir
+    resolved_scope = _coerce_scope(scope)
+    tools = _selected_mcp_tools(provider, enrolled=enrolled)
+    targets: list[McpTarget] = []
+
+    for tool in tools:
+        cfg = ctx.tool_configs[tool]
+        if tool is Tool.CLAUDE:
+            path = (
+                root / ".mcp.json"
+                if resolved_scope is McpScope.PROJECT
+                else _claude_user_config_path()
+            )
+            target_format = McpTargetFormat.JSON
+        elif tool is Tool.CODEX:
+            if resolved_scope is McpScope.LOCAL:
+                raise VaultSpecError(
+                    "Codex does not define a distinct local MCP scope.",
+                    hint="Use project scope or explicitly request user scope.",
+                )
+            path = (
+                root / ".codex" / "config.toml"
+                if resolved_scope is McpScope.PROJECT
+                else _codex_user_config_path()
+            )
+            target_format = McpTargetFormat.TOML
+        elif tool is Tool.ANTIGRAVITY:
+            if resolved_scope is not McpScope.PROJECT:
+                raise VaultSpecError(
+                    "Antigravity MCP enrollment currently supports project scope only."
+                )
+            if cfg.mcp_config_file is None:
+                raise VaultSpecError("Antigravity MCP target is not configured.")
+            path = cfg.mcp_config_file
+            target_format = McpTargetFormat.JSON
+        else:
+            raise VaultSpecError(
+                f"Provider '{tool.value}' has no native MCP target resolver."
+            )
+        targets.append(
+            McpTarget(
+                provider=tool,
+                scope=resolved_scope,
+                path=path,
+                format=target_format,
+            )
+        )
+    return tuple(targets)
+
+
+def _ownership_path(root: Path, scope: McpScope) -> Path:
+    if scope in {McpScope.PROJECT, McpScope.LOCAL}:
+        return root / ".vaultspec" / _OWNERSHIP_FILENAME
+    return Path.home() / ".vaultspec" / _OWNERSHIP_FILENAME
+
+
+def _ownership_target_key(target: McpTarget) -> str:
+    base = f"{target.provider.value}:{target.scope.value}"
+    if target.scope is McpScope.USER:
+        return f"{base}:{target.path.resolve()}"
+    return base
+
+
+def _read_ownership(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": _OWNERSHIP_VERSION, "targets": {}}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        raise VaultSpecError(
+            f"Cannot read MCP ownership state at {path}: {exc}",
+            hint="Repair or remove the corrupt sidecar before reconciling MCPs.",
+        ) from exc
+    if not isinstance(raw, dict) or not isinstance(raw.get("targets"), dict):
+        raise VaultSpecError(
+            f"Invalid MCP ownership state at {path}.",
+            hint="Expected an object with a 'targets' object.",
+        )
+    version = raw.get("version")
+    if version != _OWNERSHIP_VERSION:
+        raise VaultSpecError(f"Unsupported MCP ownership version at {path}: {version}")
+    return raw
+
+
+def _write_ownership(path: Path, state: dict[str, Any]) -> None:
+    ensure_dir(path.parent)
+    atomic_write(path, json.dumps(state, indent=2, sort_keys=True) + "\n")
 
 
 def _existing_source_server_names() -> set[str]:

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -1009,7 +1009,7 @@ def _json_server_map(
             raise VaultSpecError(
                 "Claude configuration field 'projects' is not an object."
             )
-        project = projects.setdefault(str(root.resolve()), {})
+        project = projects.setdefault(root.resolve().as_posix(), {})
         if not isinstance(project, dict):
             raise VaultSpecError("Claude local project configuration is not an object.")
         container = project
@@ -1027,7 +1027,7 @@ def _drop_empty_json_server_map(
         projects = raw.get("projects")
         if not isinstance(projects, dict):
             return
-        project_key = str(root.resolve())
+        project_key = root.resolve().as_posix()
         project = projects.get(project_key)
         if isinstance(project, dict) and not project.get("mcpServers"):
             project.pop("mcpServers", None)

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -911,6 +911,23 @@ def _set_owned_names(
     }
 
 
+def _discard_owned_names(
+    state: dict[str, Any], target: McpTarget, names: set[str]
+) -> None:
+    key = _ownership_target_key(target)
+    record = state["targets"].get(key)
+    if not isinstance(record, dict):
+        return
+    managed = record.get("managed")
+    if not isinstance(managed, dict):
+        state["targets"].pop(key, None)
+        return
+    for name in names:
+        managed.pop(name, None)
+    if not managed:
+        state["targets"].pop(key, None)
+
+
 def _apply_server_merge(
     servers: dict[str, dict[str, Any]],
     managed: set[str],
@@ -1408,9 +1425,11 @@ def mcp_uninstall(
     provider: Tool | str = "all",
     scope: McpScope | str = McpScope.PROJECT,
     enrolled: Iterable[Tool] | None = None,
+    names: Iterable[str] | None = None,
 ) -> SyncResult:
     """Remove only externally recorded Vaultspec-owned entries."""
     result = SyncResult()
+    selected_names = frozenset(names) if names is not None else None
     try:
         resolved_scope = _coerce_scope(scope)
         targets = resolve_mcp_targets(
@@ -1434,8 +1453,10 @@ def mcp_uninstall(
         for target in targets:
             sub = SyncResult()
             managed = _owned_names(state, target)
-            if not managed or not target.path.exists():
-                _set_owned_names(state, target, {})
+            requested = managed if selected_names is None else managed & selected_names
+            if not requested or not target.path.exists():
+                if not dry_run:
+                    _discard_owned_names(state, target, requested)
                 result.per_tool[target.provider.value] = sub
                 continue
             succeeded = False
@@ -1446,7 +1467,7 @@ def mcp_uninstall(
                         if not isinstance(raw, dict):
                             raise VaultSpecError("JSON root is not an object.")
                         servers = _json_server_map(raw, target, target_dir)
-                        present = managed & set(servers)
+                        present = requested & set(servers)
                         sub.pruned += len(present)
                         sub.items.extend((name, "[DELETE]") for name in sorted(present))
                         if not dry_run:
@@ -1457,7 +1478,7 @@ def mcp_uninstall(
                     else:
                         content = target.path.read_text(encoding="utf-8")
                         block_servers = _toml_servers(_managed_toml_content(content))
-                        present = managed & set(block_servers)
+                        present = requested & set(block_servers)
                         sub.pruned += len(present)
                         sub.items.extend((name, "[DELETE]") for name in sorted(present))
                         if not dry_run:
@@ -1491,7 +1512,7 @@ def mcp_uninstall(
                         f"Cannot uninstall MCPs from {target.path}: {exc}"
                     )
             if not dry_run and succeeded:
-                _set_owned_names(state, target, {})
+                _discard_owned_names(state, target, requested)
             result.merge(sub)
             result.per_tool[target.provider.value] = sub
         if not dry_run:

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -9,9 +9,12 @@ sync), MCP definitions are JSON files merged into a single provider-agnostic
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
+import re
+import tomllib
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
@@ -27,6 +30,7 @@ from .enums import (
 )
 from .exceptions import ResourceExistsError, ResourceNotFoundError, VaultSpecError
 from .helpers import advisory_lock, atomic_write, ensure_dir
+from .tags import TagError, find_blocks, strip_block, upsert_block
 from .types import McpTarget, SyncResult
 
 logger = logging.getLogger(__name__)
@@ -336,8 +340,17 @@ def resolve_mcp_targets(
     selected for the current install before the provider manifest is written.
     Ordinary callers omit it and resolution uses the committed manifest.
     """
-    ctx = _t.get_context()
+    try:
+        ctx = _t.get_context()
+    except LookupError:
+        if target_dir is None:
+            raise VaultSpecError(
+                "No workspace context or explicit MCP target directory is available."
+            ) from None
+        ctx = _t.init_paths(target_dir)
     root = target_dir or ctx.target_dir
+    if ctx.target_dir.resolve() != root.resolve():
+        ctx = _t.init_paths(root)
     resolved_scope = _coerce_scope(scope)
     tools = _selected_mcp_tools(provider, enrolled=enrolled)
     targets: list[McpTarget] = []
@@ -543,22 +556,16 @@ def mcp_list() -> list[dict[str, str]]:
     return list(items.values())
 
 
-def mcp_status() -> dict[str, Any]:
-    """Return focused status for MCP definitions and the synced config file.
-
-    This is intentionally narrower than ``spec doctor``: it reports only
-    whether source definitions under ``.vaultspec/mcps/`` are represented
-    in the workspace ``.mcp.json`` and whether managed entries have drifted.
-
-    Drift is judged mode-aware: definitions are rendered for the workspace's
-    resolved render mode (via
-    :func:`~vaultspec_core.core.workspace_mode.resolve_render_mode`) before
-    they are compared against the synced ``.mcp.json`` entries, so a
-    correctly-provisioned workspace in either mode is not reported as drifted
-    against the mode-neutral token form.
-    """
+def mcp_status(
+    *,
+    provider: Tool | str = "all",
+    scope: McpScope | str = McpScope.PROJECT,
+    target_dir: Path | None = None,
+    enrolled: Iterable[Tool] | None = None,
+) -> dict[str, Any]:
+    """Return aggregate and per-provider native MCP enrollment status."""
     try:
-        target_dir = _t.get_context().target_dir
+        root = target_dir or _t.get_context().target_dir
     except LookupError:
         return {
             "status": "no_context",
@@ -570,103 +577,163 @@ def mcp_status() -> dict[str, Any]:
             "missing": [],
             "drifted": [],
             "stale_managed": [],
+            "external": [],
+            "providers": {},
             "warnings": ["No workspace context available for MCP status."],
         }
 
     from .workspace_mode import CORE_DISTRIBUTION_NAME, resolve_render_mode
 
-    render_mode = resolve_render_mode(target_dir, package=CORE_DISTRIBUTION_NAME)
+    try:
+        resolved_scope = _coerce_scope(scope)
+        targets = resolve_mcp_targets(
+            provider,
+            scope=resolved_scope,
+            target_dir=root,
+            enrolled=enrolled,
+        )
+    except VaultSpecError as exc:
+        return {
+            "status": "invalid_target",
+            "config_path": None,
+            "config_exists": False,
+            "definitions": [],
+            "configured": [],
+            "managed": [],
+            "missing": [],
+            "drifted": [],
+            "stale_managed": [],
+            "external": [],
+            "providers": {},
+            "warnings": [str(exc)],
+        }
+
+    render_mode = resolve_render_mode(root, package=CORE_DISTRIBUTION_NAME)
     parse_warnings: list[str] = []
     sources = collect_mcp_servers(
-        warnings=parse_warnings, mode=render_mode, target=target_dir
+        warnings=parse_warnings, mode=render_mode, target=root
     )
     definitions = sorted(sources)
 
-    mcp_json = target_dir / ".mcp.json"
-    configured: list[str] = []
-    managed: list[str] = []
-    missing = definitions.copy()
-    drifted: list[str] = []
-    stale_managed: list[str] = []
     warnings = list(parse_warnings)
-    status = "ok"
-
-    if not mcp_json.exists():
-        status = "missing_config" if definitions else "no_definitions"
-        warnings.append(".mcp.json is missing; run vaultspec-core sync.")
+    try:
+        state = _read_ownership(_ownership_path(root, resolved_scope))
+    except VaultSpecError as exc:
         return {
-            "status": status,
-            "config_path": str(mcp_json),
+            "status": "invalid_target",
+            "config_path": None,
             "config_exists": False,
             "definitions": definitions,
-            "configured": configured,
-            "managed": managed,
-            "missing": missing,
-            "drifted": drifted,
-            "stale_managed": stale_managed,
-            "warnings": warnings,
+            "configured": [],
+            "managed": [],
+            "missing": definitions,
+            "drifted": [],
+            "stale_managed": [],
+            "external": [],
+            "providers": {},
+            "warnings": [*warnings, str(exc)],
         }
 
-    try:
-        raw = json.loads(mcp_json.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        return {
-            "status": "invalid_config",
-            "config_path": str(mcp_json),
-            "config_exists": True,
-            "definitions": definitions,
+    providers: dict[str, dict[str, Any]] = {}
+    for target in targets:
+        normalization = SyncResult()
+        target_sources = _normalized_sources(sources, target, normalization)
+        servers: dict[str, dict[str, Any]] = {}
+        managed = _owned_names(state, target)
+        target_warnings = list(normalization.warnings)
+        invalid = False
+        if target.path.exists():
+            try:
+                if target.format is McpTargetFormat.JSON:
+                    raw = json.loads(target.path.read_text(encoding="utf-8"))
+                    if not isinstance(raw, dict):
+                        raise VaultSpecError("JSON root is not an object.")
+                    native = _json_server_map(raw, target, root)
+                    servers = {
+                        str(name): dict(config)
+                        for name, config in native.items()
+                        if isinstance(config, dict)
+                    }
+                    legacy = raw.get(_LEGACY_MANAGED_KEY, [])
+                    if isinstance(legacy, list):
+                        managed.update(name for name in legacy if isinstance(name, str))
+                else:
+                    content = target.path.read_text(encoding="utf-8")
+                    outside = _toml_servers(strip_block(content, _TOML_BLOCK_TYPE))
+                    block = _toml_servers(_managed_toml_content(content))
+                    servers = {**outside, **block}
+                    managed.update(block)
+            except (
+                json.JSONDecodeError,
+                OSError,
+                TagError,
+                tomllib.TOMLDecodeError,
+                VaultSpecError,
+            ) as exc:
+                invalid = True
+                target_warnings.append(f"Cannot parse {target.path}: {exc}")
+        managed.intersection_update(servers)
+        configured = sorted(servers)
+        missing = sorted(set(definitions) - set(servers))
+        drifted = sorted(
+            name
+            for name in managed & set(target_sources)
+            if servers[name] != target_sources[name][1]
+        )
+        stale = sorted(managed - set(definitions))
+        external = sorted(set(servers) - managed)
+        if invalid:
+            target_status = "invalid_config"
+        elif not target.path.exists():
+            target_status = "missing_config" if definitions else "no_definitions"
+        elif missing or drifted or stale:
+            target_status = "partial"
+        else:
+            target_status = "ok"
+        providers[target.provider.value] = {
+            "status": target_status,
+            "scope": target.scope.value,
+            "config_path": str(target.path),
+            "config_exists": target.path.exists(),
             "configured": configured,
-            "managed": managed,
+            "managed": sorted(managed),
             "missing": missing,
             "drifted": drifted,
-            "stale_managed": stale_managed,
-            "warnings": [*warnings, f"Cannot parse .mcp.json: {exc}"],
+            "stale_managed": stale,
+            "external": external,
+            "warnings": target_warnings,
         }
+        warnings.extend(target_warnings)
 
-    if not isinstance(raw, dict):
-        return {
-            "status": "invalid_config",
-            "config_path": str(mcp_json),
-            "config_exists": True,
-            "definitions": definitions,
-            "configured": configured,
-            "managed": managed,
-            "missing": missing,
-            "drifted": drifted,
-            "stale_managed": stale_managed,
-            "warnings": [*warnings, ".mcp.json is not a JSON object."],
-        }
+    def aggregate(key: str) -> list[str]:
+        return sorted({item for data in providers.values() for item in data[key]})
 
-    servers = raw.get("mcpServers", {})
-    if not isinstance(servers, dict):
-        status = "invalid_config"
-        warnings.append(".mcp.json field 'mcpServers' is not a JSON object.")
-        servers = {}
-
-    configured = sorted(str(name) for name in servers)
-    raw_managed = raw.get(_MANAGED_KEY, [])
-    if isinstance(raw_managed, list):
-        managed = sorted(str(name) for name in raw_managed if isinstance(name, str))
-
-    missing = [name for name in definitions if name not in servers]
-    for name, (_source_path, config) in sources.items():
-        if name in servers and name in managed and servers[name] != config:
-            drifted.append(name)
-    stale_managed = [name for name in managed if name not in definitions]
-
-    if status == "ok" and (missing or drifted or stale_managed or warnings):
+    statuses = {data["status"] for data in providers.values()}
+    if not statuses:
+        status = "no_providers"
+    elif statuses <= {"ok", "no_definitions"}:
+        status = "ok"
+    else:
         status = "partial"
-
+    if "invalid_config" in statuses:
+        status = "invalid_config"
     return {
         "status": status,
-        "config_path": str(mcp_json),
-        "config_exists": True,
+        "config_path": (
+            next(iter(providers.values()))["config_path"]
+            if len(providers) == 1
+            else None
+        ),
+        "config_exists": bool(providers)
+        and all(data["config_exists"] for data in providers.values()),
         "definitions": definitions,
-        "configured": configured,
-        "managed": managed,
-        "missing": missing,
-        "drifted": sorted(drifted),
-        "stale_managed": stale_managed,
+        "configured": aggregate("configured"),
+        "managed": aggregate("managed"),
+        "missing": aggregate("missing"),
+        "drifted": aggregate("drifted"),
+        "stale_managed": aggregate("stale_managed"),
+        "external": aggregate("external"),
+        "providers": providers,
         "warnings": warnings,
     }
 
@@ -752,94 +819,114 @@ def mcp_remove(name: str) -> Path:
     raise ResourceNotFoundError(f"MCP definition '{name}' not found.")
 
 
-_MANAGED_KEY = "_vaultspecManaged"
+_LEGACY_MANAGED_KEY = "_vaultspecManaged"
+_TOML_BLOCK_TYPE = "mcps"
+_STDIO_FIELDS = frozenset({"command", "args", "env"})
 
 
-def _apply_mcp_merge(
-    existing: dict[str, Any],
+def _normalized_sources(
+    sources: dict[str, tuple[Path, dict[str, Any]]],
+    target: McpTarget,
+    result: SyncResult,
+) -> dict[str, tuple[Path, dict[str, Any]]]:
+    """Validate canonical stdio definitions before a provider adapter sees them."""
+    normalized: dict[str, tuple[Path, dict[str, Any]]] = {}
+    for name, (path, config) in sources.items():
+        unsupported = sorted(set(config) - _STDIO_FIELDS)
+        command = config.get("command")
+        args = config.get("args", [])
+        env = config.get("env", {})
+        if unsupported:
+            result.warnings.append(
+                f"MCP server '{name}' has fields unsupported by "
+                f"{target.provider.value}: {unsupported}; skipping this target."
+            )
+            continue
+        if not isinstance(command, str):
+            result.warnings.append(
+                f"MCP server '{name}' has a non-string command; skipping "
+                f"{target.provider.value}."
+            )
+            continue
+        if not isinstance(args, list) or not all(
+            isinstance(item, str) for item in args
+        ):
+            result.warnings.append(
+                f"MCP server '{name}' has non-string args; skipping "
+                f"{target.provider.value}."
+            )
+            continue
+        if not isinstance(env, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in env.items()
+        ):
+            result.warnings.append(
+                f"MCP server '{name}' has a non-string environment map; skipping "
+                f"{target.provider.value}."
+            )
+            continue
+        definition: dict[str, Any] = {"command": command}
+        if "args" in config:
+            definition["args"] = list(args)
+        if "env" in config:
+            definition["env"] = dict(env)
+        normalized[name] = (path, definition)
+    return normalized
+
+
+def _fingerprint(config: dict[str, Any]) -> str:
+    """Return the stable observed-content fingerprint stored in ownership state."""
+    encoded = json.dumps(config, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _owned_names(state: dict[str, Any], target: McpTarget) -> set[str]:
+    raw = state["targets"].get(_ownership_target_key(target), {})
+    managed = raw.get("managed", {}) if isinstance(raw, dict) else {}
+    if isinstance(managed, dict):
+        return {str(name) for name in managed}
+    return set()
+
+
+def _set_owned_names(
+    state: dict[str, Any], target: McpTarget, servers: dict[str, dict[str, Any]]
+) -> None:
+    key = _ownership_target_key(target)
+    if not servers:
+        state["targets"].pop(key, None)
+        return
+    state["targets"][key] = {
+        "provider": target.provider.value,
+        "scope": target.scope.value,
+        "path": str(target.path.resolve()),
+        "managed": {
+            name: _fingerprint(config) for name, config in sorted(servers.items())
+        },
+    }
+
+
+def _apply_server_merge(
+    servers: dict[str, dict[str, Any]],
+    managed: set[str],
+    external: set[str],
     sources: dict[str, tuple[Path, dict[str, Any]]],
     *,
     force: bool,
     prune: bool,
     result: SyncResult,
     label: str,
-    force_managed: frozenset[str] = frozenset(),
+    force_managed: frozenset[str],
 ) -> bool:
-    """Merge *sources* into the *existing* MCP config dict in place.
-
-    Shared merge engine for every MCP target file (the workspace
-    ``.mcp.json`` and each provider-native config such as Antigravity's
-    ``.agents/mcp_config.json``). Mutates *existing* (its ``mcpServers`` map
-    and the ``_vaultspecManaged`` ownership sidecar) and records actions and
-    warnings on *result*.
-
-    *force_managed* is a surgical, per-entry escalation of *force* scoped to
-    the named already-managed servers only. It exists for the ``install
-    --upgrade`` mode-flip case: when an upgrade flips the workspace's install
-    mode, the pre-commit and declaration renderers rewrite unconditionally but
-    an unforced MCP sync would skip a pre-existing managed ``vaultspec-core``
-    entry still carrying the old mode's launch shape, leaving the migration
-    non-atomic across the three renderers. Naming that entry in *force_managed*
-    updates it in the same run without escalating the whole sync to *force*.
-    Because it gates only the ``name in managed`` branch, a user-owned entry
-    that shares a name with a source is never adopted or overwritten by it, so
-    the foreign-entry discipline stays intact.
-
-    Args:
-        existing: Parsed target config; mutated in place.
-        sources: Collected MCP definitions keyed by server name.
-        force: Overwrite managed/user entries that differ from their source.
-        prune: Remove managed entries whose source file is gone from disk.
-        result: Accumulator for counters, items, and warnings.
-        label: Human label for the target (e.g. ``".mcp.json"``) used in
-            warning messages.
-        force_managed: Names of already-managed servers to overwrite when they
-            diverge from their source, even when *force* is ``False``. Ignored
-            for any name not currently in the managed set.
-
-    Returns:
-        ``True`` when *existing* was modified, else ``False``.
-    """
-    servers = existing.setdefault("mcpServers", {})
-    if not isinstance(servers, dict):
-        servers = {}
-        existing["mcpServers"] = servers
-
-    if _MANAGED_KEY in existing:
-        raw_managed = existing.get(_MANAGED_KEY, [])
-        if isinstance(raw_managed, list):
-            managed: set[str] = {str(n) for n in raw_managed if isinstance(n, str)}
-        else:
-            managed = set()
-    else:
-        # Legacy migration: workspaces created before ownership tracking
-        # shipped have no sidecar key. Treat any pre-existing entry whose
-        # name matches a current source as managed — preserving the legacy
-        # "differs, use --force" warning behaviour for already-installed
-        # entries. After this sync the sidecar is written and future syncs
-        # use strict ownership.
-        managed = set(servers.keys()) & set(sources.keys())
-        if managed:
-            msg = (
-                f"Legacy {label} migration: taking ownership of "
-                f"{len(managed)} pre-existing entries that match current "
-                f"sources ({sorted(managed)}). Future syncs will use strict "
-                f"ownership tracking."
-            )
-            logger.warning(msg)
-            result.warnings.append(msg)
-
+    """Apply ownership-safe desired state to one provider's normalized servers."""
     changed = False
     for name, (_path, config) in sources.items():
         if name not in servers:
-            # New entry — vaultspec creates it and takes ownership.
             servers[name] = config
             managed.add(name)
             result.added += 1
             result.items.append((name, "[ADD]"))
             changed = True
         elif name in managed:
-            # Previously managed by vaultspec — sync content.
             if servers[name] == config:
                 result.unchanged += 1
                 result.items.append((name, "[UNCHANGED]"))
@@ -852,42 +939,25 @@ def _apply_mcp_merge(
                 result.skipped += 1
                 result.items.append((name, "[SKIP]"))
                 result.warnings.append(
-                    f"MCP server '{name}' differs from definition "
-                    f"(use --force to overwrite)"
+                    f"MCP server '{name}' in {label} differs from its definition "
+                    "(use --force to overwrite)."
                 )
         elif force:
-            # User-added entry that shares a name with a current source.
-            # --force is the explicit adopt path (issue #120): overwrite it
-            # with the source definition and take ownership, so the entry
-            # converges without the user hand-editing the generated file
-            # the CLI tells them not to touch.
-            if servers[name] != config:
-                servers[name] = config
-                changed = True
+            servers[name] = config
+            external.discard(name)
             managed.add(name)
             result.updated += 1
             result.items.append((name, "[ADOPT]"))
             changed = True
         else:
-            # User-added entry that shares a name with a current
-            # source. Preserve it; never take ownership implicitly.
             result.skipped += 1
             result.items.append((name, "[SKIP]"))
             result.warnings.append(
-                f"MCP server '{name}' is user-managed and shares its name "
-                f"with a vaultspec source; skipping. Re-run with --force to "
-                f"adopt it into vaultspec management, or rename one to resolve."
+                f"MCP server '{name}' in {label} is externally managed; "
+                "use --force to adopt it explicitly."
             )
 
     if prune:
-        # Critical: prune is gated on the source file being *physically
-        # absent* from disk, not merely missing from the parsed sources
-        # dict. ``collect_mcp_servers`` omits files that exist but failed
-        # JSON parsing or read; treating those as deletions would let a
-        # transient typo silently destroy the corresponding entry under
-        # ``sync --force``. ``_existing_source_server_names`` walks the
-        # directory without opening files, so a parse failure leaves the
-        # entry intact until the source is fixed (or genuinely deleted).
         on_disk = _existing_source_server_names()
         for name in sorted(managed - on_disk):
             if name in servers:
@@ -897,90 +967,324 @@ def _apply_mcp_merge(
                 changed = True
             managed.discard(name)
 
-    # Reconcile managed set with what is actually in ``servers``
-    # (defensive cleanup against external mutations).
-    managed &= set(servers.keys())
-
-    # Persist managed set; remove the key entirely when empty so we never
-    # write a dangling sidecar.
-    prior_managed = existing.get(_MANAGED_KEY)
-    new_managed_value = sorted(managed) if managed else None
-    if new_managed_value is None:
-        if _MANAGED_KEY in existing:
-            del existing[_MANAGED_KEY]
-            changed = True
-    elif prior_managed != new_managed_value:
-        existing[_MANAGED_KEY] = new_managed_value
-        changed = True
-
+    managed.intersection_update(servers)
     return changed
 
 
-def _sync_mcp_target(
-    path: Path,
+def _json_server_map(
+    raw: dict[str, Any], target: McpTarget, root: Path
+) -> dict[str, Any]:
+    """Return the native JSON server map for a Claude/Antigravity target."""
+    container = raw
+    if target.provider is Tool.CLAUDE and target.scope is McpScope.LOCAL:
+        projects = raw.setdefault("projects", {})
+        if not isinstance(projects, dict):
+            raise VaultSpecError(
+                "Claude configuration field 'projects' is not an object."
+            )
+        project = projects.setdefault(str(root.resolve()), {})
+        if not isinstance(project, dict):
+            raise VaultSpecError("Claude local project configuration is not an object.")
+        container = project
+    servers = container.setdefault("mcpServers", {})
+    if not isinstance(servers, dict):
+        raise VaultSpecError(f"MCP server map in {target.path} is not an object.")
+    return servers
+
+
+def _drop_empty_json_server_map(
+    raw: dict[str, Any], target: McpTarget, root: Path
+) -> None:
+    """Remove empty native containers while retaining unrelated host settings."""
+    if target.provider is Tool.CLAUDE and target.scope is McpScope.LOCAL:
+        projects = raw.get("projects")
+        if not isinstance(projects, dict):
+            return
+        project_key = str(root.resolve())
+        project = projects.get(project_key)
+        if isinstance(project, dict) and not project.get("mcpServers"):
+            project.pop("mcpServers", None)
+            if not project:
+                projects.pop(project_key, None)
+        if not projects:
+            raw.pop("projects", None)
+        return
+    if not raw.get("mcpServers"):
+        raw.pop("mcpServers", None)
+
+
+def _write_json_target(
+    path: Path, raw: dict[str, Any], target: McpTarget, root: Path
+) -> None:
+    _drop_empty_json_server_map(raw, target, root)
+    if raw:
+        ensure_dir(path.parent)
+        atomic_write(path, json.dumps(raw, indent=2) + "\n")
+    elif path.exists():
+        path.unlink()
+
+
+def _sync_json_target(
+    target: McpTarget,
+    root: Path,
+    state: dict[str, Any],
     sources: dict[str, tuple[Path, dict[str, Any]]],
     *,
     dry_run: bool,
     force: bool,
     prune: bool,
     result: SyncResult,
-    label: str,
-    force_managed: frozenset[str] = frozenset(),
+    force_managed: frozenset[str],
 ) -> None:
-    """Merge *sources* into a single MCP config file at *path*.
-
-    Reads the existing file (if any), applies the shared merge via
-    :func:`_apply_mcp_merge`, and writes the result. When pruning empties
-    the file and no user-defined top-level keys remain, the file is removed
-    rather than left as an orphan ``{"mcpServers": {}}`` artefact.
-
-    *force_managed* is forwarded verbatim to :func:`_apply_mcp_merge`; see its
-    docstring for the narrowly-scoped mode-flip escalation it performs.
-    """
-    with advisory_lock(path):
-        existing: dict[str, Any] = {}
-        if path.exists():
+    """Reconcile a Claude or Antigravity JSON target without host-only keys."""
+    with advisory_lock(target.path):
+        raw: dict[str, Any] = {}
+        if target.path.exists():
             try:
-                raw = json.loads(path.read_text(encoding="utf-8"))
-                if isinstance(raw, dict):
-                    existing = raw
+                loaded = json.loads(target.path.read_text(encoding="utf-8"))
             except (json.JSONDecodeError, OSError) as exc:
-                result.warnings.append(f"Cannot parse existing {label}: {exc}")
+                result.errors.append(f"Cannot parse {target.path}: {exc}")
+                result.errored += 1
+                return
+            if not isinstance(loaded, dict):
+                result.errors.append(f"MCP target {target.path} is not a JSON object.")
+                result.errored += 1
+                return
+            raw = loaded
 
-        changed = _apply_mcp_merge(
-            existing,
+        try:
+            untyped_servers = _json_server_map(raw, target, root)
+        except VaultSpecError as exc:
+            result.errors.append(str(exc))
+            result.errored += 1
+            return
+        servers = {
+            str(name): config
+            for name, config in untyped_servers.items()
+            if isinstance(config, dict)
+        }
+        if len(servers) != len(untyped_servers):
+            result.errors.append(
+                f"MCP target {target.path} contains a non-object server."
+            )
+            result.errored += 1
+            return
+
+        managed = _owned_names(state, target) & set(servers)
+        legacy = raw.pop(_LEGACY_MANAGED_KEY, None)
+        migrated = (
+            {name for name in legacy if isinstance(name, str) and name in servers}
+            if isinstance(legacy, list)
+            else set()
+        )
+        if migrated:
+            managed.update(migrated)
+            result.warnings.append(
+                f"Migrated affirmative legacy ownership for {sorted(migrated)} "
+                f"from {target.path}."
+            )
+        external = set(servers) - managed
+        changed = legacy is not None
+        changed |= _apply_server_merge(
+            servers,
+            managed,
+            external,
             sources,
             force=force,
             prune=prune,
             result=result,
-            label=label,
+            label=str(target.path),
             force_managed=force_managed,
         )
-
+        untyped_servers.clear()
+        untyped_servers.update(servers)
+        _set_owned_names(
+            state, target, {name: servers[name] for name in managed if name in servers}
+        )
         if changed and not dry_run:
-            servers = existing.get("mcpServers", {})
-            if not servers and len(existing) == 1:
-                if path.exists():
-                    path.unlink()
-            else:
-                ensure_dir(path.parent)
-                atomic_write(path, json.dumps(existing, indent=2) + "\n")
+            _write_json_target(target.path, raw, target, root)
 
 
-def _provider_mcp_targets() -> dict[str, Path]:
-    """Return installed providers that read a provider-native MCP config file.
+def _toml_value(value: Any) -> str:
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return repr(value)
+    if isinstance(value, list):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        pairs = (
+            f"{json.dumps(str(key))} = {_toml_value(item)}"
+            for key, item in sorted(value.items())
+        )
+        return "{ " + ", ".join(pairs) + " }"
+    raise VaultSpecError(
+        f"Codex MCP configuration contains unsupported value: {value!r}"
+    )
 
-    Maps tool name to its ``mcp_config_file`` path (e.g. Antigravity's
-    ``.agents/mcp_config.json``). Providers that read the shared workspace
-    ``.mcp.json`` are not included.
-    """
-    from .manifest import installed_tool_configs
 
-    targets: dict[str, Path] = {}
-    for tool, cfg in installed_tool_configs().items():
-        if cfg.mcp_config_file is not None:
-            targets[tool.value] = cfg.mcp_config_file
-    return targets
+def _render_codex_servers(servers: dict[str, dict[str, Any]]) -> str:
+    sections: list[str] = []
+    for name, config in sorted(servers.items()):
+        lines = [f"[mcp_servers.{json.dumps(name, ensure_ascii=False)}]"]
+        lines.extend(
+            f"{key} = {_toml_value(value)}" for key, value in sorted(config.items())
+        )
+        sections.append("\n".join(lines))
+    return "\n\n".join(sections)
+
+
+def _toml_servers(content: str) -> dict[str, dict[str, Any]]:
+    if not content.strip():
+        return {}
+    parsed = tomllib.loads(content)
+    raw = parsed.get("mcp_servers", {})
+    if not isinstance(raw, dict):
+        raise VaultSpecError("Codex 'mcp_servers' field is not a table.")
+    servers: dict[str, dict[str, Any]] = {}
+    for name, config in raw.items():
+        if not isinstance(config, dict):
+            raise VaultSpecError(f"Codex MCP server '{name}' is not a table.")
+        servers[str(name)] = dict(config)
+    return servers
+
+
+def _managed_toml_content(content: str) -> str:
+    for block in find_blocks(content):
+        if block.block_type == _TOML_BLOCK_TYPE:
+            lines = content.splitlines()
+            return "\n".join(lines[block.content_start - 1 : block.content_end])
+    return ""
+
+
+_TOML_TABLE_RE = re.compile(r"^\s*\[(?!\[)(?P<header>.+)]\s*(?:#.*)?$")
+
+
+def _toml_header_path(header: str) -> tuple[str, ...] | None:
+    """Parse one TOML table header into its semantic key path."""
+    try:
+        parsed = tomllib.loads(f"[{header}]\n_vaultspec_probe = true\n")
+    except tomllib.TOMLDecodeError:
+        return None
+    path: list[str] = []
+    current: Any = parsed
+    while isinstance(current, dict) and "_vaultspec_probe" not in current:
+        if len(current) != 1:
+            return None
+        key, current = next(iter(current.items()))
+        path.append(str(key))
+    return tuple(path) if isinstance(current, dict) else None
+
+
+def _strip_external_codex_server(content: str, name: str) -> str:
+    """Remove one external Codex server's table sections without reformatting."""
+    kept: list[str] = []
+    removing = False
+    for line in content.splitlines():
+        match = _TOML_TABLE_RE.match(line)
+        if match:
+            path = _toml_header_path(match.group("header"))
+            removing = bool(
+                path and len(path) >= 2 and path[0] == "mcp_servers" and path[1] == name
+            )
+        if not removing:
+            kept.append(line)
+    rendered = "\n".join(kept)
+    if rendered and content.endswith("\n"):
+        rendered += "\n"
+    return rendered
+
+
+def _sync_toml_target(
+    target: McpTarget,
+    state: dict[str, Any],
+    sources: dict[str, tuple[Path, dict[str, Any]]],
+    *,
+    dry_run: bool,
+    force: bool,
+    prune: bool,
+    result: SyncResult,
+    force_managed: frozenset[str],
+) -> None:
+    """Reconcile Codex tables inside one comment-bounded managed block."""
+    with advisory_lock(target.path):
+        content = ""
+        if target.path.exists():
+            try:
+                content = target.path.read_text(encoding="utf-8")
+            except OSError as exc:
+                result.errors.append(f"Cannot read {target.path}: {exc}")
+                result.errored += 1
+                return
+        try:
+            if content.strip():
+                tomllib.loads(content)
+            managed_content = _managed_toml_content(content)
+            outside_content = strip_block(content, _TOML_BLOCK_TYPE)
+            outside = _toml_servers(outside_content)
+            block_servers = _toml_servers(managed_content)
+        except (TagError, tomllib.TOMLDecodeError, VaultSpecError) as exc:
+            result.errors.append(f"Cannot parse {target.path}: {exc}")
+            result.errored += 1
+            return
+
+        if force:
+            for name in sorted(set(sources) & set(outside)):
+                stripped = _strip_external_codex_server(content, name)
+                try:
+                    remaining = _toml_servers(strip_block(stripped, _TOML_BLOCK_TYPE))
+                except (TagError, tomllib.TOMLDecodeError, VaultSpecError) as exc:
+                    result.errors.append(
+                        f"Cannot adopt Codex MCP server '{name}' in "
+                        f"{target.path}: {exc}"
+                    )
+                    result.errored += 1
+                    return
+                if name in remaining:
+                    result.errors.append(
+                        f"Cannot safely adopt Codex MCP server '{name}' in "
+                        f"{target.path}; its external declaration is not a "
+                        "removable table."
+                    )
+                    result.errored += 1
+                    return
+                content = stripped
+
+        recorded = _owned_names(state, target)
+        managed = (recorded | set(block_servers)) & set(block_servers)
+        servers = {**outside, **block_servers}
+        external = set(outside)
+        changed = _apply_server_merge(
+            servers,
+            managed,
+            external,
+            sources,
+            force=force,
+            prune=prune,
+            result=result,
+            label=str(target.path),
+            force_managed=force_managed,
+        )
+        new_managed = {
+            name: servers[name]
+            for name in managed
+            if name in servers and name not in external
+        }
+        _set_owned_names(state, target, new_managed)
+        if changed and not dry_run:
+            rendered = _render_codex_servers(new_managed)
+            updated = (
+                upsert_block(content, _TOML_BLOCK_TYPE, rendered, comment_prefix="# ")
+                if rendered
+                else strip_block(content, _TOML_BLOCK_TYPE)
+            )
+            ensure_dir(target.path.parent)
+            if updated:
+                atomic_write(target.path, updated)
+            elif target.path.exists():
+                target.path.unlink()
 
 
 def mcp_sync(
@@ -989,37 +1293,18 @@ def mcp_sync(
     prune: bool = False,
     mode: InstallMode | None = None,
     force_managed: frozenset[str] = frozenset(),
+    *,
+    provider: Tool | str = "all",
+    scope: McpScope | str = McpScope.PROJECT,
+    target_dir: Path | None = None,
+    enrolled: Iterable[Tool] | None = None,
 ) -> SyncResult:
-    """Sync MCP server definitions into every MCP config target.
+    """Reconcile canonical MCP definitions into selected native host targets.
 
-    Collects all definitions from the MCP source directory and merges them
-    into the shared workspace ``.mcp.json`` plus each installed provider's
-    native MCP config file (for example Antigravity's
-    ``.agents/mcp_config.json``, which uses the same ``{"mcpServers": {...}}``
-    schema). When ``prune`` is set, managed entries whose source files have
-    been deleted are removed from every target.
-
-    Ownership tracking is persisted in each file under the reserved top-level
-    key ``_vaultspecManaged`` (a sorted list of server names vaultspec
-    created). Entries that pre-existed without being added by ``mcp_sync``
-    never enter the managed set, so user-added servers are always preserved —
-    even if they share a name with a current source. This mirrors the
-    content-marker ownership pattern used by ``sync_files``.
-
-    The launch command *core's own* definition renders to is selected by
-    *mode*. When *mode* is ``None`` (every standalone ``sync``/``doctor``
-    caller) it is resolved from core's entry in the committed workspace
-    declaration via
-    :func:`~vaultspec_core.core.workspace_mode.resolve_render_mode`, whose
-    legacy-absent rule renders dependency mode so a workspace provisioned
-    before ``install-mode`` is never silently flipped to the ``uvx`` shape. The
-    fresh-``install`` path passes its resolved mode explicitly, because the
-    declaration is written only after this render runs. Every *companion*
-    definition (one that names its own declaring package) instead renders at
-    that package's own committed render mode, so a mixed-mode workspace syncs
-    each managed entry in its own shape rather than flattening every entry onto
-    core's mode; see :func:`collect_mcp_servers` and
-    :func:`_render_definition_for_sync`.
+    Project scope is the safe default. User and Claude-local stores are touched
+    only when the caller explicitly selects those scopes. Ownership is stored
+    outside host schemas, and Codex content is bounded by a comment-only TOML
+    block so unrelated settings and comments remain byte-stable.
 
     Args:
         dry_run: If ``True``, compute changes without writing.
@@ -1028,13 +1313,11 @@ def mcp_sync(
             been deleted. Mirrors ``rules_sync``/``agents_sync``.
         mode: Provisioning mode to render definitions for, or ``None`` to
             resolve it from the committed workspace declaration.
-        force_managed: Names of already-managed servers to overwrite when they
-            diverge from their source, even when *force* is ``False``. This is
-            the ``install --upgrade`` mode-flip seam: it lets the caller migrate
-            a specific managed entry (the ``vaultspec-core`` launch command) to
-            the newly-resolved mode's shape in the same run without escalating
-            the whole sync to *force*. Scoped to managed entries only, so
-            user-owned entries stay untouched.
+        force_managed: Already-owned entries eligible for surgical updates.
+        provider: One provider name/member, or ``"all"`` enrolled providers.
+        scope: Explicit native host scope; defaults to project.
+        target_dir: Workspace root override used by companion packages.
+        enrolled: Fresh-install provider selection before manifest persistence.
 
     Returns:
         :class:`~vaultspec_core.core.types.SyncResult` with sync statistics.
@@ -1043,113 +1326,171 @@ def mcp_sync(
     result = SyncResult()
 
     try:
-        target_dir = _t.get_context().target_dir
+        root = target_dir or _t.get_context().target_dir
     except LookupError:
         result.errors.append("No workspace context available for MCP sync.")
+        return result
+
+    try:
+        resolved_scope = _coerce_scope(scope)
+        targets = resolve_mcp_targets(
+            provider, scope=resolved_scope, target_dir=root, enrolled=enrolled
+        )
+    except VaultSpecError as exc:
+        result.errors.append(str(exc))
+        result.errored += 1
         return result
 
     if mode is None:
         from .workspace_mode import CORE_DISTRIBUTION_NAME, resolve_render_mode
 
-        mode = resolve_render_mode(target_dir, package=CORE_DISTRIBUTION_NAME)
+        mode = resolve_render_mode(root, package=CORE_DISTRIBUTION_NAME)
 
     parse_warnings: list[str] = []
-    sources = collect_mcp_servers(warnings=parse_warnings, mode=mode, target=target_dir)
+    sources = collect_mcp_servers(warnings=parse_warnings, mode=mode, target=root)
     result.warnings.extend(parse_warnings)
-
-    _sync_mcp_target(
-        target_dir / ".mcp.json",
-        sources,
-        dry_run=dry_run,
-        force=force,
-        prune=prune,
-        result=result,
-        label=".mcp.json",
-        force_managed=force_managed,
-    )
-
-    for tool_name, mcp_path in sorted(_provider_mcp_targets().items()):
-        sub = SyncResult()
-        rel = (
-            str(mcp_path.relative_to(target_dir))
-            if mcp_path.is_relative_to(target_dir)
-            else str(mcp_path)
-        )
-        _sync_mcp_target(
-            mcp_path,
-            sources,
-            dry_run=dry_run,
-            force=force,
-            prune=prune,
-            result=sub,
-            label=rel.replace("\\", "/"),
-            force_managed=force_managed,
-        )
-        result.merge(sub)
-        result.per_tool[tool_name] = sub
+    ownership_path = _ownership_path(root, resolved_scope)
+    with advisory_lock(ownership_path):
+        try:
+            state = _read_ownership(ownership_path)
+        except VaultSpecError as exc:
+            result.errors.append(str(exc))
+            result.errored += 1
+            return result
+        before_state = json.dumps(state, sort_keys=True)
+        for target in targets:
+            sub = SyncResult()
+            target_sources = _normalized_sources(sources, target, sub)
+            if target.format is McpTargetFormat.JSON:
+                _sync_json_target(
+                    target,
+                    root,
+                    state,
+                    target_sources,
+                    dry_run=dry_run,
+                    force=force,
+                    prune=prune,
+                    result=sub,
+                    force_managed=force_managed,
+                )
+            else:
+                _sync_toml_target(
+                    target,
+                    state,
+                    target_sources,
+                    dry_run=dry_run,
+                    force=force,
+                    prune=prune,
+                    result=sub,
+                    force_managed=force_managed,
+                )
+            result.merge(sub)
+            result.per_tool[target.provider.value] = sub
+        if not dry_run and json.dumps(state, sort_keys=True) != before_state:
+            if state["targets"]:
+                _write_ownership(ownership_path, state)
+            elif ownership_path.exists():
+                ownership_path.unlink()
 
     return result
 
 
-def mcp_uninstall(target_dir: Path, *, dry_run: bool = False) -> list[str]:
-    """Remove all registry-managed MCP entries from ``.mcp.json``.
-
-    Collects managed server names from the registry source directory and
-    removes each from ``.mcp.json``.  User-added entries are preserved.
-    If no servers remain, the file is deleted.
-
-    Args:
-        target_dir: Workspace root directory.
-        dry_run: When ``True``, returns names without modifying files.
-
-    Returns:
-        List of server names that were (or would be) removed.
-    """
-    sources = collect_mcp_servers()
-    managed_names = set(sources.keys())
-
-    # If no registry is available, fall back to removing known built-in names
-    if not managed_names:
-        managed_names = {"vaultspec-core"}
-
-    # Every MCP target: the shared .mcp.json plus each installed provider's
-    # native MCP config (e.g. Antigravity's .agents/mcp_config.json).
-    targets = [target_dir / ".mcp.json", *_provider_mcp_targets().values()]
-
-    removed: set[str] = set()
-    for mcp_path in targets:
-        if not mcp_path.exists():
-            continue
-        with advisory_lock(mcp_path):
-            try:
-                raw = json.loads(mcp_path.read_text(encoding="utf-8"))
-            except (json.JSONDecodeError, OSError):
+def mcp_uninstall(
+    target_dir: Path,
+    *,
+    dry_run: bool = False,
+    provider: Tool | str = "all",
+    scope: McpScope | str = McpScope.PROJECT,
+    enrolled: Iterable[Tool] | None = None,
+) -> SyncResult:
+    """Remove only externally recorded Vaultspec-owned entries."""
+    result = SyncResult()
+    try:
+        resolved_scope = _coerce_scope(scope)
+        targets = resolve_mcp_targets(
+            provider,
+            scope=resolved_scope,
+            target_dir=target_dir,
+            enrolled=enrolled,
+        )
+    except VaultSpecError as exc:
+        result.errors.append(str(exc))
+        result.errored += 1
+        return result
+    ownership_path = _ownership_path(target_dir, resolved_scope)
+    with advisory_lock(ownership_path):
+        try:
+            state = _read_ownership(ownership_path)
+        except VaultSpecError as exc:
+            result.errors.append(str(exc))
+            result.errored += 1
+            return result
+        for target in targets:
+            sub = SyncResult()
+            managed = _owned_names(state, target)
+            if not managed or not target.path.exists():
+                _set_owned_names(state, target, {})
+                result.per_tool[target.provider.value] = sub
                 continue
-            if not isinstance(raw, dict):
-                continue
-            servers = raw.get("mcpServers", {})
-            if not isinstance(servers, dict):
-                continue
-
-            file_removed: list[str] = []
-            for name in managed_names:
-                if name in servers:
-                    file_removed.append(name)
-                    if not dry_run:
-                        del servers[name]
-            if not file_removed:
-                continue
-            removed.update(file_removed)
-
-            if not dry_run:
-                managed = raw.get(_MANAGED_KEY)
-                if isinstance(managed, list):
-                    raw[_MANAGED_KEY] = [n for n in managed if n in servers]
-                    if not raw[_MANAGED_KEY]:
-                        del raw[_MANAGED_KEY]
-                if servers or (len(raw) > 1):
-                    atomic_write(mcp_path, json.dumps(raw, indent=2) + "\n")
-                else:
-                    mcp_path.unlink()
-
-    return sorted(removed)
+            succeeded = False
+            with advisory_lock(target.path):
+                try:
+                    if target.format is McpTargetFormat.JSON:
+                        raw = json.loads(target.path.read_text(encoding="utf-8"))
+                        if not isinstance(raw, dict):
+                            raise VaultSpecError("JSON root is not an object.")
+                        servers = _json_server_map(raw, target, target_dir)
+                        present = managed & set(servers)
+                        sub.pruned += len(present)
+                        sub.items.extend((name, "[DELETE]") for name in sorted(present))
+                        if not dry_run:
+                            for name in present:
+                                servers.pop(name, None)
+                            raw.pop(_LEGACY_MANAGED_KEY, None)
+                            _write_json_target(target.path, raw, target, target_dir)
+                    else:
+                        content = target.path.read_text(encoding="utf-8")
+                        block_servers = _toml_servers(_managed_toml_content(content))
+                        present = managed & set(block_servers)
+                        sub.pruned += len(present)
+                        sub.items.extend((name, "[DELETE]") for name in sorted(present))
+                        if not dry_run:
+                            for name in present:
+                                block_servers.pop(name, None)
+                            rendered = _render_codex_servers(block_servers)
+                            updated = (
+                                upsert_block(
+                                    content,
+                                    _TOML_BLOCK_TYPE,
+                                    rendered,
+                                    comment_prefix="# ",
+                                )
+                                if rendered
+                                else strip_block(content, _TOML_BLOCK_TYPE)
+                            )
+                            if updated:
+                                atomic_write(target.path, updated)
+                            else:
+                                target.path.unlink()
+                    succeeded = True
+                except (
+                    json.JSONDecodeError,
+                    OSError,
+                    TagError,
+                    tomllib.TOMLDecodeError,
+                    VaultSpecError,
+                ) as exc:
+                    sub.errored += 1
+                    sub.errors.append(
+                        f"Cannot uninstall MCPs from {target.path}: {exc}"
+                    )
+            if not dry_run and succeeded:
+                _set_owned_names(state, target, {})
+            result.merge(sub)
+            result.per_tool[target.provider.value] = sub
+        if not dry_run:
+            if state["targets"]:
+                _write_ownership(ownership_path, state)
+            elif ownership_path.exists():
+                ownership_path.unlink()
+    return result

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -16,6 +16,7 @@ import os
 import re
 import tomllib
 from collections.abc import Iterable
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -437,6 +438,11 @@ def _read_ownership(path: Path) -> dict[str, Any]:
 def _write_ownership(path: Path, state: dict[str, Any]) -> None:
     ensure_dir(path.parent)
     atomic_write(path, json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+
+def _target_lock(path: Path, *, dry_run: bool) -> Any:
+    """Return a no-op context for previews and a real advisory lock for writes."""
+    return nullcontext() if dry_run else advisory_lock(path)
 
 
 def _existing_source_server_names() -> set[str]:
@@ -1037,7 +1043,7 @@ def _sync_json_target(
     force_managed: frozenset[str],
 ) -> None:
     """Reconcile a Claude or Antigravity JSON target without host-only keys."""
-    with advisory_lock(target.path):
+    with _target_lock(target.path, dry_run=dry_run):
         raw: dict[str, Any] = {}
         if target.path.exists():
             try:
@@ -1209,7 +1215,7 @@ def _sync_toml_target(
     force_managed: frozenset[str],
 ) -> None:
     """Reconcile Codex tables inside one comment-bounded managed block."""
-    with advisory_lock(target.path):
+    with _target_lock(target.path, dry_run=dry_run):
         content = ""
         if target.path.exists():
             try:
@@ -1350,7 +1356,7 @@ def mcp_sync(
     sources = collect_mcp_servers(warnings=parse_warnings, mode=mode, target=root)
     result.warnings.extend(parse_warnings)
     ownership_path = _ownership_path(root, resolved_scope)
-    with advisory_lock(ownership_path):
+    with _target_lock(ownership_path, dry_run=dry_run):
         try:
             state = _read_ownership(ownership_path)
         except VaultSpecError as exc:
@@ -1418,7 +1424,7 @@ def mcp_uninstall(
         result.errored += 1
         return result
     ownership_path = _ownership_path(target_dir, resolved_scope)
-    with advisory_lock(ownership_path):
+    with _target_lock(ownership_path, dry_run=dry_run):
         try:
             state = _read_ownership(ownership_path)
         except VaultSpecError as exc:
@@ -1433,7 +1439,7 @@ def mcp_uninstall(
                 result.per_tool[target.provider.value] = sub
                 continue
             succeeded = False
-            with advisory_lock(target.path):
+            with _target_lock(target.path, dry_run=dry_run):
                 try:
                     if target.format is McpTargetFormat.JSON:
                         raw = json.loads(target.path.read_text(encoding="utf-8"))

--- a/src/vaultspec_core/core/types.py
+++ b/src/vaultspec_core/core/types.py
@@ -18,7 +18,15 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from .enums import DirName, FileName, ProviderCapability, Resource, Tool
+from .enums import (
+    DirName,
+    FileName,
+    McpScope,
+    McpTargetFormat,
+    ProviderCapability,
+    Resource,
+    Tool,
+)
 from .exceptions import VaultSpecError
 
 logger = logging.getLogger(__name__)
@@ -86,6 +94,22 @@ class ToolConfig:
     mcp_config_file: Path | None = None
     embed_rules: bool = False
     capabilities: frozenset[ProviderCapability] = frozenset()
+
+
+@dataclass(frozen=True)
+class McpTarget:
+    """One provider-native MCP configuration destination.
+
+    ``provider`` and ``scope`` identify the host contract, while ``path`` and
+    ``format`` select its concrete serializer.  Target resolution is kept
+    separate from reconciliation so callers and companion packages can inspect
+    the exact mutation boundary before requesting a write.
+    """
+
+    provider: Tool
+    scope: McpScope
+    path: Path
+    format: McpTargetFormat
 
 
 @dataclass
@@ -257,6 +281,7 @@ def init_paths(layout: Any) -> WorkspaceContext:
                     _pc.HOOKS,
                     _pc.TEAMS,
                     _pc.SCHEDULED_TASKS,
+                    _pc.MCPS,
                 }
             ),
         ),
@@ -298,6 +323,7 @@ def init_paths(layout: Any) -> WorkspaceContext:
                     _pc.ROOT_CONFIG,
                     _pc.WORKFLOWS,
                     _pc.HOOKS,
+                    _pc.MCPS,
                 }
             ),
         ),
@@ -320,6 +346,7 @@ def init_paths(layout: Any) -> WorkspaceContext:
                     _pc.AGENTS,
                     _pc.ROOT_CONFIG,
                     _pc.HOOKS,
+                    _pc.MCPS,
                 }
             ),
         ),

--- a/src/vaultspec_core/mcp_server/catalog.py
+++ b/src/vaultspec_core/mcp_server/catalog.py
@@ -71,6 +71,7 @@ DENYLIST: frozenset[tuple[str, ...]] = frozenset(
         ("spec", "mcps", "add"),
         ("spec", "mcps", "remove"),
         ("spec", "mcps", "sync"),
+        ("spec", "mcps", "uninstall"),
         ("vault", "feature", "index"),
     }
 )

--- a/src/vaultspec_core/tests/cli/test_install.py
+++ b/src/vaultspec_core/tests/cli/test_install.py
@@ -52,6 +52,36 @@ class TestInstallForce:
         if result.exit_code != 0:
             assert "already installed" not in result.output.lower()
 
+    def test_install_api_refuses_success_when_native_mcp_reconciliation_fails(
+        self, tmp_path
+    ):
+        """A native-store parse failure is a typed install failure, not success."""
+        from vaultspec_core.core.commands import install_run
+        from vaultspec_core.core.exceptions import VaultSpecError
+
+        (tmp_path / ".mcp.json").write_text("not valid json", encoding="utf-8")
+
+        with pytest.raises(
+            VaultSpecError,
+            match="MCP provider-native enrollment failed",
+        ):
+            install_run(tmp_path, provider="claude", force=True)
+
+    def test_install_cli_exits_nonzero_when_native_mcp_reconciliation_fails(
+        self, tmp_path, runner
+    ):
+        """The CLI exposes the native-store failure and exits non-zero."""
+        (tmp_path / ".mcp.json").write_text("not valid json", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["-t", str(tmp_path), "install", "claude", "--force"],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "MCP provider-native enrollment failed" in result.output
+        assert "Cannot parse" in result.output
+
 
 class TestInstallJson:
     def test_install_json_stdout_is_parseable(self, tmp_path, runner):

--- a/src/vaultspec_core/tests/cli/test_mcp_provider_files.py
+++ b/src/vaultspec_core/tests/cli/test_mcp_provider_files.py
@@ -101,13 +101,18 @@ class TestAgyMcpConfig:
         assert _servers(agy) == _servers(root)
         assert "vaultspec-core" in _servers(agy)
 
-    def test_uses_mcpservers_schema_and_managed_sidecar(self, tmp_path: Path):
+    def test_uses_host_schema_and_external_ownership_sidecar(self, tmp_path: Path):
         WorkspaceFactory(tmp_path).install("all")
         raw = json.loads(
             (tmp_path / ".agents" / "mcp_config.json").read_text(encoding="utf-8")
         )
         assert "mcpServers" in raw
-        assert "vaultspec-core" in raw.get("_vaultspecManaged", [])
+        assert "_vaultspecManaged" not in raw
+        ownership = json.loads(
+            (tmp_path / ".vaultspec" / "mcp-ownership.json").read_text(encoding="utf-8")
+        )
+        managed = ownership["targets"]["antigravity:project"]["managed"]
+        assert "vaultspec-core" in managed
 
     def test_not_written_when_antigravity_not_installed(self, tmp_path: Path):
         WorkspaceFactory(tmp_path).install("claude")

--- a/src/vaultspec_core/tests/cli/test_sync.py
+++ b/src/vaultspec_core/tests/cli/test_sync.py
@@ -113,8 +113,9 @@ class TestSyncValidation:
 
         payload = json.loads(result.output)["data"]
         assert result.exit_code == 1, result.output
-        assert payload["status"] == "missing_config"
+        assert payload["status"] == "partial"
         assert payload["missing"] == ["vaultspec-core"]
+        assert payload["providers"]["claude"]["status"] == "missing_config"
 
     def test_mcp_status_json_reports_managed_config_drift(
         self, runner, synthetic_project
@@ -258,15 +259,16 @@ class TestSyncAuthority:
         assert "antigravity" not in output
         assert "codex" not in output
 
-    def test_provider_scoped_sync_does_not_repair_global_mcp_state(
+    def test_provider_scoped_sync_repairs_only_requested_native_mcp_state(
         self, runner, synthetic_project
     ):
-        """Provider-scoped sync must not mutate provider-agnostic MCP config."""
+        """Provider-scoped sync repairs its native target without touching peers."""
         mcp_path = synthetic_project / ".mcp.json"
+        codex_path = synthetic_project / ".codex" / "config.toml"
+        codex_before = codex_path.read_bytes()
         payload = json.loads(mcp_path.read_text(encoding="utf-8"))
         payload["mcpServers"]["vaultspec-core"]["args"] = ["run", "broken-server"]
         mcp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-        before = mcp_path.read_text(encoding="utf-8")
 
         result = runner.invoke(
             app,
@@ -274,19 +276,12 @@ class TestSyncAuthority:
         )
 
         assert result.exit_code == 0, result.output
-        assert mcp_path.read_text(encoding="utf-8") == before
-
-        repair_result = runner.invoke(
-            app,
-            ["--target", str(synthetic_project), "sync", "--force"],
-        )
-
-        assert repair_result.exit_code == 0, repair_result.output
         repaired = json.loads(mcp_path.read_text(encoding="utf-8"))
         assert repaired["mcpServers"]["vaultspec-core"]["args"] != [
             "run",
             "broken-server",
         ]
+        assert codex_path.read_bytes() == codex_before
 
     def test_provider_scoped_sync_respects_skip_for_requested_provider(
         self, runner, synthetic_project
@@ -441,7 +436,15 @@ class TestSyncAuthority:
             "command": "node",
             "args": ["user-server.js"],
         }
-        assert repaired["_vaultspecManaged"] == ["vaultspec-core"]
+        assert "_vaultspecManaged" not in repaired
+        ownership = json.loads(
+            (synthetic_project / ".vaultspec" / "mcp-ownership.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert set(ownership["targets"]["claude:project"]["managed"]) == {
+            "vaultspec-core"
+        }
 
         after = runner.invoke(
             app,
@@ -456,10 +459,9 @@ class TestSyncAuthority:
     ):
         """--force adopts a name-colliding user .mcp.json entry (issue #120).
 
-        When .mcp.json carries an entry whose name matches a source but which is
-        absent from _vaultspecManaged, a plain sync preserves it and points at
-        --force; --force then overwrites it with the source definition and
-        records it as managed, with no hand-editing of the generated file.
+        When .mcp.json carries an entry whose name matches a source but is absent
+        from the external ownership sidecar, a plain sync preserves it and points
+        at --force. --force then overwrites and records it as managed.
         """
         mcp_path = synthetic_project / ".mcp.json"
         source_path = (
@@ -473,15 +475,14 @@ class TestSyncAuthority:
             resolve_render_mode(synthetic_project),
         )
 
-        # _vaultspecManaged present but empty: vaultspec-core collides with the
-        # source yet is unmanaged, the exact state the issue reports.
         payload = {
             "mcpServers": {
                 "vaultspec-core": {"command": "node", "args": ["user-authored.js"]}
-            },
-            "_vaultspecManaged": [],
+            }
         }
         mcp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        ownership_path = synthetic_project / ".vaultspec" / "mcp-ownership.json"
+        ownership_path.unlink()
 
         plain = runner.invoke(
             app,
@@ -490,7 +491,8 @@ class TestSyncAuthority:
         assert "--force" in plain.output
         preserved = json.loads(mcp_path.read_text(encoding="utf-8"))
         assert preserved["mcpServers"]["vaultspec-core"]["args"] == ["user-authored.js"]
-        assert "vaultspec-core" not in preserved.get("_vaultspecManaged", [])
+        plain_ownership = json.loads(ownership_path.read_text(encoding="utf-8"))
+        assert "claude:project" not in plain_ownership["targets"]
 
         forced = runner.invoke(
             app,
@@ -499,4 +501,6 @@ class TestSyncAuthority:
         assert forced.exit_code == 0, forced.output
         adopted = json.loads(mcp_path.read_text(encoding="utf-8"))
         assert adopted["mcpServers"]["vaultspec-core"] == expected_config
-        assert "vaultspec-core" in adopted["_vaultspecManaged"]
+        assert "_vaultspecManaged" not in adopted
+        ownership = json.loads(ownership_path.read_text(encoding="utf-8"))
+        assert "vaultspec-core" in ownership["targets"]["claude:project"]["managed"]

--- a/tests/cli/test_mcp_hosts.py
+++ b/tests/cli/test_mcp_hosts.py
@@ -1,0 +1,204 @@
+"""Real Claude Code and Codex CLI acceptance for native MCP enrollment."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vaultspec_core.config import reset_config
+from vaultspec_core.core.commands import install_run
+from vaultspec_core.core.mcps import mcp_uninstall
+
+pytestmark = pytest.mark.integration
+
+
+def _host_executable(name: str) -> str:
+    candidates = (f"{name}.cmd", f"{name}.exe", name)
+    executable = next(
+        (
+            shutil.which(candidate)
+            for candidate in candidates
+            if shutil.which(candidate)
+        ),
+        None,
+    )
+    assert executable is not None, f"Release acceptance requires the real {name} CLI"
+    return executable
+
+
+def _isolated_env(root: Path) -> dict[str, str]:
+    home = root / "home"
+    codex_home = root / "codex-home"
+    home.mkdir(parents=True)
+    codex_home.mkdir(parents=True)
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["USERPROFILE"] = str(home)
+    env["CODEX_HOME"] = str(codex_home)
+    return env
+
+
+def _run(
+    command: list[str], *, cwd: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=cwd,
+        env=env,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def _run_core(
+    project: Path, env: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    return _run(
+        [sys.executable, "-m", "vaultspec_core", "--target", str(project), *args],
+        cwd=project,
+        env=env,
+    )
+
+
+def _install_all(project: Path) -> None:
+    project.mkdir()
+    reset_config()
+    install_run(
+        path=project,
+        provider="all",
+        upgrade=False,
+        dry_run=False,
+        force=False,
+    )
+
+
+def _trust_codex_project(project: Path, env: dict[str, str]) -> None:
+    codex_home = Path(env["CODEX_HOME"])
+    project_key = str(project.resolve()).lower().replace("'", "''")
+    (codex_home / "config.toml").write_text(
+        f"[projects.'{project_key}']\ntrust_level = \"trusted\"\n",
+        encoding="utf-8",
+    )
+
+
+def test_real_hosts_recognize_project_enrollment(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    env = _isolated_env(tmp_path)
+    _install_all(project)
+    _trust_codex_project(project, env)
+
+    claude = _run(
+        [_host_executable("claude"), "mcp", "get", "vaultspec-core"],
+        cwd=project,
+        env=env,
+    )
+    assert claude.returncode == 0, claude.stdout + claude.stderr
+    assert "vaultspec-core" in claude.stdout
+    assert "Pending approval" in claude.stdout
+
+    codex = _run(
+        [
+            _host_executable("codex"),
+            "-C",
+            str(project),
+            "mcp",
+            "get",
+            "vaultspec-core",
+            "--json",
+        ],
+        cwd=project,
+        env=env,
+    )
+    assert codex.returncode == 0, codex.stdout + codex.stderr
+    payload = json.loads(codex.stdout)
+    assert payload["name"] == "vaultspec-core"
+    assert payload["transport"]["type"] == "stdio"
+
+
+def test_real_hosts_recognize_isolated_user_enrollment(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    env = _isolated_env(tmp_path)
+    _install_all(project)
+    mcp_uninstall(project, provider="all")
+
+    for provider in ("claude", "codex"):
+        result = _run_core(
+            project,
+            env,
+            "spec",
+            "mcps",
+            "sync",
+            provider,
+            "--scope",
+            "user",
+            "--json",
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    claude = _run(
+        [_host_executable("claude"), "mcp", "get", "vaultspec-core"],
+        cwd=project,
+        env=env,
+    )
+    assert claude.returncode == 0, claude.stdout + claude.stderr
+    assert "User config" in claude.stdout
+
+    codex = _run(
+        [_host_executable("codex"), "mcp", "get", "vaultspec-core", "--json"],
+        cwd=project,
+        env=env,
+    )
+    assert codex.returncode == 0, codex.stdout + codex.stderr
+    assert json.loads(codex.stdout)["name"] == "vaultspec-core"
+
+
+def test_claude_local_is_recognized_and_codex_local_is_rejected(tmp_path: Path) -> None:
+    project = tmp_path / "project"
+    env = _isolated_env(tmp_path)
+    _install_all(project)
+    mcp_uninstall(project, provider="all")
+
+    claude_sync = _run_core(
+        project,
+        env,
+        "spec",
+        "mcps",
+        "sync",
+        "claude",
+        "--scope",
+        "local",
+        "--json",
+    )
+    assert claude_sync.returncode == 0, claude_sync.stdout + claude_sync.stderr
+    claude = _run(
+        [_host_executable("claude"), "mcp", "get", "vaultspec-core"],
+        cwd=project,
+        env=env,
+    )
+    assert claude.returncode == 0, claude.stdout + claude.stderr
+    assert "Local config" in claude.stdout
+
+    codex_sync = _run_core(
+        project,
+        env,
+        "spec",
+        "mcps",
+        "sync",
+        "codex",
+        "--scope",
+        "local",
+        "--json",
+    )
+    assert codex_sync.returncode == 1
+    assert "distinct local MCP scope" in codex_sync.stdout
+    assert not (Path(env["CODEX_HOME"]) / "config.toml").exists()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -11,10 +11,11 @@ from vaultspec_core.config import reset_config
 from vaultspec_core.core.commands import (
     CANONICAL_ENTRY_PREFIX,
     CANONICAL_HOOK_IDS,
+    entry_prefix_for_mode,
     install_run,
     sync_provider,
 )
-from vaultspec_core.core.enums import PrecommitHook
+from vaultspec_core.core.enums import InstallMode, PrecommitHook
 from vaultspec_core.core.manifest import read_manifest_data, write_manifest_data
 
 
@@ -37,8 +38,14 @@ def test_init_run_scaffolds_antigravity_workspace_layout() -> None:
         assert not (tmp_path / ".agents" / "agents").exists()
         mcp_config = json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8"))
         server = mcp_config["mcpServers"]["vaultspec-core"]
-        assert server["command"] == "uv"
-        expected = ["run", "python", "-m", "vaultspec_core.mcp_server.app"]
+        assert server["command"] == "uvx"
+        expected = [
+            "--from",
+            "vaultspec-core",
+            "python",
+            "-m",
+            "vaultspec_core.mcp_server.app",
+        ]
         assert server["args"] == expected
     finally:
         reset_config()
@@ -76,9 +83,9 @@ def test_install_run_scaffolds_full_canonical_precommit_hooks() -> None:
 
         for hook in hooks:
             if hook["id"] in CANONICAL_HOOK_IDS:
-                assert hook["entry"].startswith(CANONICAL_ENTRY_PREFIX), (
-                    f"Hook {hook['id']} uses non-canonical entry: {hook['entry']}"
-                )
+                assert hook["entry"].startswith(
+                    entry_prefix_for_mode(InstallMode.TOOL)
+                ), f"Hook {hook['id']} uses non-canonical entry: {hook['entry']}"
 
     finally:
         reset_config()
@@ -520,7 +527,15 @@ def test_sync_all_result_count_matches_resource_labels() -> None:
 
         results = sync_provider("all")
 
-        resource_labels = ["rules", "skills", "agents", "system", "config", "mcps"]
+        resource_labels = [
+            "rules",
+            "skills",
+            "agents",
+            "system",
+            "config",
+            "mcps",
+            "hooks",
+        ]
         # One result per resource label, plus the trailing structural backfill.
         assert len(results) == len(resource_labels) + 1, (
             f"sync_provider('all') returned {len(results)} results; expected "

--- a/tests/test_mcps.py
+++ b/tests/test_mcps.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import tomllib
 from uuid import uuid4
 
 import pytest
@@ -24,14 +25,27 @@ def _make_workspace(tmp: object = None):
 def _init_context(path):
     """Bootstrap a WorkspaceContext pointing at the given path."""
     from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.manifest import ManifestData, write_manifest_data
     from vaultspec_core.core.types import init_paths
 
     reset_config()
     # Create minimal .vaultspec structure for workspace resolution
     fw_dir = path / ".vaultspec"
     fw_dir.mkdir(parents=True, exist_ok=True)
+    write_manifest_data(
+        path,
+        ManifestData(installed={"claude"}),
+    )
     layout = resolve_workspace(target_override=path)
     return init_paths(layout)
+
+
+def _owned_names(path, target_key: str = "claude:project") -> set[str]:
+    """Read the real external MCP ownership record for one native target."""
+    ownership = json.loads(
+        (path / ".vaultspec" / "mcp-ownership.json").read_text(encoding="utf-8")
+    )
+    return set(ownership["targets"][target_key]["managed"])
 
 
 @pytest.mark.unit
@@ -369,7 +383,7 @@ class TestMcpAdd:
             from vaultspec_core.core.mcps import mcp_add
 
             with pytest.raises(VaultSpecError, match="dict"):
-                mcp_add("srv", config=[1, 2, 3])  # type: ignore[arg-type]
+                mcp_add("srv", config=[1, 2, 3])  # ty: ignore[invalid-argument-type]
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
@@ -633,18 +647,17 @@ class TestMcpUninstall:
             (mcps_dir / "managed.builtin.json").write_text(
                 json.dumps({"command": "uv"}), encoding="utf-8"
             )
-            mcp_data = {
-                "mcpServers": {
-                    "managed": {"command": "uv"},
-                    "user": {"command": "custom"},
-                }
-            }
-            (path / ".mcp.json").write_text(json.dumps(mcp_data), encoding="utf-8")
             _init_context(path)
-            from vaultspec_core.core.mcps import mcp_uninstall
+            from vaultspec_core.core.mcps import mcp_sync, mcp_uninstall
+
+            mcp_sync()
+            mcp_data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            mcp_data["mcpServers"]["user"] = {"command": "custom"}
+            (path / ".mcp.json").write_text(json.dumps(mcp_data), encoding="utf-8")
 
             removed = mcp_uninstall(path)
-            assert "managed" in removed
+            assert removed.pruned == 1
+            assert ("managed", "[DELETE]") in removed.items
 
             remaining = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert "managed" not in remaining["mcpServers"]
@@ -659,18 +672,17 @@ class TestMcpUninstall:
             (mcps_dir / "only.builtin.json").write_text(
                 json.dumps({"command": "uv"}), encoding="utf-8"
             )
-            mcp_data = {"mcpServers": {"only": {"command": "uv"}}}
-            (path / ".mcp.json").write_text(json.dumps(mcp_data), encoding="utf-8")
             _init_context(path)
-            from vaultspec_core.core.mcps import mcp_uninstall
+            from vaultspec_core.core.mcps import mcp_sync, mcp_uninstall
 
+            mcp_sync()
             mcp_uninstall(path)
             assert not (path / ".mcp.json").exists()
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
 
-    def test_fallback_to_vaultspec_core_when_no_registry(self):
+    def test_unowned_entry_survives_without_registry_or_ownership(self):
         path = PROJECT_ROOT / ".pytest-tmp" / f"mcps-uninstall-{uuid4().hex}"
         path.mkdir(parents=True, exist_ok=True)
         try:
@@ -680,7 +692,9 @@ class TestMcpUninstall:
             from vaultspec_core.core.mcps import mcp_uninstall
 
             removed = mcp_uninstall(path)
-            assert "vaultspec-core" in removed
+            assert removed.pruned == 0
+            remaining = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+            assert "vaultspec-core" in remaining["mcpServers"]
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
@@ -759,7 +773,8 @@ class TestMcpSyncPrune:
             assert result.added == 1
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert "ephemeral" in data["mcpServers"]
-            assert data["_vaultspecManaged"] == ["ephemeral"]
+            assert _owned_names(path) == {"ephemeral"}
+            assert "_vaultspecManaged" not in data
 
             # Delete the source file to simulate companion uninstall
             (mcps_dir / "ephemeral.builtin.json").unlink()
@@ -817,7 +832,7 @@ class TestMcpSyncPrune:
             # User entry survives the orphan prune
             assert "my-tool" in data["mcpServers"]
             assert "managed" not in data["mcpServers"]
-            # No managed key remains since the only managed entry was pruned
+            # Host schemas never carry Vaultspec ownership metadata.
             assert "_vaultspecManaged" not in data
         finally:
             reset_config()
@@ -831,9 +846,8 @@ class TestMcpSyncPrune:
         """
         path, mcps_dir = _make_workspace()
         try:
-            # User pre-registers an entry — note: file already has the
-            # _vaultspecManaged sidecar (empty), so legacy migration
-            # does NOT take ownership.
+            # User pre-registers an entry with an empty legacy host marker, so
+            # migration has no affirmative ownership evidence.
             existing = {
                 "mcpServers": {"shared": {"command": "user-binary"}},
                 "_vaultspecManaged": [],
@@ -852,26 +866,22 @@ class TestMcpSyncPrune:
             # Should NOT add (entry already there) and NOT enter managed
             assert result.added == 0
             assert result.skipped == 1
-            assert any("user-managed" in w for w in result.warnings), result.warnings
+            assert any("externally managed" in w for w in result.warnings), (
+                result.warnings
+            )
 
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             # User's entry preserved unchanged
             assert data["mcpServers"]["shared"]["command"] == "user-binary"
-            # Source name did NOT get added to managed set
-            assert "shared" not in data.get("_vaultspecManaged", [])
+            # Source name did NOT get added to external ownership state.
+            ownership_path = path / ".vaultspec" / "mcp-ownership.json"
+            assert not ownership_path.exists()
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
 
-    def test_legacy_migration_emits_explicit_warning(self):
-        """Security: legacy migration silently transferring ownership
-        of pre-existing entries is auditable. The first sync against
-        a workspace without ``_vaultspecManaged`` MUST surface a
-        warning naming every entry it took ownership of, so an
-        operator can spot unexpected migrations (e.g. an attacker
-        having dropped a ``foo.json`` source file matching a user
-        entry name).
-        """
+    def test_name_intersection_without_legacy_evidence_remains_external(self):
+        """Names alone never transfer ownership during legacy migration."""
         path, mcps_dir = _make_workspace()
         try:
             existing = {
@@ -892,23 +902,26 @@ class TestMcpSyncPrune:
             from vaultspec_core.core.mcps import mcp_sync
 
             result = mcp_sync()
-            assert any(
-                "Legacy" in w and "alpha" in w and "beta" in w for w in result.warnings
-            ), f"expected legacy-migration warning, got: {result.warnings}"
+            assert result.skipped == 2
+            assert all("externally managed" in warning for warning in result.warnings)
+            assert not (path / ".vaultspec" / "mcp-ownership.json").exists()
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
 
     def test_legacy_migration_treats_pre_existing_as_managed(self):
         """Workspaces created before ownership tracking shipped have
-        no `_vaultspecManaged` sidecar. The migration heuristic treats
-        any pre-existing entry whose name matches a current source as
-        managed (preserves the legacy 'differs, use --force' warning).
+        an affirmative `_vaultspecManaged` host marker. Migration accepts that
+        marker once, moves ownership into the external sidecar, and removes the
+        legacy field from host configuration.
         """
         path, mcps_dir = _make_workspace()
         try:
-            # Pre-existing .mcp.json without sidecar key (legacy)
-            existing = {"mcpServers": {"legacy": {"command": "old"}}}
+            # An affirmative legacy marker is accepted once as ownership evidence.
+            existing = {
+                "mcpServers": {"legacy": {"command": "old"}},
+                "_vaultspecManaged": ["legacy"],
+            }
             (path / ".mcp.json").write_text(json.dumps(existing), encoding="utf-8")
             (mcps_dir / "legacy.builtin.json").write_text(
                 json.dumps({"command": "new"}), encoding="utf-8"
@@ -923,8 +936,8 @@ class TestMcpSyncPrune:
 
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert data["mcpServers"]["legacy"]["command"] == "new"
-            # Sidecar now persisted with the migrated entry
-            assert data["_vaultspecManaged"] == ["legacy"]
+            assert "_vaultspecManaged" not in data
+            assert _owned_names(path) == {"legacy"}
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
@@ -943,12 +956,14 @@ class TestMcpSyncPrune:
 
             mcp_sync()
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
-            assert data["_vaultspecManaged"] == ["alpha", "beta"]
+            assert "_vaultspecManaged" not in data
+            assert _owned_names(path) == {"alpha", "beta"}
 
             # Re-sync: managed set should remain identical
             mcp_sync()
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
-            assert data["_vaultspecManaged"] == ["alpha", "beta"]
+            assert "_vaultspecManaged" not in data
+            assert _owned_names(path) == {"alpha", "beta"}
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)
@@ -976,7 +991,7 @@ class TestMcpSyncPrune:
             mcp_sync()
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert "fragile" in data["mcpServers"]
-            assert "fragile" in data["_vaultspecManaged"]
+            assert _owned_names(path) == {"fragile"}
 
             # Corrupt the source: file still exists but is invalid JSON.
             (mcps_dir / "fragile.builtin.json").write_text(
@@ -995,7 +1010,7 @@ class TestMcpSyncPrune:
 
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert "fragile" in data["mcpServers"]
-            assert "fragile" in data["_vaultspecManaged"]
+            assert _owned_names(path) == {"fragile"}
 
             # Now genuinely delete the source — prune SHOULD remove it.
             (mcps_dir / "fragile.builtin.json").unlink()
@@ -1007,9 +1022,8 @@ class TestMcpSyncPrune:
             shutil.rmtree(path, ignore_errors=True)
 
     def test_prune_preserves_user_top_level_keys(self):
-        """Regression: when pruning empties ``mcpServers`` AND clears
-        the managed sidecar, the file must still survive if the user
-        added other top-level keys (e.g. ``inputs``, custom config).
+        """Regression: when pruning empties ``mcpServers`` and ownership, the
+        file must still survive if the user added other top-level keys.
         Only when the file holds nothing but an empty ``mcpServers``
         dict may it be unlinked.
         """
@@ -1021,8 +1035,7 @@ class TestMcpSyncPrune:
             _init_context(path)
             from vaultspec_core.core.mcps import mcp_sync
 
-            # First sync: install. After this the file has
-            # mcpServers + _vaultspecManaged.
+            # First sync creates host enrollment plus external ownership.
             mcp_sync()
 
             # User manually adds a custom top-level key (e.g. inputs).
@@ -1038,7 +1051,7 @@ class TestMcpSyncPrune:
             assert (path / ".mcp.json").exists()
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert data["inputs"] == [{"type": "promptString", "id": "api-key"}]
-            assert data["mcpServers"] == {}
+            assert data.get("mcpServers", {}) == {}
             assert "_vaultspecManaged" not in data
         finally:
             reset_config()
@@ -1079,7 +1092,8 @@ class TestMcpSyncPrune:
             sync_provider("all", force=False)
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert "companion" in data["mcpServers"]
-            assert "companion" in data["_vaultspecManaged"]
+            assert "companion" in _owned_names(path)
+            assert "_vaultspecManaged" not in data
 
             # Companion uninstall: delete source + sync
             (mcps_dir / "companion.builtin.json").unlink()
@@ -1087,7 +1101,7 @@ class TestMcpSyncPrune:
 
             data = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert "companion" not in data["mcpServers"]
-            assert "companion" not in data.get("_vaultspecManaged", [])
+            assert "companion" not in _owned_names(path)
             # vaultspec-core's own MCP entry is preserved
             assert "vaultspec-core" in data["mcpServers"]
         finally:
@@ -1112,9 +1126,256 @@ class TestInstallSeedsMcps:
             mcp_json = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
             assert "vaultspec-core" in mcp_json["mcpServers"]
             server = mcp_json["mcpServers"]["vaultspec-core"]
-            assert server["command"] == "uv"
-            expected_args = ["run", "python", "-m", "vaultspec_core.mcp_server.app"]
+            assert server["command"] == "uvx"
+            expected_args = [
+                "--from",
+                "vaultspec-core",
+                "python",
+                "-m",
+                "vaultspec_core.mcp_server.app",
+            ]
             assert server["args"] == expected_args
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+
+def _native_servers(path, provider: str) -> dict[str, dict[str, object]]:
+    """Read one real project-scope provider target through its native schema."""
+    if provider == "claude":
+        raw = json.loads((path / ".mcp.json").read_text(encoding="utf-8"))
+        return raw["mcpServers"]
+    if provider == "antigravity":
+        raw = json.loads(
+            (path / ".agents" / "mcp_config.json").read_text(encoding="utf-8")
+        )
+        return raw["mcpServers"]
+    raw = tomllib.loads((path / ".codex" / "config.toml").read_text(encoding="utf-8"))
+    return raw["mcp_servers"]
+
+
+@pytest.mark.unit
+class TestProviderNativeMcpEnrollment:
+    def test_explicit_public_seam_writes_all_native_targets(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            definition = {
+                "command": "@@VAULTSPEC_INSTALL_MODE_COMMAND@@",
+                "args": ["@@VAULTSPEC_INSTALL_MODE_ARGS@@"],
+                "_vaultspec_mode_package": "vaultspec-rag",
+                "_vaultspec_mode_module": "vaultspec_rag.mcp_server.app",
+                "_vaultspec_mode_tool_spec": "vaultspec-rag[mcp]",
+            }
+            (mcps_dir / "vaultspec-rag.builtin.json").write_text(
+                json.dumps(definition), encoding="utf-8"
+            )
+            reset_config()
+
+            from vaultspec_core.core.enums import InstallMode, Tool
+            from vaultspec_core.core.mcps import mcp_status, mcp_sync
+            from vaultspec_core.core.workspace_mode import (
+                PackageDeclaration,
+                write_package_declaration,
+            )
+
+            enrolled = {Tool.CLAUDE, Tool.ANTIGRAVITY, Tool.CODEX}
+            write_package_declaration(
+                path,
+                "vaultspec-rag",
+                PackageDeclaration(install_mode=InstallMode.TOOL),
+            )
+            result = mcp_sync(
+                target_dir=path,
+                enrolled=enrolled,
+                mode=InstallMode.TOOL,
+            )
+
+            assert result.added == 3
+            assert set(result.per_tool) == {"claude", "antigravity", "codex"}
+            for provider in result.per_tool:
+                server = _native_servers(path, provider)["vaultspec-rag"]
+                assert server["command"] == "uvx"
+                assert server["args"] == [
+                    "--from",
+                    "vaultspec-rag[mcp]",
+                    "python",
+                    "-m",
+                    "vaultspec_rag.mcp_server.app",
+                ]
+                assert all(not key.startswith("_vaultspec_") for key in server)
+
+            ownership = json.loads(
+                (path / ".vaultspec" / "mcp-ownership.json").read_text(encoding="utf-8")
+            )
+            assert set(ownership["targets"]) == {
+                "claude:project",
+                "antigravity:project",
+                "codex:project",
+            }
+            assert "_vaultspecManaged" not in json.loads(
+                (path / ".mcp.json").read_text(encoding="utf-8")
+            )
+
+            status = mcp_status(target_dir=path, enrolled=enrolled)
+            assert status["status"] == "ok"
+            assert all(
+                provider_status["status"] == "ok"
+                for provider_status in status["providers"].values()
+            )
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_dry_run_is_byte_stable_and_creates_no_locks(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "dry.builtin.json").write_text(
+                json.dumps({"command": "dry-server"}), encoding="utf-8"
+            )
+            before = {
+                file.relative_to(path): file.read_bytes()
+                for file in path.rglob("*")
+                if file.is_file()
+            }
+            reset_config()
+
+            from vaultspec_core.core.enums import InstallMode, Tool
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync(
+                target_dir=path,
+                enrolled={Tool.CLAUDE, Tool.ANTIGRAVITY, Tool.CODEX},
+                mode=InstallMode.TOOL,
+                dry_run=True,
+            )
+            after = {
+                file.relative_to(path): file.read_bytes()
+                for file in path.rglob("*")
+                if file.is_file()
+            }
+
+            assert result.added == 3
+            assert after == before
+            assert not list(path.rglob("*.lock"))
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_selective_uninstall_preserves_core_and_ownership_fingerprints(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            for name in ("vaultspec-core", "vaultspec-rag"):
+                (mcps_dir / f"{name}.builtin.json").write_text(
+                    json.dumps({"command": name}), encoding="utf-8"
+                )
+            reset_config()
+
+            from vaultspec_core.core.enums import InstallMode, Tool
+            from vaultspec_core.core.mcps import mcp_sync, mcp_uninstall
+
+            enrolled = {Tool.CLAUDE, Tool.ANTIGRAVITY, Tool.CODEX}
+            mcp_sync(
+                target_dir=path,
+                enrolled=enrolled,
+                mode=InstallMode.TOOL,
+            )
+            ownership_path = path / ".vaultspec" / "mcp-ownership.json"
+            before = json.loads(ownership_path.read_text(encoding="utf-8"))
+            core_fingerprints = {
+                key: record["managed"]["vaultspec-core"]
+                for key, record in before["targets"].items()
+            }
+
+            result = mcp_uninstall(
+                path,
+                enrolled=enrolled,
+                names=frozenset({"vaultspec-rag"}),
+            )
+
+            assert result.pruned == 3
+            for provider in ("claude", "antigravity", "codex"):
+                servers = _native_servers(path, provider)
+                assert "vaultspec-core" in servers
+                assert "vaultspec-rag" not in servers
+            after = json.loads(ownership_path.read_text(encoding="utf-8"))
+            assert {
+                key: record["managed"]["vaultspec-core"]
+                for key, record in after["targets"].items()
+            } == core_fingerprints
+            assert all(
+                "vaultspec-rag" not in record["managed"]
+                for record in after["targets"].values()
+            )
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_codex_drift_is_independent_and_force_repairs_only_codex(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "server.builtin.json").write_text(
+                json.dumps({"command": "expected"}), encoding="utf-8"
+            )
+            reset_config()
+
+            from vaultspec_core.core.enums import InstallMode, Tool
+            from vaultspec_core.core.mcps import mcp_status, mcp_sync
+
+            enrolled = {Tool.CLAUDE, Tool.CODEX}
+            mcp_sync(
+                target_dir=path,
+                enrolled=enrolled,
+                mode=InstallMode.TOOL,
+            )
+            claude_before = (path / ".mcp.json").read_bytes()
+            codex_path = path / ".codex" / "config.toml"
+            codex_path.write_text(
+                codex_path.read_text(encoding="utf-8").replace(
+                    'command = "expected"', 'command = "drifted"'
+                ),
+                encoding="utf-8",
+            )
+
+            status = mcp_status(target_dir=path, enrolled=enrolled)
+            assert status["providers"]["claude"]["status"] == "ok"
+            assert status["providers"]["codex"]["drifted"] == ["server"]
+
+            repaired = mcp_sync(
+                target_dir=path,
+                enrolled=enrolled,
+                provider=Tool.CODEX,
+                mode=InstallMode.TOOL,
+                force=True,
+            )
+            assert repaired.updated == 1
+            assert _native_servers(path, "codex")["server"]["command"] == "expected"
+            assert (path / ".mcp.json").read_bytes() == claude_before
+        finally:
+            reset_config()
+            shutil.rmtree(path, ignore_errors=True)
+
+    def test_codex_local_scope_fails_without_writing(self):
+        path, mcps_dir = _make_workspace()
+        try:
+            (mcps_dir / "server.builtin.json").write_text(
+                json.dumps({"command": "expected"}), encoding="utf-8"
+            )
+            reset_config()
+
+            from vaultspec_core.core.enums import Tool
+            from vaultspec_core.core.mcps import mcp_sync
+
+            result = mcp_sync(
+                target_dir=path,
+                enrolled={Tool.CODEX},
+                provider=Tool.CODEX,
+                scope="local",
+            )
+
+            assert result.errored == 1
+            assert any("distinct local MCP scope" in error for error in result.errors)
+            assert not (path / ".codex" / "config.toml").exists()
+            assert not (path / ".vaultspec" / "mcp-ownership.json").exists()
         finally:
             reset_config()
             shutil.rmtree(path, ignore_errors=True)

--- a/tests/unit/mcp_server/test_catalog.py
+++ b/tests/unit/mcp_server/test_catalog.py
@@ -70,6 +70,7 @@ def test_denylisted_verbs_absent_from_catalog(vault_root):  # noqa: F811
     # Spot-check the specific classes the ADR names.
     assert catalog.is_denied(("uninstall",))
     assert catalog.is_denied(("spec", "mcps", "add"))
+    assert catalog.is_denied(("spec", "mcps", "uninstall"))
     assert catalog.is_denied(("vault", "feature", "index"))
     # Read-only MCP-registry inspection stays reachable.
     assert catalog.declares(("spec", "mcps", "list"))


### PR DESCRIPTION
## Summary

- reconcile canonical `.vaultspec/mcps/*.json` definitions into Claude, Codex, and Antigravity native configuration targets
- add explicit project/local/user scope contracts, external ownership state, safe force/prune/uninstall, and a stable companion-package API
- integrate provider-native enrollment into install, upgrade, sync, uninstall, CLI status, and generated/operator documentation
- verify recognition through installed Claude Code 2.1.210 and Codex CLI 0.144.4 binaries
- fail install honestly when native-store reconciliation returns errors

## Safety contract

- project scope remains the default
- unsupported provider/scope combinations fail explicitly
- external host entries are preserved unless `--force` adopts a same-name entry
- prune and uninstall remove only recorded Vaultspec-owned entries
- dry-run does not write files or acquire mutation locks
- host trust, approval, and runtime connectivity remain provider-owned

## Verification

- `just dev test python`: 1,761 passed, 1,052 deselected
- real Claude/Codex host acceptance: 3 passed
- Windows vault-repair regression: 23 passed
- `just dev lint all`
- `just dev audit deps`: no known vulnerabilities in 127 packages
- `just dev build python`
- generated CLI reference check and vault check
- formal Vaultspec audit: PASS; resolved HIGH false-success finding
