### PR TITLE
feat(vault): opt-in code-boundary source scanner (vault check code-boundary)

### DIFF
--- a/.vault/adr/2026-07-16-code-boundary-check-adr.md
+++ b/.vault/adr/2026-07-16-code-boundary-check-adr.md
@@ -1,0 +1,110 @@
+---
+tags:
+  - '#adr'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - "[[2026-07-16-code-boundary-check-research]]"
+  - "[[2026-07-16-firmware-code-boundary-adr]]"
+  - '[[2026-06-13-commit-linkage-adr]]'
+---
+
+# `code-boundary-check` adr: `opt-in read-only source-boundary scanner` | (**status:** `accepted`)
+
+## Problem Statement
+
+The firmware-code-boundary decision made the one-way vault reference boundary
+explicit in wording and registered mechanical enforcement as a follow-up (GitHub
+issue 213): a read-only checker that sweeps source-file content for references to the
+project's own vault records. Wording-only enforcement depends on agent compliance and
+detects nothing already embedded. The decision: the scanner's scope, its needles, its
+place in the check surface, and its default posture.
+
+## Considerations
+
+- The governing firmware-code-boundary decision fixes the constraints: advisory-only
+  (report, never block), record-stem scanning rather than path-string matching (the
+  self-hosting nuance), commit trailers and commit messages out of scope, and
+  false-positive risk as the acceptance criterion for any default-on posture.
+- The grounding research establishes: warnings exit 0 (advisory needs no new
+  machinery); `check all` is vault-scoped and snapshot-driven with explicit
+  membership; standalone check verbs are an established shape; record stems are
+  enumerable, date-prefixed, high-precision needles; a source-tree walk needs its own
+  exclusion set, decode guard, and size cap; pure-offline operation follows the
+  commit-linkage precedent.
+
+## Considered options
+
+- **Standalone opt-in verb, warnings-only, excluded from check all (chosen).**
+  `vault check code-boundary` walks the source tree on demand; `check all` stays
+  vault-scoped and its cost profile unchanged.
+- **Member of check all.** Rejected for now: adds a repo-walk to every gate run and
+  puts an unproven false-positive profile into the default pipeline; membership is
+  revisitable by amending this record once field experience exists (the issue's own
+  acceptance criterion).
+- **Scan for Step ids and the literal vault path too.** Rejected: `S##` and `.vault`
+  are false-positive-prone in vault-domain codebases; stems (plus explicit wiki-link
+  forms of stems) are the high-precision needle set the self-hosting constraint
+  admits.
+- **Git-based scan set (git ls-files).** Rejected: pure-offline walk with explicit
+  exclusions keeps the checker dependency-free and deterministic per the
+  commit-linkage precedent; git remains unrequired by any core command.
+
+## Constraints
+
+- Diagnostics are WARNING severity only; the verb never exits nonzero for findings
+  and never mutates anything (`supports_fix` false).
+- Needles are the stems of every `.vault/` document (date-prefixed authored records
+  and `<feature>.index.md` indexes), matched as plain substrings and in wiki-link
+  form; nothing else.
+- The walk excludes `.vault/`, `.vaultspec/`, every provider directory from the
+  central enum, `.git`, and common cache directories; skips files above a size cap
+  and files that do not decode as UTF-8.
+- The scanner scans tracked source-file content only in the boundary's sense (code,
+  docs, config in the working tree); commit metadata is out of scope.
+- No new dependency; no change to `run_all_checks` membership or order.
+
+## Implementation
+
+One new checker module in the checks package exposing the scan as a `CheckResult`
+producer: enumerate needle stems from the vault, walk the source tree under the
+exclusion set, and emit one WARNING diagnostic per (file, stem) hit with the matched
+stem named in the message. One new CLI subcommand `vault check code-boundary`
+following the existing standalone-verb pattern, with `--json` and `--feature`
+(restrict needles to one feature's documents) supported. The MCP surface is
+unchanged; the gateway reaches the verb as it reaches every CLI verb. Unit tests
+cover: hit in source file, wiki-link form hit, no hit on the literal vault path
+string alone, exclusion of vault/harness/provider dirs, feature filtering, undecodable
+and oversized file skips, and exit code 0 with findings. The bundled CLI reference
+regenerates; the firmware is not touched (the boundary wording already shipped, and
+naming a specific optional verb in always-on firmware is bloat the mcp-primacy
+posture avoids).
+
+## Rationale
+
+The standalone opt-in shape is the only posture consistent with the governing
+decision's acceptance criterion: it ships mechanical detection for teams that want it
+now, keeps the unproven false-positive profile out of every default gate, and leaves
+default-on membership as a one-line amendment once evidence accumulates. Stem-only
+needles are what make the scanner usable at all in vault-domain codebases - the
+governing decision's self-hosting constraint rules out the cheaper literal-path scan.
+Warnings-only falls out of the existing exit-code contract, so the
+enrichment-never-prerequisite discipline costs no new machinery.
+
+## Consequences
+
+Good: embedded dev-metadata references become mechanically discoverable; the
+boundary gains its first enforcement instrument; downstream vaults can wire the verb
+into their own hooks. Bad: opt-in means silent non-adoption is the default; a
+repo-walk verb has an unbounded worst-case runtime on very large trees (mitigated by
+exclusions and the size cap, and it runs only when invoked). Neutral: check all is
+byte-identical in behavior; membership and a pre-commit hook entry remain open
+adoption questions to revisit against field evidence by amending this record.
+
+## Codification candidates
+
+- **Rule slug:** `boundary-scan-before-audit`.
+  **Rule:** A feature audit in a vault-managed project should run
+  `vault check code-boundary` and triage its findings; scanner warnings are advisory
+  and never block a commit or a merge.

--- a/.vault/audit/2026-07-16-code-boundary-check-audit.md
+++ b/.vault/audit/2026-07-16-code-boundary-check-audit.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - '#audit'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - "[[2026-07-16-code-boundary-check-plan]]"
+  - "[[2026-07-16-code-boundary-check-adr]]"
+---
+
+# `code-boundary-check` audit: `opt-in source-boundary scanner review` | (**status:** `PASS`)
+
+## Scope
+
+Read-only review of branch `feat/issue-213-code-boundary-check` versus `main`
+(PR 218, GitHub issue 213) against the governing decision, plan, and research:
+the checker module, the standalone verb, tests, and the regenerated CLI
+reference, plus consistency with the firmware-code-boundary and commit-linkage
+decisions. Reviewed by the `vaultspec-code-reviewer` persona dispatched as an
+independent read-only subagent; verdict PASS with two MEDIUM recommendations,
+both applied in the same session.
+
+## Findings
+
+### feature-filter-substring-overmatch | medium | --feature narrowing was a bare substring test (RESOLVED)
+
+The filter over-matched short or prefix-colliding feature values and diverged
+from its own docstring. Resolved beyond the reviewer's suggestion: filename
+heuristics cannot split hyphenated feature and topic segments reliably, so the
+filter now parses each document's frontmatter and matches the feature tag
+exactly; a prefix-collision test (feature versus feature-two, single-letter
+needle) locks it in.
+
+### provider-exclusions-hardcoded-not-enum | medium | exclusion set duplicated provider names (RESOLVED)
+
+The walk exclusions now derive from the central provider-directory enum plus
+the configured docs directory at call time, keeping only VCS and cache names
+as literals; a provider added to the enum is excluded the day it lands.
+
+### docs-dir-exclusion-hardcode-mismatch | low | vault exclusion was a literal while the needle source was config-driven (RESOLVED)
+
+Folded into the same change: the vault exclusion comes from the configured
+docs directory.
+
+### reference-projection-reconciliation | low | mirror reference diff carries pre-existing wording reconciliation (ACCEPTED)
+
+The deployed mirror's reference diff includes stale-projection reconciliation
+unrelated to this feature; the canonical builtin reference gained only the
+two code-boundary lines. Benign, noted so the hunk is not read as scope creep.
+
+### Verified clean
+
+check all membership and order untouched (behavior byte-identical); advisory
+exit contract holds on both console and JSON paths; needles are stems and
+wiki-link forms only; symlink-safe iterative walk with tolerated OSErrors and
+the size cap; real-filesystem tests with no test doubles; no firmware wording
+changes; the shipped source and tests reference no real project records.
+
+## Recommendations
+
+None outstanding; both MEDIUM items were applied and re-verified (lint, type
+check, 11 scanner and verb tests, vaultcore suite 488, live scan of this repo:
+9 advisory warnings, exit 0). Dogfood note for triage outside this feature:
+the live scan surfaces one genuine product-source violation (an ADR stem cited
+in a checker docstring) and several rendered doc assets embedding vault stems.
+
+Status: PASS. Safe to merge.

--- a/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S01.md
+++ b/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S01.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - '#exec'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S01'
+related:
+  - "[[2026-07-16-code-boundary-check-plan]]"
+---
+
+# Implement the code-boundary checker module: needle enumeration from vault stems, excluded-dir source walk, decode guard, size cap, WARNING diagnostics
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/code_boundary.py`
+
+## Description
+
+- Implement the checker: needle enumeration from vault document stems
+  (including index stems), iterative excluded-dir source walk with symlink
+  skip, UTF-8 decode guard, 1 MB size cap, one WARNING diagnostic per hit
+  file naming the matched stems; export from the checks package without
+  touching the check-all membership.
+
+## Outcome
+
+Scanner authority in one module; advisory by construction (warnings only,
+`supports_fix` false). Created:
+`src/vaultspec_core/vaultcore/checks/code_boundary.py`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S02.md
+++ b/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S02.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S02'
+related:
+  - "[[2026-07-16-code-boundary-check-plan]]"
+---
+
+# Add the standalone vault check code-boundary subcommand with --json and --feature following the existing standalone-verb pattern
+
+## Scope
+
+- `src/vaultspec_core/cli/vault_cmd.py`
+
+## Description
+
+- Add the standalone `vault check code-boundary` subcommand with `--feature`,
+  `--json`, and `--verbose`, following the adr-status standalone-verb pattern
+  and the shared render-and-exit path (exit 1 on errors only).
+
+## Outcome
+
+Verb live and advisory. Modified: `src/vaultspec_core/cli/vault_cmd.py`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S03.md
+++ b/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S03.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S03'
+related:
+  - "[[2026-07-16-code-boundary-check-plan]]"
+---
+
+# Add unit tests covering stem and wiki-link hits, literal-path non-hit, exclusions, feature filter, skip guards, and advisory exit code
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py`
+
+## Description
+
+- Add real-filesystem checker tests (stem and wiki-link hits, literal vault
+  path non-hit, vault/harness/provider exclusions, feature filter, decode and
+  size skip guards, index-stem needle, empty vault) and CLI verb tests
+  (findings exit 0, clean tree reports clean).
+
+## Outcome
+
+10 tests green (8 checker + 2 CLI).
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S04.md
+++ b/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S04.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S04'
+related:
+  - "[[2026-07-16-code-boundary-check-plan]]"
+---
+
+# Regenerate the bundled CLI reference and confirm the drift test
+
+## Scope
+
+- `src/vaultspec_core/builtins/reference/cli.md`
+
+## Description
+
+- Regenerate the bundled CLI reference and the docs CLI page so the generated
+  inventory carries the new verb; roll out to the deployed mirror through the
+  owning CLI path.
+
+## Outcome
+
+Drift suite green (22 tests). Note: the reference-drift pre-commit hook makes
+the verb, its tests, and the regenerated reference atomic, so S02-S04 landed
+in one consolidated commit.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S05.md
+++ b/.vault/exec/2026-07-16-code-boundary-check/2026-07-16-code-boundary-check-S05.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+step_id: 'S05'
+related:
+  - "[[2026-07-16-code-boundary-check-plan]]"
+---
+
+# Run the gates and open the PR closing the issue
+
+## Scope
+
+- `src/vaultspec_core`
+
+## Description
+
+- Run the gates, dispatch the mandatory code review, and finalize the PR.
+
+## Outcome
+
+Unit gate green; scanner, verb, and drift suites green; live scan of this
+repo returns 9 advisory warnings at exit 0. The mandatory code review
+returned PASS with two MEDIUM recommendations (feature-filter precision,
+enum-sourced exclusions), both applied and re-verified in the same session;
+the audit records the closure.
+
+## Notes
+
+None.

--- a/.vault/index/code-boundary-check.index.md
+++ b/.vault/index/code-boundary-check.index.md
@@ -1,0 +1,30 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - '[[2026-07-16-code-boundary-check-adr]]'
+  - '[[2026-07-16-code-boundary-check-plan]]'
+  - '[[2026-07-16-code-boundary-check-research]]'
+---
+
+# `code-boundary-check` feature index
+
+Auto-generated index of all documents tagged with `#code-boundary-check`.
+
+## Documents
+
+### adr
+
+- `2026-07-16-code-boundary-check-adr` - `code-boundary-check` adr: `opt-in read-only source-boundary scanner` | (**status:** `accepted`)
+
+### plan
+
+- `2026-07-16-code-boundary-check-plan` - `code-boundary-check` plan
+
+### research
+
+- `2026-07-16-code-boundary-check-research` - `code-boundary-check` research: `check-engine grounding for the source-boundary scanner`

--- a/.vault/index/code-boundary-check.index.md
+++ b/.vault/index/code-boundary-check.index.md
@@ -6,7 +6,13 @@ tags:
 date: '2026-07-16'
 modified: '2026-07-16'
 related:
+  - '[[2026-07-16-code-boundary-check-S01]]'
+  - '[[2026-07-16-code-boundary-check-S02]]'
+  - '[[2026-07-16-code-boundary-check-S03]]'
+  - '[[2026-07-16-code-boundary-check-S04]]'
+  - '[[2026-07-16-code-boundary-check-S05]]'
   - '[[2026-07-16-code-boundary-check-adr]]'
+  - '[[2026-07-16-code-boundary-check-audit]]'
   - '[[2026-07-16-code-boundary-check-plan]]'
   - '[[2026-07-16-code-boundary-check-research]]'
 ---
@@ -20,6 +26,18 @@ Auto-generated index of all documents tagged with `#code-boundary-check`.
 ### adr
 
 - `2026-07-16-code-boundary-check-adr` - `code-boundary-check` adr: `opt-in read-only source-boundary scanner` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-16-code-boundary-check-audit` - `code-boundary-check` audit: `opt-in source-boundary scanner review` | (**status:** `PASS`)
+
+### exec
+
+- `2026-07-16-code-boundary-check-S01` - Implement the code-boundary checker module: needle enumeration from vault stems, excluded-dir source walk, decode guard, size cap, WARNING diagnostics
+- `2026-07-16-code-boundary-check-S02` - Add the standalone vault check code-boundary subcommand with --json and --feature following the existing standalone-verb pattern
+- `2026-07-16-code-boundary-check-S03` - Add unit tests covering stem and wiki-link hits, literal-path non-hit, exclusions, feature filter, skip guards, and advisory exit code
+- `2026-07-16-code-boundary-check-S04` - Regenerate the bundled CLI reference and confirm the drift test
+- `2026-07-16-code-boundary-check-S05` - Run the gates and open the PR closing the issue
 
 ### plan
 

--- a/.vault/plan/2026-07-16-code-boundary-check-plan.md
+++ b/.vault/plan/2026-07-16-code-boundary-check-plan.md
@@ -1,0 +1,44 @@
+---
+tags:
+  - '#plan'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+tier: L1
+related:
+  - '[[2026-07-16-code-boundary-check-adr]]'
+  - '[[2026-07-16-code-boundary-check-research]]'
+---
+
+# `code-boundary-check` plan
+
+## Description
+
+This plan executes the code-boundary-check decision (see related): the opt-in
+read-only source-boundary scanner as a standalone vault check code-boundary verb.
+Needles are the vault's enumerable document stems (plus wiki-link forms); the walk
+excludes vault, harness, provider, git, and cache directories with decode and size
+guards; findings are WARNING severity and never affect the exit code;
+run_all_checks membership is unchanged.
+
+## Steps
+
+- [ ] `S01` - Implement the code-boundary checker module: needle enumeration from vault stems, excluded-dir source walk, decode guard, size cap, WARNING diagnostics; `src/vaultspec_core/vaultcore/checks/code_boundary.py`.
+- [ ] `S02` - Add the standalone vault check code-boundary subcommand with --json and --feature following the existing standalone-verb pattern; `src/vaultspec_core/cli/vault_cmd.py`.
+- [ ] `S03` - Add unit tests covering stem and wiki-link hits, literal-path non-hit, exclusions, feature filter, skip guards, and advisory exit code; `src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py`.
+- [ ] `S04` - Regenerate the bundled CLI reference and confirm the drift test; `src/vaultspec_core/builtins/reference/cli.md`.
+- [ ] `S05` - Run the gates and open the PR closing the issue; `src/vaultspec_core`.
+
+## Parallelization
+
+S01 lands first (the checker is the authority); S02 follows; S03 and S04 then
+parallelize; S05 is last.
+
+## Verification
+
+- Scanner reports stem and wiki-link hits in source files and nothing for the
+  literal vault path string alone; vault, harness, and provider dirs excluded.
+- Exit code 0 with findings; no mutation surface.
+- check all output byte-identical before and after.
+- CLI reference drift test green; prek and the unit gate pass.
+- Code review audit passes; PR closes the issue.

--- a/.vault/plan/2026-07-16-code-boundary-check-plan.md
+++ b/.vault/plan/2026-07-16-code-boundary-check-plan.md
@@ -23,11 +23,11 @@ run_all_checks membership is unchanged.
 
 ## Steps
 
-- [ ] `S01` - Implement the code-boundary checker module: needle enumeration from vault stems, excluded-dir source walk, decode guard, size cap, WARNING diagnostics; `src/vaultspec_core/vaultcore/checks/code_boundary.py`.
-- [ ] `S02` - Add the standalone vault check code-boundary subcommand with --json and --feature following the existing standalone-verb pattern; `src/vaultspec_core/cli/vault_cmd.py`.
-- [ ] `S03` - Add unit tests covering stem and wiki-link hits, literal-path non-hit, exclusions, feature filter, skip guards, and advisory exit code; `src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py`.
-- [ ] `S04` - Regenerate the bundled CLI reference and confirm the drift test; `src/vaultspec_core/builtins/reference/cli.md`.
-- [ ] `S05` - Run the gates and open the PR closing the issue; `src/vaultspec_core`.
+- [x] `S01` - Implement the code-boundary checker module: needle enumeration from vault stems, excluded-dir source walk, decode guard, size cap, WARNING diagnostics; `src/vaultspec_core/vaultcore/checks/code_boundary.py`.
+- [x] `S02` - Add the standalone vault check code-boundary subcommand with --json and --feature following the existing standalone-verb pattern; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `S03` - Add unit tests covering stem and wiki-link hits, literal-path non-hit, exclusions, feature filter, skip guards, and advisory exit code; `src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py`.
+- [x] `S04` - Regenerate the bundled CLI reference and confirm the drift test; `src/vaultspec_core/builtins/reference/cli.md`.
+- [x] `S05` - Run the gates and open the PR closing the issue; `src/vaultspec_core`.
 
 ## Parallelization
 

--- a/.vault/research/2026-07-16-code-boundary-check-research.md
+++ b/.vault/research/2026-07-16-code-boundary-check-research.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - '#research'
+  - '#code-boundary-check'
+date: '2026-07-16'
+modified: '2026-07-16'
+related:
+  - "[[2026-07-16-firmware-code-boundary-adr]]"
+  - '[[2026-07-16-firmware-code-boundary-research]]'
+---
+
+# `code-boundary-check` research: `check-engine grounding for the source-boundary scanner`
+
+The question (GitHub issue 213, the follow-up the firmware-code-boundary decision
+registered): how a read-only scanner that sweeps source-file content for references to
+the project's own vault records fits the existing check engine. The boundary premise
+and design constraints are recorded in the related firmware-code-boundary documents
+and are not restated here; this research grounds the engine mechanics. The evidence
+picture: the check engine has a clean per-checker module pattern with a shared result
+model, warnings do not affect exit codes (advisory is the default posture), `check all` is strictly vault-scoped and snapshot-driven, and standalone check verbs outside
+`run_all_checks` are an established shape.
+
+## Findings
+
+### The checker contract is one module returning a CheckResult
+
+Each checker is a module under `src/vaultspec_core/vaultcore/checks/` returning
+`CheckResult` with `CheckDiagnostic` entries carrying `Severity.ERROR/WARNING/INFO`,
+`fixable`, and `fix_description` (`checks/_base.py:38-102`). Rendering is shared
+(`_base.py:175`), ASCII-only per the presentation-uniformity decision.
+
+### Warnings are advisory by construction
+
+The CLI exits 1 only on ERROR-severity findings; warnings render and exit 0
+(`src/vaultspec_core/cli/vault_cmd.py:1060-1085`, both JSON and console paths). A
+warnings-only checker is therefore advisory with no extra machinery, satisfying the
+report-never-block constraint the governing decision set.
+
+### check all is vault-scoped and snapshot-driven; membership is explicit
+
+`run_all_checks` builds one `VaultGraph` snapshot of `.vault/` documents and passes it
+to seventeen checkers in a hardcoded order (`checks/__init__.py:72-121`); every
+current checker reads vault documents, none walks the source tree. Including a
+repo-walking scanner would change `check all`'s cost profile and scope; excluding it
+means a checker is reachable only through its own verb - a shape that already exists
+(`vault check adr-status` is registered as its own subcommand at
+`cli/vault_cmd.py:1770` in addition to membership, and `vault plan check` lives
+entirely outside `run_all_checks`).
+
+### Record stems are enumerable and distinctive
+
+Every authored record's stem embeds the `yyyy-mm-dd-` date prefix, and generated
+indexes end `.index.md` (`checks/_base.py:105-138`); the stem population is
+enumerable by listing `.vault/` (the graph keys nodes by stem, per the stem-collision
+guard in `vaultcore/hydration.py:446-459`). Stems are therefore high-precision scan
+needles; bare Step ids (`S01`) or the literal `.vault` string would be
+false-positive-prone in vault-domain codebases, as the governing decision's
+self-hosting constraint anticipates.
+
+### Scan-set mechanics
+
+No existing core code walks the project source tree for content (checks read
+`.vault/` only; sync walks `.vaultspec/` and provider dirs). A scanner needs its own
+walk with exclusions (`.vault/`, `.vaultspec/`, provider directories, `.git`,
+caches), a text-decode guard, and a size cap; provider directory names are already
+enumerated centrally (`core/enums.py` `DirName`, consumed in
+`core/gitignore.py:110-155`). Pure-offline operation (no git dependency) follows the
+commit-linkage decision's precedent of validation as a pure string operation.
+
+### Not investigated
+
+Scan performance on very large source trees was not measured; the walk cost is
+bounded by the same exclusions plus the size cap, and the opt-in posture makes cost a
+caller decision. Whether downstream repos want a pre-commit hook entry for the
+scanner is deferred with the adoption question.
+
+## Sources
+
+- `src/vaultspec_core/vaultcore/checks/_base.py:38-138`
+- `src/vaultspec_core/vaultcore/checks/_base.py:175`
+- `src/vaultspec_core/vaultcore/checks/__init__.py:72-121`
+- `src/vaultspec_core/cli/vault_cmd.py:1060-1085`
+- `src/vaultspec_core/cli/vault_cmd.py:1770`
+- `src/vaultspec_core/vaultcore/hydration.py:446-459`
+- `src/vaultspec_core/core/gitignore.py:110-155`
+- https://github.com/nevenincs/vaultspec-core/issues/213

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -106,6 +106,8 @@ hand-edit between the markers.
   plans must ref ADRs.
 - `vaultspec-core vault check adr-status` - Validate ADR status against the canonical
   taxonomy.
+- `vaultspec-core vault check code-boundary` - Scan source files for references to the
+  project's own vault records.
 - `vaultspec-core vault check structure` - Check vault directory structure and filename
   conventions.
 - `vaultspec-core vault check rename-integrity` - Check name/filename integrity for

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -45,7 +45,7 @@ hand-edit between the markers.
 
 ### Top-level commands
 
-- `vaultspec-core install` - Deploy the vaultspec framework to the target directory.
+- `vaultspec-core install` - Install Vaultspec resources for the selected providers.
 - `vaultspec-core uninstall` - Remove the vaultspec framework from the target directory.
 - `vaultspec-core sync` - Sync rules, skills, agents, configs, system prompts, and MCPs.
 - `vaultspec-core doctor` - Diagnose overall workspace and vault health.
@@ -258,12 +258,14 @@ hand-edit between the markers.
 
 #### Mcps
 
-- `vaultspec-core spec mcps list` - List all registered MCP server definitions.
-- `vaultspec-core spec mcps status` - Report focused MCP definition and .mcp.json sync
-  status.
-- `vaultspec-core spec mcps add` - Add a new custom MCP server definition.
-- `vaultspec-core spec mcps remove` - Remove an MCP server definition.
-- `vaultspec-core spec mcps sync` - Sync only MCP definitions to .mcp.json.
+- `vaultspec-core spec mcps list` - List canonical MCP server definitions.
+- `vaultspec-core spec mcps status` - Inspect provider-native MCP enrollment status.
+- `vaultspec-core spec mcps add` - Add or replace a canonical MCP server definition.
+- `vaultspec-core spec mcps remove` - Remove a canonical MCP server definition.
+- `vaultspec-core spec mcps sync` - Reconcile canonical definitions into provider-native
+  enrollment.
+- `vaultspec-core spec mcps uninstall` - Remove Vaultspec-owned provider-native MCP
+  enrollment.
 
 #### Reference
 
@@ -606,15 +608,24 @@ enabled hooks; it takes `--path PATH`. Valid events: `vault.document.created`,
 
 ### vaultspec-core spec mcps
 
-Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage MCP server
-definitions and synced `.mcp.json` entries.
+Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage canonical
+definitions in `.vaultspec/mcps/*.json` and reconcile them into provider-native
+enrollment. Providers are `all`, `claude`, `antigravity`, and `codex`; scopes are
+`project`, `local`, and `user`. Unsupported provider/scope combinations fail.
 
-| Subcommand | Signature | Description | | ---------- |
---------------------------------------- | ----------------------------- | | `list` | - |
-List MCP server definitions. | | `status` | `[--json]` | Validate against `.mcp.json`. |
-| `add` | `--name NAME [--config JSON] [--force]` | Add a custom MCP definition. | |
-`remove` | `NAME [--force]` | Remove an MCP definition. | | `sync` |
-`[--dry-run] [--force]` | Sync definitions to config. |
+| Subcommand  | Signature                                                                             | Description                                                         |
+| ----------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `list`      | -                                                                                     | List canonical MCP server definitions.                              |
+| `status`    | `[PROVIDER] [--scope SCOPE] [--json] [--target PATH]`                                 | Inspect configuration and ownership state; does not probe runtimes. |
+| `add`       | `--name NAME [--config JSON] [--force]`                                               | Add or replace a canonical definition.                              |
+| `remove`    | `NAME [--force]`                                                                      | Remove a canonical definition.                                      |
+| `sync`      | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--prune] [--json] [--target PATH]` | Reconcile canonical definitions into native enrollment.             |
+| `uninstall` | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--json] [--target PATH]`           | Remove only Vaultspec-owned native enrollment.                      |
+
+The default provider is `all` and the default scope is `project`. `sync --force` adopts
+or replaces a same-name external entry; `sync --prune` removes owned enrollment whose
+canonical source was deleted. `uninstall` preserves canonical definitions and external
+host entries.
 
 ## Migration commands
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -170,6 +170,8 @@ full options.
   plans must ref ADRs.
 - `vaultspec-core vault check adr-status` - Validate ADR status against the canonical
   taxonomy.
+- `vaultspec-core vault check code-boundary` - Scan source files for references to the
+  project's own vault records.
 - `vaultspec-core vault check structure` - Check vault directory structure and filename
   conventions.
 - `vaultspec-core vault check rename-integrity` - Check name/filename integrity for

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -106,6 +106,8 @@ hand-edit between the markers.
   plans must ref ADRs.
 - `vaultspec-core vault check adr-status` - Validate ADR status against the canonical
   taxonomy.
+- `vaultspec-core vault check code-boundary` - Scan source files for references to the
+  project's own vault records.
 - `vaultspec-core vault check structure` - Check vault directory structure and filename
   conventions.
 - `vaultspec-core vault check rename-integrity` - Check name/filename integrity for

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -1796,6 +1796,37 @@ def cmd_check_adr_status(
     )
 
 
+@check_app.command("code-boundary")
+def cmd_check_code_boundary(
+    feature: Annotated[
+        str | None,
+        typer.Option(
+            "--feature",
+            "-f",
+            help="Restrict the scanned record stems to one feature's documents",
+        ),
+    ] = None,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Show INFO-level diagnostics")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Scan source files for references to the project's own vault records.
+
+    Opt-in and advisory: findings are warnings, the exit code stays zero,
+    and nothing is mutated. Not part of `vault check all`.
+    """
+    apply_target(target)
+    from vaultspec_core.core.types import get_context as _get_ctx
+    from vaultspec_core.vaultcore.checks import check_code_boundary
+
+    result = check_code_boundary(_get_ctx().target_dir, feature=feature)
+    _render_and_exit(
+        result, verbose, json_output=json_output, command="vault.check.code-boundary"
+    )
+
+
 @check_app.command("structure")
 def cmd_check_structure(
     fix: Annotated[

--- a/src/vaultspec_core/tests/cli/test_vault_cli.py
+++ b/src/vaultspec_core/tests/cli/test_vault_cli.py
@@ -464,3 +464,46 @@ class TestNoCommand:
         assert "add" in result.output, (
             f"vault help did not list the 'add' subcommand: {result.output}"
         )
+
+
+class TestCheckCodeBoundary:
+    """The opt-in source-boundary scanner verb is advisory."""
+
+    def test_findings_are_warnings_and_exit_zero(
+        self, runner, tmp_path: Path, synthetic_project
+    ):
+        from vaultspec_core.core.types import init_paths
+
+        stem = "2026-07-16-my-feat-adr"
+        doc = tmp_path / ".vault" / "adr" / f"{stem}.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            "---\ntags:\n  - '#adr'\n  - '#my-feat'\n"
+            "date: '2026-07-16'\nmodified: '2026-07-16'\nrelated: []\n---\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "module.py").write_text(f"# see {stem}\n", encoding="utf-8")
+        (tmp_path / ".vaultspec").mkdir()
+        init_paths(tmp_path)
+
+        result = runner.invoke(
+            app,
+            ["--target", str(tmp_path), "vault", "check", "code-boundary"],
+        )
+        assert result.exit_code == 0, f"Failed: {result.output}"
+        assert stem in result.output
+
+    def test_clean_tree_reports_clean(self, runner, tmp_path: Path, synthetic_project):
+        from vaultspec_core.core.types import init_paths
+
+        (tmp_path / ".vault" / "adr").mkdir(parents=True)
+        (tmp_path / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+        (tmp_path / ".vaultspec").mkdir()
+        init_paths(tmp_path)
+
+        result = runner.invoke(
+            app,
+            ["--target", str(tmp_path), "vault", "check", "code-boundary"],
+        )
+        assert result.exit_code == 0
+        assert "clean" in result.output

--- a/src/vaultspec_core/vaultcore/checks/__init__.py
+++ b/src/vaultspec_core/vaultcore/checks/__init__.py
@@ -24,6 +24,7 @@ from ._base import (
 from .adr_status import check_adr_status
 from .annotations import check_annotations
 from .body_links import check_body_links
+from .code_boundary import check_code_boundary
 from .dangling import check_dangling
 from .encoding import check_encoding
 from .feature_rename_integrity import check_feature_rename_integrity
@@ -50,6 +51,7 @@ __all__ = [
     "check_adr_status",
     "check_annotations",
     "check_body_links",
+    "check_code_boundary",
     "check_dangling",
     "check_encoding",
     "check_feature_rename_integrity",

--- a/src/vaultspec_core/vaultcore/checks/code_boundary.py
+++ b/src/vaultspec_core/vaultcore/checks/code_boundary.py
@@ -1,0 +1,186 @@
+"""Scan source-file content for references to the project's own vault records.
+
+The one-way vault reference boundary holds that ``.vault/`` and
+``.vaultspec/`` are removable development scaffolding: vault documents cite
+code by locator, and tracked source-file content never references the
+project's own development records. This checker is the boundary's opt-in
+mechanical instrument. It enumerates the vault's document stems (authored
+records and generated feature indexes), walks the source tree outside the
+vault, the harness, the provider directories, and common caches, and reports
+every source file whose text contains one of those stems - as a plain
+substring or in wiki-link form - as a ``WARNING``.
+
+The scan is advisory by construction: warnings never affect the exit code,
+nothing is mutated, and the checker is deliberately not a member of
+``run_all_checks`` (the ``check all`` pipeline stays vault-scoped). Needles
+are stems only - never bare Step ids or the literal ``.vault`` path string -
+so vault-domain codebases that legitimately construct vault paths as product
+functionality do not false-positive.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ._base import CheckDiagnostic, CheckResult, Severity
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["check_code_boundary"]
+
+# Directories never scanned: the vault and harness themselves, provider
+# directories (generated projections of the harness), VCS internals, and
+# common build/cache trees whose contents are derived, not authored.
+_EXCLUDED_DIR_NAMES = frozenset(
+    {
+        ".vault",
+        ".vaultspec",
+        ".claude",
+        ".gemini",
+        ".agents",
+        ".codex",
+        ".git",
+        ".hg",
+        ".svn",
+        ".venv",
+        "venv",
+        "node_modules",
+        "__pycache__",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".mypy_cache",
+        ".tox",
+        "dist",
+        "build",
+        ".idea",
+        ".vscode",
+    }
+)
+
+# Files larger than this are skipped: generated bundles and data blobs, not
+# authored source. The cap keeps the walk's worst case bounded.
+_MAX_FILE_BYTES = 1_000_000
+
+
+def _collect_needles(root_dir: Path, feature: str | None) -> set[str]:
+    """Return the vault's document stems to scan for.
+
+    Authored records contribute their filename stem (date-prefixed,
+    high-precision); generated feature indexes contribute their
+    ``<feature>.index`` stem. With *feature* set, only documents carrying
+    that feature tag (by stem convention: the feature segment between the
+    date prefix and the type suffix) plus that feature's index are needled.
+
+    Args:
+        root_dir: Project root directory.
+        feature: Optional feature tag (without ``#``) restricting the
+            needle set to one feature's documents.
+    """
+    from ...config import get_config
+
+    needles: set[str] = set()
+    docs_dir = root_dir / get_config().docs_dir
+    if not docs_dir.exists():
+        return needles
+
+    for path in docs_dir.rglob("*.md"):
+        if ".obsidian" in path.parts or "_archive" in path.parts:
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        stem = path.name[: -len(".md")]
+        if feature is not None and feature not in stem:
+            continue
+        needles.add(stem)
+
+    return needles
+
+
+def _iter_source_files(root_dir: Path):
+    """Yield candidate source files under *root_dir*, honoring exclusions."""
+    stack = [root_dir]
+    while stack:
+        current = stack.pop()
+        try:
+            entries = sorted(current.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            if entry.is_dir():
+                if entry.name in _EXCLUDED_DIR_NAMES:
+                    continue
+                stack.append(entry)
+                continue
+            if entry.is_file():
+                yield entry
+
+
+def check_code_boundary(
+    root_dir: Path,
+    *,
+    feature: str | None = None,
+) -> CheckResult:
+    """Report source files that reference the project's own vault records.
+
+    Enumerates the needle stems from ``.vault/`` (optionally restricted to
+    one feature), walks every non-excluded file under *root_dir*, skips
+    files above the size cap or that do not decode as UTF-8, and emits one
+    ``WARNING`` diagnostic per file naming the matched stems. Read-only and
+    advisory: ``supports_fix`` is ``False`` and warnings never fail the
+    command.
+
+    Args:
+        root_dir: Project root directory.
+        feature: Optional feature tag (without ``#``) restricting the
+            needles to that feature's documents.
+
+    Returns:
+        :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with
+        check name ``"code-boundary"``.
+    """
+    result = CheckResult(check_name="code-boundary", supports_fix=False)
+
+    needles = _collect_needles(root_dir, feature)
+    if not needles:
+        return result
+
+    for path in _iter_source_files(root_dir):
+        try:
+            if path.stat().st_size > _MAX_FILE_BYTES:
+                continue
+            raw = path.read_bytes()
+        except OSError:
+            continue
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        matched = sorted(stem for stem in needles if stem in text)
+        if not matched:
+            continue
+
+        rel_path = path.relative_to(root_dir)
+        listed = ", ".join(matched[:3])
+        if len(matched) > 3:
+            listed += f", and {len(matched) - 3} more"
+        result.diagnostics.append(
+            CheckDiagnostic(
+                path=rel_path,
+                message=(
+                    f"Source file references vault record(s): {listed}. "
+                    "Code must stand alone: move the linkage into the vault "
+                    "document (which cites code by locator) or an opt-in git "
+                    "commit trailer."
+                ),
+                severity=Severity.WARNING,
+            )
+        )
+
+    return result

--- a/src/vaultspec_core/vaultcore/checks/code_boundary.py
+++ b/src/vaultspec_core/vaultcore/checks/code_boundary.py
@@ -32,17 +32,13 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["check_code_boundary"]
 
-# Directories never scanned: the vault and harness themselves, provider
-# directories (generated projections of the harness), VCS internals, and
-# common build/cache trees whose contents are derived, not authored.
-_EXCLUDED_DIR_NAMES = frozenset(
+# VCS internals and common build/cache trees whose contents are derived,
+# not authored. The vault, harness, and provider directories are excluded
+# too, sourced from the central enum and the config at call time (see
+# :func:`_excluded_dir_names`) so a future provider is excluded the day it
+# is added to the enum.
+_STATIC_EXCLUDED_DIR_NAMES = frozenset(
     {
-        ".vault",
-        ".vaultspec",
-        ".claude",
-        ".gemini",
-        ".agents",
-        ".codex",
         ".git",
         ".hg",
         ".svn",
@@ -61,6 +57,25 @@ _EXCLUDED_DIR_NAMES = frozenset(
     }
 )
 
+
+def _excluded_dir_names() -> frozenset[str]:
+    """Return the directory names the walk never descends into.
+
+    The vault (from config, honoring a non-default ``docs_dir``), the
+    harness, and every provider directory come from
+    :class:`~vaultspec_core.core.enums.DirName`; VCS and cache names are
+    static.
+    """
+    from ...config import get_config
+    from ...core.enums import DirName
+
+    top_level = {
+        d.value for d in DirName if d is not DirName.INDEX and d.value.startswith(".")
+    }
+    top_level.add(get_config().docs_dir)
+    return frozenset(top_level | _STATIC_EXCLUDED_DIR_NAMES)
+
+
 # Files larger than this are skipped: generated bundles and data blobs, not
 # authored source. The cap keeps the walk's worst case bounded.
 _MAX_FILE_BYTES = 1_000_000
@@ -71,9 +86,11 @@ def _collect_needles(root_dir: Path, feature: str | None) -> set[str]:
 
     Authored records contribute their filename stem (date-prefixed,
     high-precision); generated feature indexes contribute their
-    ``<feature>.index`` stem. With *feature* set, only documents carrying
-    that feature tag (by stem convention: the feature segment between the
-    date prefix and the type suffix) plus that feature's index are needled.
+    ``<feature>.index`` stem. With *feature* set, a document is needled only
+    when its parsed frontmatter carries exactly that feature tag - filename
+    heuristics cannot split ``{date}-{feature}[-{topic}]-{type}`` reliably
+    because features and topics are both hyphenated kebab-case - and an
+    unparseable document is conservatively skipped under the filter.
 
     Args:
         root_dir: Project root directory.
@@ -93,15 +110,28 @@ def _collect_needles(root_dir: Path, feature: str | None) -> set[str]:
         if path.is_symlink() or not path.is_file():
             continue
         stem = path.name[: -len(".md")]
-        if feature is not None and feature not in stem:
+        if feature is not None and not _doc_matches_feature(path, feature):
             continue
         needles.add(stem)
 
     return needles
 
 
+def _doc_matches_feature(path: Path, feature: str) -> bool:
+    """Return ``True`` when the document at *path* carries *feature*'s tag."""
+    from ..parser import parse_vault_metadata
+    from ._base import extract_feature_tags
+
+    try:
+        metadata, _body = parse_vault_metadata(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError):
+        return False
+    return feature in extract_feature_tags(metadata.tags)
+
+
 def _iter_source_files(root_dir: Path):
     """Yield candidate source files under *root_dir*, honoring exclusions."""
+    excluded = _excluded_dir_names()
     stack = [root_dir]
     while stack:
         current = stack.pop()
@@ -113,7 +143,7 @@ def _iter_source_files(root_dir: Path):
             if entry.is_symlink():
                 continue
             if entry.is_dir():
-                if entry.name in _EXCLUDED_DIR_NAMES:
+                if entry.name in excluded:
                     continue
                 stack.append(entry)
                 continue

--- a/src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py
@@ -1,0 +1,127 @@
+"""Real-filesystem tests for the opt-in ``code-boundary`` source scanner.
+
+Builds real on-disk workspaces (a vault plus source files) with no test
+doubles and asserts the scanner's contract: stem and wiki-link hits are
+WARNING diagnostics, the literal vault path string alone never matches,
+vault, harness, and provider directories are excluded, the feature filter
+narrows the needle set, undecodable and oversized files are skipped, and
+findings never raise the error count that drives the CLI exit code.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from .._base import Severity
+from ..code_boundary import _MAX_FILE_BYTES, check_code_boundary
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+DATE = "2026-07-16"
+STEM = f"{DATE}-my-feat-adr"
+
+
+def _write_vault_doc(root: Path, doc_type: str, feature: str) -> Path:
+    fm = (
+        f"---\ntags:\n  - '#{doc_type}'\n  - '#{feature}'\n"
+        f"date: '{DATE}'\nmodified: '{DATE}'\nrelated: []\n---\n"
+    )
+    path = root / ".vault" / doc_type / f"{DATE}-{feature}-{doc_type}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{fm}\n# {feature} {doc_type}\n", encoding="utf-8")
+    return path
+
+
+class TestCheckCodeBoundary:
+    def test_stem_hit_in_source_file_is_warning(self, tmp_path):
+        _write_vault_doc(tmp_path, "adr", "my-feat")
+        src = tmp_path / "src" / "module.py"
+        src.parent.mkdir(parents=True)
+        src.write_text(f"# decided in {STEM}\nVALUE = 1\n", encoding="utf-8")
+
+        result = check_code_boundary(tmp_path)
+
+        assert result.warning_count == 1
+        assert result.error_count == 0
+        diag = result.diagnostics[0]
+        assert diag.severity == Severity.WARNING
+        assert STEM in diag.message
+        assert diag.path is not None and diag.path.name == "module.py"
+
+    def test_wiki_link_form_is_reported(self, tmp_path):
+        _write_vault_doc(tmp_path, "adr", "my-feat")
+        doc = tmp_path / "docs" / "guide.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(f"See [[{STEM}]] for the decision.\n", encoding="utf-8")
+
+        result = check_code_boundary(tmp_path)
+
+        assert result.warning_count == 1
+        assert STEM in result.diagnostics[0].message
+
+    def test_literal_vault_path_alone_is_not_a_finding(self, tmp_path):
+        _write_vault_doc(tmp_path, "adr", "my-feat")
+        src = tmp_path / "workspace.py"
+        src.write_text('VAULT_DIR = root / ".vault"\n', encoding="utf-8")
+
+        result = check_code_boundary(tmp_path)
+
+        assert result.is_clean
+
+    def test_vault_harness_and_provider_dirs_are_excluded(self, tmp_path):
+        _write_vault_doc(tmp_path, "adr", "my-feat")
+        for dirname in (".vault", ".vaultspec", ".claude", ".gemini", ".agents"):
+            f = tmp_path / dirname / "notes.md"
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(f"[[{STEM}]]\n", encoding="utf-8")
+
+        result = check_code_boundary(tmp_path)
+
+        assert result.is_clean
+
+    def test_feature_filter_narrows_needles(self, tmp_path):
+        _write_vault_doc(tmp_path, "adr", "my-feat")
+        _write_vault_doc(tmp_path, "adr", "other-feat")
+        src = tmp_path / "module.py"
+        src.write_text(f"# {DATE}-other-feat-adr\n", encoding="utf-8")
+
+        assert check_code_boundary(tmp_path, feature="my-feat").is_clean
+        assert check_code_boundary(tmp_path, feature="other-feat").warning_count == 1
+
+    def test_undecodable_and_oversized_files_are_skipped(self, tmp_path):
+        _write_vault_doc(tmp_path, "adr", "my-feat")
+        binary = tmp_path / "blob.bin"
+        binary.write_bytes(b"\xff\xfe" + STEM.encode("utf-16-le"))
+        big = tmp_path / "bundle.js"
+        big.write_text(
+            STEM + "x" * _MAX_FILE_BYTES,
+            encoding="utf-8",
+        )
+
+        result = check_code_boundary(tmp_path)
+
+        assert result.is_clean
+
+    def test_index_stem_is_a_needle(self, tmp_path):
+        index = tmp_path / ".vault" / "index" / "my-feat.index.md"
+        index.parent.mkdir(parents=True)
+        index.write_text(
+            "---\ntags:\n  - '#index'\n  - '#my-feat'\n"
+            f"date: '{DATE}'\nrelated: []\n---\n",
+            encoding="utf-8",
+        )
+        src = tmp_path / "module.py"
+        src.write_text('INDEX = "my-feat.index"\n', encoding="utf-8")
+
+        result = check_code_boundary(tmp_path)
+
+        assert result.warning_count == 1
+
+    def test_no_vault_means_clean(self, tmp_path):
+        (tmp_path / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+        assert check_code_boundary(tmp_path).is_clean

--- a/src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_code_boundary.py
@@ -93,6 +93,17 @@ class TestCheckCodeBoundary:
         assert check_code_boundary(tmp_path, feature="my-feat").is_clean
         assert check_code_boundary(tmp_path, feature="other-feat").warning_count == 1
 
+    def test_feature_filter_rejects_prefix_and_substring_collisions(self, tmp_path):
+        _write_vault_doc(tmp_path, "adr", "my-feat-two")
+        src = tmp_path / "module.py"
+        src.write_text(f"# {DATE}-my-feat-two-adr\n", encoding="utf-8")
+
+        # A feature that is a prefix of another must not adopt its documents,
+        # and a bare letter must not match every stem containing it.
+        assert check_code_boundary(tmp_path, feature="my-feat").is_clean
+        assert check_code_boundary(tmp_path, feature="a").is_clean
+        assert check_code_boundary(tmp_path, feature="my-feat-two").warning_count == 1
+
     def test_undecodable_and_oversized_files_are_skipped(self, tmp_path):
         _write_vault_doc(tmp_path, "adr", "my-feat")
         binary = tmp_path / "blob.bin"


### PR DESCRIPTION
Closes #213. Executes `.vault/adr/2026-07-16-code-boundary-check-adr.md` - the mechanical follow-up the firmware-code-boundary decision registered.

## Summary

`vault check code-boundary`: an opt-in, read-only source-boundary scanner. It enumerates the vault's document stems (authored records + feature indexes), walks the source tree outside the vault/harness/provider/VCS/cache directories, and reports every source file referencing one of those stems as a WARNING. Advisory by construction: exit 0 on findings, no mutation, **not** a member of `vault check all` (default gates unchanged); membership is revisitable by amending the ADR once field evidence exists.

Design constraints honored: needles are stems only (never Step ids or the literal `.vault` string, so vault-domain product code stays legal); commit trailers stay out of scope (commit-linkage ADR); pure offline walk with symlink skip, decode guard, and 1 MB size cap. Exclusions derive from the central `DirName` enum + configured `docs_dir`; `--feature` matches the document's frontmatter tag exactly.

- [x] Checker module + package export (`run_all_checks` untouched)
- [x] Standalone verb with `--feature`/`--json`/`--verbose`
- [x] Tests: 11 real-filesystem (hits, wiki-link form, literal-path non-hit, exclusions, tag-exact feature filter incl. prefix collisions, skip guards, index stems, advisory exit)
- [x] CLI reference regenerated (drift suite 22 green); unit gate green
- [x] Code review audit **PASS** (`.vault/audit/2026-07-16-code-boundary-check-audit.md`); both MEDIUM recommendations applied in-session

## Dogfood

Running the scanner on this repo yields 9 advisory warnings (exit 0), including one genuine violation - an ADR stem cited in `feature_rename_integrity.py` - and several rendered doc-asset SVGs embedding vault stems. Left for separate triage; the scanner is the deliverable here.

Note: the deployed mirror's reference diff includes stale-projection reconciliation predating this branch (audit: benign, not scope creep).