### PR TITLE
fix(mcp): MCP launch is side-effect-free static execution (--no-sync)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,4 @@ statistic/out/
 
 # Local benchmark working data (raw campaign logs)
 campaign-data/
+.qdrant-initialized

--- a/.vault/adr/2026-07-17-mcp-static-launch-adr.md
+++ b/.vault/adr/2026-07-17-mcp-static-launch-adr.md
@@ -1,0 +1,169 @@
+---
+tags:
+  - '#adr'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-mcp-static-launch-research]]"
+---
+
+# `mcp-static-launch` adr: `the MCP launch is side-effect-free static execution` | (**status:** `accepted`)
+
+## Problem Statement
+
+An MCP client connect must never mutate the governed project's environment,
+yet the dependency-mode launch the renderer writes into every provider config
+does exactly that: bare `uv run` re-syncs the venv on each connect, and on
+2026-07-17 one such sync corrupted this repository's own venv mid-flight,
+leaving every subsequent connect dead with client error -32000
+(`2026-07-17-mcp-static-launch-research`). The launch bytes are governed by
+`2026-07-13-install-mode-adr` Q2, which inherited the pre-mode-era shape
+without deciding the sync flag. This record amends that Q2 shape - it does
+not reopen the mode model - and binds the cross-repo launch-hygiene contract
+the sibling package must also meet, following the amendment pattern
+`2026-07-14-install-parity-adr` established.
+
+## Considerations
+
+- The dependency-mode MCP launch is the only dependency-mode surface without
+  the `--no-sync` guard; hooks and the firmware CLI rule already carry it
+  (`2026-07-17-mcp-static-launch-research`, renderer finding).
+- Sync-on-connect is documented uv behavior, not a uv bug; only `--no-sync`
+  prevents environment mutation (`--frozen` and `--locked` still sync)
+  (`2026-07-17-mcp-static-launch-research`, uv semantics finding).
+- The client contract is a 5-second connect window, stdout reserved for
+  JSON-RPC, and no stdio reconnect within a session; connect-time resolution
+  violates it on both latency and stream hygiene
+  (`2026-07-17-mcp-static-launch-research`, client contract finding).
+- The 2026 registry and ecosystem distribute Python stdio servers as
+  ephemeral pinned `uvx`; venv-tethered `uv run` appears nowhere as a
+  distribution shape - it is the dev/self-hosting shape in the decided
+  two-mode split (`2026-07-17-mcp-static-launch-research`, standards finding).
+- The observed-shape matcher reconstructs candidates through the renderer, so
+  changed bytes propagate to the doctor automatically, but deployed old-shape
+  entries then match neither candidate; migration semantics must be decided,
+  not inherited (`2026-07-17-mcp-static-launch-research`, architecture
+  finding).
+- Rag's shipped tokenized definition omits the tool-spec its own optional
+  `mcp` extra requires, and pre-parity workspaces still carry rag's static
+  exe-form seed - the banned exe-lock shape and the incident's actual lock
+  holder (`2026-07-17-mcp-static-launch-research`, rag findings).
+- Cross-repo precedent: a shared contract bound here, implemented by the
+  sibling under its own record (`2026-07-16-mcp-stdio-lifetime-adr`).
+
+## Considered options
+
+**A1 - dependency-mode launch bytes.** Chosen: the dependency/dev render
+gains `--no-sync` (`uv run --no-sync python -m <module>`), making the launch
+a static execution that resolves the existing venv, mutates nothing, and
+fails honestly when the venv is broken instead of self-repairing at connect
+time. Rejected: keep bare `uv run` (the incident is the refutation; the shape
+was inherited, never decided). Rejected: `--frozen`/`--locked` (still sync
+the environment). Rejected: demote dependency mode to non-MCP use and force
+tool mode for all launches - reverses install-mode's two-first-class-modes
+decision and breaks this repository's own self-hosting workflow, without
+being required by the defect.
+
+**A2 - tool-mode launch bytes.** Chosen: unchanged
+(`uvx --from <spec> python -m <module>`), already static with respect to the
+governed project and cache-fast after first resolution. Rejected: the
+ecosystem's terser `uvx <package>` exe form - install-mode Q2 already chose
+module invocation for the Windows exe-lock class, and this record does not
+reopen that trade.
+
+**A3 - old-shape migration.** Chosen: the observed-shape matcher additionally
+recognizes the legacy bare-`uv run` module launch as `DEPENDENCY`, so mode
+inference and the mode-mismatch signal do not regress on not-yet-refreshed
+workspaces; the managed-entry fingerprint machinery treats the byte change as
+ordinary drift, remediated by `spec mcps sync --force` and applied
+automatically by `install --upgrade` through the existing force-managed seam.
+Rejected: matcher returns `None` for the legacy shape (silently degrades
+doctor coverage on every existing dependency-mode workspace). Rejected: a
+one-shot migration command (the sync/upgrade path already owns definition
+refresh; a second mover violates the single-comparator discipline).
+
+**A4 - sibling contract.** Chosen: bind the contract only - every rendered
+launch, both packages, is side-effect-free and stdout-clean; rag adds
+`_vaultspec_mode_tool_spec` naming its `mcp` extra to its tokenized builtin
+and re-enrollment refreshes stale seeds - with rag implementing under its own
+record, mirroring the stdio-lifetime precedent. Rejected: fixing rag's
+builtin from core's repo (crosses the repo boundary the enrollment
+architecture deliberately keeps one-way). Rejected: core hardcoding a rag
+tool-spec fallback table (reintroduces the per-package table the
+parameterized renderer exists to avoid).
+
+## Constraints
+
+- Amends, does not supersede, `2026-07-13-install-mode-adr`: only Q2's
+  rendered dependency bytes change; the mode model, persistence schema, and
+  precedence chain stand.
+- The single-comparator discipline holds: renderer, doctor matcher, and every
+  test assert through `render_launch_for_mode`; no second hardcoded launch
+  copy may appear.
+- The launch must keep stdout clean for JSON-RPC; no wrapper that prints may
+  enter the command line.
+- Deployed old-shape entries are managed by fingerprint; the refresh must ride
+  the existing sync/upgrade force-managed seam, not bypass ownership.
+- Rag-side changes ship in the rag repository on its own release cadence; core
+  must not floor on them, and the contract must degrade gracefully (a rag
+  definition without the tool-spec key renders as today).
+- The in-flight `mcp-stdio-lifetime` plan owns `src/vaultspec_core/mcp_server/`;
+  this feature must not touch that tree.
+
+## Implementation
+
+The dependency branch of the launch renderer gains the `--no-sync` argument;
+the derived convenience table, the observed-shape matcher's candidates, and
+every launch-shape assertion in the test suites move with it automatically or
+by test-text update. The matcher grows one explicit legacy-shape recognition
+(bare `uv run python -m <module>` maps to `DEPENDENCY`) so pre-refresh
+workspaces keep honest doctor output with a drift signal pointing at
+`spec mcps sync --force` or `install --upgrade`. Documentation (the MCP doc
+and the CLI reference's rendered-launch examples) states the static-execution
+contract: an MCP connect never installs, resolves, or repairs; environment
+repair is an explicit dev action. On the rag side, tracked as a rag issue
+under its own record: the tokenized builtin gains
+`_vaultspec_mode_tool_spec: "vaultspec-rag[mcp]"`, and rag re-enrollment
+refreshes the stale static seed in pre-parity workspaces. This workspace's
+own recovery (venv repair, seed refresh, orphan sweep) is operational
+remediation alongside the feature, not part of the decision.
+
+## Rationale
+
+The incident is the knockout: a launch shape that can uninstall its own
+server package at connect time is disqualified as a distribution artifact,
+and `2026-07-17-mcp-static-launch-research` shows the guard flag is already
+the decided convention on every sibling surface - the MCP launch omitting it
+was inertia, not intent. Amendment beats supersession because install-mode's
+architecture (two first-class modes, tokenized definitions, one comparator)
+is exactly what makes the fix one line plus its comparator echoes; reopening
+the model would discard the machinery that contains the blast radius. The
+legacy-shape recognition in A3 is what keeps the doctor truthful during the
+migration window at the cost of one bounded, comparator-derived candidate,
+where the alternatives either lie (`None` on every existing workspace) or
+fork the mover. Binding rag by contract rather than by patch follows the
+proven stdio-lifetime shape for cross-repo defects and respects the one-way
+enrollment boundary.
+
+## Consequences
+
+- Good: an MCP connect becomes read-only with respect to the governed
+  project on every mode and both packages; the venv-corruption class is
+  closed at its cause, and a broken venv now fails the connect with an
+  honest remediation-shaped error instead of a destructive self-repair.
+- Good: doctor coverage survives the migration window; old-shape workspaces
+  are flagged as drifted with a working fix hint rather than unrecognized.
+- Bad: dependency-mode connects no longer self-heal a stale venv - a
+  contributor who pulls a lockfile change must run the sync explicitly or
+  see the MCP server fail until they do; this is the accepted price of
+  static execution and lands in the docs as a stated contract.
+- Bad: the legacy-shape recognition is permanent matcher surface until a
+  future record retires it; it must be tested so it cannot drift into
+  accepting arbitrary un-guarded shapes.
+- Bad: rag's fix is release-coupled to the rag repository; until it ships,
+  tool-mode rag renders remain broken (as today) and stale seeds persist in
+  pre-parity workspaces.
+- Neutral: tool-mode bytes, hooks, the mode model, and the enrollment
+  architecture are untouched; test churn is confined to launch-shape
+  assertions that already route through the comparator.

--- a/.vault/audit/2026-07-17-mcp-static-launch-audit.md
+++ b/.vault/audit/2026-07-17-mcp-static-launch-audit.md
@@ -1,0 +1,59 @@
+---
+tags:
+  - '#audit'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+  - "[[2026-07-17-mcp-static-launch-adr]]"
+---
+
+# `mcp-static-launch` audit: `static launch render review` | PASS after revision
+
+## Scope
+
+Phase P02 implementation of the static-execution launch amendment: the
+no-sync guard in the launch comparator (`src/vaultspec_core/core/mcps.py`),
+the legacy-shape recognition in the observed-shape matcher
+(`src/vaultspec_core/core/diagnosis/collectors.py`), and the migrated
+launch-shape test suites. Reviewed by an independent reviewer persona
+against the governing decision's A1/A3 sub-decisions, comparator
+discipline, matcher boundedness, consumer consistency, test integrity, and
+platform neutrality, with the four target suites re-run by the reviewer.
+
+## Findings
+
+### code-boundary-stems | high | dev-record identifiers embedded in delivered source
+
+The legacy-shape helper's comment and the matcher docstring cited a
+decision-record stem verbatim, violating the one-way vault reference
+boundary (code never cites the vault). RESOLVED: reworded to functional
+descriptions with no dated stems; boundary re-verified by grep across
+non-test sources.
+
+### review-verified-properties | low | all audited properties hold
+
+Single-comparator discipline holds (`render_launch_for_mode` is the sole
+no-sync source; the convenience table and the legacy helper both derive
+from it). The legacy recognition requires exact list equality plus module
+validation and cannot loosen: an arbitrary un-guarded shape still returns
+none, covered by a dedicated test. Mode-flip, per-package sync, and
+provider-file suites derive expected shapes through the comparator; literal
+expected bytes are pinned once as the anti-tautology anchor. No mocks,
+stubs, or skips; 120 tests passed across the four target suites; ruff and
+ty clean on every changed file. Windows/POSIX neutral.
+
+### dogfood-verification | low | deployed configs verified over the wire
+
+After a forced sync, both managed provider entries render the guarded
+shape, and both servers complete a real stdio initialize handshake with the
+exact deployed commands; the workspace doctor reports ok with declared and
+observed modes matching.
+
+## Recommendations
+
+- None open on core. The sibling package's half of the launch-hygiene
+  contract (tool-spec extra, seed-refresh verification, installer placement
+  leak) is tracked externally as rag issue 231 and needs no core follow-on
+  decision.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-S01.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-S01.md
@@ -1,0 +1,37 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S01'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Open feature branch and draft PR referencing the venv-corruption incident and the ADR amendment
+
+## Scope
+
+- `repo workflow`
+
+## Description
+
+- Branch feat/mcp-static-launch created from origin/main, keeping the
+  in-flight watchdog-parity branch (8 unmerged commits) independent.
+- Commit the pipeline documents (research, ADR, plan, index) plus a
+  gitignore entry for the local .qdrant-initialized marker, following the
+  mcp-ownership gitignore precedent.
+- Push and open draft PR 224 with the plan checklist mirrored in the body.
+
+## Outcome
+
+Draft PR 224 open at commit 629f5784; plan and grounding documents are on
+the branch; the worktree carries no foreign changes.
+
+## Notes
+
+First commit attempt failed hooks: mdformat-check on two vault documents and
+MD001 from a missing Steps heading above the Phase blocks (removed as
+scaffold residue, actually load-bearing). Restored the heading, formatted
+with the venv mdformat, recommitted clean.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-S02.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-S02.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S02'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Sweep orphaned MCP server processes holding venv DLLs and repair the venv with an explicit uv sync
+
+## Scope
+
+- `environment recovery`
+
+## Description
+
+- Enumerate processes launched from this worktree's venv; the two
+  lock-holding search-mcp processes had already exited, so no kill was
+  needed.
+- Repair the environment with an explicit uv sync (resolved 128, checked 107
+  packages; reinstalled the editable vaultspec-core the interrupted
+  connect-time sync had removed).
+- Verify recovery: single pywin32-312 dist-info remains, the CLI resolves at
+  0.1.46, and the stdio MCP server answers a real initialize request.
+
+## Outcome
+
+Venv restored to a coherent state; core MCP server handshakes over stdio;
+recovery used only explicit dev actions, matching the static-execution
+contract the feature enforces.
+
+## Notes
+
+The pywin32-311 dist-info residue reported during diagnosis was cleaned by
+the sync; no manual site-packages surgery was required.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-S03.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-S03.md
@@ -1,0 +1,39 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S03'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Refresh the stale exe-form vaultspec-rag seed via rag re-enrollment and verify both MCP servers complete an initialize handshake
+
+## Scope
+
+- `.vaultspec/mcps`
+
+## Description
+
+- Refresh the stale exe-form rag seed via the uv-tool rag 0.3.0 re-enrollment
+  (workspace files only, no heavy provisioning); the seeded definition is now
+  the tokenized mode-neutral form.
+- Declare vaultspec-rag mode dev in the committed workspace declaration so
+  the render matches this repo's dev-group placement, then re-render all
+  provider configs with a forced MCP sync; rag now launches module-form
+  through the project venv, core unchanged.
+- Verify both servers answer a real stdio initialize request.
+
+## Outcome
+
+Both managed MCP entries render through the mode renderer; the banned
+exe-form launch is gone from every provider config; handshakes verified.
+
+## Notes
+
+The rag installer's ensure-mcp-extra step appended vaultspec-rag[mcp] to
+core's runtime project dependencies even under --mode dev - a leaking
+placement this repo forbids. Reverted; the mcp extra now rides the existing
+dev-group entry instead. Recorded for the rag-side contract issue.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-summary.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P01-summary.md
@@ -1,0 +1,28 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# `mcp-static-launch` `P01` summary
+
+All three recovery steps closed. The incident-corrupted environment was
+restored with explicit dev actions only, the stale pre-parity rag seed was
+replaced by the tokenized mode-neutral definition, rag's placement was
+declared dev in the committed workspace map, and both MCP servers verified a
+real stdio initialize handshake before any code changed.
+
+- Created: feature branch and draft PR 224
+- Modified: `.vaultspec/mcps/vaultspec-rag.builtin.json`, `.vaultspec/workspace.json`, `pyproject.toml`, `uv.lock`
+
+## Description
+
+Restore the workspace the connect-time sync incident broke and stage the
+tracking surfaces. The venv was repaired with an explicit uv sync (the two
+lock-holding processes had already exited), the rag re-enrollment refreshed
+the exe-form seed, and the rag installer's runtime-dependency placement leak
+was caught and reverted here, feeding the rag-side issue.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-S04.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-S04.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S04'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Add the no-sync guard to the dependency-mode branch of render_launch_for_mode and align its docstring with the static-execution contract
+
+## Scope
+
+- `src/vaultspec_core/core/mcps.py`
+
+## Description
+
+- Add `--no-sync` to the dependency-mode branch of `render_launch_for_mode`,
+  changing the rendered launch to `uv run --no-sync python -m <module>`.
+- Rewrite the function docstring's dependency-mode paragraph to state the
+  static-execution contract: the launch resolves the existing venv and never
+  installs, syncs, or otherwise mutates it, failing honestly instead of
+  self-repairing at connect time.
+- Rewrite the `_MODE_MCP_LAUNCH` module comment to drop the old
+  "byte-identical to the launch every dependency-mode workspace has always
+  synced" framing in favor of the same static-execution language.
+
+## Outcome
+
+`render_launch_for_mode` and the derived `_MODE_MCP_LAUNCH` convenience table
+now render dependency-mode MCP launches with the `--no-sync` guard; tool-mode
+bytes are unchanged. Ruff check and format both pass on the changed file.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-S05.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-S05.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S05'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Recognize the legacy bare uv run module launch as DEPENDENCY in the observed-shape matcher with a drift hint pointing at sync --force or install --upgrade
+
+## Scope
+
+- `src/vaultspec_core/core/diagnosis/collectors.py`
+
+## Description
+
+- Add a module-level `_legacy_dependency_args` helper that derives the
+  pre-`--no-sync` dependency launch shape from the current renderer's args
+  (the current args minus `--no-sync`), bounded to that one historical shape.
+- Extend `_observed_mcp_mode`'s matching loop with a final legacy-shape check:
+  `command == "uv"` and `args` equal to the derived legacy args maps to
+  `InstallMode.DEPENDENCY`.
+- Update the docstrings of both functions to state the legacy recognition and
+  confirm the existing mismatch fix hint already points at
+  `spec mcps sync --force` / `install --upgrade`, so no new signal type or
+  hint text is introduced.
+
+## Outcome
+
+Deployed workspaces still carrying the pre-amendment `uv run python -m <module>` dependency launch (no `--no-sync`) are now inferred as
+`InstallMode.DEPENDENCY` instead of `None`, so mode inference and the
+mode-mismatch signal keep working through the migration window; the byte
+difference against the current renderer surfaces as ordinary drift with the
+pre-existing fix hint. Ruff, ruff format, and ty all pass on the changed file.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-S06.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-S06.md
@@ -1,0 +1,53 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S06'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Update every launch-shape assertion and add legacy-shape and no-sync render tests across the renderer, per-package sync, collector, and mode-flip suites
+
+## Scope
+
+- `src/vaultspec_core/tests/cli`
+
+## Description
+
+- Update the four hardcoded dependency-mode launch assertions in
+  `test_collectors.py` (`TestRenderLaunchForMode`, `TestRenderMcpDefinitionForMode`,
+  and the end-to-end `TestInstallModeDevEndToEnd` test) to the `--no-sync`
+  shape.
+- Update the `_DEPENDENCY_LAUNCH` constant in `test_mcp_provider_files.py`,
+  asserted whole against a real `install` run.
+- Confirm `test_mcp_per_package_sync.py` and `test_install_mode_flip.py`
+  already derive their expected shapes through `render_launch_for_mode` and
+  `_MODE_MCP_LAUNCH`, so they move automatically and need no edits.
+- Add `TestObservedMcpMode` to `test_collectors.py`, importing the private
+  `_observed_mcp_mode` matcher directly, covering: the current
+  `--no-sync`-guarded shape maps to `DEPENDENCY`; the legacy bare `uv run`
+  shape maps to `DEPENDENCY`; the `uvx` shape maps to `TOOL`; and an
+  arbitrary un-guarded shape that is neither candidate returns `None`, so the
+  legacy recognition cannot loosen into accepting arbitrary shapes.
+- Confirm the existing `test_mixed_partial_shapes_is_mismatch` test, which
+  writes the legacy bare shape as a mismatch fixture, still passes now that
+  the legacy shape resolves to `DEPENDENCY` (it still mismatches a
+  tool-declared workspace).
+- Run ruff check/format and ty on the changed test files.
+
+## Outcome
+
+Every launch-shape assertion across the renderer, per-package sync,
+provider-file, collector, and mode-flip suites now agrees with the
+`--no-sync` shape. `TestObservedMcpMode` directly exercises the legacy-shape
+recognition added in `S05` and proves it stays bounded. 120 tests pass across
+`test_mcp_per_package_sync.py`, `test_collectors.py`, `test_mcp_provider_files.py`,
+and `test_install_mode_flip.py`; ruff check, ruff format, and ty all pass on
+the changed files.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-summary.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P02-summary.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# `mcp-static-launch` `P02` summary
+
+All three implementation steps closed and independently reviewed. The
+dependency-mode branch of the single launch comparator gained the no-sync
+guard, the observed-shape matcher learned the bounded legacy shape, and
+every launch-shape assertion moved through the comparator with new coverage
+for the legacy and adversarial shapes. Review verdict: pass after one high
+finding (decision-record stems in source comments) was resolved by
+rewording; details in the feature audit.
+
+- Modified: `src/vaultspec_core/core/mcps.py`, `src/vaultspec_core/core/diagnosis/collectors.py`, `src/vaultspec_core/tests/cli/test_collectors.py`, `src/vaultspec_core/tests/cli/test_mcp_provider_files.py`
+
+## Description
+
+Land the decision's core amendment: a rendered dependency or dev launch is
+now a static execution, the doctor keeps honest mode inference on
+pre-refresh workspaces, and the test suites pin the guarded shape once as
+the anti-tautology anchor while deriving everything else through the
+renderer.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-S07.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-S07.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S07'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Document the static-execution launch contract and refresh rendered-launch examples in the MCP doc and the CLI reference builtins source
+
+## Scope
+
+- `docs/MCP.md`
+
+## Description
+
+- State the static-execution launch contract in the MCP doc install-modes
+  section: a client connect never installs, resolves, or repairs; broken
+  environments fail honestly; repair is an explicit dev action; pre-guard
+  bare launches surface as doctor drift with the sync --force / install
+  --upgrade remediation.
+- Update the dependency and development mode launch descriptions to the
+  guarded uv run --no-sync shape.
+- Update the module-invocation entry-point examples in the CLI doc and the
+  CLI reference builtins source, then roll the mirror with install
+  --upgrade.
+
+## Outcome
+
+User documentation now states the contract the renderer enforces; no doc or
+reference example shows the un-guarded launch shape.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-S08.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-S08.md
@@ -1,0 +1,35 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S08'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# File the rag-side contract issue covering the tool-spec key and stale-seed refresh, referencing the shared launch-hygiene contract
+
+## Scope
+
+- `repo workflow`
+
+## Description
+
+- File rag issue 231 binding the sibling to the launch-hygiene contract:
+  the missing tool-spec key (tool mode silently broken without the mcp
+  extra), verification that re-enrollment refreshes pre-parity exe-form
+  seeds, and the installer's runtime-dependency placement leak observed
+  during this feature's P01 recovery.
+
+## Outcome
+
+Rag-side half of the contract is tracked as rag issue 231, referencing core
+PR 224; core carries no rag-release coupling.
+
+## Notes
+
+The static-launch parity itself needs no rag code change - rag entries
+render through core's comparator - so the issue is scoped to the builtin
+metadata, seed-refresh verification, and the installer placement bug.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-S09.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-S09.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S09'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# Run gates, dispatch code review, resolve findings, append audit entries, dogfood the refreshed .mcp.json, finalize PR
+
+## Scope
+
+- `quality gates`
+
+## Description
+
+- Run the CI-matching unit gate (1778 passed, 1051 deselected) and the
+  repo-root suite (321 passed); ruff and ty clean on changed files.
+- Dispatch independent code review; resolve its one high finding
+  (decision-record stems in source comments) by rewording; verdict pass.
+- Author the feature audit recording the review outcome and dogfood
+  verification.
+- Re-render provider configs with a forced sync and verify both servers
+  handshake with the exact deployed guarded commands.
+- Update the PR body and mark PR 224 ready for review.
+
+## Outcome
+
+Feature complete: 9 of 9 steps closed, gates green, audit pass after
+revision, PR 224 ready for review, rag half tracked as rag issue 231.
+
+## Notes
+
+Nine pre-existing ty diagnostics remain at baseline in unrelated files (the
+known temp-compat and analytics items); changed files are clean.

--- a/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-summary.md
+++ b/.vault/exec/2026-07-17-mcp-static-launch/2026-07-17-mcp-static-launch-P03-summary.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-mcp-static-launch-plan]]"
+---
+
+# `mcp-static-launch` `P03` summary
+
+All three closing steps done. The static-execution contract is stated in
+the MCP doc and the CLI reference, the rag-side half of the contract is
+tracked as rag issue 231, and the full gate set ran green: 1778 unit tests
+(CI-matching gate), 321 repo-root tests, ruff, ty (changed files clean;
+nine pre-existing baseline diagnostics untouched), prek hooks on every
+commit, and a live dogfood of the re-rendered provider configs with real
+stdio handshakes.
+
+- Modified: `docs/MCP.md`, `docs/CLI.md`, `src/vaultspec_core/builtins/reference/cli.md`
+- Created: `.vault/audit/2026-07-17-mcp-static-launch-audit.md`, rag issue 231
+
+## Description
+
+Close the feature: document the contract users rely on, hand the sibling
+its bounded work without release-coupling core to it, and prove the whole
+set with the CI-matching gates plus over-the-wire verification of the
+deployed launch commands.

--- a/.vault/index/mcp-static-launch.index.md
+++ b/.vault/index/mcp-static-launch.index.md
@@ -1,0 +1,30 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - '[[2026-07-17-mcp-static-launch-adr]]'
+  - '[[2026-07-17-mcp-static-launch-plan]]'
+  - '[[2026-07-17-mcp-static-launch-research]]'
+---
+
+# `mcp-static-launch` feature index
+
+Auto-generated index of all documents tagged with `#mcp-static-launch`.
+
+## Documents
+
+### adr
+
+- `2026-07-17-mcp-static-launch-adr` - `mcp-static-launch` adr: `the MCP launch is side-effect-free static execution` | (**status:** `accepted`)
+
+### plan
+
+- `2026-07-17-mcp-static-launch-plan` - `mcp-static-launch` plan
+
+### research
+
+- `2026-07-17-mcp-static-launch-research` - `mcp-static-launch` research: `side-effect-free MCP launch rendering`

--- a/.vault/index/mcp-static-launch.index.md
+++ b/.vault/index/mcp-static-launch.index.md
@@ -6,7 +6,20 @@ tags:
 date: '2026-07-17'
 modified: '2026-07-17'
 related:
+  - '[[2026-07-17-mcp-static-launch-P01-S01]]'
+  - '[[2026-07-17-mcp-static-launch-P01-S02]]'
+  - '[[2026-07-17-mcp-static-launch-P01-S03]]'
+  - '[[2026-07-17-mcp-static-launch-P01-summary]]'
+  - '[[2026-07-17-mcp-static-launch-P02-S04]]'
+  - '[[2026-07-17-mcp-static-launch-P02-S05]]'
+  - '[[2026-07-17-mcp-static-launch-P02-S06]]'
+  - '[[2026-07-17-mcp-static-launch-P02-summary]]'
+  - '[[2026-07-17-mcp-static-launch-P03-S07]]'
+  - '[[2026-07-17-mcp-static-launch-P03-S08]]'
+  - '[[2026-07-17-mcp-static-launch-P03-S09]]'
+  - '[[2026-07-17-mcp-static-launch-P03-summary]]'
   - '[[2026-07-17-mcp-static-launch-adr]]'
+  - '[[2026-07-17-mcp-static-launch-audit]]'
   - '[[2026-07-17-mcp-static-launch-plan]]'
   - '[[2026-07-17-mcp-static-launch-research]]'
 ---
@@ -20,6 +33,25 @@ Auto-generated index of all documents tagged with `#mcp-static-launch`.
 ### adr
 
 - `2026-07-17-mcp-static-launch-adr` - `mcp-static-launch` adr: `the MCP launch is side-effect-free static execution` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-17-mcp-static-launch-audit` - `mcp-static-launch` audit: `static launch render review` | PASS after revision
+
+### exec
+
+- `2026-07-17-mcp-static-launch-P01-S01` - Open feature branch and draft PR referencing the venv-corruption incident and the ADR amendment
+- `2026-07-17-mcp-static-launch-P01-S02` - Sweep orphaned MCP server processes holding venv DLLs and repair the venv with an explicit uv sync
+- `2026-07-17-mcp-static-launch-P01-S03` - Refresh the stale exe-form vaultspec-rag seed via rag re-enrollment and verify both MCP servers complete an initialize handshake
+- `2026-07-17-mcp-static-launch-P01-summary` - `mcp-static-launch` `P01` summary
+- `2026-07-17-mcp-static-launch-P02-S04` - Add the no-sync guard to the dependency-mode branch of render_launch_for_mode and align its docstring with the static-execution contract
+- `2026-07-17-mcp-static-launch-P02-S05` - Recognize the legacy bare uv run module launch as DEPENDENCY in the observed-shape matcher with a drift hint pointing at sync --force or install --upgrade
+- `2026-07-17-mcp-static-launch-P02-S06` - Update every launch-shape assertion and add legacy-shape and no-sync render tests across the renderer, per-package sync, collector, and mode-flip suites
+- `2026-07-17-mcp-static-launch-P02-summary` - `mcp-static-launch` `P02` summary
+- `2026-07-17-mcp-static-launch-P03-S07` - Document the static-execution launch contract and refresh rendered-launch examples in the MCP doc and the CLI reference builtins source
+- `2026-07-17-mcp-static-launch-P03-S08` - File the rag-side contract issue covering the tool-spec key and stale-seed refresh, referencing the shared launch-hygiene contract
+- `2026-07-17-mcp-static-launch-P03-S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood the refreshed .mcp.json, finalize PR
+- `2026-07-17-mcp-static-launch-P03-summary` - `mcp-static-launch` `P03` summary
 
 ### plan
 

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -34,7 +34,7 @@ Amend the dependency-mode launch bytes with the no-sync guard through the single
 
 Document the static-execution contract, hand the rag-side contract off as a rag issue, and run the full gate set through review to a ready PR.
 
-- [ ] `P03.S07` - Document the static-execution launch contract and refresh rendered-launch examples in the MCP doc and the CLI reference builtins source; `docs/MCP.md`.
+- [x] `P03.S07` - Document the static-execution launch contract and refresh rendered-launch examples in the MCP doc and the CLI reference builtins source; `docs/MCP.md`.
 - [ ] `P03.S08` - File the rag-side contract issue covering the tool-spec key and stale-seed refresh, referencing the shared launch-hygiene contract; `repo workflow`.
 - [ ] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood the refreshed .mcp.json, finalize PR; `quality gates`.
 

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -35,7 +35,7 @@ Amend the dependency-mode launch bytes with the no-sync guard through the single
 Document the static-execution contract, hand the rag-side contract off as a rag issue, and run the full gate set through review to a ready PR.
 
 - [x] `P03.S07` - Document the static-execution launch contract and refresh rendered-launch examples in the MCP doc and the CLI reference builtins source; `docs/MCP.md`.
-- [ ] `P03.S08` - File the rag-side contract issue covering the tool-spec key and stale-seed refresh, referencing the shared launch-hygiene contract; `repo workflow`.
+- [x] `P03.S08` - File the rag-side contract issue covering the tool-spec key and stale-seed refresh, referencing the shared launch-hygiene contract; `repo workflow`.
 - [ ] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood the refreshed .mcp.json, finalize PR; `quality gates`.
 
 ## Description

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -27,7 +27,7 @@ Restore this workspace to a working state (the incident left the venv without va
 Amend the dependency-mode launch bytes with the no-sync guard through the single comparator and add the legacy-shape recognition that keeps doctor coverage honest on pre-refresh workspaces, with tests.
 
 - [x] `P02.S04` - Add the no-sync guard to the dependency-mode branch of render_launch_for_mode and align its docstring with the static-execution contract; `src/vaultspec_core/core/mcps.py`.
-- [ ] `P02.S05` - Recognize the legacy bare uv run module launch as DEPENDENCY in the observed-shape matcher with a drift hint pointing at sync --force or install --upgrade; `src/vaultspec_core/core/diagnosis/collectors.py`.
+- [x] `P02.S05` - Recognize the legacy bare uv run module launch as DEPENDENCY in the observed-shape matcher with a drift hint pointing at sync --force or install --upgrade; `src/vaultspec_core/core/diagnosis/collectors.py`.
 - [ ] `P02.S06` - Update every launch-shape assertion and add legacy-shape and no-sync render tests across the renderer, per-package sync, collector, and mode-flip suites; `src/vaultspec_core/tests/cli`.
 
 ### Phase `P03` - documentation, sibling handoff, and gates

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -26,7 +26,7 @@ Restore this workspace to a working state (the incident left the venv without va
 
 Amend the dependency-mode launch bytes with the no-sync guard through the single comparator and add the legacy-shape recognition that keeps doctor coverage honest on pre-refresh workspaces, with tests.
 
-- [ ] `P02.S04` - Add the no-sync guard to the dependency-mode branch of render_launch_for_mode and align its docstring with the static-execution contract; `src/vaultspec_core/core/mcps.py`.
+- [x] `P02.S04` - Add the no-sync guard to the dependency-mode branch of render_launch_for_mode and align its docstring with the static-execution contract; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P02.S05` - Recognize the legacy bare uv run module launch as DEPENDENCY in the observed-shape matcher with a drift hint pointing at sync --force or install --upgrade; `src/vaultspec_core/core/diagnosis/collectors.py`.
 - [ ] `P02.S06` - Update every launch-shape assertion and add legacy-shape and no-sync render tests across the renderer, per-package sync, collector, and mode-flip suites; `src/vaultspec_core/tests/cli`.
 

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - '#plan'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+tier: L2
+related:
+  - '[[2026-07-17-mcp-static-launch-adr]]'
+  - '[[2026-07-17-mcp-static-launch-research]]'
+---
+
+# `mcp-static-launch` plan
+
+## Steps
+
+### Phase `P01` - workspace recovery and branch
+
+Restore this workspace to a working state (the incident left the venv without vaultspec-core) and open the feature branch and draft PR, so gates and dogfooding can run.
+
+- [ ] `P01.S01` - Open feature branch and draft PR referencing the venv-corruption incident and the ADR amendment; `repo workflow`.
+- [ ] `P01.S02` - Sweep orphaned MCP server processes holding venv DLLs and repair the venv with an explicit uv sync; `environment recovery`.
+- [ ] `P01.S03` - Refresh the stale exe-form vaultspec-rag seed via rag re-enrollment and verify both MCP servers complete an initialize handshake; `.vaultspec/mcps`.
+
+### Phase `P02` - static launch render and legacy recognition
+
+Amend the dependency-mode launch bytes with the no-sync guard through the single comparator and add the legacy-shape recognition that keeps doctor coverage honest on pre-refresh workspaces, with tests.
+
+- [ ] `P02.S04` - Add the no-sync guard to the dependency-mode branch of render_launch_for_mode and align its docstring with the static-execution contract; `src/vaultspec_core/core/mcps.py`.
+- [ ] `P02.S05` - Recognize the legacy bare uv run module launch as DEPENDENCY in the observed-shape matcher with a drift hint pointing at sync --force or install --upgrade; `src/vaultspec_core/core/diagnosis/collectors.py`.
+- [ ] `P02.S06` - Update every launch-shape assertion and add legacy-shape and no-sync render tests across the renderer, per-package sync, collector, and mode-flip suites; `src/vaultspec_core/tests/cli`.
+
+### Phase `P03` - documentation, sibling handoff, and gates
+
+Document the static-execution contract, hand the rag-side contract off as a rag issue, and run the full gate set through review to a ready PR.
+
+- [ ] `P03.S07` - Document the static-execution launch contract and refresh rendered-launch examples in the MCP doc and the CLI reference builtins source; `docs/MCP.md`.
+- [ ] `P03.S08` - File the rag-side contract issue covering the tool-spec key and stale-seed refresh, referencing the shared launch-hygiene contract; `repo workflow`.
+- [ ] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood the refreshed .mcp.json, finalize PR; `quality gates`.
+
+## Description
+
+Execute 2026-07-17-mcp-static-launch-adr: make every rendered MCP launch a
+side-effect-free static execution. P01 restores this workspace (the incident
+that motivated the record left the venv without vaultspec-core) and opens the
+tracking PR. P02 lands the decision's core: the dependency-mode branch of the
+single launch comparator gains the no-sync guard, the observed-shape matcher
+learns the legacy bare-run shape so doctor coverage survives the migration
+window, and every launch-shape assertion moves with the comparator. P03
+states the contract in user documentation, hands the rag-side half (tool-spec
+key, stale-seed refresh) to the sibling repository as an issue per the ADR's
+A4 contract-only boundary, and gates the set. The in-flight mcp-stdio-lifetime
+plan owns the server-lifetime tree; this plan touches only launch rendering,
+diagnosis, tests, and docs.
+
+## Parallelization
+
+Phases are sequential: P02 needs the repaired environment from P01 to run
+its suites, and P03 documents and gates what P02 built. Within P02, S04 and
+S05 are independent edits that may interleave, with S06 last. Within P03,
+S07 and S08 are independent; S09 closes.
+
+## Verification
+
+- A dependency-mode render emits the no-sync guard, byte-identically across
+  the renderer, the convenience table, the doctor's candidates, and the
+  synced provider configs; no test asserts the old shape.
+- The legacy bare-run shape is recognized as DEPENDENCY by the matcher, is
+  reported as drift with a working fix hint, and a sync --force or install
+  --upgrade rewrites it to the guarded shape on a real workspace.
+- Both MCP servers in this workspace complete a real initialize handshake
+  over stdio after the refresh; repeated connects leave the venv byte-stable.
+- prek clean on changed files; ty clean; the CI-matching unit gate and the
+  MCP suites green; code review dispatched and findings resolved; audit
+  appended; the rag issue filed and cross-referenced in the PR.

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -36,7 +36,7 @@ Document the static-execution contract, hand the rag-side contract off as a rag 
 
 - [x] `P03.S07` - Document the static-execution launch contract and refresh rendered-launch examples in the MCP doc and the CLI reference builtins source; `docs/MCP.md`.
 - [x] `P03.S08` - File the rag-side contract issue covering the tool-spec key and stale-seed refresh, referencing the shared launch-hygiene contract; `repo workflow`.
-- [ ] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood the refreshed .mcp.json, finalize PR; `quality gates`.
+- [x] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood the refreshed .mcp.json, finalize PR; `quality gates`.
 
 ## Description
 

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -18,9 +18,9 @@ related:
 
 Restore this workspace to a working state (the incident left the venv without vaultspec-core) and open the feature branch and draft PR, so gates and dogfooding can run.
 
-- [ ] `P01.S01` - Open feature branch and draft PR referencing the venv-corruption incident and the ADR amendment; `repo workflow`.
-- [ ] `P01.S02` - Sweep orphaned MCP server processes holding venv DLLs and repair the venv with an explicit uv sync; `environment recovery`.
-- [ ] `P01.S03` - Refresh the stale exe-form vaultspec-rag seed via rag re-enrollment and verify both MCP servers complete an initialize handshake; `.vaultspec/mcps`.
+- [x] `P01.S01` - Open feature branch and draft PR referencing the venv-corruption incident and the ADR amendment; `repo workflow`.
+- [x] `P01.S02` - Sweep orphaned MCP server processes holding venv DLLs and repair the venv with an explicit uv sync; `environment recovery`.
+- [x] `P01.S03` - Refresh the stale exe-form vaultspec-rag seed via rag re-enrollment and verify both MCP servers complete an initialize handshake; `.vaultspec/mcps`.
 
 ### Phase `P02` - static launch render and legacy recognition
 

--- a/.vault/plan/2026-07-17-mcp-static-launch-plan.md
+++ b/.vault/plan/2026-07-17-mcp-static-launch-plan.md
@@ -28,7 +28,7 @@ Amend the dependency-mode launch bytes with the no-sync guard through the single
 
 - [x] `P02.S04` - Add the no-sync guard to the dependency-mode branch of render_launch_for_mode and align its docstring with the static-execution contract; `src/vaultspec_core/core/mcps.py`.
 - [x] `P02.S05` - Recognize the legacy bare uv run module launch as DEPENDENCY in the observed-shape matcher with a drift hint pointing at sync --force or install --upgrade; `src/vaultspec_core/core/diagnosis/collectors.py`.
-- [ ] `P02.S06` - Update every launch-shape assertion and add legacy-shape and no-sync render tests across the renderer, per-package sync, collector, and mode-flip suites; `src/vaultspec_core/tests/cli`.
+- [x] `P02.S06` - Update every launch-shape assertion and add legacy-shape and no-sync render tests across the renderer, per-package sync, collector, and mode-flip suites; `src/vaultspec_core/tests/cli`.
 
 ### Phase `P03` - documentation, sibling handoff, and gates
 

--- a/.vault/research/2026-07-17-mcp-static-launch-research.md
+++ b/.vault/research/2026-07-17-mcp-static-launch-research.md
@@ -1,0 +1,232 @@
+---
+tags:
+  - '#research'
+  - '#mcp-static-launch'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - '[[2026-07-13-install-mode-adr]]'
+  - '[[2026-07-14-install-parity-adr]]'
+  - '[[2026-07-15-provider-mcp-enrollment-adr]]'
+  - '[[2026-07-16-mcp-stdio-lifetime-adr]]'
+---
+
+# `mcp-static-launch` research: `side-effect-free MCP launch rendering`
+
+The question: should an MCP client connect ever be able to mutate the governed
+project's environment, and is the dependency-mode launch shape
+(`uv run python -m <module>`) production-grade or a dev-era artifact? The
+question matters because a live incident on 2026-07-17 showed one MCP connect
+attempt corrupting this repository's venv: bare `uv run` triggers an implicit
+`uv sync`, the sync uninstalled `vaultspec-core` from site-packages and then
+died on a pywin32 DLL held open by a running sibling MCP server, leaving every
+subsequent connect failing with client error -32000. The evidence picture:
+the launch renderer is the single line that omits the `--no-sync` guard every
+other dependency-mode surface already carries; the sibling rag definition
+seeded in this workspace additionally predates install-parity and still
+carries the banned exe-form launch; and rag's shipped tokenized definition
+omits the tool-mode extra spec its own packaging requires. The mode
+architecture itself (tool/dependency/dev, tokenized definitions, one launch
+comparator) is sound and recently decided; the defects are all in the
+concrete launch bytes the dependency branch renders and in stale seeded
+state, not in the model.
+
+## Findings
+
+### The incident: one bare `uv run` sync corrupted the venv at MCP connect time
+
+An MCP client connect is currently a mutating operation in dependency mode.
+The deployed `.mcp.json` launches `uv run python -m vaultspec_core.mcp_server.app`; without `--no-sync`, `uv run` re-syncs the
+project environment on every invocation. Reproduced 2026-07-17 on this
+workspace: the launch exited code 2 before any JSON-RPC bytes with
+`error: failed to remove file .venv\Lib\site-packages\pywin32_system32/pywintypes313.dll: Access is denied. (os error 5)`,
+the DLL being held by two long-lived `vaultspec-search-mcp` processes running
+from the same venv. A prior interrupted sync of the same shape had already
+uninstalled `vaultspec-core` from site-packages entirely (site-packages held
+`vaultspec_rag` but no `vaultspec_core`, plus overlapping `pywin32-311` and
+`pywin32-312` dist-info residue), so even a sync-free launch then failed with
+`ModuleNotFoundError`. The client surfaces all of this as JSON-RPC error
+-32000 (connection closed before initialize). The failure is self-inflicted
+by the launch shape, not by the server code: the watchdog and tool surface
+(`2026-07-16-mcp-stdio-lifetime-adr`, `2026-07-09-mcp-tool-schema-adr`) never
+executed.
+
+### The renderer omits the `--no-sync` guard that every sibling surface carries
+
+The single launch comparator `render_launch_for_mode`
+(`src/vaultspec_core/core/mcps.py:106-108`) renders dependency mode as
+`uv run python -m <module>`. The canonical hook entries for the same mode
+render `uv run --no-sync vaultspec-core ...`
+(`src/vaultspec_core/core/commands.py:396`), and the firmware CLI-fallback
+rule mandates `uv run --no-sync` for agent-driven CLI use
+(`.claude/rules/vaultspec-cli.builtin.md`). The MCP launch is therefore the
+one dependency-mode surface where invocation implies environment mutation.
+The omission is deliberate-by-inertia, not decided: the docstring
+(`src/vaultspec_core/core/mcps.py:89-91`) pins the shape as "byte-identical
+to the launch every dependency-mode workspace has always synced", carrying
+forward the pre-mode-era default that `2026-07-13-install-mode-adr` Q2
+inherited without revisiting the sync flag. No test or decision record
+asserts that the sync-on-connect behavior is wanted; the install-mode ADR's
+own Windows exe-lock consideration argues the opposite direction (launches
+must not contend with running processes over environment files).
+
+### The mode architecture is decided and sound; this is a launch-bytes defect
+
+Three accepted decisions already govern this surface and none needs
+reopening: `2026-07-13-install-mode-adr` (tool mode default via
+`uvx --from <package> python -m <module>`, dependency mode first-class,
+module invocation over exe form for the Windows exe-lock class),
+`2026-07-14-install-parity-adr` (rag adopts the same tokenized definition and
+per-package `workspace.json` map through core's single renderer), and
+`2026-07-15-provider-mcp-enrollment-adr` (`.vaultspec/mcps/*.json` is the
+only desired-state authority; installation never launches an MCP process).
+The observed-shape matcher (`src/vaultspec_core/core/diagnosis/collectors.py:813-873`)
+reconstructs candidate shapes through `render_launch_for_mode` itself, so a
+change to the rendered bytes propagates to doctor detection automatically -
+the single-comparator discipline holds. The consequence cuts both ways:
+already-deployed old-shape entries (`uv run python -m ...` without
+`--no-sync`) will match neither candidate after the change and report
+observed mode `None`, so migration/refresh behavior (sync `--force`,
+`install --upgrade`, doctor hint wording) must be settled deliberately.
+
+### This workspace's rag definition is stale pre-parity state with the banned exe-form launch
+
+`.vaultspec/mcps/vaultspec-rag.builtin.json` in this workspace contains the
+static `{"command": "uv", "args": ["run", "vaultspec-search-mcp"]}` - venv
+exe-form, no mode tokens, no `--no-sync`. This is doubly wrong under current
+decisions: exe-form launch is the Windows exe-lock class install-mode Q2
+banned (and the two lock-holding processes in the incident were exactly this
+venv's `vaultspec-search-mcp.exe`), and a non-tokenized definition bypasses
+the mode renderer entirely. The rag repository has already shipped the
+correct tokenized form
+(`Y:/code/vaultspec-rag-worktrees/main/src/vaultspec_rag/builtins/mcps/vaultspec-rag.builtin.json`:
+mode tokens plus `_vaultspec_mode_package: vaultspec-rag`,
+`_vaultspec_mode_module: vaultspec_rag.server`), so the workspace copy is
+stale seeded state, refreshed only by a rag-side re-enrollment. Additionally
+`workspace.json` here declares only `vaultspec-core` (dependency mode, floor
+0.1.37) with no `vaultspec-rag` entry, so rag's render mode is unpinned in
+the very workspace that runs both.
+
+### Rag's shipped definition omits the tool-mode extra its packaging requires
+
+`vaultspec-rag` made `mcp` an optional extra: the base install must not drag
+`mcp` (or its Windows `pywin32` transitive), and the MCP server requires
+`vaultspec-rag[mcp]`
+(`Y:/code/vaultspec-rag-worktrees/main/pyproject.toml:91-95`, entry point
+`vaultspec-search-mcp = "vaultspec_rag.server:main"` at line 65). Core's
+renderer supports exactly this via `_vaultspec_mode_tool_spec`
+(`src/vaultspec_core/core/mcps.py:59,99-101`, docstring example
+`"vaultspec-rag[mcp]"`), but rag's shipped builtin does not carry the key, so
+a tool-mode render produces `uvx --from vaultspec-rag python -m vaultspec_rag.server` - an environment without the `mcp` dependency, a
+guaranteed import failure. Dependency-mode workspaces mask this because the
+dev environment installs the extra; tool mode (the decided default for new
+workspaces) is silently broken for rag.
+
+### What "static execution" can and cannot mean per mode
+
+The user framing - an MCP connect should be a static tool execution - maps
+onto the decided modes as follows. Dependency mode: `uv run --no-sync python -m <module>` is fully static (resolves the existing venv, mutates nothing,
+fails honestly with a remediation-shaped error when the venv is stale or
+broken instead of self-repairing at connect time). Tool mode: `uvx --from <spec> python -m <module>` is static with respect to the governed project
+(never touches its venv) but not hermetic in time - first run and
+post-cache-prune runs hit the network, which install-mode already accepted
+as a bounded cost. Full hermeticity (a pinned `uv tool install`-provisioned
+environment, launch via its absolute interpreter path) was considered and
+carries the committed-path portability problem (absolute per-machine paths
+cannot be committed to `.mcp.json`) plus the exe-lock class on upgrades;
+the two decided shapes plus `--no-sync` are the evidence-favored point. What
+the ADR must settle: whether dependency mode gains `--no-sync` as a pure
+amendment to install-mode Q2's rendered bytes, how deployed old-shape
+entries migrate (doctor signal semantics for shape-mismatch, refresh verb),
+and whether rag's missing `_vaultspec_mode_tool_spec` and this workspace's
+stale seed are folded into the same feature or tracked as rag-side issues.
+
+### uv semantics: sync-on-connect is documented behavior, `--no-sync` is the surgical guard
+
+Bare `uv run` creating and updating the project environment before executing
+is uv's documented design, not a defect: "When used in a project, the project
+environment will be created and updated before invoking the command"
+(https://docs.astral.sh/uv/reference/cli/#uv-run, fetched 2026-07-17). Of the
+guard flags, only `--no-sync` prevents venv mutation: it "avoid[s] syncing
+the virtual environment" and implies `--frozen`; `--frozen` alone skips the
+lockfile update but still syncs the environment, and `--locked` still syncs.
+`uvx` runs in temporary isolated environments, caches after first resolution
+("uvx will use the cached version of the tool unless a different version is
+requested, the cache is pruned, or the cache is refreshed",
+https://docs.astral.sh/uv/concepts/tools/), and never touches a project venv
+\- structurally immune to the DLL-lock incident class. Pinning semantics:
+`--from 'pkg==X'` resolves from cache thereafter; `pkg@latest` forces a
+network refresh every run and belongs nowhere in a connect path. The related
+Windows exe-lock defect astral-sh/uv issue 11930 (`uv tool upgrade` failing
+on a held binary, reported 2025-03-03) was still open at last verified read;
+it concerns `uv tool` upgrades, a cousin of - not the same path as - this
+incident, and reinforces the ADR-established preference for module/ephemeral
+invocation over held executables.
+
+### 2026 standards: registry and ecosystem distribute Python stdio servers as ephemeral uvx
+
+The current MCP specification revision is 2025-11-25 (supersedes 2025-06-18;
+https://modelcontextprotocol.io/specification, fetched 2026-07-17); the stdio
+launch contract is unchanged. The official MCP Registry `server.json` schema
+distributes Python servers as `registryType: pypi` with `runtimeHint: "uvx"`
+and `transport.type: "stdio"`, launching as `uvx <package>@<version>`; no
+venv or `uv run` runtime hint exists in the schema
+(https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md).
+Reference servers agree: `mcp-server-git` and `mcp-server-fetch` both
+recommend `"command": "uvx"` configs, with `python -m` after pip install and
+Docker as the only alternatives - venv-tethered `uv run` appears nowhere as a
+recommended distribution shape
+(https://github.com/modelcontextprotocol/servers/blob/main/src/git/README.md,
+https://github.com/modelcontextprotocol/servers/blob/main/src/fetch/README.md).
+This maps cleanly onto the decided two-mode model: dependency mode is the
+dev/self-hosting shape, tool mode is the distribution shape the ecosystem
+blesses. The ecosystem's terser `uvx <package>` exe form versus the decided
+`uvx --from <package> python -m <module>` module form is a deliberate local
+divergence: install-mode Q2 chose module invocation for the exe-lock class,
+and both remain valid mitigations per that record.
+
+### Client contract: 5-second connect window, no stdio reconnect, -32000 = crashed child
+
+Claude Code gives stdio servers a 5-second connect timeout (overridable via
+`MCP_TIMEOUT`), starts them non-blocking, and never auto-reconnects a dead
+stdio server within a session - only HTTP/SSE transports get backoff
+(https://code.claude.com/docs/en/mcp). Error -32000 is the child process
+exiting before the JSON-RPC handshake, with stdout contamination as the top
+documented cause - stdio transport reserves stdout for JSON-RPC, so any
+`uv sync` resolver output on stdout corrupts the stream even when the sync
+succeeds. Connect-time dependency resolution therefore violates the client
+contract twice: a cold resolution can blow the 5-second window, and its
+output can poison the handshake. There is no single normative "no sync at
+connect" mandate; the convergent convention follows from the latency and
+side-effect expectations (non-blocking init, small artifacts, initialization
+out of the handshake path).
+
+### Sibling-session boundary
+
+The in-flight `2026-07-17-mcp-stdio-lifetime-plan` (P03.S11 open, branch
+`feat/mcp-watchdog-parity`) owns server lifetime after a successful start;
+this feature owns the launch bytes before the process exists. No file
+overlap: watchdog work lives in `src/vaultspec_core/mcp_server/`, launch
+rendering in `src/vaultspec_core/core/mcps.py` and its consumers.
+
+## Sources
+
+- `src/vaultspec_core/core/mcps.py:106-108` - dependency render without `--no-sync`
+- `src/vaultspec_core/core/mcps.py:59,89-101` - tool-spec key, byte-identical docstring
+- `src/vaultspec_core/core/commands.py:396` - hook prefix `uv run --no-sync vaultspec-core`
+- `src/vaultspec_core/core/diagnosis/collectors.py:813-873` - observed-shape matcher
+- `.vaultspec/mcps/vaultspec-rag.builtin.json` (workspace copy, stale exe-form)
+- `Y:/code/vaultspec-rag-worktrees/main/src/vaultspec_rag/builtins/mcps/vaultspec-rag.builtin.json` - rag shipped tokenized form
+- `Y:/code/vaultspec-rag-worktrees/main/pyproject.toml:65,91-95` - `vaultspec-rag[mcp]` optional extra, entry point
+- `.vaultspec/workspace.json` - core-only per-package map, dependency mode, floor 0.1.37
+- Incident reproduction 2026-07-17, this workspace: `uv run` exit 2, pywin32 DLL lock, missing `vaultspec_core` in site-packages
+- https://docs.astral.sh/uv/reference/cli/#uv-run - `uv run` sync semantics, `--no-sync`/`--frozen`/`--locked`
+- https://docs.astral.sh/uv/concepts/tools/ - uvx isolated environments and cache semantics
+- https://docs.astral.sh/uv/concepts/cache/ - cache refresh and prune controls
+- https://github.com/astral-sh/uv/issues/11930 - Windows exe-lock on `uv tool upgrade` (open; comment trail after the original report unverified)
+- https://modelcontextprotocol.io/specification - MCP spec revision 2025-11-25
+- https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md - `runtimeHint: uvx` for pypi servers
+- https://github.com/modelcontextprotocol/servers/blob/main/src/git/README.md - uvx-recommended reference config
+- https://github.com/modelcontextprotocol/servers/blob/main/src/fetch/README.md - uvx-recommended reference config
+- https://code.claude.com/docs/en/mcp - project-scope `.mcp.json`, 5s connect timeout, `MCP_TIMEOUT`, no stdio reconnect
+- https://startdebugging.net/2026/06/fix-mcp-error-32000-connection-closed-in-claude-code/ - -32000 taxonomy (secondary source)

--- a/.vaultspec/mcps/vaultspec-rag.builtin.json
+++ b/.vaultspec/mcps/vaultspec-rag.builtin.json
@@ -1,7 +1,6 @@
 {
-  "command": "uv",
-  "args": [
-    "run",
-    "vaultspec-search-mcp"
-  ]
+  "command": "@@VAULTSPEC_INSTALL_MODE_COMMAND@@",
+  "args": ["@@VAULTSPEC_INSTALL_MODE_ARGS@@"],
+  "_vaultspec_mode_package": "vaultspec-rag",
+  "_vaultspec_mode_module": "vaultspec_rag.server"
 }

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -20,8 +20,8 @@ configuration.
 | Command | Purpose | | ------------------------------------------------ |
 --------------------------------------------------- | | `vaultspec-core` | Workspace
 management, vault operations, sync. | | `vaultspec-mcp` | Console script launching the
-stdio MCP server. | | `uv run python -m vaultspec_core.mcp_server.app` | Module
-invocation of the MCP server (Windows-safe). |
+stdio MCP server. | | `uv run --no-sync python -m vaultspec_core.mcp_server.app` |
+Module invocation of the MCP server (Windows-safe, never syncs). |
 
 ## Global options
 

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -45,7 +45,7 @@ hand-edit between the markers.
 
 ### Top-level commands
 
-- `vaultspec-core install` - Deploy the vaultspec framework to the target directory.
+- `vaultspec-core install` - Install Vaultspec resources for the selected providers.
 - `vaultspec-core uninstall` - Remove the vaultspec framework from the target directory.
 - `vaultspec-core sync` - Sync rules, skills, agents, configs, system prompts, and MCPs.
 - `vaultspec-core doctor` - Diagnose overall workspace and vault health.
@@ -258,12 +258,14 @@ hand-edit between the markers.
 
 #### Mcps
 
-- `vaultspec-core spec mcps list` - List all registered MCP server definitions.
-- `vaultspec-core spec mcps status` - Report focused MCP definition and .mcp.json sync
-  status.
-- `vaultspec-core spec mcps add` - Add a new custom MCP server definition.
-- `vaultspec-core spec mcps remove` - Remove an MCP server definition.
-- `vaultspec-core spec mcps sync` - Sync only MCP definitions to .mcp.json.
+- `vaultspec-core spec mcps list` - List canonical MCP server definitions.
+- `vaultspec-core spec mcps status` - Inspect provider-native MCP enrollment status.
+- `vaultspec-core spec mcps add` - Add or replace a canonical MCP server definition.
+- `vaultspec-core spec mcps remove` - Remove a canonical MCP server definition.
+- `vaultspec-core spec mcps sync` - Reconcile canonical definitions into provider-native
+  enrollment.
+- `vaultspec-core spec mcps uninstall` - Remove Vaultspec-owned provider-native MCP
+  enrollment.
 
 #### Reference
 
@@ -606,15 +608,24 @@ enabled hooks; it takes `--path PATH`. Valid events: `vault.document.created`,
 
 ### vaultspec-core spec mcps
 
-Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage MCP server
-definitions and synced `.mcp.json` entries.
+Signature: `vaultspec-core spec mcps [OPTIONS] COMMAND [ARGS]...`. Manage canonical
+definitions in `.vaultspec/mcps/*.json` and reconcile them into provider-native
+enrollment. Providers are `all`, `claude`, `antigravity`, and `codex`; scopes are
+`project`, `local`, and `user`. Unsupported provider/scope combinations fail.
 
-| Subcommand | Signature | Description | | ---------- |
---------------------------------------- | ----------------------------- | | `list` | - |
-List MCP server definitions. | | `status` | `[--json]` | Validate against `.mcp.json`. |
-| `add` | `--name NAME [--config JSON] [--force]` | Add a custom MCP definition. | |
-`remove` | `NAME [--force]` | Remove an MCP definition. | | `sync` |
-`[--dry-run] [--force]` | Sync definitions to config. |
+| Subcommand  | Signature                                                                             | Description                                                         |
+| ----------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `list`      | -                                                                                     | List canonical MCP server definitions.                              |
+| `status`    | `[PROVIDER] [--scope SCOPE] [--json] [--target PATH]`                                 | Inspect configuration and ownership state; does not probe runtimes. |
+| `add`       | `--name NAME [--config JSON] [--force]`                                               | Add or replace a canonical definition.                              |
+| `remove`    | `NAME [--force]`                                                                      | Remove a canonical definition.                                      |
+| `sync`      | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--prune] [--json] [--target PATH]` | Reconcile canonical definitions into native enrollment.             |
+| `uninstall` | `[PROVIDER] [--scope SCOPE] [--dry-run] [--force] [--json] [--target PATH]`           | Remove only Vaultspec-owned native enrollment.                      |
+
+The default provider is `all` and the default scope is `project`. `sync --force` adopts
+or replaces a same-name external entry; `sync --prune` removes owned enrollment whose
+canonical source was deleted. `uninstall` preserves canonical definitions and external
+host entries.
 
 ## Migration commands
 

--- a/.vaultspec/rules/vaultspec-rag.builtin.md
+++ b/.vaultspec/rules/vaultspec-rag.builtin.md
@@ -2,58 +2,63 @@
 name: vaultspec-rag
 ---
 
-# vaultspec-rag — semantic search
+# vaultspec-rag — semantic search for code and decisions
 
-Use semantic search for codebase discovery and implementation discovery. When you need
-to find where or how something is done and don't know the exact name, search by meaning
-instead of grepping keywords or guessing identifiers.
+Discover by MEANING when you do not know the exact name, instead of grepping keywords or
+guessing identifiers. vaultspec-rag does two jobs: find the CODE, and find the DECISIONS -
+the ADRs (architecture decision records) that govern it.
 
-## Write good queries
+Server mode is the default backend. If a search reports the service is down, start it with
+`uvx vaultspec-rag server start` (small or offline projects opt into the on-disk local
+backend with `--local-only`). The running service auto-reindexes on file changes.
+DO NOT manually reindex during normal work.
 
-The index is hybrid: dense embeddings match meaning, sparse vectors match exact terms,
-and a cross-encoder reranks the top hits. So:
+## Discover code by meaning
 
-- Describe the concept or behavior in a short natural-language phrase.
-- Include the concrete domain nouns the target code or docs would use - they drive the
-  exact-match half of the search.
-- One concept per query. Narrow with filters; don't paste bare keywords or a guessed
-  function name.
-
-```
-vaultspec-rag search "where file locks are acquired during indexing" --type code
-vaultspec-rag search "retry policy for failed webhook delivery" --type code --language python
-vaultspec-rag search "decision on gpu lock scope" --type vault --doc-type adr
-```
-
-Code filters: `--language --path --function-name --class-name --include-path GLOB`.
-Vault filters: `--doc-type --feature --date --tag`. Filters also work inline in the
-query: `type:adr lang:python func:main`.
-
-## Run the server
-
-If the server is not running, start it:
+`--type code` searches source by meaning. Phrase the query as a short behaviour plus the
+concrete domain nouns the target code would use: the behaviour drives semantic matching, the
+nouns drive exact matching, so a bare keyword or pure prose finds less than both together.
 
 ```
-vaultspec-rag server start
+uvx vaultspec-rag search "retry backoff around failed webhook delivery" --type code
 ```
 
-Server mode is the default backend: `server start` supervises the managed Qdrant
-server and loads the GPU models. The server is the only workable backend at codebase
-scale - local mode is orders of magnitude slower - so it is the assumed default, not an
-opt-in. Provision the binary and models once with `vaultspec-rag install` (it fetches
-torch, the models, and the Qdrant binary by default).
+## Discover architecture decisions
 
-Local mode is a first-class explicit opt-out for small projects, CI, or air-gapped
-hosts: `vaultspec-rag server start --local-only` (or `VAULTSPEC_RAG_LOCAL_ONLY=1`, or
-`vaultspec-rag install --local-only` which persists the choice). It uses the on-disk
-store and needs no server binary.
+When you need the WHY - the rationale, constraints, or decision behind code - search the
+vault's ADRs, not the source. `--type vault --doc-type adr` returns the governing records.
 
-Check dependency readiness any time with `vaultspec-rag server doctor` (`--json` for the
-machine-readable snapshot): it reports torch CUDA, model presence, and the Qdrant binary
-and supervised-server state.
+```
+uvx vaultspec-rag search "decision on gpu lock scope around the forward pass" --type vault --doc-type adr
+```
 
-The running service auto-reindexes on file changes - DO NOT manually reindex during
-normal work.
+`--doc-type` also accepts `audit`, `plan`, `reference`, `research`, and `exec` (comma-separate
+to union several).
 
-The same search is available through MCP as the `search_vault` and `search_codebase`
-tools.
+## Cut noise with filters
+
+Semantic search competes production code against its own noise - overlapping tests, parallel
+locale files, generated and vendored trees, worktree clones. Code search is production-biased
+by default: it hides duplicate/derivative domains (`generated`, `worktree`) and demotes
+`tests`, `docs`, `locale`, and `vendored` beneath production. When noise still crowds a page,
+narrow by DOMAIN rather than raising `--max-results`. The domains are `prod`, `tests`, `docs`,
+`locale`, `generated`, `vendored`, `worktree`.
+
+Steer with inline query tokens (comma-separated, repeatable):
+
+```
+uvx vaultspec-rag search "fixture setup helpers exclude:tests" --type code
+uvx vaultspec-rag search "auth token validation only:prod" --type code
+uvx vaultspec-rag search "translation table lookup include:locale" --type code
+```
+
+`exclude:` hides a domain, `only:` keeps just the named domains, and `include:` re-admits a
+domain the default profile hides or demotes. Compose with path and category filters:
+
+```
+uvx vaultspec-rag search "request handler" --type code --include-path "src/**" --exclude-path "**/legacy/**"
+uvx vaultspec-rag search "encode batch" --type code --prefer production
+```
+
+The full option set is `uvx vaultspec-rag search --help`. The same search is available through
+MCP as the `search_codebase` and `search_vault` tools.

--- a/.vaultspec/skills/vaultspec-rag-discovery/SKILL.md
+++ b/.vaultspec/skills/vaultspec-rag-discovery/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: vaultspec-rag-discovery
+description: Semantic codebase and architecture-decision discovery with vaultspec-rag - find code and the ADRs that govern it by meaning, then narrow with advanced filters and noise controls. Use to locate where or how something is done, or the decision behind it, instead of guessing identifiers or sweeping with keyword/grep search.
+---
+
+# Semantic discovery with vaultspec-rag
+
+vaultspec-rag finds things by MEANING. When you need to locate where or how something is done
+and do not already know the exact symbol, lead with a semantic search rather than a keyword
+sweep: keyword search only finds the words you already guessed, while semantic search finds the
+concept even when the code names it differently. The project's own discovery benchmarking is
+the basis for leading with it - a semantic-led hybrid sweep reaches the right file in about one
+call at roughly 1.3-2x less context than a broad grep or glob on a large tree, and recalls the
+governing decision with almost no noise.
+
+Treat vaultspec-rag as a discovery instrument and grep as the exact-symbol confirmer: a search
+lands you on the right surface, grep pins the precise line. Never conclude "there is no such
+site" from a search alone - confirm with grep.
+
+## The method: locate by meaning, read, confirm
+
+1. **Locate by meaning.** Run a semantic search to reach the epicenter file (code) or the
+   governing record (a decision). One tight query gets you there.
+1. **Read the epicenter whole.** Open the top file (or the nearest existing analogue) in full.
+   This whole-file read is the step that actually grounds you.
+1. **Confirm with grep.** Pin the exact symbol, call site, or insertion point with a targeted
+   grep, which is sharper than semantic search at exact-name lookup.
+
+## Two corpora: code and decisions
+
+vaultspec-rag searches two things. Choose with `--type`:
+
+- **Code** (`--type code`) - the source tree, chunked by structure.
+- **The vault** (`--type vault`) - the project's decision and planning records. Architecture
+  decisions live as ADRs, reached with `--doc-type adr`.
+
+Bind them together: find the code that does something, then find the ADR that decided why it
+does it that way.
+
+## Write queries that both halves can match
+
+The index is hybrid: dense embeddings match meaning, sparse vectors match exact terms, and a
+cross-encoder reranks the top hits. A good query feeds both halves - describe the behaviour in
+a short phrase (that drives the semantic half) AND name the concrete domain nouns the target
+would use (that drives the exact-match half). A bare keyword or pure prose finds less than both
+together. One concept per query; narrow with filters rather than piling clauses into the text.
+
+Phrase the target as a thing, not as a question - a noun phrase for the concept lands better
+than a "what happens when X" flow question. Search for `"file lock around the incremental index write"`, not `"what happens when two indexers run at once"`.
+
+## Discover code
+
+`--type code` searches source by meaning.
+
+```
+uvx vaultspec-rag search "retry backoff around failed webhook delivery" --type code
+uvx vaultspec-rag search "file lock acquired around the incremental index write" --type code
+```
+
+Narrow code results with these flags:
+
+- `--language <lang>` - one programming language.
+- `--path <exact/relative/path>` - one exact project-relative path.
+- `--include-path <glob>` / `--exclude-path <glob>` - keep or drop files by glob (repeatable).
+- `--structure <kind>` - one source-code structure, e.g. a function or class definition.
+- `--function-name <name>` / `--class-name <name>` - results inside a named function or class.
+
+```
+uvx vaultspec-rag search "encode batch on the gpu" --type code --language python
+uvx vaultspec-rag search "request handler" --type code --include-path "src/**" --exclude-path "**/legacy/**"
+```
+
+## Discover architecture decisions
+
+When you need the WHY - the rationale, constraints, or the decision behind code - search the
+vault's ADRs, not the source.
+
+```
+uvx vaultspec-rag search "decision on gpu lock scope around the forward pass" --type vault --doc-type adr
+```
+
+`--doc-type` accepts `adr`, `audit`, `plan`, `reference`, `research`, and `exec`
+(comma-separate to union several). Narrow the vault further with `--feature <tag>`,
+`--date <yyyy-mm-dd>`, and `--tag <tag>` (no leading `#`).
+
+```
+uvx vaultspec-rag search "retry policy tradeoffs" --type vault --doc-type adr,research --feature webhooks
+```
+
+## Cut noise with domain filters
+
+Semantic search competes production code against its own noise - overlapping tests, parallel
+locale files, generated and vendored trees, worktree clones. Every code chunk carries a domain
+derived from its path: `prod`, `tests`, `docs`, `locale`, `generated`, `vendored`, `worktree`.
+Code search is production-biased by default: it hides duplicate/derivative domains (`generated`,
+`worktree`) and demotes `tests`, `docs`, `locale`, and `vendored` beneath production, and it
+collapses locale-variant duplicates to a single result. So a plain query already leads with
+production.
+
+When noise still crowds a page, narrow by DOMAIN rather than raising `--max-results` and reading
+past it. Steer with inline query tokens - they ride in the query string (no flags), take
+comma-separated sets, and repeat:
+
+```
+uvx vaultspec-rag search "fixture setup helpers exclude:tests" --type code
+uvx vaultspec-rag search "auth token validation only:prod" --type code
+uvx vaultspec-rag search "translation table lookup include:locale" --type code
+uvx vaultspec-rag search "payment capture path exclude:tests,docs,vendored" --type code
+```
+
+- `exclude:<domains>` hides those domains for this search.
+- `only:<domains>` restricts results to those domains - e.g. `only:tests` to find just the
+  tests that exercise a behaviour.
+- `include:<domains>` re-admits a domain the default profile hides or demotes - e.g.
+  `include:locale` when you actually want the translation tables.
+
+Two more controls compose with domains:
+
+- `--prefer production|tests|documentation` biases the ranking toward one kind of file without
+  removing the others.
+- `--dedup-locales` / `--no-dedup-locales` forces locale-duplicate collapse on or off (on by
+  default).
+
+```
+uvx vaultspec-rag search "greeting string" --type code --no-dedup-locales   # audit every locale
+uvx vaultspec-rag search "encode batch" --type code --prefer production
+```
+
+## Read results as clusters, not just the top hit
+
+Read the directory CLUSTERING across the top few hits, not only the single top score. When
+scores are close or collapse, the repeating module or feature folder is usually the right
+surface even if no one line is a perfect match. Skip near-identical hits that are one signal
+(parallel locale files return the same string several times), and be wary of a test docstring
+that outranks the production module - the domain filters above exist to clear exactly that.
+
+## Operating notes
+
+Server mode is the default backend; the running service auto-reindexes on file changes, so DO
+NOT manually reindex during normal work. If a search reports the service is down, start it with
+`uvx vaultspec-rag server start` (small or offline projects opt into the on-disk local backend
+with `--local-only`). The full option set is `uvx vaultspec-rag search --help`. The same search
+is available through MCP as the `search_codebase` and `search_vault` tools.

--- a/.vaultspec/workspace.json
+++ b/.vaultspec/workspace.json
@@ -3,6 +3,9 @@
     "vaultspec-core": {
       "install_mode": "dependency",
       "minimum_version": "0.1.37"
+    },
+    "vaultspec-rag": {
+      "install_mode": "dev"
     }
   },
   "schema_version": "2.0"

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -23,8 +23,9 @@ Complete command-line interface (CLI) reference for `vaultspec-core`. See the
 - `vaultspec-core` - Workspace management, vault operations, resource sync.
 - `vaultspec-mcp` - Console script that launches the stdio Model Context Protocol (MCP)
   server.
-- `uv run python -m vaultspec_core.mcp_server.app` - Module invocation of the MCP server
-  (avoids binary locking on Windows). See [MCP reference](./MCP.md).
+- `uv run --no-sync python -m vaultspec_core.mcp_server.app` - Module invocation of the
+  MCP server (avoids binary locking on Windows; `--no-sync` keeps a client connect from
+  mutating the environment). See [MCP reference](./MCP.md).
 
 ## Global options
 

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -53,10 +53,21 @@ launch command for the active install mode:
 - Tool mode, the default, uses `uvx --from ...` without adding Vaultspec to the
   project's dependencies. A companion may declare a dedicated tool requirement such as
   `vaultspec-rag[mcp]`.
-- Dependency mode uses `uv run ...` against the project's environment and ships in built
-  distributions.
-- Development mode also uses `uv run ...`, but records a development-only placement that
-  does not ship in built distributions.
+- Dependency mode uses `uv run --no-sync ...` against the project's environment and
+  ships in built distributions.
+- Development mode also uses `uv run --no-sync ...`, but records a development-only
+  placement that does not ship in built distributions.
+
+Every rendered launch is a static execution: connecting a client never installs,
+resolves, or repairs anything. Tool mode runs from `uvx`'s isolated cache and never
+touches the project's environment; dependency and development modes resolve the
+project's existing environment as-is - the `--no-sync` guard means a client connect
+never runs an implicit `uv sync`. If the environment is stale or broken, the connect
+fails with the underlying Python error instead of mutating shared state while other
+processes may hold it; repair it explicitly with `uv sync`, then reconnect. A launch
+rendered before this guard existed (a bare `uv run` shape) is reported by
+`vaultspec-core spec doctor` as drift; refresh it with
+`vaultspec-core spec mcps sync --force` or `vaultspec-core install --upgrade`.
 
 Select a mode with `install --mode tool`, `install --mode dependency`, or
 `install --mode dev`. Vaultspec consumes the package, module, and optional tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ dev = [
   "ruff>=0.15.2",
   "torch>=2.4",
   "ty>=0.0.15",
-  "vaultspec-rag>=0.2.19",
+  "vaultspec-rag[mcp]>=0.3.0",
 ]
 
 [tool.hatch.metadata]

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -20,8 +20,8 @@ configuration.
 | Command | Purpose | | ------------------------------------------------ |
 --------------------------------------------------- | | `vaultspec-core` | Workspace
 management, vault operations, sync. | | `vaultspec-mcp` | Console script launching the
-stdio MCP server. | | `uv run python -m vaultspec_core.mcp_server.app` | Module
-invocation of the MCP server (Windows-safe). |
+stdio MCP server. | | `uv run --no-sync python -m vaultspec_core.mcp_server.app` |
+Module invocation of the MCP server (Windows-safe, never syncs). |
 
 ## Global options
 

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -810,9 +810,8 @@ def _observed_precommit_mode(
     return None
 
 
-#: The pre-``--no-sync`` dependency-mode MCP launch shape
-#: (``2026-07-17-mcp-static-launch-adr`` A1). Deployed workspaces seeded before
-#: that amendment still carry this exact byte sequence, so
+#: The pre-``--no-sync`` dependency-mode MCP launch shape. Deployed workspaces
+#: seeded before the guard was introduced still carry this exact byte sequence, so
 #: :func:`_observed_mcp_mode` recognizes it as a bounded, explicit legacy
 #: candidate rather than silently reporting ``None`` for every not-yet-refreshed
 #: dependency-mode workspace. It is derived from the current renderer's args
@@ -846,10 +845,10 @@ def _observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode 
     (``uv run python -m <module>``, no guard) also matches
     :attr:`~vaultspec_core.core.enums.InstallMode.DEPENDENCY`
     (:data:`_legacy_dependency_args`), so mode inference and the mode-mismatch
-    signal do not regress to ``None`` on workspaces seeded before
-    ``2026-07-17-mcp-static-launch-adr``; the byte difference between the
-    legacy and current shapes then reports as ordinary drift with a fix hint
-    pointing at ``spec mcps sync --force`` or ``install --upgrade``.
+    signal do not regress to ``None`` on workspaces seeded before the guard was
+    introduced; the byte difference between the legacy and current shapes then
+    reports as ordinary drift with a fix hint pointing at
+    ``spec mcps sync --force`` or ``install --upgrade``.
 
     Args:
         target: Workspace root directory.

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -810,17 +810,46 @@ def _observed_precommit_mode(
     return None
 
 
+#: The pre-``--no-sync`` dependency-mode MCP launch shape
+#: (``2026-07-17-mcp-static-launch-adr`` A1). Deployed workspaces seeded before
+#: that amendment still carry this exact byte sequence, so
+#: :func:`_observed_mcp_mode` recognizes it as a bounded, explicit legacy
+#: candidate rather than silently reporting ``None`` for every not-yet-refreshed
+#: dependency-mode workspace. It is derived from the current renderer's args
+#: with the ``--no-sync`` element removed, so it can never drift into a second
+#: hand-maintained launch copy: only this one historical shape is recognized,
+#: and the mismatch it produces against the current declaration surfaces as
+#: ordinary drift, remediated by ``spec mcps sync --force`` or
+#: ``install --upgrade`` through the existing force-managed seam.
+def _legacy_dependency_args(module: str) -> list[str]:
+    from ..enums import InstallMode
+    from ..mcps import render_launch_for_mode
+
+    _, current_args = render_launch_for_mode(InstallMode.DEPENDENCY, "", module)
+    return [arg for arg in current_args if arg != "--no-sync"]
+
+
 def _observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode | None:
     """Infer the install mode *package*'s deployed MCP launch command is shaped for.
 
     Reads ``.mcp.json`` and matches *package*'s server entry (the server name is
     the distribution name) against the concrete launch each mode renders
-    (dependency mode launches through ``uv run``, tool mode through ``uvx``). The
-    runnable module is recovered from the deployed ``args`` (the token after
-    ``-m``) and the two candidate shapes are reconstructed through the renderer's
-    own :func:`~vaultspec_core.core.mcps.render_launch_for_mode`, so this matches
-    against the single launch comparator rather than a second hardcoded copy and
-    works for any package's module without a per-package table.
+    (dependency mode launches through ``uv run --no-sync``, tool mode through
+    ``uvx``). The runnable module is recovered from the deployed ``args`` (the
+    token after ``-m``) and the two candidate shapes are reconstructed through
+    the renderer's own :func:`~vaultspec_core.core.mcps.render_launch_for_mode`,
+    so this matches against the single launch comparator rather than a second
+    hardcoded copy and works for any package's module without a per-package
+    table.
+
+    A deployed entry shaped like the pre-``--no-sync`` legacy dependency launch
+    (``uv run python -m <module>``, no guard) also matches
+    :attr:`~vaultspec_core.core.enums.InstallMode.DEPENDENCY`
+    (:data:`_legacy_dependency_args`), so mode inference and the mode-mismatch
+    signal do not regress to ``None`` on workspaces seeded before
+    ``2026-07-17-mcp-static-launch-adr``; the byte difference between the
+    legacy and current shapes then reports as ordinary drift with a fix hint
+    pointing at ``spec mcps sync --force`` or ``install --upgrade``.
 
     Args:
         target: Workspace root directory.
@@ -830,7 +859,7 @@ def _observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode 
     Returns:
         The matching :class:`~vaultspec_core.core.enums.InstallMode`, or ``None``
         when there is no config, no matching server entry, the module cannot be
-        recovered, or the entry matches neither rendered launch shape.
+        recovered, or the entry matches neither rendered nor legacy launch shape.
     """
     from ..enums import InstallMode
     from ..mcps import render_launch_for_mode
@@ -870,6 +899,10 @@ def _observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode 
         mode_command, mode_args = render_launch_for_mode(mode, pkg, module)
         if command == mode_command and args == mode_args:
             return mode
+
+    if command == "uv" and args == _legacy_dependency_args(module):
+        return InstallMode.DEPENDENCY
+
     return None
 
 

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -86,10 +86,13 @@ def render_launch_for_mode(
     the dev-scoped bookkeeping member never grows a third launch branch.
 
     Dependency-rendered mode launches the module through the governed project's
-    own venv (``uv run python -m <module>``), byte-identical to the launch every
-    dependency-mode workspace has always synced. Tool mode launches the same
-    module through an ephemeral ``uvx --from <package>`` invocation so the
-    distribution never enters the governed project's dependency set.
+    own venv with the ``--no-sync`` guard (``uv run --no-sync python -m
+    <module>``): a static execution that resolves the existing venv and never
+    installs, syncs, or otherwise mutates it, failing honestly when the venv is
+    stale or broken instead of self-repairing at connect time. Tool mode
+    launches the same module through an ephemeral ``uvx --from <package>``
+    invocation so the distribution never enters the governed project's
+    dependency set.
 
     Args:
         mode: The provisioning mode whose launch to render.
@@ -104,15 +107,15 @@ def render_launch_for_mode(
         The ``(command, args)`` pair for the rendered mode.
     """
     if render_mode(mode) is InstallMode.DEPENDENCY:
-        return "uv", ["run", "python", "-m", module]
+        return "uv", ["run", "--no-sync", "python", "-m", module]
     return "uvx", ["--from", tool_spec or package, "python", "-m", module]
 
 
 #: Core's own concrete MCP-server launch per mode, derived from the generalized
 #: :func:`render_launch_for_mode` so this convenience table and the renderer can
-#: never drift. Dependency mode reproduces byte-for-byte the launch every
-#: dependency-mode workspace has always synced; tool mode launches the same
-#: module entry point through an ephemeral ``uvx`` invocation. Only the two
+#: never drift. Dependency mode is a static, ``--no-sync``-guarded execution
+#: that resolves the existing venv without mutating it; tool mode launches the
+#: same module entry point through an ephemeral ``uvx`` invocation. Only the two
 #: rendered shapes are keyed (``DEV`` collapses onto ``DEPENDENCY``), which is
 #: what the observed-shape matcher and the mode-flip tests read.
 _MODE_MCP_LAUNCH: dict[InstallMode, tuple[str, list[str]]] = {

--- a/src/vaultspec_core/tests/cli/test_collectors.py
+++ b/src/vaultspec_core/tests/cli/test_collectors.py
@@ -15,6 +15,7 @@ from vaultspec_core.core.commands import (
     entry_prefix_for_mode,
 )
 from vaultspec_core.core.diagnosis.collectors import (
+    _observed_mcp_mode,
     collect_builtin_version_state,
     collect_config_state,
     collect_content_integrity,
@@ -94,6 +95,15 @@ def _write_manifest(root: Path, installed: list[str]) -> None:
 def _write_gitignore(root: Path, content: str) -> None:
     gi = root / ".gitignore"
     gi.write_text(content, encoding="utf-8")
+
+
+def _write_mcp_server_entry(
+    root: Path, package: str, command: str, args: list[str]
+) -> None:
+    """Write a single ``.mcp.json`` server entry with an arbitrary launch shape."""
+    path = root / ".mcp.json"
+    payload = {"mcpServers": {package: {"command": command, "args": args}}}
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------
@@ -624,6 +634,54 @@ class TestModeMismatchState:
 
 
 # ---------------------------------------------------------------------------
+# _observed_mcp_mode: current, legacy, and unguarded launch shapes
+# ---------------------------------------------------------------------------
+class TestObservedMcpMode:
+    _MODULE = "vaultspec_core.mcp_server.app"
+
+    def test_current_dependency_shape_is_dependency(self, tmp_path: Path) -> None:
+        """The current --no-sync-guarded dependency shape maps to DEPENDENCY."""
+        _write_mcp_server_entry(
+            tmp_path,
+            "vaultspec-core",
+            "uv",
+            ["run", "--no-sync", "python", "-m", self._MODULE],
+        )
+        assert _observed_mcp_mode(tmp_path, "vaultspec-core") == InstallMode.DEPENDENCY
+
+    def test_legacy_bare_shape_is_dependency(self, tmp_path: Path) -> None:
+        """The pre-amendment bare uv run shape (no --no-sync) still maps to
+        DEPENDENCY, so doctor coverage does not regress on not-yet-refreshed
+        workspaces."""
+        _write_mcp_server_entry(
+            tmp_path, "vaultspec-core", "uv", ["run", "python", "-m", self._MODULE]
+        )
+        assert _observed_mcp_mode(tmp_path, "vaultspec-core") == InstallMode.DEPENDENCY
+
+    def test_tool_shape_is_tool(self, tmp_path: Path) -> None:
+        _write_mcp_server_entry(
+            tmp_path,
+            "vaultspec-core",
+            "uvx",
+            ["--from", "vaultspec-core", "python", "-m", self._MODULE],
+        )
+        assert _observed_mcp_mode(tmp_path, "vaultspec-core") == InstallMode.TOOL
+
+    def test_arbitrary_unguarded_shape_is_none(self, tmp_path: Path) -> None:
+        """An un-guarded shape that is neither the current nor the legacy
+        candidate must not be swept up by the legacy recognition - it reports
+        None rather than loosening the matcher into accepting arbitrary
+        shapes."""
+        _write_mcp_server_entry(
+            tmp_path,
+            "vaultspec-core",
+            "uv",
+            ["run", "--isolated", "python", "-m", self._MODULE],
+        )
+        assert _observed_mcp_mode(tmp_path, "vaultspec-core") is None
+
+
+# ---------------------------------------------------------------------------
 # resolver mode-mismatch advisory and precommit completeness
 # ---------------------------------------------------------------------------
 class TestModeMismatchResolution:
@@ -990,7 +1048,7 @@ class TestRenderLaunchForMode:
     def test_dependency_shape(self) -> None:
         assert render_launch_for_mode(
             InstallMode.DEPENDENCY, "vaultspec-core", _CORE_MODULE
-        ) == ("uv", ["run", "python", "-m", _CORE_MODULE])
+        ) == ("uv", ["run", "--no-sync", "python", "-m", _CORE_MODULE])
 
     def test_tool_shape(self) -> None:
         assert render_launch_for_mode(
@@ -1015,7 +1073,7 @@ class TestRenderLaunchForMode:
         )
         assert render_launch_for_mode(
             InstallMode.DEV, "vaultspec-rag", "vaultspec_rag.server"
-        ) == ("uv", ["run", "python", "-m", "vaultspec_rag.server"])
+        ) == ("uv", ["run", "--no-sync", "python", "-m", "vaultspec_rag.server"])
 
 
 # ---------------------------------------------------------------------------
@@ -1042,7 +1100,7 @@ class TestRenderMcpDefinitionForMode:
             self._tokened(), InstallMode.DEPENDENCY
         )
         assert rendered["command"] == "uv"
-        assert rendered["args"] == ["run", "python", "-m", _CORE_MODULE]
+        assert rendered["args"] == ["run", "--no-sync", "python", "-m", _CORE_MODULE]
 
     def test_dev_renders_byte_identically_to_dependency(self) -> None:
         assert render_mcp_definition_for_mode(
@@ -1312,11 +1370,11 @@ class TestInstallModeDevEndToEnd:
         install = factory.run("install", "--mode", "dev")
         assert install.exit_code == 0, self._combined(install)
 
-        # Dependency-shaped MCP launch (uv run), not the uvx tool shape.
+        # Dependency-shaped MCP launch (uv run --no-sync), not the uvx tool shape.
         mcp = json.loads((tmp_path / ".mcp.json").read_text(encoding="utf-8"))
         core_server = mcp["mcpServers"]["vaultspec-core"]
         assert core_server["command"] == "uv"
-        assert core_server["args"] == ["run", "python", "-m", _CORE_MODULE]
+        assert core_server["args"] == ["run", "--no-sync", "python", "-m", _CORE_MODULE]
 
         # Dependency-shaped hook entries (uv run --no-sync).
         precommit = (tmp_path / ".pre-commit-config.yaml").read_text(encoding="utf-8")

--- a/src/vaultspec_core/tests/cli/test_mcp_provider_files.py
+++ b/src/vaultspec_core/tests/cli/test_mcp_provider_files.py
@@ -28,7 +28,7 @@ pytestmark = [pytest.mark.unit]
 # either the command or a single arg is caught.
 _DEPENDENCY_LAUNCH = {
     "command": "uv",
-    "args": ["run", "python", "-m", "vaultspec_core.mcp_server.app"],
+    "args": ["run", "--no-sync", "python", "-m", "vaultspec_core.mcp_server.app"],
 }
 _TOOL_LAUNCH = {
     "command": "uvx",

--- a/uv.lock
+++ b/uv.lock
@@ -2223,7 +2223,7 @@ dev = [
     { name = "torch", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "torch", version = "2.12.1+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "ty" },
-    { name = "vaultspec-rag" },
+    { name = "vaultspec-rag", extra = ["mcp"] },
 ]
 
 [package.metadata]
@@ -2273,16 +2273,15 @@ dev = [
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32'", specifier = ">=2.4" },
     { name = "torch", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = ">=2.4", index = "https://download.pytorch.org/whl/cu130" },
     { name = "ty", specifier = ">=0.0.15" },
-    { name = "vaultspec-rag", specifier = ">=0.2.19" },
+    { name = "vaultspec-rag", extras = ["mcp"], specifier = ">=0.3.0" },
 ]
 
 [[package]]
 name = "vaultspec-rag"
-version = "0.2.23"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "mcp" },
     { name = "packaging" },
     { name = "pathspec" },
     { name = "psutil" },
@@ -2301,9 +2300,14 @@ dependencies = [
     { name = "vaultspec-core" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/a3/0b3edbd25df1dcdaf78819f53dbf8a6c3d92e9e4ac79ca84cc65b62677c3/vaultspec_rag-0.2.23.tar.gz", hash = "sha256:fd9750dc333272447f1503334169d44ec6a2a5cb2891ec97ee5a08be1d0a7a3d", size = 2069720, upload-time = "2026-06-21T11:22:29.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/b7/8596a01b762bc1b3eb2c967a11fa0001fb02ff01a96e0b149ad0d69ed8a1/vaultspec_rag-0.3.0.tar.gz", hash = "sha256:570948fc9223dd98f017a38f7d6b1747d0fffc0390f504dd91534acc46876980", size = 2745331, upload-time = "2026-07-14T20:26:11.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/d9/9f8a9b6366917a21e9d44afb73ed6d438c08f40fd6ed53c9196a43d19f83/vaultspec_rag-0.2.23-py3-none-any.whl", hash = "sha256:b7b16a3368e53109f77f827f7f847a6a63db02c8c3d351dc53cfc4fe80660aad", size = 693969, upload-time = "2026-06-21T11:22:27.655Z" },
+    { url = "https://files.pythonhosted.org/packages/96/98/0479424eb325ed36c3e7231a8f7b58a3ee301fe85aa0b529cd8352314af4/vaultspec_rag-0.3.0-py3-none-any.whl", hash = "sha256:16dd6cf47fe47ea28fc955d5b07753f9993c026ed561d984a3a13491fa8e933f", size = 921648, upload-time = "2026-07-14T20:26:10.035Z" },
+]
+
+[package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

An MCP client connect must never mutate the governed project's environment, yet the dependency-mode MCP launch renders as bare `uv run python -m ...`, which re-syncs the venv on every connect (documented uv behavior). On 2026-07-17 one such connect-time sync corrupted this repository's own venv: it uninstalled `vaultspec-core` from site-packages, then died on a pywin32 DLL held by a running sibling MCP server, leaving every subsequent connect failing with client error -32000.

## Decision

Amends install-mode Q2 (ADR `2026-07-17-mcp-static-launch-adr`):

- Dependency/dev-mode MCP launch gains `--no-sync`: a connect resolves the existing venv, mutates nothing, and fails honestly when the venv is broken instead of self-repairing at connect time.
- Tool-mode `uvx` launch unchanged (the 2026 registry/ecosystem distribution shape).
- The observed-shape doctor matcher additionally recognizes the legacy bare-run shape as DEPENDENCY, so existing workspaces stay diagnosable through the migration window; refresh rides `spec mcps sync --force` / `install --upgrade`.
- The rag sibling binds to the same launch-hygiene contract in its own repo: nevenincs/vaultspec-rag#231 (tool-spec extra for its `mcp` optional dependency, stale exe-form seed refresh, installer placement leak).

## Plan - complete (9/9)

Executed `.vault/plan/2026-07-17-mcp-static-launch-plan.md`:

- [x] P01.S01 branch + draft PR
- [x] P01.S02 venv repair + orphan sweep
- [x] P01.S03 rag seed refresh + handshake verification
- [x] P02.S04 --no-sync in render_launch_for_mode
- [x] P02.S05 legacy-shape recognition in observed-shape matcher
- [x] P02.S06 launch-shape test updates (120 targeted tests green)
- [x] P03.S07 docs: static-execution contract in MCP doc + CLI reference
- [x] P03.S08 rag-side contract issue (nevenincs/vaultspec-rag#231)
- [x] P03.S09 gates, review, audit

## Verification

- CI-matching unit gate: 1778 passed. Repo-root suite: 321 passed. ruff + ty clean on changed files.
- Independent code review: PASS after one HIGH resolved (decision-record stems in source comments, reworded per the code-stands-alone boundary). Audit: `.vault/audit/2026-07-17-mcp-static-launch-audit.md`.
- Dogfooded: both managed provider entries re-rendered with the guarded shape and verified with real stdio initialize handshakes; repeated connects leave the venv untouched.