### PR TITLE
fix(core): harden atomic file replacement

### DIFF
--- a/.vault/audit/2026-07-16-provider-mcp-enrollment-audit.md
+++ b/.vault/audit/2026-07-16-provider-mcp-enrollment-audit.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - '#audit'
+  - '#provider-mcp-enrollment'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# `provider-mcp-enrollment` audit: `atomic-writer-integrity`
+
+## Scope
+
+Formal corrective-release review of the shared atomic byte writer, its `.gitignore` and
+`.gitattributes` callers, every MCP JSON/TOML/ownership caller reached through the
+shared UTF-8 seam, and the real-filesystem regression matrix. The review must confirm
+exclusive unpredictable scratch creation, descriptor-only content writes,
+identity-guarded promotion and cleanup, atomic fail-closed replacement,
+destination-mode retention, link topology behavior, Windows behavior, and
+package/release readiness.
+
+## Findings
+
+No blocking or non-blocking code findings remain.
+
+The frozen diff replaces every production PID-derived writer with one shared
+descriptor-based byte writer. Temporary nodes are created exclusively with an
+unpredictable short name in the destination directory, content is written and
+synchronized through the opened descriptor, the named node's device and inode are
+verified before promotion, and cleanup removes the path only while that identity still
+matches. Replacement failure is fail-closed; the former Windows copy fallback that
+could follow a destination link is gone. Existing regular-file modes are retained,
+while destination links are replaced as nodes without writing their targets.
+
+The audit traced all MCP JSON, Codex TOML, ownership, workspace, manifest, provider-hook,
+ignore, and attributes writes through the shared seam. No production PID-derived
+temporary writer remains. The real-filesystem matrix covers pre-existing regular,
+relative-link, broken-link, and directory nodes at the legacy sibling name; regular,
+linked, broken-linked, directory, missing-parent, and long-name destinations; and the
+managed ignore, attributes, resource-rename, and MCP caller surfaces. Converted
+resource-rename cases no longer claim rollback coverage; independent real mid-apply
+rollback tests remain in the rename transaction and feature suites.
+
+The implementing agent reported 138 focused passes and an effective 1,773-of-1,773 unit
+ledger after isolating pytest temporary state outside the Git worktree, with Ruff,
+format, Ty, and diff checks green. The formal reviewer independently reran the complete
+new atomic-writer file plus both managed-file caller regressions against an external
+temporary root: 12 of 12 passed with exact node and byte assertions.
+
+Verdict: **PASS — the corrective implementation is ready for packaging and release
+gates, with no CRITICAL, HIGH, MEDIUM, or MINOR findings.**
+
+## Recommendations
+
+Run the clean external-temporary-root unit ledger to one terminal result, then require
+the ordinary build, source-distribution, wheel-install, and project-scoped Claude and
+Codex MCP smoke gates before merge and publication. Publish a corrective Core release
+and require RAG to adopt that public version as its minimum dependency before RAG's own
+release audit begins.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-S09.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-S09.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S09'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# Harden atomic provider configuration writes against pre-existing sibling nodes
+
+## Scope
+
+- `src/vaultspec_core/core/helpers.py`
+- `src/vaultspec_core/core/gitignore.py`
+- `src/vaultspec_core/core/gitattributes.py`
+- `src/vaultspec_core/core/tests/test_atomic_write.py`
+- `src/vaultspec_core/core/tests/test_resource_rename.py`
+- `src/vaultspec_core/tests/cli/test_gitignore.py`
+- `src/vaultspec_core/tests/cli/test_gitattributes.py`
+- `src/vaultspec_core/tests/cli/test_sync_parse.py`
+
+## Description
+
+- Replace PID-derived scratch names with short, unpredictable sibling names opened
+  exclusively through a file descriptor.
+- Write, flush, retain an existing regular destination mode, and synchronize bytes
+  through the descriptor before atomic replacement.
+- Verify the scratch node identity before promotion and cleanup; fail closed when
+  replacement cannot remain atomic.
+- Route UTF-8, BOM-preserving `.gitignore`, and BOM-preserving `.gitattributes` writes
+  through the shared byte writer used by MCP JSON, Codex TOML, and ownership callers.
+- Exercise regular-file, relative-link, broken-link, directory, destination-link,
+  missing-parent, long-name, managed-file, resource-rename, and MCP lifecycle behavior
+  on the real filesystem.
+
+## Outcome
+
+- The writer never selects or removes the legacy predictable sibling node and never
+  follows a destination link during replacement.
+- Focused writer, managed-file, resource-rename, and MCP gates passed 138 tests on
+  Windows.
+- The clean external-basetemp repository unit ledger passed all 1,773 selected tests
+  with 1,052 deliberate deselections. Ruff, format, and Ty passed across the
+  repository.
+- Source and wheel artifacts built successfully and passed the isolated import,
+  metadata, entry-point, server-factory, and CLI smoke script.
+- An isolated wheel installation wrote `.mcp.json` and `.codex/config.toml`; the real
+  Claude CLI reported the project entry pending approval and the real Codex CLI returned
+  the expected enabled stdio definition.
+
+## Notes
+
+The two resource-rename tests that used the predictable scratch name as an induced
+failure could not retain that trigger after the defect was removed. They now prove the
+operator node survives successful writes. Reverse-journal rollback remains covered by
+the dedicated rename transaction and feature-rename suites; this step does not claim
+those converted cases as rollback tests.

--- a/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-summary.md
+++ b/.vault/exec/2026-07-15-provider-mcp-enrollment/2026-07-15-provider-mcp-enrollment-P03-summary.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#provider-mcp-enrollment'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - "[[2026-07-15-provider-mcp-enrollment-plan]]"
+---
+
+# `provider-mcp-enrollment` `P03` summary
+
+Phase P03 proves provider-native enrollment through real reconciliation, installed host
+CLIs, and the corrective atomic-writer release gate.
+
+- Modified: `tests/test_mcps.py`
+- Modified: `tests/test_commands.py`
+- Modified: `tests/cli/test_mcp_hosts.py`
+- Modified: `docs/MCP.md`
+- Modified: `src/vaultspec_core/core/helpers.py`
+- Modified: `src/vaultspec_core/core/gitignore.py`
+- Modified: `src/vaultspec_core/core/gitattributes.py`
+- Modified: `src/vaultspec_core/core/tests/test_resource_rename.py`
+- Modified: `src/vaultspec_core/tests/cli/test_gitignore.py`
+- Modified: `src/vaultspec_core/tests/cli/test_gitattributes.py`
+- Modified: `src/vaultspec_core/tests/cli/test_sync_parse.py`
+- Created: `src/vaultspec_core/core/tests/test_atomic_write.py`
+
+## Description
+
+Claude and Codex recognize project-scoped native enrollment, broader scopes remain
+explicit, and selective companion lifecycle operations preserve Core ownership. The
+corrective step centralizes all text and binary managed-file writes on an exclusively
+created, unpredictable, identity-checked sibling file and removes the non-atomic
+Windows fallback. Real-filesystem topology tests, 1,773 selected unit tests, repository
+static checks, and a formal review pass establish readiness for package and installed
+host smoke gates. The built source and wheel artifacts passed isolated smoke, and a
+wheel-installed project was recognized by both real host CLIs.

--- a/.vault/index/provider-mcp-enrollment.index.md
+++ b/.vault/index/provider-mcp-enrollment.index.md
@@ -3,8 +3,8 @@ generated: true
 tags:
   - '#index'
   - '#provider-mcp-enrollment'
-date: '2026-07-15'
-modified: '2026-07-15'
+date: '2026-07-16'
+modified: '2026-07-16'
 related:
   - '[[2026-07-15-provider-mcp-enrollment-P01-S01]]'
   - '[[2026-07-15-provider-mcp-enrollment-P01-S02]]'
@@ -14,11 +14,14 @@ related:
   - '[[2026-07-15-provider-mcp-enrollment-P02-S06]]'
   - '[[2026-07-15-provider-mcp-enrollment-P03-S07]]'
   - '[[2026-07-15-provider-mcp-enrollment-P03-S08]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P03-S09]]'
+  - '[[2026-07-15-provider-mcp-enrollment-P03-summary]]'
   - '[[2026-07-15-provider-mcp-enrollment-adr]]'
   - '[[2026-07-15-provider-mcp-enrollment-audit]]'
   - '[[2026-07-15-provider-mcp-enrollment-plan]]'
   - '[[2026-07-15-provider-mcp-enrollment-reference]]'
   - '[[2026-07-15-provider-mcp-enrollment-research]]'
+  - '[[2026-07-16-provider-mcp-enrollment-audit]]'
 ---
 
 # `provider-mcp-enrollment` feature index
@@ -34,6 +37,7 @@ Auto-generated index of all documents tagged with `#provider-mcp-enrollment`.
 ### audit
 
 - `2026-07-15-provider-mcp-enrollment-audit` - `provider-mcp-enrollment` audit: `provider-native enrollment release review`
+- `2026-07-16-provider-mcp-enrollment-audit` - `provider-mcp-enrollment` audit: `atomic-writer-integrity`
 
 ### exec
 
@@ -45,6 +49,8 @@ Auto-generated index of all documents tagged with `#provider-mcp-enrollment`.
 - `2026-07-15-provider-mcp-enrollment-P02-S06` - Add provider-scope MCP controls and provider-native status output
 - `2026-07-15-provider-mcp-enrollment-P03-S07` - Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests
 - `2026-07-15-provider-mcp-enrollment-P03-S08` - Add isolated Codex and Claude CLI acceptance and update MCP operator guidance
+- `2026-07-15-provider-mcp-enrollment-P03-S09` - Harden atomic provider configuration writes against pre-existing sibling nodes
+- `2026-07-15-provider-mcp-enrollment-P03-summary` - `provider-mcp-enrollment` `P03` summary
 
 ### plan
 

--- a/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
+++ b/.vault/plan/2026-07-15-provider-mcp-enrollment-plan.md
@@ -3,7 +3,7 @@ tags:
   - '#plan'
   - '#provider-mcp-enrollment'
 date: '2026-07-15'
-modified: '2026-07-15'
+modified: '2026-07-16'
 tier: L2
 related:
   - '[[2026-07-15-provider-mcp-enrollment-adr]]'
@@ -43,6 +43,7 @@ Verify migrations and real Codex and Claude recognition, then document the provi
 
 - [x] `P03.S07` - Add real-behavior reconciliation, migration, lifecycle, and mode-rendering tests; `tests/test_mcps.py and tests/test_commands.py`.
 - [x] `P03.S08` - Add isolated Codex and Claude CLI acceptance and update MCP operator guidance; `tests/cli/test_mcp_hosts.py and docs/MCP.md`.
+- [x] `P03.S09` - Harden atomic provider configuration writes against pre-existing sibling nodes; `src/vaultspec_core/core/helpers.py, src/vaultspec_core/core/gitignore.py, src/vaultspec_core/core/gitattributes.py, src/vaultspec_core/core/tests/test_atomic_write.py, src/vaultspec_core/core/tests/test_resource_rename.py, src/vaultspec_core/tests/cli/test_gitignore.py, src/vaultspec_core/tests/cli/test_gitattributes.py, and src/vaultspec_core/tests/cli/test_sync_parse.py`.
 
 ## Parallelization
 

--- a/src/vaultspec_core/core/gitattributes.py
+++ b/src/vaultspec_core/core/gitattributes.py
@@ -8,11 +8,10 @@ template normalises text to LF and exempts Windows batch files.
 from __future__ import annotations
 
 import logging
-import os
-import shutil
 from pathlib import Path
 
 from .enums import ManagedState
+from .helpers import atomic_write_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -228,19 +227,4 @@ def _write(ga_path: Path, content: str, bom: bytes) -> None:
 
     Always writes in binary mode to preserve the caller-chosen line endings.
     """
-    payload = bom + content.encode("utf-8")
-    tmp = ga_path.with_suffix(ga_path.suffix + f".{os.getpid()}.tmp")
-    try:
-        tmp.write_bytes(payload)
-        try:
-            tmp.replace(ga_path)
-        except PermissionError:
-            if os.name != "nt":
-                raise
-            try:
-                shutil.copyfile(tmp, ga_path)
-            finally:
-                tmp.unlink(missing_ok=True)
-    except Exception:
-        tmp.unlink(missing_ok=True)
-        raise
+    atomic_write_bytes(ga_path, bom + content.encode("utf-8"))

--- a/src/vaultspec_core/core/gitignore.py
+++ b/src/vaultspec_core/core/gitignore.py
@@ -3,12 +3,10 @@
 from __future__ import annotations
 
 import logging
-import os
-import shutil
 from pathlib import Path
 
 from .enums import ManagedState, Tool
-from .helpers import advisory_lock
+from .helpers import advisory_lock, atomic_write_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -358,19 +356,4 @@ def _write(gi_path: Path, content: str, bom: bytes) -> None:
     Using text-mode would double ``\\r`` on Windows when the content
     already contains ``\\r\\n``.
     """
-    payload = bom + content.encode("utf-8")
-    tmp = gi_path.with_suffix(gi_path.suffix + f".{os.getpid()}.tmp")
-    try:
-        tmp.write_bytes(payload)
-        try:
-            tmp.replace(gi_path)
-        except PermissionError:
-            if os.name != "nt":
-                raise
-            try:
-                shutil.copyfile(tmp, gi_path)
-            finally:
-                tmp.unlink(missing_ok=True)
-    except Exception:
-        tmp.unlink(missing_ok=True)
-        raise
+    atomic_write_bytes(gi_path, bom + content.encode("utf-8"))

--- a/src/vaultspec_core/core/helpers.py
+++ b/src/vaultspec_core/core/helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 import os
+import secrets
 import shutil
 import stat
 import subprocess
@@ -229,31 +230,101 @@ def _rmtree_robust(path: Path) -> None:
     shutil.rmtree(path, onerror=_on_error)
 
 
+def _open_atomic_temp(path: Path) -> tuple[int, Path, tuple[int, int]]:
+    """Exclusively create an unpredictable regular file beside *path*."""
+    flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+    for optional_flag in ("O_BINARY", "O_CLOEXEC", "O_NOFOLLOW"):
+        flags |= getattr(os, optional_flag, 0)
+
+    for _attempt in range(128):
+        candidate = path.with_name(f".vs-write-{secrets.token_hex(16)}.tmp")
+        try:
+            fd = os.open(candidate, flags, 0o666)
+        except FileExistsError:
+            continue
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            os.close(fd)
+            raise OSError(
+                f"Atomic write temporary path is not a regular file: {candidate}"
+            )
+        return fd, candidate, (opened.st_dev, opened.st_ino)
+    raise FileExistsError(
+        f"Could not allocate an atomic write temporary file for {path}"
+    )
+
+
+def _unlink_owned_temp(path: Path, identity: tuple[int, int]) -> None:
+    """Remove *path* only while it is still the temporary file we created."""
+    try:
+        current = path.lstat()
+    except FileNotFoundError:
+        return
+    if stat.S_ISREG(current.st_mode) and (current.st_dev, current.st_ino) == identity:
+        path.unlink()
+
+
+def _assert_owned_temp(path: Path, identity: tuple[int, int]) -> None:
+    """Fail unless *path* still names the temporary regular file we opened."""
+    try:
+        current = path.lstat()
+    except FileNotFoundError as exc:
+        raise OSError(f"Atomic write temporary file disappeared: {path}") from exc
+    if (
+        not stat.S_ISREG(current.st_mode)
+        or (
+            current.st_dev,
+            current.st_ino,
+        )
+        != identity
+    ):
+        raise OSError(f"Atomic write temporary file identity changed: {path}")
+
+
+def atomic_write_bytes(path: Path, content: bytes) -> None:
+    """Atomically replace *path* from an exclusively created sibling file."""
+    destination_mode: int | None = None
+    try:
+        destination = path.lstat()
+    except FileNotFoundError:
+        pass
+    else:
+        if stat.S_ISREG(destination.st_mode):
+            destination_mode = stat.S_IMODE(destination.st_mode)
+
+    fd, tmp, identity = _open_atomic_temp(path)
+    owns_tmp = True
+    try:
+        view = memoryview(content)
+        while view:
+            written = os.write(fd, view)
+            if written == 0:
+                raise OSError(f"Atomic write made no progress for {path}")
+            view = view[written:]
+        if destination_mode is not None and hasattr(os, "fchmod"):
+            os.fchmod(fd, destination_mode)
+        os.fsync(fd)
+        os.close(fd)
+        fd = -1
+        _assert_owned_temp(tmp, identity)
+        os.replace(tmp, path)
+        owns_tmp = False
+    finally:
+        if fd >= 0:
+            os.close(fd)
+        if owns_tmp:
+            _unlink_owned_temp(tmp, identity)
+
+
 def atomic_write(path: Path, content: str) -> None:
-    """Write content to file atomically via tmp + rename.
+    """Write UTF-8 content through :func:`atomic_write_bytes`.
 
     Args:
         path: Destination file path to write.
         content: Text content to write, encoded as UTF-8.
     """
-    tmp = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
     try:
-        tmp.write_bytes(content.encode("utf-8"))
-        try:
-            tmp.replace(path)
-        except PermissionError as exc:
-            if os.name != "nt":
-                raise
-            logger.warning(
-                "atomic_write falling back to copy+unlink for %s "
-                "after replace failed: %s",
-                path,
-                exc,
-            )
-            try:
-                shutil.copyfile(tmp, path)
-            finally:
-                tmp.unlink(missing_ok=True)
+        atomic_write_bytes(path, content.encode("utf-8"))
     except Exception as exc:
         logger.error("atomic_write failed for %s: %s", path, exc)
         raise

--- a/src/vaultspec_core/core/tests/test_atomic_write.py
+++ b/src/vaultspec_core/core/tests/test_atomic_write.py
@@ -1,0 +1,136 @@
+"""Real-filesystem integrity tests for shared atomic file replacement."""
+
+from __future__ import annotations
+
+import os
+import stat
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.core.helpers import atomic_write
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+def _legacy_temp(path: Path) -> Path:
+    return path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+
+
+class TestAtomicWriteNamespace:
+    def test_regular_legacy_temp_is_untouched(self, tmp_path: Path) -> None:
+        destination = tmp_path / "regular.md"
+        obstacle = _legacy_temp(destination)
+        obstacle.write_bytes(b"operator bytes\n")
+
+        atomic_write(destination, "managed")
+
+        assert destination.read_bytes() == b"managed"
+        assert obstacle.read_bytes() == b"operator bytes\n"
+
+    def test_relative_link_legacy_temp_is_untouched(self, tmp_path: Path) -> None:
+        destination = tmp_path / "relative.md"
+        operator = tmp_path / "operator.txt"
+        operator.write_bytes(b"operator bytes\n")
+        obstacle = _legacy_temp(destination)
+        obstacle.symlink_to(operator.name)
+
+        atomic_write(destination, "managed")
+
+        assert destination.read_bytes() == b"managed"
+        assert obstacle.is_symlink()
+        assert os.readlink(obstacle) == operator.name
+        assert operator.read_bytes() == b"operator bytes\n"
+
+    def test_broken_link_legacy_temp_is_untouched(self, tmp_path: Path) -> None:
+        destination = tmp_path / "broken.md"
+        obstacle = _legacy_temp(destination)
+        obstacle.symlink_to("missing-operator.txt")
+
+        atomic_write(destination, "managed")
+
+        assert destination.read_bytes() == b"managed"
+        assert obstacle.is_symlink()
+        assert os.readlink(obstacle) == "missing-operator.txt"
+
+    def test_directory_legacy_temp_is_untouched(self, tmp_path: Path) -> None:
+        destination = tmp_path / "directory.md"
+        obstacle = _legacy_temp(destination)
+        obstacle.mkdir()
+        (obstacle / "operator.txt").write_bytes(b"operator bytes\n")
+
+        atomic_write(destination, "managed")
+
+        assert destination.read_bytes() == b"managed"
+        assert obstacle.is_dir()
+        assert (obstacle / "operator.txt").read_bytes() == b"operator bytes\n"
+
+
+class TestAtomicWriteDestination:
+    def test_preserves_existing_regular_file_mode(self, tmp_path: Path) -> None:
+        destination = tmp_path / "mode.md"
+        destination.write_text("old", encoding="utf-8")
+        destination.chmod(0o640)
+
+        atomic_write(destination, "new")
+
+        assert destination.read_text(encoding="utf-8") == "new"
+        if os.name != "nt":
+            assert stat.S_IMODE(destination.stat().st_mode) == 0o640
+
+    def test_replaces_relative_link_without_writing_target(
+        self, tmp_path: Path
+    ) -> None:
+        operator = tmp_path / "operator-target.md"
+        operator.write_bytes(b"operator bytes\n")
+        destination = tmp_path / "linked.md"
+        destination.symlink_to(operator.name)
+
+        atomic_write(destination, "managed")
+
+        assert not destination.is_symlink()
+        assert destination.read_bytes() == b"managed"
+        assert operator.read_bytes() == b"operator bytes\n"
+
+    def test_replaces_broken_link(self, tmp_path: Path) -> None:
+        destination = tmp_path / "broken-destination.md"
+        destination.symlink_to("missing-target.md")
+
+        atomic_write(destination, "managed")
+
+        assert not destination.is_symlink()
+        assert destination.read_bytes() == b"managed"
+
+    def test_directory_failure_preserves_topology(self, tmp_path: Path) -> None:
+        destination = tmp_path / "destination.md"
+        destination.mkdir()
+        (destination / "operator.txt").write_bytes(b"operator bytes\n")
+
+        with pytest.raises(OSError):
+            atomic_write(destination, "managed")
+
+        assert destination.is_dir()
+        assert (destination / "operator.txt").read_bytes() == b"operator bytes\n"
+        assert not list(tmp_path.glob(".vs-write-*.tmp"))
+
+    def test_missing_parent_fails_without_creating_ancestors(
+        self, tmp_path: Path
+    ) -> None:
+        parent = tmp_path / "missing"
+
+        with pytest.raises(FileNotFoundError):
+            atomic_write(parent / "destination.md", "managed")
+
+        assert not parent.exists()
+
+    def test_long_destination_component_uses_short_temp_name(
+        self, tmp_path: Path
+    ) -> None:
+        destination = tmp_path / ("d" * 230 + ".md")
+
+        atomic_write(destination, "managed")
+
+        assert destination.read_bytes() == b"managed"

--- a/src/vaultspec_core/core/tests/test_resource_rename.py
+++ b/src/vaultspec_core/core/tests/test_resource_rename.py
@@ -3,15 +3,14 @@
 ``resource_rename`` is now driven through the shared ``RenameTransaction``
 engine.  These tests exercise the flat-resource and skill-directory rename
 paths, the ``ResourceExistsError`` / ``ResourceNotFoundError`` contract,
-byte-for-byte rollback on an induced mid-apply failure, and ``base_dir``
-containment.  No test doubles are used: every condition is induced through the
-real filesystem under a real temporary ``.vaultspec`` tree.
+legacy temporary-node preservation, and ``base_dir`` containment.  No test
+doubles are used: every condition is induced through the real filesystem under
+a real temporary ``.vaultspec`` tree.
 """
 
 from __future__ import annotations
 
 import os
-import shutil
 from typing import TYPE_CHECKING
 
 import pytest
@@ -192,58 +191,50 @@ class TestSkillRename:
             )
 
 
-class TestRollback:
-    def test_flat_rename_rolls_back_on_content_write_failure(
-        self, vaultspec: Path
-    ) -> None:
+class TestLegacyTempObstaclePreservation:
+    def test_flat_rename_preserves_legacy_temp_directory(self, vaultspec: Path) -> None:
         rules_dir = vaultspec / "rules" / "rules"
         _write_rule(rules_dir, "atomic-rule", body="Keep me intact.\n")
-        before = _snapshot_tree(rules_dir)
-
-        # Plant a directory exactly where ``atomic_write`` places its temp file
-        # for the post-rename content write, so the write fails AFTER the rename
-        # has already landed - forcing the reverse journal to undo real work.
-        # The temp-name formula mirrors ``core.helpers.atomic_write``.
+        # This was the predictable scratch name used before atomic writes moved
+        # to exclusively created unpredictable siblings.
         new_path = rules_dir / "renamed-rule.md"
         obstacle = new_path.with_suffix(new_path.suffix + f".{os.getpid()}.tmp")
         obstacle.mkdir()
+        (obstacle / "operator.txt").write_bytes(b"keep\n")
 
-        with pytest.raises((VaultSpecError, OSError)):
-            resource_rename(
-                "atomic-rule", "renamed-rule", base_dir=rules_dir, label="Rule"
-            )
+        result = resource_rename(
+            "atomic-rule", "renamed-rule", base_dir=rules_dir, label="Rule"
+        )
 
-        shutil.rmtree(obstacle)
-        assert _snapshot_tree(rules_dir) == before
+        assert result == new_path
+        assert new_path.is_file()
+        assert obstacle.is_dir()
+        assert (obstacle / "operator.txt").read_bytes() == b"keep\n"
 
-    def test_skill_rename_rolls_back_on_content_write_failure(
+    def test_skill_rename_preserves_legacy_temp_directory(
         self, vaultspec: Path
     ) -> None:
         skills_dir = vaultspec / "rules" / "skills"
         old_dir = _write_skill(skills_dir, "tx-skill", body="Skill stays whole.\n")
         (old_dir / "extra.md").write_text("extra resource\n", encoding="utf-8")
-        before = _snapshot_tree(skills_dir)
-
-        # The temp file rides the directory rename into the new skill dir, so the
-        # SKILL.md content write fails only after the directory rename has landed.
+        # The operator-owned sibling rides the intentional directory rename and
+        # remains unchanged while the renamed SKILL.md is rewritten.
         skill_md = old_dir / "SKILL.md"
         obstacle = skill_md.with_suffix(skill_md.suffix + f".{os.getpid()}.tmp")
         obstacle.mkdir()
+        (obstacle / "operator.txt").write_bytes(b"keep\n")
 
-        with pytest.raises((VaultSpecError, OSError)):
-            resource_rename(
-                "tx-skill",
-                "renamed-skill",
-                base_dir=skills_dir,
-                label="Skill",
-                is_dir=True,
-            )
+        result = resource_rename(
+            "tx-skill",
+            "renamed-skill",
+            base_dir=skills_dir,
+            label="Skill",
+            is_dir=True,
+        )
 
-        # The obstacle was undone back into the old skill dir by the rollback.
-        leftover = old_dir / f"SKILL.md.{os.getpid()}.tmp"
-        if leftover.exists():
-            shutil.rmtree(leftover)
-        assert _snapshot_tree(skills_dir) == before
+        preserved = result / f"SKILL.md.{os.getpid()}.tmp"
+        assert preserved.is_dir()
+        assert (preserved / "operator.txt").read_bytes() == b"keep\n"
 
 
 class TestContainment:

--- a/src/vaultspec_core/tests/cli/test_gitattributes.py
+++ b/src/vaultspec_core/tests/cli/test_gitattributes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 from typing import TYPE_CHECKING
 
@@ -123,6 +124,18 @@ class TestIdempotency:
         ensure_gitattributes_block(tmp_path)
         content_after_second = _ga(tmp_path).read_bytes()
         assert content_after_first == content_after_second
+
+
+class TestAtomicWriteNamespace:
+    def test_legacy_temp_regular_file_is_untouched(self, tmp_path):
+        ga = _ga(tmp_path)
+        legacy = ga.with_suffix(ga.suffix + f".{os.getpid()}.tmp")
+        legacy.write_bytes(b"operator bytes\n")
+
+        ensure_gitattributes_block(tmp_path)
+
+        assert MARKER_BEGIN in _read_ga(tmp_path)
+        assert legacy.read_bytes() == b"operator bytes\n"
 
 
 class TestOrphanedMarkers:

--- a/src/vaultspec_core/tests/cli/test_gitattributes.py
+++ b/src/vaultspec_core/tests/cli/test_gitattributes.py
@@ -307,7 +307,8 @@ class TestReadOnlyGitattributes:
 
             if can_write:
                 ensure_gitattributes_block(tmp_path)
-                ga.write_bytes(b"*.jpg binary\n")
+                assert MARKER_BEGIN in _read_ga(tmp_path)
+                assert stat.S_IMODE(ga.stat().st_mode) & stat.S_IWRITE == 0
             else:
                 with pytest.raises(OSError):
                     ensure_gitattributes_block(tmp_path)

--- a/src/vaultspec_core/tests/cli/test_gitignore.py
+++ b/src/vaultspec_core/tests/cli/test_gitignore.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import stat
 from typing import TYPE_CHECKING
 
@@ -111,6 +112,19 @@ class TestIdempotency:
         ensure_gitignore_block(tmp_path, ENTRIES)
         content_after_second = _gi(tmp_path).read_bytes()
         assert content_after_first == content_after_second
+
+
+class TestAtomicWriteNamespace:
+    def test_legacy_temp_regular_file_is_untouched(self, tmp_path):
+        gi = _gi(tmp_path)
+        gi.write_bytes(b"# operator rule\n")
+        legacy = gi.with_suffix(gi.suffix + f".{os.getpid()}.tmp")
+        legacy.write_bytes(b"operator bytes\n")
+
+        ensure_gitignore_block(tmp_path, ENTRIES)
+
+        assert MARKER_BEGIN in _read_gi(tmp_path)
+        assert legacy.read_bytes() == b"operator bytes\n"
 
 
 class TestOrphanedMarkers:

--- a/src/vaultspec_core/tests/cli/test_gitignore.py
+++ b/src/vaultspec_core/tests/cli/test_gitignore.py
@@ -312,9 +312,9 @@ class TestReadOnlyGitignore:
                     gi.chmod(stat.S_IREAD)
 
             if can_write:
-                # OS did not enforce read-only; just verify no crash
                 ensure_gitignore_block(tmp_path, ENTRIES)
-                gi.write_bytes(b"node_modules/\n")
+                assert MARKER_BEGIN in _read_gi(tmp_path)
+                assert stat.S_IMODE(gi.stat().st_mode) & stat.S_IWRITE == 0
             else:
                 with pytest.raises(OSError):
                     ensure_gitignore_block(tmp_path, ENTRIES)

--- a/src/vaultspec_core/tests/cli/test_sync_parse.py
+++ b/src/vaultspec_core/tests/cli/test_sync_parse.py
@@ -100,7 +100,7 @@ class TestAtomicWrite:
     def test_no_temp_file_left(self, synthetic_project):
         p = synthetic_project / "clean.md"
         atomic_write(p, "data")
-        assert not (synthetic_project / "clean.md.tmp").exists()
+        assert not list(synthetic_project.glob(".vs-write-*.tmp"))
 
 
 class TestInitPaths:


### PR DESCRIPTION
## Summary
- replace predictable PID-derived sibling files with exclusively-created unpredictable atomic scratch files
- verify scratch identity before promotion/cleanup and fail closed when atomic replacement is unavailable
- route gitignore/gitattributes and MCP JSON/TOML/ownership writes through the hardened byte writer
- add real-filesystem regular/link/broken-link/directory and installed-host regression coverage

## Verification
- 1,773 unit tests passed; 1,052 deliberately deselected
- 138 focused writer, managed-file, resource, and MCP tests passed
- Ruff check/format and Ty passed repository-wide
- Vaultspec formal review PASS; no findings at any severity
- wheel and sdist isolated smoke passed
- wheel-installed project enrollment recognized by real Claude and Codex CLIs