### PR TITLE
feat(mcp): watchdog parity - hybrid anchors, kill switch, telemetry, POSIX backstop

### DIFF
--- a/.vault/adr/2026-07-16-mcp-stdio-lifetime-adr.md
+++ b/.vault/adr/2026-07-16-mcp-stdio-lifetime-adr.md
@@ -31,7 +31,13 @@ now.
 - The stdin pipe's creating process is recoverable from the handle itself via
   `GetNamedPipeServerProcessId`, which works for anonymous pipes
   (`2026-07-16-mcp-stdio-lifetime-research`).
-- POSIX delivers EOF reliably on process death; the gap is Windows-only.
+- POSIX delivers EOF reliably on process death; the residual POSIX risk is
+  abandonment without pipe closure, which a coarse reparent poll covers at
+  negligible cost (parity with the sibling repo's shipped behavior).
+- Operability parity with the sibling repo
+  (`2026-07-16-mcp-stdio-lifetime-research`, cross-repo parity delta): an
+  operator kill switch, an explicit client override, structured exit
+  telemetry, and documented knobs exist there and are absent here.
 - `pywin32` must not become a load-bearing dependency: upstream `mcp` is
   actively removing its eager `pywin32` import
   (https://github.com/modelcontextprotocol/python-sdk/pull/2365), so the
@@ -42,14 +48,19 @@ now.
 
 ## Considered options
 
-- **Client-PID watchdog (chosen).** Resolve the stdin pipe creator, hold a
-  `SYNCHRONIZE` handle, wait on it in a daemon thread, hard-exit when
+- **Client-PID watchdog (chosen primary).** Resolve the stdin pipe creator,
+  hold a `SYNCHRONIZE` handle, wait on it in a daemon thread, hard-exit when
   signaled. Anchors lifetime to the actual client regardless of wrapper depth
   or leaked pipe handles.
 - **Parent-PID (`getppid`) watchdog.** Rejected: the immediate parent is the
   `uv`/launcher wrapper, alive in every audited leak.
-- **Ancestor-chain walking.** Rejected: racy (PID reuse), fragile across
-  launch paths, and still guesses which ancestor is the client.
+- **Ancestor-chain walking.** Rejected as the primary anchor (blunter
+  semantics: any ancestor's death fires it, including a terminal above the
+  client); adopted in the 2026-07-17 parity revision as the FALLBACK when
+  stdin pipe resolution declines, in the PID-reuse-safe form the sibling
+  repo proved out (handles taken at startup, creation-time monotonicity,
+  grace-window pruning of transient spawn helpers) - see
+  `2026-07-16-mcp-stdio-lifetime-research`, cross-repo parity delta.
 - **Idle timeout.** Rejected for now: kills long-lived quiet sessions or waits
   hours to reap, and the watchdog already covers every server-side-reachable
   case; may be revisited as an opt-in if client-side pipe leaks prove chronic.
@@ -72,17 +83,31 @@ now.
 
 ## Implementation
 
-A new module in the MCP server package owns the mechanism: a resolver that
-maps the process's real stdin handle to the pipe-creating PID, and an arming
-function that opens that PID with `SYNCHRONIZE` access, spawns a daemon thread
-blocking on `WaitForSingleObject(INFINITE)`, and calls `os._exit(0)` when the
-handle signals. The server entrypoint arms the watchdog immediately before
-starting the stdio transport, on Windows only; every failure path logs to
-stderr at debug level and falls back to EOF-only behavior. Non-Windows
-platforms never touch the module's Win32 surface. vaultspec-rag closes the
-same defect for `vaultspec-search-mcp` under its own decision record, which
-settled on an ancestor-chain watchdog; the repos share the backstop contract
-(hard-exit daemon thread, fail-open, EOF path untouched), not the module.
+The MCP server package's watchdog module owns the mechanism as a layered
+hybrid (2026-07-17 parity revision):
+
+- **Primary anchor (Windows):** a resolver maps the process's real stdin
+  handle to the pipe-creating PID; arming opens that PID with `SYNCHRONIZE`
+  access, spawns a daemon thread blocking on an infinite wait, and calls
+  `os._exit(0)` when the handle signals.
+- **Fallback anchor (Windows):** when pipe resolution declines (console or
+  file stdin, console-less launch), arming falls back to ancestor-chain
+  discovery - handles taken at startup, creation-time monotonicity guarding
+  PID reuse, a grace window pruning transient spawn helpers, wait-any over
+  the survivors.
+- **POSIX backstop:** a coarse reparent poll that exits when the process is
+  orphaned or an explicitly named client dies; EOF remains the primary exit.
+- **Operability:** `VAULTSPEC_STDIO_WATCHDOG` (off values disable arming
+  entirely), a `--parent-pid` entrypoint override watched ahead of
+  discovery, and one structured JSON exit event flushed to stderr before the
+  hard exit. The contract and knobs are user-documented.
+
+The server entrypoint arms the watchdog immediately before starting the
+stdio transport; every failure path logs and falls back to EOF-only
+behavior. vaultspec-rag closes the same defect for `vaultspec-search-mcp`
+under its own decision record (ancestor-chain primary); the repos now share
+the full backstop and operability contract, differing only in primary
+anchor.
 
 ## Rationale
 
@@ -108,5 +133,14 @@ new dependency.
 - Servers whose client is alive but leaked their pipe are reaped only at that
   client's exit; a host-side sweep remains the remedy for chains predating the
   fix.
-- vaultspec-rag closes the sibling report under its own decision record; the
-  two repos converge on the backstop contract while differing in mechanism.
+- vaultspec-rag closes the sibling report under its own decision record; after
+  the parity revision the repos share the backstop and operability contract
+  (kill switch, override, fallback discipline, telemetry, POSIX poll) and
+  differ only in primary anchor.
+- The ancestor-chain fallback inherits its known bluntness: on non-pipe
+  launches, an above-client ancestor's death (a closed terminal) also reaps
+  the server; acceptable because such launches previously had no backstop at
+  all.
+- The kill switch introduces the first watchdog-scoped environment variable;
+  it follows the bare `VAULTSPEC_*` naming convention and must be registered
+  in the CLI reference env table.

--- a/.vault/audit/2026-07-16-mcp-stdio-lifetime-audit.md
+++ b/.vault/audit/2026-07-16-mcp-stdio-lifetime-audit.md
@@ -81,6 +81,28 @@ If the client dies and its PID recycles between resolution and
 the decision's accepted residual; the window is microseconds at server
 spawn, when the client is by definition alive.
 
+### parity-dedup-handle-leak | medium | Deduped fallback ancestors leaked their opened handles
+
+In the 2026-07-17 parity revision, when an explicit parent override was
+also a discovered ancestor and the fallback engaged, the duplicate's
+freshly opened `SYNCHRONIZE` handle was dropped without `CloseHandle` -
+the sibling implementation dedups inside the walk and closes duplicates.
+RESOLVED: duplicates are now closed at the dedup site.
+
+### parity-thread-start-leak | low | Thread-start failure left opened handles behind
+
+An arming-thread start failure failed open correctly but unwound past the
+watched handle set without closing it. RESOLVED: the start is wrapped and
+every handle closes before the fail-open guard absorbs the error.
+
+### parity-kill-switch-test-nit | low | Kill-switch test asserted an environment-incidental resolver result
+
+The in-process kill-switch test asserted the resolver's `None` under
+the disabled env, which the switch does not govern; under a harness that
+pipes stdin into the test runner it could flake. RESOLVED: the assertion
+was dropped; the switch is proven by the disable predicate and the arming
+refusal.
+
 ## Recommendations
 
 - Ship after the resolved findings above; verdict PASS-with-notes, no

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S01.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S01.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S01'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Open feature branch and draft PR referencing issue 220 and the parity revision
+
+## Scope
+
+- `repo workflow`
+
+## Description
+
+- Create branch `feat/mcp-watchdog-parity` from fresh main
+- Commit the amended ADR, parity research section, and L2 plan
+- Open draft PR 223 referencing issue 220 and rag issue 229
+
+## Outcome
+
+Draft PR https://github.com/nevenincs/vaultspec-core/pull/223 open.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S02.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S02.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S02'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Add VAULTSPEC_STDIO_WATCHDOG kill switch honored before any arming, with off values matching the sibling repo
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/watchdog.py`
+
+## Description
+
+- Add `STDIO_WATCHDOG_ENV` and `watchdog_disabled()` honoring `0`/`false`/`off`/`no`
+- Check the switch before any anchor work in `arm_client_watchdog`
+
+## Outcome
+
+Kill switch active on every platform path; committed as `7659724d`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S03.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S03.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S03'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Emit one structured JSON exit event to stderr before every hard exit, shared by all anchors
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/watchdog.py`
+
+## Description
+
+- Add `_exit_on_watched_death` flushing one JSON event line to stderr before `os._exit(0)`
+- Route every anchor's exit through it
+
+## Outcome
+
+Event shape matches the sibling server's (`event`, `dead_ancestor_pid`, `dead_ancestor_exe`, `shim_pid`); committed as `7659724d`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S04.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S04.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S04'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Add PID-reuse-safe ancestor-chain fallback armed when stdin pipe resolution declines: startup handles, creation-time monotonicity, grace-window pruning, wait-any
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/watchdog.py`
+
+## Description
+
+- Restructure the module to a platform-gated Win32 section with full argtypes for all eight bindings
+- Port the PID-reuse-safe ancestor walk: toolhelp snapshot, creation-time monotonicity, startup handles
+- Engage the fallback only when the client anchor is absent; grace-prune discovered targets only, wait-any over survivors
+
+## Outcome
+
+Fallback covers non-pipe launches previously left with no backstop; committed as `7659724d`.
+
+## Notes
+
+Grace window parameterized (`grace_seconds`) for real-process testability, matching the sibling installer's signature.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S05.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S05.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S05'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Add POSIX coarse reparent poll exiting on orphaning or explicit client death
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/watchdog.py`
+
+## Description
+
+- Add `_posix_watchdog` coarse reparent poll with explicit-pid liveness checks
+- Arm it on non-Windows platforms behind the same kill switch and fail-open guard
+
+## Outcome
+
+POSIX arming now returns True (was a hard no-op); committed as `7659724d`.
+
+## Notes
+
+POSIX liveness probes use `os.kill(pid, 0)` which is POSIX-only semantics by design.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S06.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P01-S06.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S06'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Add --parent-pid entrypoint option watched ahead of discovery and wire arming outcomes through \_serve logging
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/app.py`
+
+## Description
+
+- Add `--parent-pid` option to the vaultspec-mcp typer callback
+- Thread it through `_serve` into `arm_client_watchdog(parent_pid=...)`, watched ahead of discovery and never grace-pruned
+
+## Outcome
+
+Flag proves out end-to-end against the real server module; committed as `7659724d`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P02-S07.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P02-S07.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S07'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Add kill-switch and parent-pid override tests driving real worker subprocesses
+
+## Scope
+
+- `tests/unit/mcp_server/test_watchdog.py`
+
+## Description
+
+- Add in-process kill-switch test with real environment mutation restored in finally
+- Add worker-subprocess kill-switch test (armed=False, stays alive)
+- Extend the dead-client test to the parent_pid override and assert the structured exit event JSON
+
+## Outcome
+
+Committed as `e6737158`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P02-S08.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P02-S08.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S08'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Rework the non-pipe stdin test for fallback semantics and add ancestor-death and grace-window fallback tests with real process chains
+
+## Scope
+
+- `tests/unit/mcp_server/test_watchdog.py`
+
+## Description
+
+- Rework the non-pipe stdin test: resolution declines, arming now succeeds via fallback on every platform
+- Add ancestor-death fallback test through a real intermediary chain (short grace)
+- Add grace-window pruning test reporting through a result file so a dead parent's pipe cannot fake the outcome
+
+## Outcome
+
+Committed as `e6737158`.
+
+## Notes
+
+Both pre-existing e2e server tests were passing vacuously: the standalone server refuses a bare cwd, so the server under test had been crashing at boot. They now scaffold the minimal workspace and assert liveness before the kill.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P02-S09.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P02-S09.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S09'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Add POSIX-contract assertions for the reparent poll and explicit-pid path exercised on the current platform honestly
+
+## Scope
+
+- `tests/unit/mcp_server/test_watchdog.py`
+
+## Description
+
+- Platform-branch the new tests so POSIX asserts the reparent-poll contract honestly (armed=True, poll cadence bounds)
+- Keep the real-server parent-pid e2e platform-neutral (explicit-pid poll covers POSIX)
+
+## Outcome
+
+Committed as `e6737158`.
+
+## Notes
+
+POSIX branches execute only on a non-Windows checkout; CI does not run this tree.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P03-S10.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P03-S10.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S10'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Document the watchdog contract and knobs in the MCP doc and register VAULTSPEC_STDIO_WATCHDOG in the CLI reference env table via the builtins source
+
+## Scope
+
+- `docs/MCP.md`
+
+## Description
+
+- Add a Server lifetime section to the MCP doc: contract, anchors, event line, both knobs
+- Register `VAULTSPEC_STDIO_WATCHDOG` in the CLI reference env table (builtins source), roll the mirror via install --upgrade and sync
+
+## Outcome
+
+Committed as `4a7480ea`.
+
+## Notes
+
+The env table is a hand-zone; only the command inventory is generator-owned.

--- a/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P03-S11.md
+++ b/.vault/exec/2026-07-17-mcp-stdio-lifetime/2026-07-17-mcp-stdio-lifetime-P03-S11.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S11'
+related:
+  - "[[2026-07-17-mcp-stdio-lifetime-plan]]"
+---
+
+# Run gates, dispatch code review, resolve findings, append audit entries, finalize PR
+
+## Scope
+
+- `quality gates`
+
+## Description
+
+- Run the gate battery: CI-matching unit gate 1773 passed, MCP suites 66 passed, tests tree 257 passed, ty clean on both platform assumptions, dependency audit clean
+- Dispatch the code-reviewer persona against the branch and the sibling reference implementation: verdict PASS-with-notes
+- Resolve the medium dedup handle leak and both low findings; append all entries to the audit
+- Finalize the PR body and mark ready for review
+
+## Outcome
+
+All gates green; review findings resolved (`ae3656f8`); PR 223 ready.
+
+## Notes
+
+None.

--- a/.vault/index/mcp-stdio-lifetime.index.md
+++ b/.vault/index/mcp-stdio-lifetime.index.md
@@ -3,8 +3,8 @@ generated: true
 tags:
   - '#index'
   - '#mcp-stdio-lifetime'
-date: '2026-07-16'
-modified: '2026-07-16'
+date: '2026-07-17'
+modified: '2026-07-17'
 related:
   - '[[2026-07-16-mcp-stdio-lifetime-S01]]'
   - '[[2026-07-16-mcp-stdio-lifetime-S02]]'
@@ -16,6 +16,7 @@ related:
   - '[[2026-07-16-mcp-stdio-lifetime-audit]]'
   - '[[2026-07-16-mcp-stdio-lifetime-plan]]'
   - '[[2026-07-16-mcp-stdio-lifetime-research]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-plan]]'
 ---
 
 # `mcp-stdio-lifetime` feature index
@@ -44,6 +45,7 @@ Auto-generated index of all documents tagged with `#mcp-stdio-lifetime`.
 ### plan
 
 - `2026-07-16-mcp-stdio-lifetime-plan` - `mcp-stdio-lifetime` plan
+- `2026-07-17-mcp-stdio-lifetime-plan` - `mcp-stdio-lifetime` plan
 
 ### research
 

--- a/.vault/plan/2026-07-17-mcp-stdio-lifetime-plan.md
+++ b/.vault/plan/2026-07-17-mcp-stdio-lifetime-plan.md
@@ -18,26 +18,26 @@ related:
 
 Bring the watchdog module to the shared cross-repo contract: kill switch, structured telemetry, ancestor-chain fallback, POSIX poll, and the entrypoint override.
 
-- [ ] `P01.S01` - Open feature branch and draft PR referencing issue 220 and the parity revision; `repo workflow`.
-- [ ] `P01.S02` - Add VAULTSPEC_STDIO_WATCHDOG kill switch honored before any arming, with off values matching the sibling repo; `src/vaultspec_core/mcp_server/watchdog.py`.
-- [ ] `P01.S03` - Emit one structured JSON exit event to stderr before every hard exit, shared by all anchors; `src/vaultspec_core/mcp_server/watchdog.py`.
-- [ ] `P01.S04` - Add PID-reuse-safe ancestor-chain fallback armed when stdin pipe resolution declines: startup handles, creation-time monotonicity, grace-window pruning, wait-any; `src/vaultspec_core/mcp_server/watchdog.py`.
-- [ ] `P01.S05` - Add POSIX coarse reparent poll exiting on orphaning or explicit client death; `src/vaultspec_core/mcp_server/watchdog.py`.
-- [ ] `P01.S06` - Add --parent-pid entrypoint option watched ahead of discovery and wire arming outcomes through \_serve logging; `src/vaultspec_core/mcp_server/app.py`.
+- [x] `P01.S01` - Open feature branch and draft PR referencing issue 220 and the parity revision; `repo workflow`.
+- [x] `P01.S02` - Add VAULTSPEC_STDIO_WATCHDOG kill switch honored before any arming, with off values matching the sibling repo; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [x] `P01.S03` - Emit one structured JSON exit event to stderr before every hard exit, shared by all anchors; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [x] `P01.S04` - Add PID-reuse-safe ancestor-chain fallback armed when stdin pipe resolution declines: startup handles, creation-time monotonicity, grace-window pruning, wait-any; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [x] `P01.S05` - Add POSIX coarse reparent poll exiting on orphaning or explicit client death; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [x] `P01.S06` - Add --parent-pid entrypoint option watched ahead of discovery and wire arming outcomes through \_serve logging; `src/vaultspec_core/mcp_server/app.py`.
 
 ### Phase `P02` - real-process test parity
 
 Prove every new anchor and knob with real processes and pipes, updating the tests whose semantics the fallback changes.
 
-- [ ] `P02.S07` - Add kill-switch and parent-pid override tests driving real worker subprocesses; `tests/unit/mcp_server/test_watchdog.py`.
-- [ ] `P02.S08` - Rework the non-pipe stdin test for fallback semantics and add ancestor-death and grace-window fallback tests with real process chains; `tests/unit/mcp_server/test_watchdog.py`.
-- [ ] `P02.S09` - Add POSIX-contract assertions for the reparent poll and explicit-pid path exercised on the current platform honestly; `tests/unit/mcp_server/test_watchdog.py`.
+- [x] `P02.S07` - Add kill-switch and parent-pid override tests driving real worker subprocesses; `tests/unit/mcp_server/test_watchdog.py`.
+- [x] `P02.S08` - Rework the non-pipe stdin test for fallback semantics and add ancestor-death and grace-window fallback tests with real process chains; `tests/unit/mcp_server/test_watchdog.py`.
+- [x] `P02.S09` - Add POSIX-contract assertions for the reparent poll and explicit-pid path exercised on the current platform honestly; `tests/unit/mcp_server/test_watchdog.py`.
 
 ### Phase `P03` - documentation and gates
 
 Document the contract and knobs, register the env var, and run the full gate set through review to a ready PR.
 
-- [ ] `P03.S10` - Document the watchdog contract and knobs in the MCP doc and register VAULTSPEC_STDIO_WATCHDOG in the CLI reference env table via the builtins source; `docs/MCP.md`.
+- [x] `P03.S10` - Document the watchdog contract and knobs in the MCP doc and register VAULTSPEC_STDIO_WATCHDOG in the CLI reference env table via the builtins source; `docs/MCP.md`.
 - [ ] `P03.S11` - Run gates, dispatch code review, resolve findings, append audit entries, finalize PR; `quality gates`.
 
 ## Description

--- a/.vault/plan/2026-07-17-mcp-stdio-lifetime-plan.md
+++ b/.vault/plan/2026-07-17-mcp-stdio-lifetime-plan.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - '#plan'
+  - '#mcp-stdio-lifetime'
+date: '2026-07-17'
+modified: '2026-07-17'
+tier: L2
+related:
+  - '[[2026-07-16-mcp-stdio-lifetime-adr]]'
+  - '[[2026-07-16-mcp-stdio-lifetime-research]]'
+---
+
+# `mcp-stdio-lifetime` plan
+
+## Steps
+
+### Phase `P01` - watchdog engine parity
+
+Bring the watchdog module to the shared cross-repo contract: kill switch, structured telemetry, ancestor-chain fallback, POSIX poll, and the entrypoint override.
+
+- [ ] `P01.S01` - Open feature branch and draft PR referencing issue 220 and the parity revision; `repo workflow`.
+- [ ] `P01.S02` - Add VAULTSPEC_STDIO_WATCHDOG kill switch honored before any arming, with off values matching the sibling repo; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [ ] `P01.S03` - Emit one structured JSON exit event to stderr before every hard exit, shared by all anchors; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [ ] `P01.S04` - Add PID-reuse-safe ancestor-chain fallback armed when stdin pipe resolution declines: startup handles, creation-time monotonicity, grace-window pruning, wait-any; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [ ] `P01.S05` - Add POSIX coarse reparent poll exiting on orphaning or explicit client death; `src/vaultspec_core/mcp_server/watchdog.py`.
+- [ ] `P01.S06` - Add --parent-pid entrypoint option watched ahead of discovery and wire arming outcomes through \_serve logging; `src/vaultspec_core/mcp_server/app.py`.
+
+### Phase `P02` - real-process test parity
+
+Prove every new anchor and knob with real processes and pipes, updating the tests whose semantics the fallback changes.
+
+- [ ] `P02.S07` - Add kill-switch and parent-pid override tests driving real worker subprocesses; `tests/unit/mcp_server/test_watchdog.py`.
+- [ ] `P02.S08` - Rework the non-pipe stdin test for fallback semantics and add ancestor-death and grace-window fallback tests with real process chains; `tests/unit/mcp_server/test_watchdog.py`.
+- [ ] `P02.S09` - Add POSIX-contract assertions for the reparent poll and explicit-pid path exercised on the current platform honestly; `tests/unit/mcp_server/test_watchdog.py`.
+
+### Phase `P03` - documentation and gates
+
+Document the contract and knobs, register the env var, and run the full gate set through review to a ready PR.
+
+- [ ] `P03.S10` - Document the watchdog contract and knobs in the MCP doc and register VAULTSPEC_STDIO_WATCHDOG in the CLI reference env table via the builtins source; `docs/MCP.md`.
+- [ ] `P03.S11` - Run gates, dispatch code review, resolve findings, append audit entries, finalize PR; `quality gates`.
+
+## Description
+
+Execute the 2026-07-17 parity revision of 2026-07-16-mcp-stdio-lifetime-adr:
+bring core's stdio watchdog to the cross-repo backstop and operability
+contract the sibling repo shipped, keeping the client-PID pipe-creator as the
+precise primary anchor. New surface: the VAULTSPEC_STDIO_WATCHDOG kill
+switch, structured JSON exit telemetry, a PID-reuse-safe ancestor-chain
+fallback for non-pipe launches, a POSIX coarse reparent poll, a --parent-pid
+entrypoint override, and user documentation of the contract. Grounded by the
+cross-repo parity delta in 2026-07-16-mcp-stdio-lifetime-research; the
+rag-side half of the convergence is tracked as rag issue 229.
+
+## Parallelization
+
+Phases are sequential: P02's tests exercise P01's engine, and P03 gates the
+finished set. Within P01, S02 through S05 are independent module additions
+and may interleave, but S06 (wiring) lands last; within P02 the three test
+steps are independent.
+
+## Verification
+
+- Kill-switch, override, fallback ancestor-death, grace-window, and POSIX
+  contract tests all pass with real processes; the original client-PID e2e
+  orphan test still passes unchanged.
+- Behavior parity with the sibling repo's shipped contract is
+  point-for-point: disable values, override precedence, telemetry event
+  shape, fail-open discipline.
+- prek clean on changed files; ty clean on both Windows and linux platform
+  assumptions; CI-matching unit gate and the MCP suites green; dependency
+  audit clean.
+- Code review dispatched and findings resolved; audit entries appended; PR
+  references issue 220 and rag issue 229 and is marked ready for review.

--- a/.vault/plan/2026-07-17-mcp-stdio-lifetime-plan.md
+++ b/.vault/plan/2026-07-17-mcp-stdio-lifetime-plan.md
@@ -38,7 +38,7 @@ Prove every new anchor and knob with real processes and pipes, updating the test
 Document the contract and knobs, register the env var, and run the full gate set through review to a ready PR.
 
 - [x] `P03.S10` - Document the watchdog contract and knobs in the MCP doc and register VAULTSPEC_STDIO_WATCHDOG in the CLI reference env table via the builtins source; `docs/MCP.md`.
-- [ ] `P03.S11` - Run gates, dispatch code review, resolve findings, append audit entries, finalize PR; `quality gates`.
+- [x] `P03.S11` - Run gates, dispatch code review, resolve findings, append audit entries, finalize PR; `quality gates`.
 
 ## Description
 

--- a/.vault/research/2026-07-16-mcp-stdio-lifetime-research.md
+++ b/.vault/research/2026-07-16-mcp-stdio-lifetime-research.md
@@ -78,6 +78,51 @@ vaultspec-rag's `vaultspec-search-mcp` stdio entrypoint shows identical
 behavior per issue 220; the same mechanism applies. Not investigated: HTTP/SSE
 transports (not used by either package's stdio registration).
 
+### Cross-repo parity delta (added 2026-07-17, post-merge)
+
+Both fixes are merged: core's client-PID watchdog
+(`src/vaultspec_core/mcp_server/watchdog.py`) and vaultspec-rag's
+ancestor-chain watchdog (rag `src/vaultspec_rag/server/_stdio_lifetime.py`,
+rag main `6ee6f8f`). Comparing the two, rag carries robustness features core
+lacks:
+
+- **Operator kill switch**: `VAULTSPEC_RAG_STDIO_WATCHDOG=0|false|off|no`
+  disables the watchdog; core has no disable path. Core's env convention is
+  bare `VAULTSPEC_*` (per the CLI reference env table), so the parity name
+  is `VAULTSPEC_STDIO_WATCHDOG`.
+- **Explicit client override**: rag accepts `--parent-pid` on the shim
+  entrypoint, watched ahead of discovery; core's `client_pid` parameter is
+  reachable only in code.
+- **Coverage when stdin is not a client pipe**: rag's ancestor-chain
+  discovery works for any launch shape; core fails open entirely when pipe
+  resolution declines (console-less or exotic launches get no backstop).
+  Rag's chain walk is PID-reuse safe (handles taken at startup plus
+  creation-time monotonicity) and prunes transient spawn helpers with a 10s
+  grace window; the trade-off is semantic bluntness - any ancestor's death
+  (including a terminal above the client) fires it.
+- **POSIX backstop**: rag runs a coarse reparent poll (15s) plus explicit
+  parent liveness; core is a strict POSIX no-op on the grounds that EOF
+  delivery is reliable there.
+- **Structured exit telemetry**: rag emits one JSON event line to stderr
+  (`stdio_watchdog_exit` with the dead ancestor pid/exe) before
+  `os._exit(0)`; core logs a plain warning line.
+- **Documentation**: rag documents the watchdog contract and its knobs in
+  its configuration and MCP docs; core's watchdog is undocumented.
+
+Where core is ahead: the pipe-creator anchor identifies the exact client
+regardless of wrapper depth (rag fires on above-client ancestor deaths too)
+and needs no grace heuristics on the primary path; the ctypes prototypes
+are fully declared on both sides.
+
+### Board sweep (2026-07-17)
+
+Open issues: core `#215`, `#213`, `#205` - all covered by open PRs 216-218
+awaiting review, none watchdog-scoped (`#215` is MCP-adjacent gitignore
+hygiene). vaultspec-rag has zero open issues (`rag#184` closed 2026-07-16).
+No board item requires handling inside this parity sweep; the rag-side
+parity recommendation (adopting a pipe-creator primary anchor) has no home
+yet and would need a new rag issue.
+
 ## Sources
 
 - https://github.com/nevenincs/vaultspec-core/issues/220
@@ -86,3 +131,6 @@ transports (not used by either package's stdio registration).
 - `pyproject.toml:20`
 - https://learn.microsoft.com/en-us/windows/win32/api/namedpipeapi/nf-namedpipeapi-getnamedpipeserverprocessid
 - Live process audit and EOF experiment, reporting host, 2026-07-17 (transient; not re-fetchable)
+- vaultspec-rag `src/vaultspec_rag/server/_stdio_lifetime.py` and `server/_main.py` at rag main `6ee6f8f`
+- https://github.com/nevenincs/vaultspec-rag/pull/228
+- `src/vaultspec_core/builtins/reference/cli.md:657` (env-var naming convention)

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -45,7 +45,7 @@ hand-edit between the markers.
 
 ### Top-level commands
 
-- `vaultspec-core install` - Deploy the vaultspec framework to the target directory.
+- `vaultspec-core install` - Install Vaultspec resources for the selected providers.
 - `vaultspec-core uninstall` - Remove the vaultspec framework from the target directory.
 - `vaultspec-core sync` - Sync rules, skills, agents, configs, system prompts, and MCPs.
 - `vaultspec-core doctor` - Diagnose overall workspace and vault health.
@@ -258,12 +258,14 @@ hand-edit between the markers.
 
 #### Mcps
 
-- `vaultspec-core spec mcps list` - List all registered MCP server definitions.
-- `vaultspec-core spec mcps status` - Report focused MCP definition and .mcp.json sync
-  status.
-- `vaultspec-core spec mcps add` - Add a new custom MCP server definition.
-- `vaultspec-core spec mcps remove` - Remove an MCP server definition.
-- `vaultspec-core spec mcps sync` - Sync only MCP definitions to .mcp.json.
+- `vaultspec-core spec mcps list` - List canonical MCP server definitions.
+- `vaultspec-core spec mcps status` - Inspect provider-native MCP enrollment status.
+- `vaultspec-core spec mcps add` - Add or replace a canonical MCP server definition.
+- `vaultspec-core spec mcps remove` - Remove a canonical MCP server definition.
+- `vaultspec-core spec mcps sync` - Reconcile canonical definitions into provider-native
+  enrollment.
+- `vaultspec-core spec mcps uninstall` - Remove Vaultspec-owned provider-native MCP
+  enrollment.
 
 #### Reference
 
@@ -606,15 +608,24 @@ enabled hooks; it takes `--path PATH`. Valid events: `vault.document.created`,
 
 ### vaultspec-core spec mcps
 
-Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage MCP server
-definitions and synced `.mcp.json` entries.
+Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage canonical
+definitions in `.vaultspec/mcps/*.json` and reconcile them into provider-native
+enrollment. Providers are `all`, `claude`, `antigravity`, and `codex`; scopes are
+`project`, `local`, and `user`. Unsupported provider/scope combinations fail.
 
-| Subcommand | Signature | Description | | ---------- |
---------------------------------------- | ----------------------------- | | `list` | - |
-List MCP server definitions. | | `status` | `[--json]` | Validate against `.mcp.json`. |
-| `add` | `--name NAME [--config JSON] [--force]` | Add a custom MCP definition. | |
-`remove` | `NAME [--force]` | Remove an MCP definition. | | `sync` |
-`[--dry-run] [--force]` | Sync definitions to config. |
+| Subcommand  | Signature                                                                             | Description                                                         |
+| ----------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `list`      | -                                                                                     | List canonical MCP server definitions.                              |
+| `status`    | `[PROVIDER] [--scope SCOPE] [--json] [--target PATH]`                                 | Inspect configuration and ownership state; does not probe runtimes. |
+| `add`       | `--name NAME [--config JSON] [--force]`                                               | Add or replace a canonical definition.                              |
+| `remove`    | `NAME [--force]`                                                                      | Remove a canonical definition.                                      |
+| `sync`      | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--prune] [--json] [--target PATH]` | Reconcile canonical definitions into native enrollment.             |
+| `uninstall` | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--json] [--target PATH]`           | Remove only Vaultspec-owned native enrollment.                      |
+
+The default provider is `all` and the default scope is `project`. `sync --force` adopts
+or replaces a same-name external entry; `sync --prune` removes owned enrollment whose
+canonical source was deleted. `uninstall` preserves canonical definitions and external
+host entries.
 
 ## Migration commands
 
@@ -652,4 +663,5 @@ name. | | `VAULTSPEC_CLAUDE_DIR` | str | `.claude` | Claude tool directory name.
 `VAULTSPEC_IO_BUFFER_SIZE` | int | `8192` | I/O read buffer size in bytes. | |
 `VAULTSPEC_TERMINAL_OUTPUT_LIMIT` | int | `1000000` | Subprocess stdout capture limit. |
 | `VAULTSPEC_LOG_LEVEL` | str | `INFO` | Root log level for the CLI. | |
-`VAULTSPEC_EDITOR` | str | `zed -w` | Editor command for resource editing. |
+`VAULTSPEC_EDITOR` | str | `zed -w` | Editor command for resource editing. | |
+`VAULTSPEC_STDIO_WATCHDOG` | str | on | MCP server lifetime watchdog; `0`/`false`/`off`/`no` disables it (EOF-only exit). |

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -756,6 +756,32 @@ denylist covers:
   `spec mcps list` and `spec mcps status` stay available)
 - `vault feature index` - index documents stay uncreatable through the MCP surface
 
+## Server lifetime
+
+The server's lifetime is its client connection. It exits when stdin reaches EOF, and a
+lifetime watchdog backstops the cases where EOF never arrives - on Windows, a client
+that restarts or dies can leave the server's stdin pipe held open by inherited handles,
+which would otherwise leave orphaned server processes running indefinitely.
+
+The watchdog anchors shutdown to the client process itself. On Windows it identifies the
+process that created the server's stdin pipe and exits the moment that process
+terminates; when stdin is not a client-created pipe (a console launch, for example) it
+watches the server's ancestor process chain instead, ignoring short-lived launcher
+processes. On other platforms a coarse poll exits the server if it is ever orphaned.
+When the watchdog fires, one JSON event line (`"event": "stdio_watchdog_exit"`) is
+written to stderr before the server exits cleanly.
+
+Two knobs control it:
+
+- `VAULTSPEC_STDIO_WATCHDOG` - set to `0`, `false`, `off`, or `no` to disable the
+  watchdog entirely; the server then exits only on stdin EOF.
+- `--parent-pid <PID>` - names an explicit client process to watch in addition to the
+  detected one. Useful for hosts that spawn the server through wrappers the detection
+  cannot see through.
+
+A watchdog that cannot start never prevents the server from serving; every failure falls
+back to plain EOF-only behavior.
+
 ## Logging
 
 All server logs go to stderr. Stdout is reserved exclusively for the JSON-RPC protocol

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -663,4 +663,6 @@ name. | | `VAULTSPEC_CLAUDE_DIR` | str | `.claude` | Claude tool directory name.
 `VAULTSPEC_IO_BUFFER_SIZE` | int | `8192` | I/O read buffer size in bytes. | |
 `VAULTSPEC_TERMINAL_OUTPUT_LIMIT` | int | `1000000` | Subprocess stdout capture limit. |
 | `VAULTSPEC_LOG_LEVEL` | str | `INFO` | Root log level for the CLI. | |
-`VAULTSPEC_EDITOR` | str | `zed -w` | Editor command for resource editing. |
+`VAULTSPEC_EDITOR` | str | `zed -w` | Editor command for resource editing. | |
+`VAULTSPEC_STDIO_WATCHDOG` | str | on | MCP server lifetime watchdog;
+`0`/`false`/`off`/`no` disables it (EOF-only exit). |

--- a/src/vaultspec_core/mcp_server/app.py
+++ b/src/vaultspec_core/mcp_server/app.py
@@ -104,7 +104,7 @@ def create_server() -> FastMCP:
     return mcp
 
 
-def _serve(ctx_obj: dict | None = None) -> None:
+def _serve(ctx_obj: dict | None = None, parent_pid: int | None = None) -> None:
     """Resolve runtime context, initialise paths, and start the MCP stdio server.
 
     Configures logging to stderr (to protect JSON-RPC on stdout), resolves
@@ -114,6 +114,8 @@ def _serve(ctx_obj: dict | None = None) -> None:
     Args:
         ctx_obj: Optional Typer context object injected by the root CLI app.
             Must contain ``"layout"`` and ``"target"`` keys when present.
+        parent_pid: Optional explicit client PID the lifetime watchdog
+            watches ahead of discovery.
 
     Raises:
         typer.Exit: If ``root_dir`` cannot be resolved in standalone mode.
@@ -144,12 +146,13 @@ def _serve(ctx_obj: dict | None = None) -> None:
 
     mcp = create_server()
 
-    # Windows backstop for the stdio lifetime contract: stdin EOF can be
-    # defeated by inherited pipe handles, so anchor shutdown to the client
-    # process itself. Fails open to EOF-only behavior when it cannot arm.
+    # Backstop for the stdio lifetime contract: stdin EOF can be defeated by
+    # inherited pipe handles, so anchor shutdown to the client process itself
+    # (pipe creator primary, ancestor chain fallback, POSIX reparent poll).
+    # Fails open to EOF-only behavior when it cannot arm.
     from .watchdog import arm_client_watchdog
 
-    if arm_client_watchdog():
+    if arm_client_watchdog(parent_pid=parent_pid):
         logger.debug("Client watchdog armed")
     else:
         logger.debug("Client watchdog not armed; relying on stdin EOF")
@@ -161,14 +164,26 @@ def _serve(ctx_obj: dict | None = None) -> None:
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    parent_pid: int | None = typer.Option(
+        None,
+        "--parent-pid",
+        help=(
+            "Explicit client PID for the stdio lifetime watchdog "
+            "(watched in addition to the discovered client)"
+        ),
+    ),
+) -> None:
     """Typer callback entrypoint for vaultspec-mcp.
 
     Args:
         ctx: Typer context carrying the optional ``obj`` dict injected by
             the root CLI app (contains ``"layout"`` and ``"target"`` keys).
+        parent_pid: Optional explicit client PID forwarded to the lifetime
+            watchdog.
     """
-    _serve(ctx.obj)
+    _serve(ctx.obj, parent_pid=parent_pid)
 
 
 def run() -> None:

--- a/src/vaultspec_core/mcp_server/watchdog.py
+++ b/src/vaultspec_core/mcp_server/watchdog.py
@@ -1,174 +1,507 @@
-"""Windows client-process watchdog for the stdio MCP server.
+"""Client-process lifetime watchdog for the stdio MCP server.
 
 The stdio transport's lifetime contract is "exit on stdin EOF", but on
 Windows inherited pipe handles can keep the stdin pipe open after the
 spawning client is gone, so EOF never arrives and the server outlives its
 client. This module anchors the server's lifetime to the client process
-itself: it resolves the process that created the stdin pipe, holds a
-``SYNCHRONIZE`` handle to it, and hard-exits the server the moment that
-process terminates.
+through layered anchors:
 
-Every failure path fails open: when the watchdog cannot arm (non-Windows
-platform, console stdin, inaccessible client process), the server keeps the
-plain EOF-only behavior.
+- **Primary (Windows):** resolve the process that created the stdin pipe,
+  hold a ``SYNCHRONIZE`` handle to it, and hard-exit the moment it
+  terminates - exact-client semantics regardless of wrapper depth.
+- **Fallback (Windows):** when stdin is not a client-created pipe, watch
+  the discovered ancestor chain instead (handles taken at startup so PID
+  reuse cannot retarget the wait, creation-time monotonicity ending the
+  walk at a reused PID, and a grace window dropping transient spawn
+  helpers).
+- **POSIX backstop:** a coarse reparent poll that exits when the server is
+  orphaned or an explicitly named client dies; stdin EOF stays the primary
+  exit path everywhere.
+
+``VAULTSPEC_STDIO_WATCHDOG`` (``0``/``false``/``off``/``no``) disables all
+arming. Every failure path fails open: a watchdog that cannot arm must
+never prevent the server from serving. Before every hard exit one
+structured JSON event line is flushed to stderr, matching the companion
+vaultspec-rag server's event shape so host-side tooling can consume both.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import sys
 import threading
+import time
 
 logger = logging.getLogger(__name__)
 
+#: Operator kill switch; off values disable all arming.
+STDIO_WATCHDOG_ENV = "VAULTSPEC_STDIO_WATCHDOG"
+
+_OFF_VALUES = frozenset({"0", "false", "off", "no"})
+
+#: Ancestors beyond this depth are noise (session managers, init); the
+#: spawning client is always within a few hops (client -> uv -> launcher).
+_MAX_ANCESTOR_DEPTH = 8
+
+#: Seconds before the fallback watchdog arms. Transient spawn helpers
+#: (``cmd /c`` wrappers) exit within moments of spawning the chain;
+#: discovered ancestors that die during the grace window are dropped
+#: instead of treated as termination intent. The precise anchors (resolved
+#: client, explicit override) are never grace-pruned.
+_GRACE_SECONDS = 10.0
+
+#: Coarse POSIX reparent-poll interval; the backstop does not need to be
+#: fast, only eventual.
+_POSIX_POLL_SECONDS = 15.0
+
 _SYNCHRONIZE = 0x0010_0000
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x0000_1000
 _INFINITE = 0xFFFF_FFFF
 _WAIT_OBJECT_0 = 0x0000_0000
+_WAIT_TIMEOUT = 0x0000_0102
+_TH32CS_SNAPPROCESS = 0x0000_0002
 
 
-def _kernel32():  # pragma: no cover - trivial loader, Windows-only
-    """Load ``kernel32`` with last-error capture and declared prototypes.
+def watchdog_disabled() -> bool:
+    """Return whether the operator kill switch disables the watchdog."""
+    return os.environ.get(STDIO_WATCHDOG_ENV, "").strip().lower() in _OFF_VALUES
 
-    Every foreign function declares ``argtypes`` and ``restype``: undeclared
-    ctypes signatures marshal by default int inference and fail silently,
-    and ``OpenProcess`` in particular needs a pointer-sized restype or
-    64-bit handle values truncate.
 
-    Returns:
-        The configured :class:`ctypes.WinDLL` instance.
+class _WatchedProcess:
+    """A process the watchdog holds a ``SYNCHRONIZE`` handle on."""
 
-    Raises:
-        RuntimeError: When called off Windows; callers gate on the platform.
+    __slots__ = ("exe", "grace_prunable", "handle", "pid")
+
+    def __init__(
+        self, pid: int, exe: str, handle: int, *, grace_prunable: bool
+    ) -> None:
+        self.pid = pid
+        self.exe = exe
+        self.handle = handle
+        self.grace_prunable = grace_prunable
+
+
+def _exit_on_watched_death(pid: int, exe: str) -> None:
+    """Flush one structured event line and hard-exit.
+
+    :func:`os._exit` is deliberate: shutdown must not depend on the event
+    loop cooperating mid-teardown, and the blocked stdio reader cannot be
+    cancelled in-process. Exit code 0 because self-reaping after the client
+    died is the intended outcome, not a crash a supervisor should retry.
     """
-    if sys.platform != "win32":
-        raise RuntimeError("kernel32 is only loadable on Windows")
+    print(
+        json.dumps(
+            {
+                "event": "stdio_watchdog_exit",
+                "dead_ancestor_pid": pid,
+                "dead_ancestor_exe": exe,
+                "shim_pid": os.getpid(),
+            }
+        ),
+        file=sys.stderr,
+        flush=True,
+    )
+    os._exit(0)
 
+
+def _walk_ancestor_pids(
+    start_pid: int,
+    parents: dict[int, int],
+    max_depth: int = _MAX_ANCESTOR_DEPTH,
+) -> list[int]:
+    """Ancestor PIDs of ``start_pid``, nearest first, bounded and cycle-safe.
+
+    ``parents`` maps pid to parent pid as observed in one snapshot. The walk
+    stops at the depth bound, at a missing entry, at pid 0/self-parenting,
+    and at any pid already seen (snapshot cycles happen when PIDs were
+    reused between rows).
+    """
+    chain: list[int] = []
+    seen: set[int] = {start_pid}
+    pid = start_pid
+    for _ in range(max_depth):
+        ppid = parents.get(pid)
+        if ppid is None or ppid == 0 or ppid == pid or ppid in seen:
+            break
+        chain.append(ppid)
+        seen.add(ppid)
+        pid = ppid
+    return chain
+
+
+if sys.platform == "win32":
     import ctypes
     from ctypes import wintypes
 
-    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
-    kernel32.GetNamedPipeServerProcessId.argtypes = (
+    class _PROCESSENTRY32(ctypes.Structure):
+        _fields_ = (
+            ("dwSize", wintypes.DWORD),
+            ("cntUsage", wintypes.DWORD),
+            ("th32ProcessID", wintypes.DWORD),
+            ("th32DefaultHeapID", ctypes.c_size_t),
+            ("th32ModuleID", wintypes.DWORD),
+            ("cntThreads", wintypes.DWORD),
+            ("th32ParentProcessID", wintypes.DWORD),
+            ("pcPriClassBase", ctypes.c_long),
+            ("dwFlags", wintypes.DWORD),
+            ("szExeFile", ctypes.c_char * 260),
+        )
+
+    class _FILETIME(ctypes.Structure):
+        _fields_ = (
+            ("dwLowDateTime", wintypes.DWORD),
+            ("dwHighDateTime", wintypes.DWORD),
+        )
+
+    # Undeclared ctypes signatures marshal through default int inference and
+    # fail silently when they drift, so every binding declares argtypes and
+    # restype (OpenProcess in particular truncates 64-bit handles without a
+    # pointer-sized restype).
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _kernel32.GetNamedPipeServerProcessId.argtypes = (
         wintypes.HANDLE,
         ctypes.POINTER(wintypes.DWORD),
     )
-    kernel32.GetNamedPipeServerProcessId.restype = wintypes.BOOL
-    kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
-    kernel32.OpenProcess.restype = wintypes.HANDLE
-    kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
-    kernel32.WaitForSingleObject.restype = wintypes.DWORD
-    kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
-    kernel32.CloseHandle.restype = wintypes.BOOL
-    return kernel32
+    _kernel32.GetNamedPipeServerProcessId.restype = wintypes.BOOL
+    _kernel32.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+    _kernel32.OpenProcess.restype = wintypes.HANDLE
+    _kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+    _kernel32.WaitForSingleObject.argtypes = (wintypes.HANDLE, wintypes.DWORD)
+    _kernel32.WaitForSingleObject.restype = wintypes.DWORD
+    _kernel32.WaitForMultipleObjects.argtypes = (
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.HANDLE),
+        wintypes.BOOL,
+        wintypes.DWORD,
+    )
+    _kernel32.WaitForMultipleObjects.restype = wintypes.DWORD
+    _kernel32.CreateToolhelp32Snapshot.argtypes = (wintypes.DWORD, wintypes.DWORD)
+    _kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+    _kernel32.Process32First.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(_PROCESSENTRY32),
+    )
+    _kernel32.Process32First.restype = wintypes.BOOL
+    _kernel32.Process32Next.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(_PROCESSENTRY32),
+    )
+    _kernel32.Process32Next.restype = wintypes.BOOL
+    _kernel32.GetProcessTimes.argtypes = (
+        wintypes.HANDLE,
+        ctypes.POINTER(_FILETIME),
+        ctypes.POINTER(_FILETIME),
+        ctypes.POINTER(_FILETIME),
+        ctypes.POINTER(_FILETIME),
+    )
+    _kernel32.GetProcessTimes.restype = wintypes.BOOL
 
+    _INVALID_HANDLE_VALUE = wintypes.HANDLE(-1).value
 
-def resolve_stdin_client_pid() -> int | None:
-    """Resolve the PID of the process that created this process's stdin pipe.
-
-    Anonymous pipes are named pipes under the hood on Windows, so
-    ``GetNamedPipeServerProcessId`` on the inherited stdin handle yields the
-    pipe-creating process: the MCP client, regardless of how many wrapper
-    processes (``uv``, venv launchers) sit in between.
-
-    Returns:
-        The client PID, or ``None`` when stdin is not a pipe (console or
-        redirected-file stdin), the handle is unavailable, or the resolved
-        PID is this process itself.
-    """
-    if sys.platform != "win32":
-        return None
-
-    # Fail open on anything unexpected (no stdin object, a Windows build
-    # missing the export, ...): arming failures must never prevent serving.
-    try:
-        import ctypes
-        import msvcrt
-
+    def _snapshot_processes() -> tuple[dict[int, int], dict[int, str]]:
+        """One Toolhelp32 pass: pid to ppid and pid to exe name."""
+        snap = _kernel32.CreateToolhelp32Snapshot(_TH32CS_SNAPPROCESS, 0)
+        if snap is None or snap == _INVALID_HANDLE_VALUE:
+            raise ctypes.WinError(ctypes.get_last_error())
+        parents: dict[int, int] = {}
+        names: dict[int, str] = {}
         try:
-            handle = msvcrt.get_osfhandle(sys.stdin.fileno())
-        except OSError:
-            logger.debug("watchdog: no stdin OS handle; not arming")
+            entry = _PROCESSENTRY32()
+            entry.dwSize = ctypes.sizeof(_PROCESSENTRY32)
+            ok = bool(_kernel32.Process32First(snap, ctypes.byref(entry)))
+            while ok:
+                pid = int(entry.th32ProcessID)
+                parents[pid] = int(entry.th32ParentProcessID)
+                names[pid] = entry.szExeFile.decode(errors="replace")
+                ok = bool(_kernel32.Process32Next(snap, ctypes.byref(entry)))
+        finally:
+            _kernel32.CloseHandle(snap)
+        return parents, names
+
+    def _creation_time(handle: int) -> int:
+        """Process creation time as a FILETIME integer; 0 when unreadable."""
+        created = _FILETIME()
+        exited = _FILETIME()
+        kernel = _FILETIME()
+        user = _FILETIME()
+        ok = _kernel32.GetProcessTimes(
+            handle,
+            ctypes.byref(created),
+            ctypes.byref(exited),
+            ctypes.byref(kernel),
+            ctypes.byref(user),
+        )
+        if not ok:
+            return 0
+        return (int(created.dwHighDateTime) << 32) | int(created.dwLowDateTime)
+
+    def _open_process(pid: int) -> int | None:
+        handle = _kernel32.OpenProcess(
+            _SYNCHRONIZE | _PROCESS_QUERY_LIMITED_INFORMATION, False, pid
+        )
+        return int(handle) if handle else None
+
+    def resolve_stdin_client_pid() -> int | None:
+        """Resolve the PID of the process that created this process's stdin pipe.
+
+        Anonymous pipes are named pipes under the hood on Windows, so
+        ``GetNamedPipeServerProcessId`` on the inherited stdin handle yields
+        the pipe-creating process: the MCP client, regardless of how many
+        wrapper processes (``uv``, venv launchers) sit in between.
+
+        Returns:
+            The client PID, or ``None`` when stdin is not a pipe (console or
+            redirected-file stdin), the handle is unavailable, or the
+            resolved PID is this process itself. Fails open on anything
+            unexpected.
+        """
+        try:
+            import msvcrt
+
+            try:
+                handle = msvcrt.get_osfhandle(sys.stdin.fileno())
+            except OSError:
+                logger.debug("watchdog: no stdin OS handle")
+                return None
+
+            server_pid = ctypes.c_ulong(0)
+            ok = _kernel32.GetNamedPipeServerProcessId(handle, ctypes.byref(server_pid))
+            if not ok:
+                logger.debug(
+                    "watchdog: stdin is not a pipe (error %d)",
+                    ctypes.get_last_error(),
+                )
+                return None
+
+            pid = int(server_pid.value)
+            if pid == 0 or pid == os.getpid():
+                logger.debug("watchdog: pipe creator is self or unresolved (%d)", pid)
+                return None
+            return pid
+        except Exception:
+            logger.debug("watchdog: client resolution failed", exc_info=True)
             return None
 
-        kernel32 = _kernel32()
-        server_pid = ctypes.c_ulong(0)
-        ok = kernel32.GetNamedPipeServerProcessId(handle, ctypes.byref(server_pid))
-        if not ok:
+    def _open_ancestor_chain() -> list[_WatchedProcess]:
+        """SYNCHRONIZE handles on the live ancestor chain, PID-reuse safe.
+
+        Walks the snapshot parent chain from this process, opening each
+        ancestor's handle immediately and enforcing creation-time
+        monotonicity: a genuine ancestor existed before its child, so a
+        "parent" younger than the child is a reused PID and ends the walk.
+        """
+        watched: list[_WatchedProcess] = []
+        parents, names = _snapshot_processes()
+        my_handle = _open_process(os.getpid())
+        child_ctime = _creation_time(my_handle) if my_handle is not None else 0
+        if my_handle is not None:
+            _kernel32.CloseHandle(my_handle)
+        for pid in _walk_ancestor_pids(os.getpid(), parents):
+            handle = _open_process(pid)
+            if handle is None:
+                break
+            ancestor_ctime = _creation_time(handle)
+            if child_ctime and (ancestor_ctime == 0 or ancestor_ctime > child_ctime):
+                _kernel32.CloseHandle(handle)
+                break
+            watched.append(
+                _WatchedProcess(pid, names.get(pid, "?"), handle, grace_prunable=True)
+            )
+            child_ctime = ancestor_ctime
+        return watched
+
+    def _open_watched(pid: int, *, grace_prunable: bool) -> _WatchedProcess | None:
+        """Open one explicit PID as a watched process; ``None`` when refused."""
+        handle = _open_process(pid)
+        if handle is None:
             logger.debug(
-                "watchdog: stdin is not a pipe (error %d); not arming",
+                "watchdog: cannot open process %d (error %d)",
+                pid,
                 ctypes.get_last_error(),
             )
             return None
+        try:
+            _, names = _snapshot_processes()
+            exe = names.get(pid, "?")
+        except Exception:
+            exe = "?"
+        return _WatchedProcess(pid, exe, handle, grace_prunable=grace_prunable)
 
-        pid = int(server_pid.value)
-        if pid == 0 or pid == os.getpid():
-            logger.debug(
-                "watchdog: pipe creator is self or unresolved (%d); not arming", pid
+    def _windows_wait(watched: list[_WatchedProcess], grace_seconds: float) -> None:
+        """Grace-prune the prunable targets, then wait-any; hard-exit on death.
+
+        Runs on a daemon thread. Only discovered-chain targets are grace
+        prunable; the resolved client and an explicit override signal exit
+        immediately, preserving the instant reap of an already-dead client.
+        A failed wait disarms the backstop (stdin EOF remains) rather than
+        killing a live session.
+        """
+        if any(w.grace_prunable for w in watched):
+            time.sleep(grace_seconds)
+        survivors: list[_WatchedProcess] = []
+        for target in watched:
+            if not target.grace_prunable:
+                survivors.append(target)
+                continue
+            if _kernel32.WaitForSingleObject(target.handle, 0) == _WAIT_TIMEOUT:
+                survivors.append(target)
+            else:
+                _kernel32.CloseHandle(target.handle)
+                logger.info(
+                    "watchdog: dropping ancestor %d (%s) gone during grace",
+                    target.pid,
+                    target.exe,
+                )
+        if not survivors:
+            logger.warning(
+                "watchdog: no targets survived the grace window; "
+                "backstop disarmed, stdin EOF is the only exit path"
             )
-            return None
-        return pid
-    except Exception:
-        logger.debug("watchdog: client resolution failed; not arming", exc_info=True)
+            return
+        handles = (wintypes.HANDLE * len(survivors))(
+            *[target.handle for target in survivors]
+        )
+        result = int(
+            _kernel32.WaitForMultipleObjects(len(survivors), handles, False, _INFINITE)
+        )
+        index = result - _WAIT_OBJECT_0
+        if not 0 <= index < len(survivors):
+            for target in survivors:
+                _kernel32.CloseHandle(target.handle)
+            logger.warning(
+                "watchdog: wait failed (result 0x%x, error %d); "
+                "backstop disarmed, stdin EOF is the only exit path",
+                result,
+                ctypes.get_last_error(),
+            )
+            return
+        _exit_on_watched_death(survivors[index].pid, survivors[index].exe)
+
+else:
+
+    def resolve_stdin_client_pid() -> int | None:
+        """POSIX has no pipe-creator resolution; the reparent poll covers it."""
         return None
 
 
-def arm_client_watchdog(client_pid: int | None = None) -> bool:
-    """Arm a daemon thread that exits the server when the client process dies.
+def _pid_alive(pid: int) -> bool:
+    """POSIX liveness probe (never use ``os.kill(pid, 0)`` on Windows)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        logger.debug("watchdog: liveness probe failed for pid %d", pid, exc_info=True)
+        return True
+    return True
 
-    Opens the client process with ``SYNCHRONIZE`` access and blocks on
-    ``WaitForSingleObject`` in a daemon thread. When the client's process
-    handle signals, the thread calls :func:`os._exit` so shutdown does not
-    depend on the event loop cooperating mid-teardown; the wrapper chain
-    above the worker unwinds on its own once the worker exits.
+
+def _posix_watchdog(initial_ppid: int, extra_pids: tuple[int, ...]) -> None:
+    """Coarse reparent poll: exit when orphaned or an explicit client dies."""
+    while True:
+        time.sleep(_POSIX_POLL_SECONDS)
+        ppid = os.getppid()
+        if ppid != initial_ppid:
+            _exit_on_watched_death(initial_ppid, "parent")
+        for pid in extra_pids:
+            if not _pid_alive(pid):
+                _exit_on_watched_death(pid, "explicit-client")
+
+
+def arm_client_watchdog(
+    client_pid: int | None = None,
+    parent_pid: int | None = None,
+    grace_seconds: float = _GRACE_SECONDS,
+) -> bool:
+    """Arm the lifetime backstop; return whether a watchdog thread started.
+
+    On Windows the primary anchor is the stdin pipe creator resolved by
+    :func:`resolve_stdin_client_pid` (or the injected ``client_pid``); when
+    resolution declines, the discovered ancestor chain is watched instead,
+    grace-pruned so transient spawn helpers do not count as termination
+    intent. An explicit ``parent_pid`` (the ``--parent-pid`` entrypoint
+    override) is watched ahead of discovery in either mode. On POSIX a
+    coarse reparent poll backstops abandonment without pipe closure.
+
+    Every path fails open, and ``VAULTSPEC_STDIO_WATCHDOG`` off values skip
+    arming entirely.
 
     Args:
-        client_pid: Explicit client PID to watch. Defaults to the stdin
-            pipe creator resolved by :func:`resolve_stdin_client_pid`.
+        client_pid: Explicit client PID for the primary anchor. Defaults to
+            the stdin pipe creator.
+        parent_pid: Additional process to watch ahead of discovery.
+        grace_seconds: Fallback grace window before discovered ancestors
+            count as termination intent.
 
     Returns:
-        ``True`` when the watchdog armed, ``False`` when it failed open and
-        the server retains EOF-only shutdown.
+        ``True`` when a watchdog thread armed, ``False`` when arming was
+        disabled or failed open and the server retains EOF-only shutdown.
     """
-    if sys.platform != "win32":
-        return False
-    if client_pid is None:
-        client_pid = resolve_stdin_client_pid()
-    if client_pid is None:
+    if watchdog_disabled():
+        logger.info(
+            "watchdog: disabled via %s; stdin EOF is the only exit path",
+            STDIO_WATCHDOG_ENV,
+        )
         return False
 
     try:
-        import ctypes
-
-        kernel32 = _kernel32()
-        process_handle = kernel32.OpenProcess(_SYNCHRONIZE, False, client_pid)
-        if not process_handle:
-            logger.debug(
-                "watchdog: cannot open client process %d (error %d); not arming",
-                client_pid,
-                ctypes.get_last_error(),
-            )
-            return False
-
-        def _wait_for_client_exit() -> None:
-            result = kernel32.WaitForSingleObject(process_handle, _INFINITE)
-            if result == _WAIT_OBJECT_0:
-                logger.warning(
-                    "watchdog: client process %d exited; shutting down", client_pid
+        if sys.platform == "win32":
+            watched: list[_WatchedProcess] = []
+            if parent_pid is not None:
+                explicit = _open_watched(parent_pid, grace_prunable=False)
+                if explicit is None:
+                    logger.warning(
+                        "watchdog: explicit parent pid %d not watchable", parent_pid
+                    )
+                else:
+                    watched.append(explicit)
+            resolved = client_pid or resolve_stdin_client_pid()
+            client_watched = False
+            if resolved is not None:
+                if any(w.pid == resolved for w in watched):
+                    client_watched = True
+                else:
+                    client = _open_watched(resolved, grace_prunable=False)
+                    if client is not None:
+                        watched.append(client)
+                        client_watched = True
+            if not client_watched:
+                fallback = _open_ancestor_chain()
+                known = {w.pid for w in watched}
+                watched.extend(w for w in fallback if w.pid not in known)
+            if not watched:
+                logger.debug(
+                    "watchdog: no watchable targets; "
+                    "backstop disarmed, stdin EOF is the only exit path"
                 )
-                os._exit(0)
-            kernel32.CloseHandle(process_handle)
-            logger.debug(
-                "watchdog: wait on client %d ended without exit signal (result %d)",
-                client_pid,
-                result,
+                return False
+            thread = threading.Thread(
+                target=_windows_wait,
+                args=(watched, grace_seconds),
+                name="mcp-client-watchdog",
+                daemon=True,
             )
+            thread.start()
+            logger.debug(
+                "watchdog: armed on %s",
+                ", ".join(f"{w.pid}({w.exe})" for w in watched),
+            )
+            return True
 
-        threading.Thread(
-            target=_wait_for_client_exit,
+        extra = (parent_pid,) if parent_pid is not None else ()
+        thread = threading.Thread(
+            target=_posix_watchdog,
+            args=(os.getppid(), extra),
             name="mcp-client-watchdog",
             daemon=True,
-        ).start()
-        logger.debug("watchdog: armed on client process %d", client_pid)
+        )
+        thread.start()
+        logger.debug("watchdog: armed POSIX reparent poll")
         return True
     except Exception:
         logger.debug("watchdog: arming failed; not arming", exc_info=True)

--- a/src/vaultspec_core/mcp_server/watchdog.py
+++ b/src/vaultspec_core/mcp_server/watchdog.py
@@ -473,7 +473,14 @@ def arm_client_watchdog(
             if not client_watched:
                 fallback = _open_ancestor_chain()
                 known = {w.pid for w in watched}
-                watched.extend(w for w in fallback if w.pid not in known)
+                for target in fallback:
+                    if target.pid in known:
+                        # Already watched (an explicit override on the
+                        # chain); drop the duplicate without leaking its
+                        # freshly opened handle.
+                        _kernel32.CloseHandle(target.handle)
+                    else:
+                        watched.append(target)
             if not watched:
                 logger.debug(
                     "watchdog: no watchable targets; "
@@ -486,7 +493,12 @@ def arm_client_watchdog(
                 name="mcp-client-watchdog",
                 daemon=True,
             )
-            thread.start()
+            try:
+                thread.start()
+            except Exception:
+                for target in watched:
+                    _kernel32.CloseHandle(target.handle)
+                raise
             logger.debug(
                 "watchdog: armed on %s",
                 ", ".join(f"{w.pid}({w.exe})" for w in watched),

--- a/tests/unit/mcp_server/test_watchdog.py
+++ b/tests/unit/mcp_server/test_watchdog.py
@@ -179,7 +179,6 @@ def test_kill_switch_disables_arming_in_process() -> None:
     os.environ[STDIO_WATCHDOG_ENV] = "off"
     try:
         assert watchdog_disabled() is True
-        assert resolve_stdin_client_pid() is None
         assert arm_client_watchdog() is False
     finally:
         if previous is None:

--- a/tests/unit/mcp_server/test_watchdog.py
+++ b/tests/unit/mcp_server/test_watchdog.py
@@ -1,20 +1,26 @@
-"""Tests for the Windows client-PID stdio watchdog.
+"""Tests for the stdio lifetime watchdog: anchors, knobs, and telemetry.
 
 Every test drives real processes and real pipes: children are spawned with
 ``sys.executable``, stdin pipes are genuine OS pipes, and liveness is
 observed through the same Win32 process-handle semantics the watchdog
 relies on. No mocks, stubs, or skips: on non-Windows platforms the same
-tests assert the module's genuine fail-open contract (resolver yields no
-PID, arming declines) instead of being deselected.
+tests assert the module's genuine POSIX contract (no pipe-creator
+resolution, reparent-poll arming) instead of being deselected.
 
-The end-to-end test reproduces the leak scenario from the field report: a
-client dies while a sibling process still holds the write end of the
-server's stdin pipe, so EOF can never arrive and only the watchdog can
-reap the server.
+Coverage spans the layered anchors: the client-PID primary (resolution
+directly and through wrapper depth, instant reap of a dead client), the
+ancestor-chain fallback (non-pipe launches, ancestor death, grace-window
+pruning of transient spawners), the operator kill switch, the explicit
+``--parent-pid`` override through the real entrypoint, and the structured
+exit event. The end-to-end test reproduces the leak scenario from the
+field report: a client dies while a sibling process still holds the write
+end of the server's stdin pipe, so EOF can never arrive and only the
+watchdog can reap the server.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -28,8 +34,10 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from vaultspec_core.mcp_server.watchdog import (
+    STDIO_WATCHDOG_ENV,
     arm_client_watchdog,
     resolve_stdin_client_pid,
+    watchdog_disabled,
 )
 
 pytestmark = pytest.mark.unit
@@ -65,6 +73,24 @@ def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
         return result == 0
     finally:
         kernel32.CloseHandle(ctypes.c_void_p(handle))
+
+
+def _wait_for_posix_pid_exit(pid: int, timeout: float) -> bool:
+    """Poll POSIX liveness until *pid* exits or the deadline passes.
+
+    ``os.kill(pid, 0)`` is the correct probe on POSIX only; on Windows it
+    terminates the target, hence the separate handle-based helper above.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            pass
+        time.sleep(0.5)
+    return False
 
 
 def test_resolver_identifies_pipe_creating_process() -> None:
@@ -116,8 +142,13 @@ def test_resolver_sees_through_wrapper_processes() -> None:
         assert resolved == "None"
 
 
-def test_non_pipe_stdin_fails_open(tmp_path: Path) -> None:
-    """A file-backed stdin is not a pipe: resolver and arming both decline."""
+def test_non_pipe_stdin_arms_ancestor_fallback(tmp_path: Path) -> None:
+    """A file-backed stdin declines resolution but still arms a backstop.
+
+    The resolver yields no client PID, so on Windows arming falls back to
+    the discovered ancestor chain and on POSIX the reparent poll arms:
+    every launch shape gets a watchdog, not only pipe-spawned ones.
+    """
     snippet = (
         "from vaultspec_core.mcp_server.watchdog import"
         " arm_client_watchdog, resolve_stdin_client_pid;"
@@ -134,19 +165,50 @@ def test_non_pipe_stdin_fails_open(tmp_path: Path) -> None:
             timeout=60,
         )
     assert proc.returncode == 0, proc.stderr
-    assert proc.stdout.strip() == "None False"
+    assert proc.stdout.strip() == "None True"
 
 
-def test_in_process_contract_on_this_platform() -> None:
-    """Direct calls honor the platform contract without side effects.
+def test_kill_switch_disables_arming_in_process() -> None:
+    """The env kill switch declines arming before any anchor is touched.
 
-    The contract is identical on every platform: POSIX returns the hard
-    ``None``, and under pytest on Windows the captured stdin is not a
-    client-owned pipe, so arming must decline rather than spawn a watchdog
-    thread against a live process this test cannot control.
+    Exercised in-process with a real environment mutation (restored in
+    ``finally``) so no watchdog thread is ever spawned inside the test
+    runner.
     """
-    assert resolve_stdin_client_pid() is None
-    assert arm_client_watchdog() is False
+    previous = os.environ.get(STDIO_WATCHDOG_ENV)
+    os.environ[STDIO_WATCHDOG_ENV] = "off"
+    try:
+        assert watchdog_disabled() is True
+        assert resolve_stdin_client_pid() is None
+        assert arm_client_watchdog() is False
+    finally:
+        if previous is None:
+            del os.environ[STDIO_WATCHDOG_ENV]
+        else:
+            os.environ[STDIO_WATCHDOG_ENV] = previous
+
+
+def test_kill_switch_disables_arming_in_worker() -> None:
+    """A worker launched with the kill switch set stays alive and unarmed."""
+    worker_code = textwrap.dedent(
+        """
+        import time
+        from vaultspec_core.mcp_server.watchdog import arm_client_watchdog
+        print(f"armed={arm_client_watchdog()}", flush=True)
+        time.sleep(2)
+        print("still-alive", flush=True)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", worker_code],
+        env={**os.environ, STDIO_WATCHDOG_ENV: "0"},
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "armed=False" in proc.stdout
+    assert "still-alive" in proc.stdout
 
 
 def test_armed_worker_exits_when_dead_client_pid_signals() -> None:
@@ -206,6 +268,8 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
         assert resolve_stdin_client_pid() is None
         return
 
+    (tmp_path / ".vaultspec").mkdir()
+    (tmp_path / ".vault").mkdir()
     client_code = textwrap.dedent(
         f"""
         import os, subprocess, sys, time
@@ -240,8 +304,13 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
         server_pid = int(client.stdout.readline())
         sleeper_pid = int(client.stdout.readline())
 
-        # Give the server a moment to boot and arm before the client dies.
+        # Give the server a moment to boot and arm before the client dies,
+        # and prove it actually booted: a server that crashed at startup
+        # would make the post-kill exit assertion pass vacuously.
         time.sleep(5)
+        assert not _wait_for_pid_exit(server_pid, timeout=0.1), (
+            "server was already dead before its client was killed"
+        )
         client.kill()
         client.wait(timeout=60)
 
@@ -257,3 +326,230 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
     finally:
         if client.poll() is None:
             client.kill()
+
+
+def test_dead_parent_pid_override_emits_exit_event() -> None:
+    """Arming with a dead explicit override exits with the structured event.
+
+    The test holds the victim's ``Popen`` handle so ``OpenProcess``
+    succeeds on the exited process and the wait fires immediately; the
+    worker's stderr must carry the one JSON event line shared with the
+    companion server's tooling. On POSIX the explicit PID rides the coarse
+    poll, so the worker is still alive at its 2s checkpoint.
+    """
+    victim = subprocess.Popen([sys.executable, "-c", "pass"], stdout=subprocess.DEVNULL)
+    victim.wait(timeout=60)
+
+    worker_code = textwrap.dedent(
+        f"""
+        import time
+        from vaultspec_core.mcp_server.watchdog import arm_client_watchdog
+        armed = arm_client_watchdog(client_pid={victim.pid}, parent_pid={victim.pid})
+        print(f"armed={{armed}}", flush=True)
+        time.sleep(2)
+        print("still-alive", flush=True)
+        time.sleep(18)
+        """
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", worker_code],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if sys.platform == "win32":
+        assert proc.returncode == 0
+        assert "still-alive" not in proc.stdout
+        events = [
+            json.loads(line)
+            for line in proc.stderr.splitlines()
+            if line.startswith("{")
+        ]
+        assert events, f"no exit event on stderr: {proc.stderr!r}"
+        event = events[-1]
+        assert event["event"] == "stdio_watchdog_exit"
+        assert event["dead_ancestor_pid"] == victim.pid
+        assert "dead_ancestor_exe" in event
+        assert event["shim_pid"] != os.getpid()
+    else:
+        assert "armed=True" in proc.stdout
+        assert "still-alive" in proc.stdout
+
+
+def test_fallback_reaps_worker_when_ancestor_dies() -> None:
+    """Killing a mid-chain ancestor reaps a worker with no client pipe.
+
+    An intermediary spawns the worker with a null stdin, so the worker's
+    watchdog arms on the discovered ancestor chain (short grace). Killing
+    the intermediary after the grace window must reap the worker on
+    Windows via wait-any; on POSIX the reparent poll notices the
+    orphaning. Both resolve within the wait bound.
+    """
+    worker_code = textwrap.dedent(
+        """
+        import subprocess, time
+        from vaultspec_core.mcp_server.watchdog import arm_client_watchdog
+        print(f"armed={arm_client_watchdog(grace_seconds=1.0)}", flush=True)
+        time.sleep(120)
+        """
+    )
+    intermediary_code = textwrap.dedent(
+        f"""
+        import subprocess, sys, time
+        worker = subprocess.Popen(
+            [sys.executable, "-c", {worker_code!r}],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        print(worker.pid, flush=True)
+        print(worker.stdout.readline().strip(), flush=True)
+        time.sleep(3600)
+        """
+    )
+    worker_pid = 0
+    intermediary = subprocess.Popen(
+        [sys.executable, "-c", intermediary_code],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert intermediary.stdout is not None
+        worker_pid = int(intermediary.stdout.readline())
+        armed_line = intermediary.stdout.readline().strip()
+        assert armed_line == "armed=True"
+
+        # Let the fallback's grace window elapse before the kill counts as
+        # termination intent rather than a transient spawn helper.
+        time.sleep(3)
+        intermediary.kill()
+        intermediary.wait(timeout=60)
+
+        if sys.platform == "win32":
+            assert _wait_for_pid_exit(worker_pid, timeout=30), (
+                "worker survived its dead ancestor; fallback did not fire"
+            )
+        else:
+            # Reparent poll cadence bounds detection on POSIX.
+            assert _wait_for_posix_pid_exit(worker_pid, timeout=40)
+    finally:
+        if intermediary.poll() is None:
+            intermediary.kill()
+        if worker_pid:
+            subprocess.run(
+                ["taskkill", "/PID", str(worker_pid), "/F"]
+                if sys.platform == "win32"
+                else ["kill", "-9", str(worker_pid)],
+                capture_output=True,
+            )
+
+
+def test_fallback_grace_window_prunes_transient_ancestor(tmp_path: Path) -> None:
+    """An ancestor dying inside the grace window is not termination intent.
+
+    The intermediary exits right after spawning the worker (a transient
+    spawn helper); the worker's fallback must prune it during the grace
+    window and keep serving on the surviving ancestors. The worker reports
+    through a result file, never through a pipe its dead parent owned, so a
+    broken pipe cannot fake the outcome. The still-alive checkpoint at 8s
+    precedes the POSIX poll cadence, so the assertion holds on every
+    platform; the POSIX reparent-reap after the checkpoint is covered by
+    the ancestor-death test.
+    """
+    result_file = tmp_path / "worker-result.txt"
+    worker_code = textwrap.dedent(
+        f"""
+        import time
+        from vaultspec_core.mcp_server.watchdog import arm_client_watchdog
+        armed = arm_client_watchdog(grace_seconds=4.0)
+        with open({str(result_file)!r}, "a", encoding="utf-8") as fh:
+            fh.write(f"armed={{armed}}\\n")
+            fh.flush()
+            time.sleep(8)
+            fh.write("still-alive\\n")
+        """
+    )
+    intermediary_code = textwrap.dedent(
+        f"""
+        import subprocess, sys, time
+        worker = subprocess.Popen(
+            [sys.executable, "-c", {worker_code!r}],
+            stdin=subprocess.DEVNULL,
+        )
+        print(worker.pid, flush=True)
+        time.sleep(1)
+        """
+    )
+    worker_pid = 0
+    intermediary = subprocess.Popen(
+        [sys.executable, "-c", intermediary_code],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert intermediary.stdout is not None
+        worker_pid = int(intermediary.stdout.readline())
+        intermediary.wait(timeout=60)
+
+        deadline = time.monotonic() + 30
+        content = ""
+        while time.monotonic() < deadline:
+            content = (
+                result_file.read_text(encoding="utf-8") if result_file.exists() else ""
+            )
+            if "still-alive" in content or "armed=False" in content:
+                break
+            time.sleep(0.5)
+        assert "armed=True" in content, content
+        assert "still-alive" in content, (
+            "worker was reaped by a grace-window death instead of pruning it"
+        )
+    finally:
+        if intermediary.poll() is None:
+            intermediary.kill()
+        if worker_pid:
+            subprocess.run(
+                ["taskkill", "/PID", str(worker_pid), "/F"]
+                if sys.platform == "win32"
+                else ["kill", "-9", str(worker_pid)],
+                capture_output=True,
+            )
+
+
+def test_real_server_parent_pid_flag_reaps_on_override_death(
+    tmp_path: Path,
+) -> None:
+    """The real server exits when its --parent-pid override target dies.
+
+    The test itself is the pipe client (alive throughout), so only the
+    explicit override can fire: this proves the flag reaches the watchdog
+    through the entrypoint and that wait-any covers the override alongside
+    the resolved client. Works on POSIX too via the explicit-pid poll.
+    """
+    (tmp_path / ".vaultspec").mkdir()
+    (tmp_path / ".vault").mkdir()
+    sleeper = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(120)"])
+    server = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "vaultspec_core.mcp_server.app",
+            "--parent-pid",
+            str(sleeper.pid),
+        ],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        cwd=tmp_path,
+    )
+    try:
+        time.sleep(5)
+        assert server.poll() is None, "server exited before the override died"
+        sleeper.kill()
+        sleeper.wait(timeout=60)
+        server.wait(timeout=40)
+    finally:
+        if server.poll() is None:
+            server.kill()
+        if sleeper.poll() is None:
+            sleeper.kill()


### PR DESCRIPTION
Refs #220; cross-repo convergence with nevenincs/vaultspec-rag#228 (rag-side half: nevenincs/vaultspec-rag#229).

## Summary

Brings the stdio watchdog to the shared cross-repo backstop and operability contract, keeping the client-PID pipe-creator as the precise primary anchor:

- `VAULTSPEC_STDIO_WATCHDOG` operator kill switch (off values match the sibling repo)
- one structured JSON exit event on stderr before every hard exit (`stdio_watchdog_exit`, same shape as the sibling server's)
- PID-reuse-safe ancestor-chain fallback when stdin pipe resolution declines (startup handles, creation-time monotonicity, grace-window pruning, wait-any) - non-pipe launches previously had no backstop at all
- POSIX coarse reparent poll (plus explicit-pid liveness)
- `--parent-pid` entrypoint override watched ahead of discovery, never grace-pruned
- documented contract and knobs (MCP doc + CLI reference env table)

The governing ADR was amended in place to the hybrid contract; the repos now differ only in primary anchor.

## Verification

- 11 real-process tests: primary resolution (direct and through wrappers), instant dead-client reap, kill switch (in-process and worker), override + telemetry event shape, fallback ancestor-death reap, grace-window pruning, and the original leaked-pipe orphan e2e.
- Both e2e server tests were found to be passing **vacuously** (the standalone server refuses a bare cwd, so it crashed at boot before the assertions) - they now scaffold the minimal workspace and assert liveness pre-kill.
- Code review vs the sibling reference implementation: PASS-with-notes; the medium (dedup handle leak) and both actionable lows resolved on-branch.
- Gates: CI-matching unit suite 1773 passed, MCP suites 66 passed, tests tree 257 passed, ty clean on Windows and linux platform assumptions, dependency audit clean.