### PR TITLE
fix(sync): managed gitignore covers mcp-ownership.json; honest stale-file warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,14 +191,12 @@ statistic/out/
 .vault/logs/
 .vaultspec/*.lock
 .vaultspec/_snapshots/
+.vaultspec/mcp-ownership.json
 .vaultspec/providers.json
 /.gitignore.lock
 /.mcp.json.lock
 /.pre-commit-config.yaml.lock
 # <<< vaultspec-managed <<<
-
-# Local MCP ownership state (absolute machine paths; pending managed-block coverage, see #215)
-.vaultspec/mcp-ownership.json
 
 # Local benchmark working data (raw campaign logs)
 campaign-data/

--- a/src/vaultspec_core/core/gitignore.py
+++ b/src/vaultspec_core/core/gitignore.py
@@ -38,15 +38,18 @@ def get_recommended_entries(target: Path) -> list[str]:
 
     try:
         # Internal state that must ALWAYS be ignored if the framework
-        # exists. The snapshot directory, advisory-lock sentinels, and the
-        # install manifest (providers.json) are per-machine state, never
-        # authored content. Everything else under .vaultspec/ (rules,
-        # skills, agents, system) is team-shared and is not listed here.
+        # exists. The snapshot directory, advisory-lock sentinels, the
+        # install manifest (providers.json), and the MCP ownership ledger
+        # (mcp-ownership.json, absolute machine paths) are per-machine
+        # state, never authored content. Everything else under .vaultspec/
+        # (rules, skills, agents, system) is team-shared and is not listed
+        # here.
         framework_installed = (target / ".vaultspec").is_dir()
         if framework_installed:
             entries.add(".vaultspec/_snapshots/")
             entries.add(".vaultspec/*.lock")
             entries.add(".vaultspec/providers.json")
+            entries.add(".vaultspec/mcp-ownership.json")
         if (target / ".vault").is_dir():
             entries.add(".vault/.obsidian/")
             entries.add(".vault/.trash/")

--- a/src/vaultspec_core/core/sync.py
+++ b/src/vaultspec_core/core/sync.py
@@ -207,29 +207,36 @@ def sync_files(
                 continue
 
             abs_path = str(item).replace("\\", "/")
-            if prune:
-                # Content-ownership guard: only prune .md files that
-                # vaultspec created (have a matching source or carry the
-                # AUTO-GENERATED marker).  User-authored files are skipped.
-                if not is_skill and item.is_file() and item.suffix == ".md":
-                    has_source = item.name in source_names
-                    if not has_source:
-                        try:
-                            head = item.read_text(encoding="utf-8")[:512]
-                        except OSError:
-                            head = ""
-                        is_managed = (
-                            CONFIG_HEADER in head
-                            or "<vaultspec " in head
-                            or "trigger:" in head
-                        )
-                        if not is_managed:
-                            result.warnings.append(
-                                f"Skipped pruning user file: {abs_path} "
-                                f"(not managed by vaultspec)"
-                            )
-                            continue
 
+            # Content-ownership guard: vaultspec only ever prunes .md files
+            # it created (a matching source or a managed-content marker).
+            # User-authored files are never pruned, so the ownership probe
+            # runs in both modes to keep the warning honest: an unmanaged
+            # file must not be advertised as removable via --force.
+            is_managed = True
+            if not is_skill and item.is_file() and item.suffix == ".md":
+                try:
+                    head = item.read_text(encoding="utf-8")[:512]
+                except OSError:
+                    head = ""
+                is_managed = (
+                    CONFIG_HEADER in head or "<vaultspec " in head or "trigger:" in head
+                )
+
+            if not is_managed:
+                if prune:
+                    result.warnings.append(
+                        f"Skipped pruning user file: {abs_path} "
+                        f"(not managed by vaultspec)"
+                    )
+                else:
+                    result.warnings.append(
+                        f"Stale {label} file: {abs_path} "
+                        f"(not managed by vaultspec; remove manually if unwanted)"
+                    )
+                continue
+
+            if prune:
                 result.items.append((abs_path, "[DELETE]"))
                 if not dry_run:
                     if is_skill:

--- a/src/vaultspec_core/migrations/m_0_1_20_gitignore_reversal.py
+++ b/src/vaultspec_core/migrations/m_0_1_20_gitignore_reversal.py
@@ -49,10 +49,15 @@ def _old_policy_vocabulary() -> frozenset[str]:
     from ..core.enums import DirName, FileName
 
     # Runtime by-products - emitted by both the old and the reversed policy.
+    # The set also covers entries later releases added to the reversed
+    # policy (mcp-ownership.json), so a re-run over an already-reversed
+    # block stays a no-op instead of reading its own output as operator
+    # edits.
     vocabulary = {
         ".vaultspec/_snapshots/",
         ".vaultspec/*.lock",
         ".vaultspec/providers.json",
+        ".vaultspec/mcp-ownership.json",
         ".vault/.obsidian/",
         ".vault/.trash/",
         ".vault/data/",

--- a/src/vaultspec_core/tests/cli/test_gitignore.py
+++ b/src/vaultspec_core/tests/cli/test_gitignore.py
@@ -385,6 +385,7 @@ class TestRecommendedEntries:
         assert ".vaultspec/_snapshots/" in entries
         assert ".vaultspec/*.lock" in entries
         assert ".vaultspec/providers.json" in entries
+        assert ".vaultspec/mcp-ownership.json" in entries
 
     def test_root_lock_sentinel_when_companion_exists(self, tmp_path):
         (tmp_path / ".vaultspec").mkdir()

--- a/src/vaultspec_core/tests/cli/test_sync_operations.py
+++ b/src/vaultspec_core/tests/cli/test_sync_operations.py
@@ -123,6 +123,64 @@ class TestSyncFiles:
         assert result.pruned == 1
         assert not (dest / "stale.md").exists()
 
+    def test_prune_skips_unmanaged_stale_file(self, synthetic_project):
+        dest = synthetic_project / "dest"
+        dest.mkdir()
+        (dest / "user.md").write_text("hand-authored notes", encoding="utf-8")
+        sources = self._make_sources(synthetic_project, ["a.md"])
+        result = sync_files(
+            sources=sources,
+            dest_dir=dest,
+            transform_fn=lambda _t, n, m, b: transform_rule(Tool.CLAUDE, n, m, b),
+            dest_path_fn=lambda d, n: d / n,
+            prune=True,
+            dry_run=False,
+            label="test",
+        )
+        assert result.pruned == 0
+        assert (dest / "user.md").exists()
+        assert any("Skipped pruning user file" in w for w in result.warnings)
+
+    def test_stale_managed_file_warns_force_removable(self, synthetic_project):
+        dest = synthetic_project / "dest"
+        dest.mkdir()
+        (dest / "stale.md").write_text(
+            "---\nname: stale\ntrigger: always_on\n---\n\nold stale content",
+            encoding="utf-8",
+        )
+        sources = self._make_sources(synthetic_project, ["a.md"])
+        result = sync_files(
+            sources=sources,
+            dest_dir=dest,
+            transform_fn=lambda _t, n, m, b: transform_rule(Tool.CLAUDE, n, m, b),
+            dest_path_fn=lambda d, n: d / n,
+            prune=False,
+            dry_run=False,
+            label="test",
+        )
+        assert (dest / "stale.md").exists()
+        assert any("use --force to remove" in w for w in result.warnings)
+
+    def test_stale_unmanaged_file_warns_manual_removal(self, synthetic_project):
+        # An unmanaged stale file must never be advertised as --force
+        # removable: --force skips it, so the warning says so honestly.
+        dest = synthetic_project / "dest"
+        dest.mkdir()
+        (dest / "user.md").write_text("hand-authored notes", encoding="utf-8")
+        sources = self._make_sources(synthetic_project, ["a.md"])
+        result = sync_files(
+            sources=sources,
+            dest_dir=dest,
+            transform_fn=lambda _t, n, m, b: transform_rule(Tool.CLAUDE, n, m, b),
+            dest_path_fn=lambda d, n: d / n,
+            prune=False,
+            dry_run=False,
+            label="test",
+        )
+        assert (dest / "user.md").exists()
+        assert not any("use --force to remove" in w for w in result.warnings)
+        assert any("remove manually if unwanted" in w for w in result.warnings)
+
 
 class TestSyncSkills:
     """Tests for skills_sync."""


### PR DESCRIPTION
Closes #215.

## Summary

Two fixes from the issue:

- `.vaultspec/mcp-ownership.json` (created by the MCP ownership migration; per-machine state with absolute paths, same class as `providers.json`) is now covered by the vaultspec-managed gitignore block via `get_recommended_entries`. This repo's stopgap entry outside the block is removed; the managed block carries it.
- `sync` no longer advertises 'use --force to remove' for stale files that `--force` would then skip as unmanaged. The content-ownership probe now runs in both modes: managed stale files keep the --force hint; unmanaged files get 'not managed by vaultspec; remove manually if unwanted'.

## Verification

- New unit tests: gitignore entry assertion; prune-skips-unmanaged; managed-stale keeps --force hint; unmanaged-stale gets manual-removal message (`test_sync_operations.py`, `test_gitignore.py` - 67 pass).
- Verified live in this repo: both sync modes emit the honest message for a fake unmanaged stale agent file; `git check-ignore` confirms the managed block covers `mcp-ownership.json`.