### PR TITLE
feat(vault): topic-infix scaffolding for audit, reference, and research (--topic)

### DIFF
--- a/.vault/adr/2026-07-16-reference-topic-infix-adr.md
+++ b/.vault/adr/2026-07-16-reference-topic-infix-adr.md
@@ -1,0 +1,111 @@
+---
+tags:
+  - '#adr'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - "[[2026-07-16-reference-topic-infix-research]]"
+  - '[[2026-06-09-firmware-wording-review-adr]]'
+  - '[[2026-06-27-rename-convergence-adr]]'
+  - '[[2026-07-09-mcp-tool-schema-adr]]'
+---
+
+# `reference-topic-infix` adr: `topic-infix scaffolding for the narrative document trio` | (**status:** `accepted`)
+
+## Problem Statement
+
+A feature's second reference, research, or audit document has no route through the
+owning scaffolder: the filename builder always resolves
+`{date}-{feature}-{type}.md`, collides with the first document, and forces
+hand-authored frontmatter - the exact violation the owning-verb mandate exists to
+prevent (GitHub issue 205; grounded in
+`2026-07-16-reference-topic-infix-research`). The audit infix convention decided by
+the firmware-wording-review record is documented but unimplemented. The decision:
+which document types admit a topic infix, through which surfaces, with what
+validation.
+
+## Considerations
+
+- The grounding research establishes: one structural collision site in the filename
+  builder; validators and real corpora already accept infixed filenames; the change
+  surface is the filename builder, the CLI flag set, the MCP create tool, and the
+  firmware filename patterns plus the generated CLI reference.
+- Standing cardinality rules exclude adr and plan from disambiguation-by-infix
+  (amend-or-supersede; one plan per decision cluster), and exec filenames are
+  machine-derived from plan identifiers.
+- `vault feature rename` refuses narrative-filename features (rename-convergence
+  decision, open follow-on); an infix flag grows that population but does not create
+  the condition.
+- Both CLI and MCP transports must converge on the same owning-verb logic per the
+  mcp-tool-schema decision; a CLI-only flag would fork the surfaces.
+
+## Considered options
+
+- **Infix for the narrative trio only - audit, reference, research (chosen).**
+  Matches the documented audit convention, answers the issue, and respects the adr,
+  plan, and exec cardinality rules.
+- **Infix for all doc types.** Rejected: invites sibling ADRs and fragmented plans,
+  contradicting two standing decisions.
+- **Reference-only (issue minimum).** Rejected: leaves audit's documented convention
+  unimplemented and research inconsistent for no saved complexity; the builder change
+  is type-agnostic either way.
+- **Overload --title to also drive the filename.** Rejected: title is narrative prose
+  with unconstrained characters; filenames need the kebab-case identifier discipline,
+  and silently coupling the two changes existing behavior.
+
+## Constraints
+
+- The topic value is validated kebab-case through the shared normalizer
+  (`normalize_feature_tag` with a topic label), the same validator the feature tag
+  uses on both transports.
+- `--topic` on a non-admitting doc type is a hard error, mirroring the existing
+  step-flag validation pattern in the add command.
+- Omitted topic preserves today's filename exactly (backward compatible); the
+  existing exists- and stem-collision guards stay in force on the infixed path.
+- The MCP `create` tool gains the same optional field converging on the same
+  `create_vault_doc` call; the tool-schema decision's owning-verb invariant is
+  untouched.
+- The generated CLI reference must be regenerated and its drift test stay green.
+
+## Implementation
+
+`create_vault_doc` gains an optional `topic` parameter; when set on an admitting doc
+type the filename resolves to `{date}-{feature}-{topic}-{type}.md`, otherwise
+behavior is byte-identical to today. The CLI `vault add` gains `--topic` with
+normalization and the non-admitting-type error; the MCP `DocumentSpec` gains the
+matching optional field. The vaultspec rule's file-name patterns and document list
+name the infix form for audit, reference, and research (audit already documented);
+the CLI reference regenerates via the reference generator. Unit tests cover the
+infixed filename for each admitting type, the omitted-topic fallback, the
+non-admitting-type error, topic normalization, and collision behavior between two
+different topics (allowed) and duplicate topics (refused).
+
+## Rationale
+
+The narrative-trio scope is the only option consistent with all standing decisions
+at once: it implements the convention the firmware already documents, closes the
+issue's owning-verb violation for reference and research, and declines to hand adr
+and plan a disambiguation mechanism their cardinality rules forbid. Routing the flag
+through the shared normalizer and the single filename builder keeps one
+identifier-discipline authority and one collision authority, and adding the field on
+both transports keeps the CLI and MCP surfaces converged per the tool-schema
+decision.
+
+## Consequences
+
+Good: second documents scaffold through the owning verb with machine-owned
+frontmatter; the documented audit convention becomes real; downstream vaults stop
+hand-mirroring filenames. Bad: the narrative-filename population grows, enlarging the
+known `vault feature rename` refusal class until that follow-on is decided; one more
+optional flag on an already wide add command. Neutral: omitted-topic behavior is
+byte-identical; adr, plan, and exec are untouched; the infix remains optional
+disambiguation, never required.
+
+## Codification candidates
+
+- **Rule slug:** `narrative-infix-owning-verb`.
+  **Rule:** A second audit, reference, or research document for a feature is
+  scaffolded with the owning verb's topic infix
+  (`{date}-{feature}-{topic}-{type}.md`), never by hand-writing a filename; adr,
+  plan, and exec documents never take an infix.

--- a/.vault/audit/2026-07-16-reference-topic-infix-audit.md
+++ b/.vault/audit/2026-07-16-reference-topic-infix-audit.md
@@ -1,0 +1,66 @@
+---
+tags:
+  - '#audit'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - "[[2026-07-16-reference-topic-infix-plan]]"
+  - "[[2026-07-16-reference-topic-infix-adr]]"
+---
+
+# `reference-topic-infix` audit: `topic-infix scaffolding review` | (**status:** `PASS (after revision)`)
+
+## Scope
+
+Read-only review of branch `feat/issue-205-reference-topic-infix` versus `main`
+(PR 217, GitHub issue 205) against the governing decision, plan, and research:
+the scaffolder topic parameter, the CLI `--topic` flag, the MCP `DocumentSpec`
+field, firmware wording, and tests. Reviewed by the `vaultspec-code-reviewer`
+persona dispatched as an independent read-only subagent; initial verdict
+REVISION REQUIRED, resolved in the same session.
+
+## Findings
+
+### topic-flag-leaves-body-placeholder-residue | high | --topic left the template heading placeholder unhydrated (RESOLVED)
+
+The flag filled only the filename; a no-title invocation produced a document whose
+`{topic}` heading placeholder survived and failed `vault check placeholders`
+(exit 1), forcing the hand-editing the owning-verb mandate forbids. Resolved: the
+humanized topic hydrates the heading when no title is given, an explicit title
+still wins, and residue assertions were added to the scaffolder and CLI tests.
+Verified end-to-end: a fresh workspace scaffold via
+`vault add reference -f my-feat --topic engine-wire` now passes
+`vault check placeholders` clean with heading `# my-feat reference: engine wire`.
+
+### cli-reference-option-table-omits-topic | medium | bundled reference option table lacked --topic (RESOLVED)
+
+The `vault add` option table in the bundled CLI reference did not list the new
+flag. Resolved: the table row was added in the hand-authored zone of
+`src/vaultspec_core/builtins/reference/cli.md` and the file re-normalized through
+`spec reference generate`; the drift suite (22 tests) passes.
+
+### regeneration-swept-unrelated-mcps-drift | low | reference regeneration bundles pending generator-owned churn (ACCEPTED)
+
+Regenerating the generator-owned region swept in pending `spec mcps` signature
+wording unrelated to this feature. Benign and noted in the PR body.
+
+### mcp-batch-partial-semantics-uncovered | low | no mixed-batch coverage (RESOLVED)
+
+A mixed-batch test (valid infixed reference + topic-rejected adr + plain
+research) now locks in per-item failure semantics.
+
+### Positive confirmations
+
+Guards intact on the infixed path (exists- and stem-collision), omitted-topic
+byte-identical, CLI and MCP transports converge on the shared normalizer and one
+builder call, firmware wording consistent with the audit-infix convention and
+the code-stands-alone clause, zero em dashes, no drift beyond the decided
+surfaces.
+
+## Recommendations
+
+None outstanding; all blocking findings resolved and verified. Final gates:
+scaffolder, CLI, and MCP suites green; drift suite green; unit gate green.
+
+Status: PASS after revision. Safe to merge.

--- a/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S01.md
+++ b/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S01.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S01'
+related:
+  - "[[2026-07-16-reference-topic-infix-plan]]"
+---
+
+# Add the optional topic parameter to create_vault_doc with the infixed filename for audit, reference, and research and a hard error for other types
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/hydration.py`
+
+## Description
+
+- Add the optional topic parameter to `create_vault_doc`: infixed filename
+  `{date}-{feature}-{topic}-{type}.md` for the narrative trio, `ValueError` for
+  any other type, omitted topic byte-identical to prior behavior.
+
+## Outcome
+
+Filename authority extended in one place; exists- and stem-collision guards
+apply unchanged on the infixed path. Modified:
+`src/vaultspec_core/vaultcore/hydration.py`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S02.md
+++ b/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S02.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S02'
+related:
+  - "[[2026-07-16-reference-topic-infix-plan]]"
+---
+
+# Add the --topic flag with shared-normalizer validation and non-admitting-type error to vault add
+
+## Scope
+
+- `src/vaultspec_core/cli/vault_cmd.py`
+
+## Description
+
+- Add the `--topic` flag to `vault add` with shared-normalizer kebab-case
+  validation and a hard error for non-admitting types, passing the normalized
+  value to the scaffolder.
+
+## Outcome
+
+CLI transport converges on the same builder; error wording mirrors the existing
+step-flag validations. Modified: `src/vaultspec_core/cli/vault_cmd.py`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S03.md
+++ b/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S03.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S03'
+related:
+  - "[[2026-07-16-reference-topic-infix-plan]]"
+---
+
+# Add the optional topic field to DocumentSpec converging on the same create_vault_doc call
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/tools/documents.py`
+
+## Description
+
+- Add the optional `topic` field to `DocumentSpec` with the same validation and
+  per-item failure semantics, converging on the same `create_vault_doc` call.
+
+## Outcome
+
+MCP create tool at parity with the CLI flag. Modified:
+`src/vaultspec_core/mcp_server/tools/documents.py`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S04.md
+++ b/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S04.md
@@ -1,0 +1,35 @@
+---
+tags:
+  - '#exec'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S04'
+related:
+  - "[[2026-07-16-reference-topic-infix-plan]]"
+---
+
+# Add unit tests covering infixed filenames per admitting type, omitted-topic fallback, non-admitting-type error, normalization, and collision behavior
+
+## Scope
+
+- `src/vaultspec_core tests`
+
+## Description
+
+- Add scaffolder tests (infixed filename per admitting type, omitted-topic
+  fallback, non-admitting `ValueError`, coexisting topics, duplicate-topic
+  collision), CLI tests (success, type guard, non-kebab rejection), and MCP
+  batch tests (second same-day reference, per-item type failure).
+
+## Outcome
+
+38 + 8 tests green across the three surfaces (suites run separately per the
+known cross-conftest interaction). Modified:
+`src/vaultspec_core/vaultcore/tests/test_hydration.py`,
+`src/vaultspec_core/tests/cli/test_vault_cli.py`,
+`tests/unit/mcp_server/test_create_tool.py`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S05.md
+++ b/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S05.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S05'
+related:
+  - "[[2026-07-16-reference-topic-infix-plan]]"
+---
+
+# Document the infix form for the narrative trio in the firmware filename patterns and regenerate the bundled CLI reference
+
+## Scope
+
+- `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`
+
+## Description
+
+- Extend the audit-infix sentence in the vaultspec rule to the narrative trio
+  and add the infix pattern to the File names conventions; roll out via install
+  upgrade and sync; run the reference generator.
+
+## Outcome
+
+Firmware documents the trio-wide convention. The generated CLI reference is
+command-level (no per-flag inventory), so the generator correctly reports up to
+date and the drift test passes. Modified:
+`src/vaultspec_core/builtins/rules/vaultspec.builtin.md` (+ CLI-written mirror).
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S06.md
+++ b/.vault/exec/2026-07-16-reference-topic-infix/2026-07-16-reference-topic-infix-S06.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S06'
+related:
+  - "[[2026-07-16-reference-topic-infix-plan]]"
+---
+
+# Run the gates and open the PR closing the issue
+
+## Scope
+
+- `src/vaultspec_core`
+
+## Description
+
+- Run the unit gate, vault check all, and prek hooks; push and finalize the PR.
+
+## Outcome
+
+Scaffolder, CLI, MCP, and drift suites green; unit gate green. The mandatory
+code review returned REVISION REQUIRED (one HIGH: unhydrated heading
+placeholder on the no-title path); the revision landed, was verified
+end-to-end in a fresh workspace, and the audit closes at PASS.
+
+## Notes
+
+None.

--- a/.vault/index/reference-topic-infix.index.md
+++ b/.vault/index/reference-topic-infix.index.md
@@ -1,0 +1,30 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - '[[2026-07-16-reference-topic-infix-adr]]'
+  - '[[2026-07-16-reference-topic-infix-plan]]'
+  - '[[2026-07-16-reference-topic-infix-research]]'
+---
+
+# `reference-topic-infix` feature index
+
+Auto-generated index of all documents tagged with `#reference-topic-infix`.
+
+## Documents
+
+### adr
+
+- `2026-07-16-reference-topic-infix-adr` - `reference-topic-infix` adr: `topic-infix scaffolding for the narrative document trio` | (**status:** `accepted`)
+
+### plan
+
+- `2026-07-16-reference-topic-infix-plan` - `reference-topic-infix` plan
+
+### research
+
+- `2026-07-16-reference-topic-infix-research` - `reference-topic-infix` research: `scaffolding a second reference or research document per feature`

--- a/.vault/index/reference-topic-infix.index.md
+++ b/.vault/index/reference-topic-infix.index.md
@@ -6,7 +6,14 @@ tags:
 date: '2026-07-16'
 modified: '2026-07-16'
 related:
+  - '[[2026-07-16-reference-topic-infix-S01]]'
+  - '[[2026-07-16-reference-topic-infix-S02]]'
+  - '[[2026-07-16-reference-topic-infix-S03]]'
+  - '[[2026-07-16-reference-topic-infix-S04]]'
+  - '[[2026-07-16-reference-topic-infix-S05]]'
+  - '[[2026-07-16-reference-topic-infix-S06]]'
   - '[[2026-07-16-reference-topic-infix-adr]]'
+  - '[[2026-07-16-reference-topic-infix-audit]]'
   - '[[2026-07-16-reference-topic-infix-plan]]'
   - '[[2026-07-16-reference-topic-infix-research]]'
 ---
@@ -20,6 +27,19 @@ Auto-generated index of all documents tagged with `#reference-topic-infix`.
 ### adr
 
 - `2026-07-16-reference-topic-infix-adr` - `reference-topic-infix` adr: `topic-infix scaffolding for the narrative document trio` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-16-reference-topic-infix-audit` - `reference-topic-infix` audit: `topic-infix scaffolding review` | (**status:** `PASS (after revision)`)
+
+### exec
+
+- `2026-07-16-reference-topic-infix-S01` - Add the optional topic parameter to create_vault_doc with the infixed filename for audit, reference, and research and a hard error for other types
+- `2026-07-16-reference-topic-infix-S02` - Add the --topic flag with shared-normalizer validation and non-admitting-type error to vault add
+- `2026-07-16-reference-topic-infix-S03` - Add the optional topic field to DocumentSpec converging on the same create_vault_doc call
+- `2026-07-16-reference-topic-infix-S04` - Add unit tests covering infixed filenames per admitting type, omitted-topic fallback, non-admitting-type error, normalization, and collision behavior
+- `2026-07-16-reference-topic-infix-S05` - Document the infix form for the narrative trio in the firmware filename patterns and regenerate the bundled CLI reference
+- `2026-07-16-reference-topic-infix-S06` - Run the gates and open the PR closing the issue
 
 ### plan
 

--- a/.vault/plan/2026-07-16-reference-topic-infix-plan.md
+++ b/.vault/plan/2026-07-16-reference-topic-infix-plan.md
@@ -1,0 +1,44 @@
+---
+tags:
+  - '#plan'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+tier: L1
+related:
+  - '[[2026-07-16-reference-topic-infix-adr]]'
+  - '[[2026-07-16-reference-topic-infix-research]]'
+---
+
+# `reference-topic-infix` plan
+
+## Description
+
+This plan executes the reference-topic-infix decision (see related): topic-infix
+scaffolding for the narrative document trio (audit, reference, research) through
+the single filename builder, the CLI --topic flag, and the MCP create tool's
+DocumentSpec, with firmware filename patterns and the generated CLI reference
+updated in step. Omitted topic preserves current behavior byte-identically; adr,
+plan, and exec never take an infix.
+
+## Steps
+
+- [ ] `S01` - Add the optional topic parameter to create_vault_doc with the infixed filename for audit, reference, and research and a hard error for other types; `src/vaultspec_core/vaultcore/hydration.py`.
+- [ ] `S02` - Add the --topic flag with shared-normalizer validation and non-admitting-type error to vault add; `src/vaultspec_core/cli/vault_cmd.py`.
+- [ ] `S03` - Add the optional topic field to DocumentSpec converging on the same create_vault_doc call; `src/vaultspec_core/mcp_server/tools/documents.py`.
+- [ ] `S04` - Add unit tests covering infixed filenames per admitting type, omitted-topic fallback, non-admitting-type error, normalization, and collision behavior; `src/vaultspec_core tests`.
+- [ ] `S05` - Document the infix form for the narrative trio in the firmware filename patterns and regenerate the bundled CLI reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
+- [ ] `S06` - Run the gates and open the PR closing the issue; `src/vaultspec_core`.
+
+## Parallelization
+
+S01 lands first (the builder is the shared authority); S02 and S03 then
+parallelize over disjoint files; S04 and S05 follow implementation; S06 is last.
+
+## Verification
+
+- Infixed filename produced for each admitting type; omitted topic byte-identical.
+- --topic on adr, plan, or exec exits with a hard error on both transports.
+- Topic values normalize kebab-case through the shared normalizer.
+- CLI reference drift test green after regeneration; prek and the unit gate pass.
+- Code review audit passes; PR closes the issue.

--- a/.vault/plan/2026-07-16-reference-topic-infix-plan.md
+++ b/.vault/plan/2026-07-16-reference-topic-infix-plan.md
@@ -23,12 +23,12 @@ plan, and exec never take an infix.
 
 ## Steps
 
-- [ ] `S01` - Add the optional topic parameter to create_vault_doc with the infixed filename for audit, reference, and research and a hard error for other types; `src/vaultspec_core/vaultcore/hydration.py`.
-- [ ] `S02` - Add the --topic flag with shared-normalizer validation and non-admitting-type error to vault add; `src/vaultspec_core/cli/vault_cmd.py`.
-- [ ] `S03` - Add the optional topic field to DocumentSpec converging on the same create_vault_doc call; `src/vaultspec_core/mcp_server/tools/documents.py`.
-- [ ] `S04` - Add unit tests covering infixed filenames per admitting type, omitted-topic fallback, non-admitting-type error, normalization, and collision behavior; `src/vaultspec_core tests`.
-- [ ] `S05` - Document the infix form for the narrative trio in the firmware filename patterns and regenerate the bundled CLI reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
-- [ ] `S06` - Run the gates and open the PR closing the issue; `src/vaultspec_core`.
+- [x] `S01` - Add the optional topic parameter to create_vault_doc with the infixed filename for audit, reference, and research and a hard error for other types; `src/vaultspec_core/vaultcore/hydration.py`.
+- [x] `S02` - Add the --topic flag with shared-normalizer validation and non-admitting-type error to vault add; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `S03` - Add the optional topic field to DocumentSpec converging on the same create_vault_doc call; `src/vaultspec_core/mcp_server/tools/documents.py`.
+- [x] `S04` - Add unit tests covering infixed filenames per admitting type, omitted-topic fallback, non-admitting-type error, normalization, and collision behavior; `src/vaultspec_core tests`.
+- [x] `S05` - Document the infix form for the narrative trio in the firmware filename patterns and regenerate the bundled CLI reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
+- [x] `S06` - Run the gates and open the PR closing the issue; `src/vaultspec_core`.
 
 ## Parallelization
 

--- a/.vault/research/2026-07-16-reference-topic-infix-research.md
+++ b/.vault/research/2026-07-16-reference-topic-infix-research.md
@@ -1,0 +1,100 @@
+---
+tags:
+  - '#research'
+  - '#reference-topic-infix'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - '[[2026-06-09-firmware-wording-review-adr]]'
+  - '[[2026-06-27-rename-convergence-adr]]'
+---
+
+# `reference-topic-infix` research: `scaffolding a second reference or research document per feature`
+
+The question (GitHub issue 205): the owning scaffolder cannot create a second
+reference (or research, or audit) document for a feature - the filename always
+resolves to `{date}-{feature}-{type}.md` and collides - so the second document is
+forced into hand-authored frontmatter, violating the owning-verb mandate. The evidence
+picture: the collision is structural in one function, a topic-infix convention already
+exists in the firmware for audits (documented but not implemented in the scaffolder
+either), the validators already accept infixed filenames, and the change surface is
+four sites (filename builder, CLI flag, MCP create tool, firmware filename patterns)
+plus the generated CLI reference.
+
+## Findings
+
+### The collision is structural in one filename builder
+
+`create_vault_doc` resolves every non-exec filename as
+`f"{date_str}-{feature}-{doc_type.value}.md"`
+(`src/vaultspec_core/vaultcore/hydration.py:434`); `title` maps only to the heading
+placeholders (`hydration.py:97,127`), never the filename. A second same-day document
+of the same type and feature raises `ResourceExistsError` (`hydration.py:439-444`),
+and the stem-collision guard (`hydration.py:449-459`) blocks even cross-type stem
+duplicates. `--force` overwrites rather than disambiguates.
+
+### The topic-infix convention exists in firmware but no scaffolder implements it
+
+The vaultspec rule documents the audit disambiguation
+`yyyy-mm-dd-{feature}-{topic}-audit.md`
+(`src/vaultspec_core/builtins/rules/vaultspec.builtin.md`, Audits node and workflow
+list), decided by D2 of the firmware-wording-review decision (see `related:`). No
+`topic` parameter exists anywhere in the scaffolding path: `create_vault_doc`
+(`hydration.py:318-339`) has no such argument, the CLI `vault add` flag set
+(`src/vaultspec_core/cli/vault_cmd.py:83-159`) has no `--topic`, and the MCP `create`
+tool's `DocumentSpec` (`src/vaultspec_core/mcp_server/tools/documents.py:137`) carries
+only `title`. Even a second audit - whose infix form the firmware documents - cannot
+be scaffolded through an owning verb today.
+
+### Validators and real corpora already accept infixed filenames
+
+Issue 205 reports two real hand-mirrored infixed reference documents in a downstream
+vault validating clean via `vault check all`, and this repo's own audit corpus uses
+narrative infixes (e.g. a `-check-engine-review-audit` stem, prior art acknowledged in
+the firmware-wording-review decision). The filename checkers do not bind the
+`{date}-{feature}-{type}` shape strictly; features are derived from frontmatter tags,
+not filenames.
+
+### Known interaction: narrative filenames and feature rename
+
+`vault feature rename` refuses on narrative-filename features (recorded in the
+rename-convergence decision, see `related:`); adding more infixed filenames grows that
+population. This is a pre-existing, open follow-on of that decision, not a new
+regression introduced by an infix flag - but the decision record should acknowledge
+it.
+
+### Change surface
+
+- `hydration.py` filename builder and `create_vault_doc` signature: a `topic`
+  parameter producing `{date}-{feature}-{topic}-{type}.md`.
+- CLI `vault add`: a `--topic` flag; kebab-case validation exists via
+  `normalize_feature_tag(value, label=...)` (`vault_cmd.py:240,254` shows the shared
+  normalizer pattern for feature and tags).
+- MCP `create` tool: `DocumentSpec` field with the same validation, converging on the
+  same `create_vault_doc` call (`documents.py:274-277`).
+- Firmware: the vaultspec rule's file-name patterns document the infix for the types
+  the decision admits; the CLI reference regenerates via `spec reference generate`
+  (drift-tested).
+
+### Scope question the decision must settle
+
+Which document types admit the infix. The issue requests `reference`, suggests
+`research`; `audit` is already convention. `adr` and `plan` have standing cardinality
+rules pointing the other way (one accepted record per decision with amend-or-supersede;
+one plan per decision cluster - both in the vaultspec firmware and prior decisions),
+and `exec` filenames are machine-derived from plan identifiers. The evidence favors
+admitting the infix for the narrative trio (audit, reference, research) and excluding
+adr, plan, exec.
+
+## Sources
+
+- `src/vaultspec_core/vaultcore/hydration.py:97`
+- `src/vaultspec_core/vaultcore/hydration.py:127`
+- `src/vaultspec_core/vaultcore/hydration.py:318-339`
+- `src/vaultspec_core/vaultcore/hydration.py:434-459`
+- `src/vaultspec_core/cli/vault_cmd.py:83-159`
+- `src/vaultspec_core/cli/vault_cmd.py:240-258`
+- `src/vaultspec_core/mcp_server/tools/documents.py:137`
+- `src/vaultspec_core/mcp_server/tools/documents.py:274-277`
+- `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`
+- https://github.com/nevenincs/vaultspec-core/issues/205

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -353,15 +353,17 @@ Create a `.vault/` document from a template.
 | Option | Short | Default | Description | | --------------- | ----- | ------- |
 -------------------------------------------------------------------- | | `--feature TAG`
 | `-f` | None | Feature tag (kebab-case). | | `--date DATE` | - | today | Override date
-(ISO 8601). | | `--title TITLE` | - | None | Document title. | | `--related DOC` | `-r`
-| None | Related document(s). Repeatable. | | `--tags TAG` | - | None | Additional
-freeform tags. Repeatable. | | `--force` | - | off | Overwrite an existing document. | |
-`--dry-run` | - | off | Preview without writing. | | `--json` | - | off | Emit
-machine-readable output. | | `--no-hints` | - | off | Suppress next-step advisory hints.
-| | `--tier TIER` | - | `L1` | Plan tier (`L1`..`L4`). Ignored for non-plan document
-types. | | `--step ID` | - | None | Canonical ID or display path of the Step to scaffold
-(exec records). | | `--all-steps` | - | off | Scaffold execution records for all Steps
-in the parent plan. |
+(ISO 8601). | | `--title TITLE` | - | None | Document title. | | `--topic TOPIC` | - |
+None | Narrative filename infix (kebab-case) producing
+`{date}-{feature}-{topic}-{type}.md`; audit, reference, and research only. | |
+`--related DOC` | `-r` | None | Related document(s). Repeatable. | | `--tags TAG` | - |
+None | Additional freeform tags. Repeatable. | | `--force` | - | off | Overwrite an
+existing document. | | `--dry-run` | - | off | Preview without writing. | | `--json` | -
+| off | Emit machine-readable output. | | `--no-hints` | - | off | Suppress next-step
+advisory hints. | | `--tier TIER` | - | `L1` | Plan tier (`L1`..`L4`). Ignored for
+non-plan document types. | | `--step ID` | - | None | Canonical ID or display path of
+the Step to scaffold (exec records). | | `--all-steps` | - | off | Scaffold execution
+records for all Steps in the parent plan. |
 
 ### vaultspec-core status
 

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -45,7 +45,7 @@ hand-edit between the markers.
 
 ### Top-level commands
 
-- `vaultspec-core install` - Deploy the vaultspec framework to the target directory.
+- `vaultspec-core install` - Install Vaultspec resources for the selected providers.
 - `vaultspec-core uninstall` - Remove the vaultspec framework from the target directory.
 - `vaultspec-core sync` - Sync rules, skills, agents, configs, system prompts, and MCPs.
 - `vaultspec-core doctor` - Diagnose overall workspace and vault health.
@@ -258,12 +258,14 @@ hand-edit between the markers.
 
 #### Mcps
 
-- `vaultspec-core spec mcps list` - List all registered MCP server definitions.
-- `vaultspec-core spec mcps status` - Report focused MCP definition and .mcp.json sync
-  status.
-- `vaultspec-core spec mcps add` - Add a new custom MCP server definition.
-- `vaultspec-core spec mcps remove` - Remove an MCP server definition.
-- `vaultspec-core spec mcps sync` - Sync only MCP definitions to .mcp.json.
+- `vaultspec-core spec mcps list` - List canonical MCP server definitions.
+- `vaultspec-core spec mcps status` - Inspect provider-native MCP enrollment status.
+- `vaultspec-core spec mcps add` - Add or replace a canonical MCP server definition.
+- `vaultspec-core spec mcps remove` - Remove a canonical MCP server definition.
+- `vaultspec-core spec mcps sync` - Reconcile canonical definitions into provider-native
+  enrollment.
+- `vaultspec-core spec mcps uninstall` - Remove Vaultspec-owned provider-native MCP
+  enrollment.
 
 #### Reference
 
@@ -606,15 +608,24 @@ enabled hooks; it takes `--path PATH`. Valid events: `vault.document.created`,
 
 ### vaultspec-core spec mcps
 
-Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage MCP server
-definitions and synced `.mcp.json` entries.
+Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage canonical
+definitions in `.vaultspec/mcps/*.json` and reconcile them into provider-native
+enrollment. Providers are `all`, `claude`, `antigravity`, and `codex`; scopes are
+`project`, `local`, and `user`. Unsupported provider/scope combinations fail.
 
-| Subcommand | Signature | Description | | ---------- |
---------------------------------------- | ----------------------------- | | `list` | - |
-List MCP server definitions. | | `status` | `[--json]` | Validate against `.mcp.json`. |
-| `add` | `--name NAME [--config JSON] [--force]` | Add a custom MCP definition. | |
-`remove` | `NAME [--force]` | Remove an MCP definition. | | `sync` |
-`[--dry-run] [--force]` | Sync definitions to config. |
+| Subcommand  | Signature                                                                             | Description                                                         |
+| ----------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `list`      | -                                                                                     | List canonical MCP server definitions.                              |
+| `status`    | `[PROVIDER] [--scope SCOPE] [--json] [--target PATH]`                                 | Inspect configuration and ownership state; does not probe runtimes. |
+| `add`       | `--name NAME [--config JSON] [--force]`                                               | Add or replace a canonical definition.                              |
+| `remove`    | `NAME [--force]`                                                                      | Remove a canonical definition.                                      |
+| `sync`      | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--prune] [--json] [--target PATH]` | Reconcile canonical definitions into native enrollment.             |
+| `uninstall` | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--json] [--target PATH]`           | Remove only Vaultspec-owned native enrollment.                      |
+
+The default provider is `all` and the default scope is `project`. `sync --force` adopts
+or replaces a same-name external entry; `sync --prune` removes owned enrollment whose
+canonical source was deleted. `uninstall` preserves canonical definitions and external
+host entries.
 
 ## Migration commands
 

--- a/.vaultspec/rules/vaultspec.builtin.md
+++ b/.vaultspec/rules/vaultspec.builtin.md
@@ -27,8 +27,10 @@ The workflow persists the following documents, bound by a single feature tag:
 - `.vault/exec/yyyy-mm-dd-<feature>/...-summary.md`: The `<Phase Summary>`.
 
 - `.vault/audit/yyyy-mm-dd-<feature>-audit.md`: The `<Audit>` report. A feature with
-  multiple audits disambiguates each with an optional narrative infix:
-  `yyyy-mm-dd-<feature>-<topic>-audit.md`.
+  multiple audits, references, or research documents disambiguates each with an optional
+  narrative infix - `yyyy-mm-dd-<feature>-<topic>-<type>.md` - scaffolded through the
+  owning verb's `--topic` flag (`vault add` for audit, reference, and research only),
+  never by hand-picking a filename.
 
 - `.vault/index/<feature>.index.md`: The auto-generated `<Feature Index>` linking every
   document for a feature. The index regenerates as a side effect of the `create` and
@@ -273,6 +275,11 @@ instead.
 
   - Top-level docs: `yyyy-mm-dd-{feature}-{type}.md` (e.g.,
     `2026-02-04-editor-demo-plan.md`)
+
+  - Narrative infix (audit, reference, research only):
+    `yyyy-mm-dd-{feature}-{topic}-{type}.md` (e.g.,
+    `2026-02-04-editor-demo-engine-wire-reference.md`), scaffolded with the owning
+    verb's `--topic` flag
 
   - Exec Steps (L1): `yyyy-mm-dd-{feature}-{step}.md` (e.g.,
     `2026-02-04-editor-demo-S01.md`)

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -353,15 +353,17 @@ Create a `.vault/` document from a template.
 | Option | Short | Default | Description | | --------------- | ----- | ------- |
 -------------------------------------------------------------------- | | `--feature TAG`
 | `-f` | None | Feature tag (kebab-case). | | `--date DATE` | - | today | Override date
-(ISO 8601). | | `--title TITLE` | - | None | Document title. | | `--related DOC` | `-r`
-| None | Related document(s). Repeatable. | | `--tags TAG` | - | None | Additional
-freeform tags. Repeatable. | | `--force` | - | off | Overwrite an existing document. | |
-`--dry-run` | - | off | Preview without writing. | | `--json` | - | off | Emit
-machine-readable output. | | `--no-hints` | - | off | Suppress next-step advisory hints.
-| | `--tier TIER` | - | `L1` | Plan tier (`L1`..`L4`). Ignored for non-plan document
-types. | | `--step ID` | - | None | Canonical ID or display path of the Step to scaffold
-(exec records). | | `--all-steps` | - | off | Scaffold execution records for all Steps
-in the parent plan. |
+(ISO 8601). | | `--title TITLE` | - | None | Document title. | | `--topic TOPIC` | - |
+None | Narrative filename infix (kebab-case) producing
+`{date}-{feature}-{topic}-{type}.md`; audit, reference, and research only. | |
+`--related DOC` | `-r` | None | Related document(s). Repeatable. | | `--tags TAG` | - |
+None | Additional freeform tags. Repeatable. | | `--force` | - | off | Overwrite an
+existing document. | | `--dry-run` | - | off | Preview without writing. | | `--json` | -
+| off | Emit machine-readable output. | | `--no-hints` | - | off | Suppress next-step
+advisory hints. | | `--tier TIER` | - | `L1` | Plan tier (`L1`..`L4`). Ignored for
+non-plan document types. | | `--step ID` | - | None | Canonical ID or display path of
+the Step to scaffold (exec records). | | `--all-steps` | - | off | Scaffold execution
+records for all Steps in the parent plan. |
 
 ### vaultspec-core status
 

--- a/src/vaultspec_core/builtins/rules/vaultspec.builtin.md
+++ b/src/vaultspec_core/builtins/rules/vaultspec.builtin.md
@@ -27,8 +27,10 @@ The workflow persists the following documents, bound by a single feature tag:
 - `.vault/exec/yyyy-mm-dd-<feature>/...-summary.md`: The `<Phase Summary>`.
 
 - `.vault/audit/yyyy-mm-dd-<feature>-audit.md`: The `<Audit>` report. A feature with
-  multiple audits disambiguates each with an optional narrative infix:
-  `yyyy-mm-dd-<feature>-<topic>-audit.md`.
+  multiple audits, references, or research documents disambiguates each with an optional
+  narrative infix - `yyyy-mm-dd-<feature>-<topic>-<type>.md` - scaffolded through the
+  owning verb's `--topic` flag (`vault add` for audit, reference, and research only),
+  never by hand-picking a filename.
 
 - `.vault/index/<feature>.index.md`: The auto-generated `<Feature Index>` linking every
   document for a feature. The index regenerates as a side effect of the `create` and
@@ -273,6 +275,11 @@ instead.
 
   - Top-level docs: `yyyy-mm-dd-{feature}-{type}.md` (e.g.,
     `2026-02-04-editor-demo-plan.md`)
+
+  - Narrative infix (audit, reference, research only):
+    `yyyy-mm-dd-{feature}-{topic}-{type}.md` (e.g.,
+    `2026-02-04-editor-demo-engine-wire-reference.md`), scaffolded with the owning
+    verb's `--topic` flag
 
   - Exec Steps (L1): `yyyy-mm-dd-{feature}-{step}.md` (e.g.,
     `2026-02-04-editor-demo-S01.md`)

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -90,6 +90,18 @@ def cmd_add(
         str | None, typer.Option("--date", help="Override date (YYYY-MM-DD)")
     ] = None,
     title: Annotated[str | None, typer.Option("--title", help="Document title")] = None,
+    topic: Annotated[
+        str | None,
+        typer.Option(
+            "--topic",
+            help=(
+                "Narrative filename infix (kebab-case) disambiguating a "
+                "second document of the same type for a feature; produces "
+                "{date}-{feature}-{topic}-{type}.md. Only valid for audit, "
+                "reference, and research documents."
+            ),
+        ),
+    ] = None,
     related: Annotated[
         list[str] | None,
         typer.Option(
@@ -234,6 +246,22 @@ def cmd_add(
             f"[red]Invalid tier '{tier}'. Allowed values: L1, L2, L3, L4.[/red]"
         )
         raise typer.Exit(code=1)
+
+    # Validate the topic infix: admitted only for the narrative trio, and
+    # held to the same kebab-case discipline as the feature tag.
+    topic_value: str | None = None
+    if topic is not None:
+        if dt not in (DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH):
+            console.print(
+                "[red]Error: --topic is only valid for 'audit', 'reference', "
+                "and 'research' documents.[/red]"
+            )
+            raise typer.Exit(code=1)
+        topic_result = normalize_feature_tag(topic, label="topic")
+        if not topic_result.ok or topic_result.value is None:
+            console.print(f"[red]{topic_result.error}[/red]")
+            raise typer.Exit(code=1)
+        topic_value = topic_result.value
 
     # Validate feature tag through the shared vaultcore normalizer (the one
     # validator the MCP surface also converges on).
@@ -509,6 +537,7 @@ def cmd_add(
                 feature=feat,
                 date_str=date_str,
                 title=title,
+                topic=topic_value,
                 related=resolved_related,
                 extra_tags=extra_tags,
                 force=force,

--- a/src/vaultspec_core/mcp_server/tools/documents.py
+++ b/src/vaultspec_core/mcp_server/tools/documents.py
@@ -130,6 +130,10 @@ class DocumentSpec(BaseModel):
             directory and feature tags.
         tier: The plan tier (``L1``-``L4``) for a ``plan`` document; defaults
             to ``L1``. Ignored for other document types.
+        topic: Optional kebab-case narrative filename infix disambiguating a
+            second document of the same type for a feature
+            (``{date}-{feature}-{topic}-{type}.md``). Only valid for
+            ``audit``, ``reference``, and ``research`` documents.
     """
 
     feature: str
@@ -140,6 +144,7 @@ class DocumentSpec(BaseModel):
     related: list[str] | None = None
     tags: list[str] | None = None
     tier: str | None = None
+    topic: str | None = None
 
 
 class EditOperation(BaseModel):
@@ -267,6 +272,18 @@ def _create_one(
         if tier not in ("L1", "L2", "L3", "L4"):
             return _failed(f"Invalid tier '{tier}'. Allowed values: L1, L2, L3, L4.")
 
+    topic: str | None = None
+    if spec.topic is not None:
+        if doc_type not in (DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH):
+            return _failed(
+                "topic is only valid for 'audit', 'reference', and "
+                "'research' documents."
+            )
+        topic_norm = normalize_feature_tag(spec.topic, label="topic")
+        if not topic_norm.ok or topic_norm.value is None:
+            return _failed(topic_norm.error or "invalid topic")
+        topic = topic_norm.value
+
     date_str = spec.date or today
     try:
         created = create_vault_doc(
@@ -275,6 +292,7 @@ def _create_one(
             feature,
             date_str,
             spec.title,
+            topic=topic,
             related=resolved_related,
             extra_tags=extra_tags,
             tier=tier,

--- a/src/vaultspec_core/tests/cli/test_vault_cli.py
+++ b/src/vaultspec_core/tests/cli/test_vault_cli.py
@@ -89,6 +89,71 @@ class TestAddSubcommand:
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert expected_path.exists()
 
+    def test_add_topic_infix_generates_disambiguated_filename(
+        self, runner, synthetic_project
+    ):
+        date_str = datetime.now(UTC).strftime("%Y-%m-%d")
+        expected_path = (
+            synthetic_project
+            / ".vault"
+            / "reference"
+            / f"{date_str}-topic-feat-engine-wire-reference.md"
+        )
+        if expected_path.exists():
+            expected_path.unlink()
+
+        result = runner.invoke(
+            app,
+            [
+                "--target",
+                str(synthetic_project),
+                "vault",
+                "add",
+                "reference",
+                "--feature",
+                "topic-feat",
+                "--topic",
+                "engine-wire",
+            ],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert expected_path.exists()
+
+    def test_add_topic_rejected_for_non_admitting_type(self, runner, synthetic_project):
+        result = runner.invoke(
+            app,
+            [
+                "--target",
+                str(synthetic_project),
+                "vault",
+                "add",
+                "adr",
+                "--feature",
+                "topic-feat",
+                "--topic",
+                "second",
+            ],
+        )
+        assert result.exit_code == 1
+        assert "--topic is only valid" in result.output
+
+    def test_add_topic_rejects_non_kebab_value(self, runner, synthetic_project):
+        result = runner.invoke(
+            app,
+            [
+                "--target",
+                str(synthetic_project),
+                "vault",
+                "add",
+                "reference",
+                "--feature",
+                "topic-feat",
+                "--topic",
+                "Not Kebab!",
+            ],
+        )
+        assert result.exit_code == 1
+
     def test_add_strips_hash_from_feature(self, runner, synthetic_project):
         """Creating with #feature should strip the hash."""
         date_str = datetime.now(UTC).strftime("%Y-%m-%d")

--- a/src/vaultspec_core/tests/cli/test_vault_cli.py
+++ b/src/vaultspec_core/tests/cli/test_vault_cli.py
@@ -118,6 +118,9 @@ class TestAddSubcommand:
         )
         assert result.exit_code == 0, f"Failed: {result.output}"
         assert expected_path.exists()
+        body = expected_path.read_text(encoding="utf-8")
+        assert "{topic}" not in body
+        assert "{title}" not in body
 
     def test_add_topic_rejected_for_non_admitting_type(self, runner, synthetic_project):
         result = runner.invoke(

--- a/src/vaultspec_core/vaultcore/hydration.py
+++ b/src/vaultspec_core/vaultcore/hydration.py
@@ -40,6 +40,12 @@ _TEMPLATE_NAMES = {
     DocType.INDEX: "index.md",
 }
 
+# Document types that admit the narrative topic infix
+# (``{date}-{feature}-{topic}-{type}.md``). The adr and plan cardinality
+# rules forbid disambiguation-by-infix, and exec filenames are
+# machine-derived, so only the narrative trio is listed.
+_TOPIC_INFIX_TYPES = frozenset({DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH})
+
 # The exec document type has two templates: the Step-record template (above)
 # and the Phase-summary template, selected via the ``summary`` flag on
 # :func:`get_template_path` / :func:`create_vault_doc`.
@@ -322,6 +328,7 @@ def create_vault_doc(
     date_str: str,
     title: str | None = None,
     *,
+    topic: str | None = None,
     related: list[str] | None = None,
     extra_tags: list[str] | None = None,
     content_root: pathlib.Path | None = None,
@@ -345,6 +352,13 @@ def create_vault_doc(
         feature: Feature name in kebab-case (leading ``#`` stripped).
         date_str: ISO 8601 date string (e.g. ``2026-02-06``).
         title: Optional document title.
+        topic: Optional kebab-case narrative infix. Admitted only for the
+            narrative trio (``audit``, ``reference``, ``research``); the
+            filename resolves to ``{date}-{feature}-{topic}-{type}.md``.
+            Omitted, the filename keeps its ``{date}-{feature}-{type}.md``
+            form. Raises :class:`ValueError` for any other document type
+            (adr and plan cardinality rules forbid disambiguation-by-infix;
+            exec filenames are machine-derived).
         related: Pre-resolved ``[[wiki-link]]`` strings for the
             ``related:`` frontmatter field.
         extra_tags: Additional ``#tag`` strings to append to ``tags:``.
@@ -376,6 +390,12 @@ def create_vault_doc(
             *force* is ``False``.
     """
     from ..config import get_config
+
+    if topic is not None and doc_type not in _TOPIC_INFIX_TYPES:
+        raise ValueError(
+            f"topic infix is not supported for '{doc_type.value}' documents; "
+            "admitted types: audit, reference, research"
+        )
 
     template_path = get_template_path(
         root_dir, doc_type, content_root=content_root, summary=summary
@@ -430,6 +450,9 @@ def create_vault_doc(
             / doc_type.value
             / f"{plan_date or date_str}-{feature}"
         )
+    elif topic is not None:
+        filename = f"{date_str}-{feature}-{topic}-{doc_type.value}.md"
+        target_dir = root_dir / get_config().docs_dir / doc_type.value
     else:
         filename = f"{date_str}-{feature}-{doc_type.value}.md"
         target_dir = root_dir / get_config().docs_dir / doc_type.value

--- a/src/vaultspec_core/vaultcore/hydration.py
+++ b/src/vaultspec_core/vaultcore/hydration.py
@@ -417,11 +417,19 @@ def create_vault_doc(
         if plan_link not in effective_related:
             effective_related.insert(0, plan_link)
 
+    # A topic-infixed document scaffolded without an explicit title would
+    # otherwise leave the template's `{topic}`/`{title}` heading placeholder
+    # unhydrated and fail the placeholder check; the humanized topic is a
+    # valid concise-prose heading value, and an explicit title still wins.
+    effective_title = title
+    if effective_title is None and topic is not None:
+        effective_title = topic.replace("-", " ")
+
     hydrated = hydrate_template(
         content,
         feature,
         date_str,
-        title,
+        effective_title,
         related=effective_related,
         extra_tags=extra_tags,
         tier=tier,

--- a/src/vaultspec_core/vaultcore/tests/test_hydration.py
+++ b/src/vaultspec_core/vaultcore/tests/test_hydration.py
@@ -395,3 +395,79 @@ class TestCreateVaultDocStemCollision:
         )
         assert path.exists()
         assert path.stem == "2026-03-20-unique-feat-adr"
+
+
+class TestCreateVaultDocTopicInfix:
+    """Topic-infix filenames for the narrative trio (audit, reference, research)."""
+
+    @pytest.fixture()
+    def vault_project(self, tmp_path):
+        from vaultspec_core.builtins import seed_builtins
+
+        rules_dir = tmp_path / ".vaultspec"
+        rules_dir.mkdir(parents=True)
+        seed_builtins(rules_dir, force=True)
+        for dt in DocType:
+            (tmp_path / ".vault" / dt.value).mkdir(parents=True, exist_ok=True)
+        return tmp_path
+
+    @pytest.mark.parametrize(
+        "doc_type",
+        [DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH],
+    )
+    def test_infixed_filename_for_admitting_types(self, vault_project, doc_type):
+        path = create_vault_doc(
+            vault_project,
+            doc_type,
+            "my-feat",
+            "2026-07-16",
+            topic="engine-wire",
+        )
+        assert path.name == f"2026-07-16-my-feat-engine-wire-{doc_type.value}.md"
+        assert path.exists()
+
+    def test_omitted_topic_keeps_plain_filename(self, vault_project):
+        path = create_vault_doc(
+            vault_project,
+            DocType.REFERENCE,
+            "my-feat",
+            "2026-07-16",
+        )
+        assert path.name == "2026-07-16-my-feat-reference.md"
+
+    @pytest.mark.parametrize("doc_type", [DocType.ADR, DocType.PLAN, DocType.EXEC])
+    def test_non_admitting_type_raises(self, vault_project, doc_type):
+        with pytest.raises(ValueError, match="topic infix is not supported"):
+            create_vault_doc(
+                vault_project,
+                doc_type,
+                "my-feat",
+                "2026-07-16",
+                topic="second",
+            )
+
+    def test_two_topics_coexist_and_duplicate_collides(self, vault_project):
+        first = create_vault_doc(
+            vault_project,
+            DocType.REFERENCE,
+            "my-feat",
+            "2026-07-16",
+            topic="engine-wire",
+        )
+        second = create_vault_doc(
+            vault_project,
+            DocType.REFERENCE,
+            "my-feat",
+            "2026-07-16",
+            topic="deletion-manifest",
+        )
+        assert first.exists() and second.exists()
+        assert first.name != second.name
+        with pytest.raises(ResourceExistsError, match="already exists"):
+            create_vault_doc(
+                vault_project,
+                DocType.REFERENCE,
+                "my-feat",
+                "2026-07-16",
+                topic="engine-wire",
+            )

--- a/src/vaultspec_core/vaultcore/tests/test_hydration.py
+++ b/src/vaultspec_core/vaultcore/tests/test_hydration.py
@@ -426,6 +426,33 @@ class TestCreateVaultDocTopicInfix:
         assert path.name == f"2026-07-16-my-feat-engine-wire-{doc_type.value}.md"
         assert path.exists()
 
+    def test_topic_hydrates_heading_when_title_absent(self, vault_project):
+        path = create_vault_doc(
+            vault_project,
+            DocType.REFERENCE,
+            "my-feat",
+            "2026-07-16",
+            topic="engine-wire",
+        )
+        text = path.read_text(encoding="utf-8")
+        assert "{topic}" not in text
+        assert "{title}" not in text
+        assert "engine wire" in text
+
+    def test_explicit_title_wins_over_topic_in_heading(self, vault_project):
+        path = create_vault_doc(
+            vault_project,
+            DocType.REFERENCE,
+            "my-feat",
+            "2026-07-16",
+            title="wire shapes deep dive",
+            topic="engine-wire",
+        )
+        text = path.read_text(encoding="utf-8")
+        assert "wire shapes deep dive" in text
+        assert "{topic}" not in text
+        assert path.name == "2026-07-16-my-feat-engine-wire-reference.md"
+
     def test_omitted_topic_keeps_plain_filename(self, vault_project):
         path = create_vault_doc(
             vault_project,

--- a/tests/unit/mcp_server/test_create_tool.py
+++ b/tests/unit/mcp_server/test_create_tool.py
@@ -175,3 +175,23 @@ async def test_create_topic_rejected_for_non_admitting_type(vault_root):
         )
         assert payload["status"] == "failed"
         assert "topic is only valid" in payload["items"][0]["error"]["message"]
+
+
+async def test_create_mixed_batch_topic_failure_beside_success(vault_root):
+    """A topic-rejected item fails per-item while its batch siblings apply."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        payload = await _create(
+            client,
+            [
+                {"feature": "mixed-feat", "type": "reference", "topic": "wire"},
+                {"feature": "mixed-feat", "type": "adr", "topic": "second"},
+                {"feature": "mixed-feat", "type": "research"},
+            ],
+        )
+        assert payload["status"] == "mixed"
+        items = payload["items"]
+        assert items[0]["status"] == "created"
+        assert items[1]["status"] == "failed"
+        assert "topic is only valid" in items[1]["error"]["message"]
+        assert items[2]["status"] == "created"

--- a/tests/unit/mcp_server/test_create_tool.py
+++ b/tests/unit/mcp_server/test_create_tool.py
@@ -142,3 +142,36 @@ async def test_create_seed_content_appended(vault_root):
         adr = next((vault_root / ".vault" / "adr").glob("*-seed-feat-adr.md"))
         text = adr.read_text(encoding="utf-8")
         assert "A distinctive seeded paragraph." in text
+
+
+async def test_create_topic_infix_scaffolds_second_reference(vault_root):
+    """A topic-infixed spec scaffolds a second same-day reference document."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        payload = await _create(
+            client,
+            [
+                {"feature": "infix-feat", "type": "reference"},
+                {
+                    "feature": "infix-feat",
+                    "type": "reference",
+                    "topic": "engine-wire",
+                },
+            ],
+        )
+        assert payload["status"] == "ok"
+        ref_dir = vault_root / ".vault" / "reference"
+        assert any(ref_dir.glob("*-infix-feat-reference.md"))
+        assert any(ref_dir.glob("*-infix-feat-engine-wire-reference.md"))
+
+
+async def test_create_topic_rejected_for_non_admitting_type(vault_root):
+    """A topic on an adr spec is a per-item failure."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        payload = await _create(
+            client,
+            [{"feature": "infix-feat", "type": "adr", "topic": "second"}],
+        )
+        assert payload["status"] == "failed"
+        assert "topic is only valid" in payload["items"][0]["error"]["message"]


### PR DESCRIPTION
Closes #205. Executes `.vault/adr/2026-07-16-reference-topic-infix-adr.md`.

## Summary

`vault add --topic` (and the MCP `create` tool's `DocumentSpec.topic`) scaffold a second audit, reference, or research document per feature with the narrative infix `{date}-{feature}-{topic}-{type}.md` - implementing the convention the firmware already documented for audits and closing the owning-verb violation for second documents. Omitted topic is byte-identical to today; adr/plan/exec reject the flag (their cardinality rules forbid disambiguation-by-infix). The humanized topic hydrates the heading when no `--title` is given, so the scaffolded document passes `vault check placeholders` clean.

- [x] Scaffolder `topic` parameter (single filename authority; exists- and stem-collision guards unchanged)
- [x] CLI `--topic` with shared-normalizer kebab-case validation and type guard
- [x] MCP `DocumentSpec.topic` with per-item failure semantics
- [x] Tests: infix per type, fallback, type guard, normalization, coexisting/duplicate topics, heading hydration + residue assertions, MCP mixed batch (40 + 9 green)
- [x] Firmware filename patterns + bundled CLI reference option table (drift suite 22 green)
- [x] Unit gate green (1787+ passed); code review audit **PASS after revision** (`.vault/audit/2026-07-16-reference-topic-infix-audit.md`)

Note: regenerating the generator-owned reference region swept in pending `spec mcps` signature wording unrelated to this feature (benign; flagged in the audit).