### PR TITLE
test(mcp): functional assertion floor - spawned servers must prove they serve

### DIFF
--- a/.vault/adr/2026-02-22-mcp-testing-adr.md
+++ b/.vault/adr/2026-02-22-mcp-testing-adr.md
@@ -3,10 +3,11 @@ tags:
   - '#adr'
   - '#mcp-testing'
 date: '2026-02-22'
-modified: '2026-06-13'
+modified: '2026-07-17'
 related:
   - '[[2026-02-22-mcp-testing-research]]'
   - '[[2026-02-22-mcp-consolidation-adr]]'
+  - '[[2026-07-17-mcp-testing-research]]'
 ---
 
 # `mcp-testing` adr: `add in-memory client session tests` | (**status:** `accepted`)
@@ -81,6 +82,26 @@ classes:
   single session.
 
 Fixture pattern per \[[2026-02-22-mcp-testing-research]\] section 7.
+
+## Functional assertion floor (2026-07-17 amendment)
+
+Per the operator's directive and the inventory in
+`2026-07-17-mcp-testing-research`, existence is not functionality: a test
+that spawns the real MCP server process may not pass on liveness alone.
+Every such test asserts, before or alongside any lifecycle claim, at least
+one measurable served capability:
+
+- the `initialize` handshake completes and identifies the server, and/or
+- `tools/list` returns the exact expected tool surface, and/or
+- one tool call returns a correct, structurally asserted payload.
+
+Lifecycle tests (orphan reaping, EOF exit, watchdog behavior) satisfy the
+floor by proving the server was serving when the lifecycle event fired -
+the client side of the test performs the JSON-RPC exchange itself when it
+owns the transport pipes. In-memory session tests already exceed the floor
+by construction. The same floor is the recommended contract for the
+companion vaultspec-rag server's spawned-shim tests, handed to that repo's
+board.
 
 ## Rationale
 

--- a/.vault/audit/2026-07-17-mcp-testing-audit.md
+++ b/.vault/audit/2026-07-17-mcp-testing-audit.md
@@ -1,0 +1,64 @@
+---
+tags:
+  - '#audit'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-mcp-testing-plan]]"
+  - "[[2026-02-22-mcp-testing-adr]]"
+---
+
+# `mcp-testing` audit: `functional assertion floor review`
+
+## Scope
+
+Stacked-diff review of the functional assertion floor (branch stacked on
+the watchdog-parity PR): the raw JSON-RPC serving probes added to
+`tests/unit/mcp_server/test_watchdog.py` and
+`tests/mcp/test_mcp_entrypoint.py`, against the 2026-07-17 amendment to
+the testing decision. Reviewed by the code-reviewer persona for protocol
+correctness, deadlock and flakiness hazards, assertion strength versus
+the floor, test integrity, and conventions.
+
+## Findings
+
+### protocol-correctness | low | Exchange confirmed valid MCP end to end
+
+Framing, initialize params, the initialized notification ordering, and
+the id-keyed receive loops were confirmed correct; server logging is
+stderr-only so stdout carries pure JSON-RPC, and the 20-message skip
+bound tolerates id-less notifications. CLEAN: no action.
+
+### stderr-backpressure | low | Serving-EOF test piped stderr it never drained
+
+The serving-session EOF test blocked on stdout mid-handshake while
+stderr accumulated in an undrained pipe - a latent buffer deadlock,
+ceiling-bounded by the suite timeout. RESOLVED: stderr is discarded for
+that test, with the rationale recorded inline.
+
+### orphan-on-failure | low | Failed serving assertion could leak the pipe-holding sleeper
+
+The leaked-pipe test's new serving assertions ran before the inner
+cleanup that reaps the 120-second sleeper. RESOLVED: the sleeper reap
+was hoisted into the outer cleanup covering every exit path.
+
+### blocking-readline | low | Handshake reads rely on the suite-wide timeout ceiling
+
+Bare blocking reads during the handshake are bounded only by the
+300-second function-scoped pytest ceiling. ACCEPTED: stdout is pure
+protocol and the response is prompt; a per-read guard would only
+tighten failure latency.
+
+### assertion-strength | low | Floor satisfied; single sanctioned exception verified
+
+Every spawned-server test asserts served capability (handshake identity
+and/or the exact nine-tool surface); the zero-input EOF test is the
+decision's documented exception and states it. CLEAN: no action.
+
+## Recommendations
+
+- Ship after the two resolved findings; verdict PASS-with-notes, no
+  revision cycle required.
+- The rag half of the floor is tracked on that repo's board with the
+  inventory and the reference probe; no core follow-up.

--- a/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S01.md
+++ b/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S01.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S01'
+related:
+  - "[[2026-07-17-mcp-testing-plan]]"
+---
+
+# Ground the sweep: inventory both repos' MCP tests and amend the testing decision with the functional assertion floor
+
+## Scope
+
+- `.vault/adr/2026-02-22-mcp-testing-adr.md`
+
+## Description
+
+- Inventory core and rag MCP tests (rag via a read-only agent), classifying functional vs existence-only assertions
+- Persist the inventory as the feature's research grounding
+- Amend the testing decision in place with the functional assertion floor and its one degenerate exception
+
+## Outcome
+
+ADR amendment live; research doc records the two-repo picture.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S02.md
+++ b/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S02.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S02'
+related:
+  - "[[2026-07-17-mcp-testing-plan]]"
+---
+
+# Add a raw JSON-RPC serving probe and wire it into the leaked-pipe and parent-pid watchdog e2es so lifecycle asserts count only from a serving server
+
+## Scope
+
+- `tests/unit/mcp_server/test_watchdog.py`
+
+## Description
+
+- Add a raw newline-JSON-RPC serving probe asserting initialize identity and the exact nine-tool surface
+- Wire it into the parent-pid e2e over the server's own pipes
+- Rework the leaked-pipe e2e's client script to handshake through the very pipe it later leaks, printing a SERVING verdict the test asserts before the kill
+
+## Outcome
+
+Both lifecycle e2es now count only from a proven-serving server; committed as `9caa4f48`. The blind boot sleeps became handshake round-trips, cutting the pair from ~40s to ~4s.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S03.md
+++ b/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S03.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S03'
+related:
+  - "[[2026-07-17-mcp-testing-plan]]"
+---
+
+# Upgrade the entrypoint tests: handshake through the stdout-purity queue, EOF exit proven from a serving session, zero-input EOF kept as the documented exception
+
+## Scope
+
+- `tests/mcp/test_mcp_entrypoint.py`
+
+## Description
+
+- Extend the startup test with an initialize round-trip through the stdout-purity queue
+- Split EOF coverage: serving-session disconnect (handshake then close stdin) and zero-input EOF kept as the documented floor exception
+
+## Outcome
+
+Committed as `9caa4f48`.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S04.md
+++ b/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S04.md
@@ -1,0 +1,28 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S04'
+related:
+  - "[[2026-07-17-mcp-testing-plan]]"
+---
+
+# Hand the rag half to that repo's board with the inventory and the floor spec
+
+## Scope
+
+- `repo workflow`
+
+## Description
+
+- File the rag half on that repo's board with the full inventory, the floor contract, per-test upgrade spec, and the reference probe locator
+
+## Outcome
+
+rag issue 232 filed; rag worktree was mid-flight in another session, so board handoff per the established pattern.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S05.md
+++ b/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S05.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S05'
+related:
+  - "[[2026-07-17-mcp-testing-plan]]"
+---
+
+# Run gates, dispatch code review, resolve findings, append audit entries, open stacked PR
+
+## Scope
+
+- `quality gates`
+
+## Description
+
+- Run gates and dispatch the code-reviewer persona on the stacked diff
+- Resolve findings, append audit entries, open the stacked PR
+
+## Outcome
+
+Pending completion at record time; outcome recorded in the audit and PR.
+
+## Notes
+
+Branch stacks on the watchdog-parity PR; it must merge after it.

--- a/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S05.md
+++ b/.vault/exec/2026-07-17-mcp-testing/2026-07-17-mcp-testing-S05.md
@@ -22,7 +22,7 @@ related:
 
 ## Outcome
 
-Pending completion at record time; outcome recorded in the audit and PR.
+Gates green (MCP suites 83, unit gate 1773, ty both platforms); review PASS-with-notes with both actionable findings resolved (`59a0e04d`); audit written; stacked PR open.
 
 ## Notes
 

--- a/.vault/index/mcp-stdio-lifetime.index.md
+++ b/.vault/index/mcp-stdio-lifetime.index.md
@@ -16,6 +16,17 @@ related:
   - '[[2026-07-16-mcp-stdio-lifetime-audit]]'
   - '[[2026-07-16-mcp-stdio-lifetime-plan]]'
   - '[[2026-07-16-mcp-stdio-lifetime-research]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P01-S01]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P01-S02]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P01-S03]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P01-S04]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P01-S05]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P01-S06]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P02-S07]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P02-S08]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P02-S09]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P03-S10]]'
+  - '[[2026-07-17-mcp-stdio-lifetime-P03-S11]]'
   - '[[2026-07-17-mcp-stdio-lifetime-plan]]'
 ---
 
@@ -41,6 +52,17 @@ Auto-generated index of all documents tagged with `#mcp-stdio-lifetime`.
 - `2026-07-16-mcp-stdio-lifetime-S04` - Add real-pipe resolver test, real-process watchdog exit test, and fail-open tests for console stdin and dead client PID
 - `2026-07-16-mcp-stdio-lifetime-S05` - Add end-to-end orphan test spawning the real MCP server through an intermediary client, killing the client while a sibling holds the pipe, asserting server exit
 - `2026-07-16-mcp-stdio-lifetime-S06` - Run prek, ty, and unit pytest gates, fix findings, finalize PR body and mark ready for review
+- `2026-07-17-mcp-stdio-lifetime-P01-S01` - Open feature branch and draft PR referencing issue 220 and the parity revision
+- `2026-07-17-mcp-stdio-lifetime-P01-S02` - Add VAULTSPEC_STDIO_WATCHDOG kill switch honored before any arming, with off values matching the sibling repo
+- `2026-07-17-mcp-stdio-lifetime-P01-S03` - Emit one structured JSON exit event to stderr before every hard exit, shared by all anchors
+- `2026-07-17-mcp-stdio-lifetime-P01-S04` - Add PID-reuse-safe ancestor-chain fallback armed when stdin pipe resolution declines: startup handles, creation-time monotonicity, grace-window pruning, wait-any
+- `2026-07-17-mcp-stdio-lifetime-P01-S05` - Add POSIX coarse reparent poll exiting on orphaning or explicit client death
+- `2026-07-17-mcp-stdio-lifetime-P01-S06` - Add --parent-pid entrypoint option watched ahead of discovery and wire arming outcomes through \_serve logging
+- `2026-07-17-mcp-stdio-lifetime-P02-S07` - Add kill-switch and parent-pid override tests driving real worker subprocesses
+- `2026-07-17-mcp-stdio-lifetime-P02-S08` - Rework the non-pipe stdin test for fallback semantics and add ancestor-death and grace-window fallback tests with real process chains
+- `2026-07-17-mcp-stdio-lifetime-P02-S09` - Add POSIX-contract assertions for the reparent poll and explicit-pid path exercised on the current platform honestly
+- `2026-07-17-mcp-stdio-lifetime-P03-S10` - Document the watchdog contract and knobs in the MCP doc and register VAULTSPEC_STDIO_WATCHDOG in the CLI reference env table via the builtins source
+- `2026-07-17-mcp-stdio-lifetime-P03-S11` - Run gates, dispatch code review, resolve findings, append audit entries, finalize PR
 
 ### plan
 

--- a/.vault/index/mcp-testing.index.md
+++ b/.vault/index/mcp-testing.index.md
@@ -1,14 +1,21 @@
 ---
 generated: true
 tags:
-  - '#mcp-testing'
   - '#index'
-date: '2026-04-21'
-modified: '2026-06-13'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
 related:
   - '[[2026-02-22-mcp-testing-adr]]'
   - '[[2026-02-22-mcp-testing-plan]]'
   - '[[2026-02-22-mcp-testing-research]]'
+  - '[[2026-07-17-mcp-testing-S01]]'
+  - '[[2026-07-17-mcp-testing-S02]]'
+  - '[[2026-07-17-mcp-testing-S03]]'
+  - '[[2026-07-17-mcp-testing-S04]]'
+  - '[[2026-07-17-mcp-testing-S05]]'
+  - '[[2026-07-17-mcp-testing-plan]]'
+  - '[[2026-07-17-mcp-testing-research]]'
 ---
 
 # `mcp-testing` feature index
@@ -21,10 +28,20 @@ Auto-generated index of all documents tagged with `#mcp-testing`.
 
 - `2026-02-22-mcp-testing-adr` - `mcp-testing` adr: `add in-memory client session tests` | (**status:** `accepted`)
 
+### exec
+
+- `2026-07-17-mcp-testing-S01` - Ground the sweep: inventory both repos' MCP tests and amend the testing decision with the functional assertion floor
+- `2026-07-17-mcp-testing-S02` - Add a raw JSON-RPC serving probe and wire it into the leaked-pipe and parent-pid watchdog e2es so lifecycle asserts count only from a serving server
+- `2026-07-17-mcp-testing-S03` - Upgrade the entrypoint tests: handshake through the stdout-purity queue, EOF exit proven from a serving session, zero-input EOF kept as the documented exception
+- `2026-07-17-mcp-testing-S04` - Hand the rag half to that repo's board with the inventory and the floor spec
+- `2026-07-17-mcp-testing-S05` - Run gates, dispatch code review, resolve findings, append audit entries, open stacked PR
+
 ### plan
 
 - `2026-02-22-mcp-testing-plan` - `mcp-testing` plan
+- `2026-07-17-mcp-testing-plan` - `mcp-testing` plan
 
 ### research
 
 - `2026-02-22-mcp-testing-research` - `mcp-testing` research: in-memory client session tests
+- `2026-07-17-mcp-testing-research` - `mcp-testing` research: `functional assertion floor inventory`

--- a/.vault/index/mcp-testing.index.md
+++ b/.vault/index/mcp-testing.index.md
@@ -14,6 +14,7 @@ related:
   - '[[2026-07-17-mcp-testing-S03]]'
   - '[[2026-07-17-mcp-testing-S04]]'
   - '[[2026-07-17-mcp-testing-S05]]'
+  - '[[2026-07-17-mcp-testing-audit]]'
   - '[[2026-07-17-mcp-testing-plan]]'
   - '[[2026-07-17-mcp-testing-research]]'
 ---
@@ -27,6 +28,10 @@ Auto-generated index of all documents tagged with `#mcp-testing`.
 ### adr
 
 - `2026-02-22-mcp-testing-adr` - `mcp-testing` adr: `add in-memory client session tests` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-17-mcp-testing-audit` - `mcp-testing` audit: `functional assertion floor review`
 
 ### exec
 

--- a/.vault/plan/2026-07-17-mcp-testing-plan.md
+++ b/.vault/plan/2026-07-17-mcp-testing-plan.md
@@ -16,7 +16,7 @@ related:
 - [x] `S02` - Add a raw JSON-RPC serving probe and wire it into the leaked-pipe and parent-pid watchdog e2es so lifecycle asserts count only from a serving server; `tests/unit/mcp_server/test_watchdog.py`.
 - [x] `S03` - Upgrade the entrypoint tests: handshake through the stdout-purity queue, EOF exit proven from a serving session, zero-input EOF kept as the documented exception; `tests/mcp/test_mcp_entrypoint.py`.
 - [x] `S04` - Hand the rag half to that repo's board with the inventory and the floor spec; `repo workflow`.
-- [ ] `S05` - Run gates, dispatch code review, resolve findings, append audit entries, open stacked PR; `quality gates`.
+- [x] `S05` - Run gates, dispatch code review, resolve findings, append audit entries, open stacked PR; `quality gates`.
 
 ## Description
 

--- a/.vault/plan/2026-07-17-mcp-testing-plan.md
+++ b/.vault/plan/2026-07-17-mcp-testing-plan.md
@@ -1,0 +1,51 @@
+---
+tags:
+  - '#plan'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+tier: L1
+related:
+  - '[[2026-02-22-mcp-testing-adr]]'
+  - '[[2026-07-17-mcp-testing-research]]'
+---
+
+# `mcp-testing` plan
+
+- [x] `S01` - Ground the sweep: inventory both repos' MCP tests and amend the testing decision with the functional assertion floor; `.vault/adr/2026-02-22-mcp-testing-adr.md`.
+- [x] `S02` - Add a raw JSON-RPC serving probe and wire it into the leaked-pipe and parent-pid watchdog e2es so lifecycle asserts count only from a serving server; `tests/unit/mcp_server/test_watchdog.py`.
+- [x] `S03` - Upgrade the entrypoint tests: handshake through the stdout-purity queue, EOF exit proven from a serving session, zero-input EOF kept as the documented exception; `tests/mcp/test_mcp_entrypoint.py`.
+- [x] `S04` - Hand the rag half to that repo's board with the inventory and the floor spec; `repo workflow`.
+- [ ] `S05` - Run gates, dispatch code review, resolve findings, append audit entries, open stacked PR; `quality gates`.
+
+## Description
+
+Execute the functional assertion floor amendment of
+2026-02-22-mcp-testing-adr, grounded by the two-repo inventory in
+2026-07-17-mcp-testing-research: every test that spawns the real MCP
+server must prove served capability (handshake identity, exact tool
+surface, or a measurable payload) before lifecycle assertions count.
+Core's four offenders are upgraded on a branch stacked on the
+watchdog-parity PR; the rag half is handed to that repo's board.
+
+## Steps
+
+## Parallelization
+
+Sequential: the inventory and decision precede the test upgrades, and the
+gates close over the finished set. S02 and S03 are independent of each
+other.
+
+## Verification
+
+- Both watchdog e2es assert a completed handshake and the exact nine-tool
+  surface through their own transport pipes before any kill or exit
+  assertion.
+- The entrypoint suite proves serving through the stdout-purity queue and
+  EOF exit from a serving session; the zero-input EOF exception is
+  documented in the test itself.
+- The amended decision names the floor and its one degenerate exception;
+  the rag board carries the sibling half with the reference probe.
+- Gates green (unit gate, MCP suites, tests tree, ty both platforms,
+  dependency audit); review dispatched and findings resolved; stacked PR
+  open and ready.

--- a/.vault/research/2026-07-17-mcp-testing-research.md
+++ b/.vault/research/2026-07-17-mcp-testing-research.md
@@ -1,0 +1,84 @@
+---
+tags:
+  - '#research'
+  - '#mcp-testing'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-02-22-mcp-testing-adr]]"
+---
+
+# `mcp-testing` research: `functional assertion floor inventory`
+
+Which MCP-server tests in vaultspec-core and vaultspec-rag assert served
+functionality, and which assert only process existence? The operator's
+standard is that a spawned server must prove measurable capability - a
+correct handshake, the expected tool surface, a correct command result -
+not merely that a process booted, stayed alive, or exited. The inventory
+found the in-memory and one core wire-level suite already functional, and
+exactly one class of offender in each repo: the lifecycle end-to-end tests
+that spawn the real server and assert nothing about serving.
+
+## Findings
+
+### vaultspec-core: the wire-level and in-memory suites are functional
+
+`tests/mcp/test_mcp_stdio_e2e.py` drives the real spawned server through
+the `mcp` SDK's `stdio_client` and a real `ClientSession`: it asserts the
+`initialize` result's server name, the exact nine-tool surface with output
+schemas, a `status` call returning a rollup payload, an `invoke`
+round-trip's `ok`/`exit_code`/`command`, and denylist rejection.
+`tests/unit/mcp_server/` (66 tests) exercises every tool through the
+in-memory session transport with payload assertions per
+`2026-02-22-mcp-testing-adr`. `tests/mcp/test_mcp_entrypoint.py` asserts
+stdout protocol hygiene and EOF exit; `tests/mcp/test_mcp_context_budget.py`
+measures real serialized definitions.
+
+### vaultspec-core: the watchdog lifecycle e2es assert liveness only
+
+The two watchdog end-to-end tests in
+`tests/unit/mcp_server/test_watchdog.py` (leaked-pipe orphan reap;
+`--parent-pid` override reap) spawn the real server but assert only boot
+liveness and exit. Nothing distinguishes "a process that will serve" from
+"a process wedged after arming": the lifecycle claim rests on an unproven
+serving assumption. A functional precondition (handshake completed, nine
+tools listed) is expressible in both: the flag test owns the server's
+pipes directly, and the leaked-pipe test's client script can perform the
+newline-delimited JSON-RPC exchange itself before the kill.
+
+### vaultspec-rag: functional assertions exist but never cross the wire
+
+`test_mcp_conformance_surface.py` asserts the exact five-tool surface,
+read-only annotations, schema defaults, and output schemas - all via
+in-process `mcp.list_tools()`. `test_mcp_no_local_fallback.py` drives each
+tool coroutine directly and asserts exact degraded-mode errors. No rag
+test performs an `initialize`/`tools/list`/tool-call exchange against a
+spawned `vaultspec-search-mcp` subprocess over its actual stdio transport.
+
+### vaultspec-rag: both stdio-lifetime e2es are liveness only
+
+`test_stdio_lifetime_e2e.py::test_worker_reaps_itself_when_an_ancestor_dies`
+uses a synthetic watchdog-only worker that never touches MCP.
+`test_stdin_eof_still_exits_the_real_shim_cleanly` spawns the real shim,
+writes zero bytes to its stdin, reads nothing from its stdout, sleeps 5s
+on an unverified "reached the read loop" assumption, and asserts only
+`returncode == 0`. Neither proves the shim serves.
+
+### Sweep context
+
+The core offenders live on the watchdog-parity branch (PR 223), so the fix
+stacks on it. The rag worktree is mid-flight in another session (branch
+`chore/prerelease-maintenance`), so the rag half is handed to that repo's
+board alongside its open parity items. Not investigated: HTTP daemon-mode
+serving assertions in rag (`test_service_eviction.py` covers the REST
+routes directly).
+
+## Sources
+
+- `tests/mcp/test_mcp_stdio_e2e.py:74` (`_drive_session`, the functional wire template)
+- `tests/unit/mcp_server/test_watchdog.py` (leaked-pipe and parent-pid e2es, branch feat/mcp-watchdog-parity)
+- `tests/mcp/test_mcp_entrypoint.py:42`
+- rag `src/vaultspec_rag/tests/test_mcp_conformance_surface.py:61`
+- rag `src/vaultspec_rag/tests/test_mcp_no_local_fallback.py:105`
+- rag `src/vaultspec_rag/tests/integration/test_stdio_lifetime_e2e.py:71` and `:115` (at rag main `6ee6f8f` lineage)
+- Operator directive of 2026-07-17: functional capability, not existence, is the pass criterion for a running MCP service

--- a/tests/mcp/test_mcp_entrypoint.py
+++ b/tests/mcp/test_mcp_entrypoint.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import queue
 import subprocess
@@ -12,6 +13,17 @@ import pytest
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_INITIALIZE_REQUEST = {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "initialize",
+    "params": {
+        "protocolVersion": "2025-03-26",
+        "capabilities": {},
+        "clientInfo": {"name": "entrypoint-probe", "version": "0"},
+    },
+}
 
 
 def _build_minimal_workspace(root: Path) -> None:
@@ -91,6 +103,17 @@ def test_mcp_entrypoint_starts_and_keeps_stdout_clean(tmp_path: Path) -> None:
 
         time.sleep(0.2)
         assert stdout_queue.empty()
+
+        # Functional floor: liveness and clean stdout are not serving.
+        # Prove the process answers the protocol - the initialize response
+        # must be the FIRST stdout bytes and must identify this server.
+        assert proc.stdin is not None
+        proc.stdin.write((json.dumps(_INITIALIZE_REQUEST) + "\n").encode("utf-8"))
+        proc.stdin.flush()
+        response_line = stdout_queue.get(timeout=15)
+        response = json.loads(response_line)
+        assert response["id"] == 1, response
+        assert response["result"]["serverInfo"]["name"] == "vaultspec-mcp", response
     finally:
         proc.terminate()
         try:
@@ -101,13 +124,59 @@ def test_mcp_entrypoint_starts_and_keeps_stdout_clean(tmp_path: Path) -> None:
 
 
 @pytest.mark.integration
-def test_mcp_entrypoint_exits_cleanly_on_stdin_eof(tmp_path: Path) -> None:
-    """The stdio server must exit promptly on stdin EOF, not spin or hang.
+def test_mcp_entrypoint_exits_cleanly_on_stdin_eof_while_serving(
+    tmp_path: Path,
+) -> None:
+    """EOF from a serving session must exit promptly - the disconnect path.
 
-    Regression guard for the busy-signal concern (#137): with no input and an
-    immediate EOF (``stdin`` closed), the server must terminate on its own
-    within a short window. A busy-loop or hang on EOF - the failure mode the
-    concern describes - would block until the timeout and fail this test.
+    Regression guard for the busy-signal concern (#137), upgraded to the
+    functional floor: the server first proves it serves (the initialize
+    response identifies it), then its client closes stdin - the real
+    client-disconnect lifecycle. A busy-loop or hang on EOF would block
+    until the timeout and fail this test.
+    """
+    _build_minimal_workspace(tmp_path)
+
+    env = os.environ.copy()
+    env["VAULTSPEC_TARGET_DIR"] = str(tmp_path)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "from vaultspec_core.mcp_server.app import run; run()"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        assert proc.stdin is not None and proc.stdout is not None
+        proc.stdin.write((json.dumps(_INITIALIZE_REQUEST) + "\n").encode("utf-8"))
+        proc.stdin.flush()
+        response = json.loads(proc.stdout.readline())
+        assert response["result"]["serverInfo"]["name"] == "vaultspec-mcp", response
+
+        proc.stdin.close()
+        returncode = proc.wait(timeout=20)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+        pytest.fail(
+            "MCP stdio server did not exit on stdin EOF within 20s; "
+            "possible busy-loop or hang (#137)."
+        )
+    assert returncode == 0, proc.stderr.read().decode("utf-8", errors="replace")
+
+
+@pytest.mark.integration
+def test_mcp_entrypoint_exits_on_immediate_eof_before_any_request(
+    tmp_path: Path,
+) -> None:
+    """Zero-input EOF exits cleanly - the degenerate startup lifecycle.
+
+    EOF here precedes any request, so a serving assertion is impossible by
+    construction: this is the documented exception to the functional floor,
+    kept because a spawn-then-abandon client must not leave a wedged
+    process. The serving-session disconnect path is covered by the test
+    above.
     """
     _build_minimal_workspace(tmp_path)
 
@@ -126,8 +195,5 @@ def test_mcp_entrypoint_exits_cleanly_on_stdin_eof(tmp_path: Path) -> None:
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait(timeout=5)
-        pytest.fail(
-            "MCP stdio server did not exit on stdin EOF within 20s; "
-            "possible busy-loop or hang (#137)."
-        )
+        pytest.fail("MCP stdio server did not exit on immediate stdin EOF within 20s.")
     assert returncode == 0, proc.stderr.read().decode("utf-8", errors="replace")

--- a/tests/mcp/test_mcp_entrypoint.py
+++ b/tests/mcp/test_mcp_entrypoint.py
@@ -140,11 +140,14 @@ def test_mcp_entrypoint_exits_cleanly_on_stdin_eof_while_serving(
     env = os.environ.copy()
     env["VAULTSPEC_TARGET_DIR"] = str(tmp_path)
 
+    # stderr is discarded rather than piped: the test blocks on stdout
+    # mid-handshake, and an undrained stderr pipe filling its buffer would
+    # deadlock the server's logging against this read.
     proc = subprocess.Popen(
         [sys.executable, "-c", "from vaultspec_core.mcp_server.app import run; run()"],
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
         env=env,
     )
     try:
@@ -163,7 +166,7 @@ def test_mcp_entrypoint_exits_cleanly_on_stdin_eof_while_serving(
             "MCP stdio server did not exit on stdin EOF within 20s; "
             "possible busy-loop or hang (#137)."
         )
-    assert returncode == 0, proc.stderr.read().decode("utf-8", errors="replace")
+    assert returncode == 0
 
 
 @pytest.mark.integration

--- a/tests/unit/mcp_server/test_watchdog.py
+++ b/tests/unit/mcp_server/test_watchdog.py
@@ -384,6 +384,7 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
         time.sleep(3600)
         """
     )
+    sleeper_pid = 0
     client = subprocess.Popen(
         [sys.executable, "-c", client_code],
         stdout=subprocess.PIPE,
@@ -404,18 +405,19 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
         client.kill()
         client.wait(timeout=60)
 
-        try:
-            assert _wait_for_pid_exit(server_pid, timeout=30), (
-                "server survived its client; watchdog did not fire"
-            )
-        finally:
+        assert _wait_for_pid_exit(server_pid, timeout=30), (
+            "server survived its client; watchdog did not fire"
+        )
+    finally:
+        if client.poll() is None:
+            client.kill()
+        # The sleeper is reaped on every exit path, including a failed
+        # serving assertion, so no failure mode leaks the 120s holder.
+        if sleeper_pid:
             subprocess.run(
                 ["taskkill", "/PID", str(sleeper_pid), "/F"],
                 capture_output=True,
             )
-    finally:
-        if client.poll() is None:
-            client.kill()
 
 
 def test_dead_parent_pid_override_emits_exit_event() -> None:

--- a/tests/unit/mcp_server/test_watchdog.py
+++ b/tests/unit/mcp_server/test_watchdog.py
@@ -47,6 +47,67 @@ _RESOLVER_SNIPPET = (
     "print(resolve_stdin_client_pid(), flush=True)"
 )
 
+#: The nine tools the served surface must advertise; a lifecycle test only
+#: counts once the spawned server has proven it serves exactly these.
+_EXPECTED_TOOLS = frozenset(
+    {
+        "status",
+        "find",
+        "create",
+        "edit",
+        "plan_progress",
+        "plan_edit",
+        "check",
+        "discover",
+        "invoke",
+    }
+)
+
+
+def _assert_server_serves(stdin_pipe, stdout_pipe) -> None:
+    """Prove a spawned server serves MCP before any lifecycle assertion.
+
+    Drives the real newline-delimited JSON-RPC exchange over the given
+    binary pipes: ``initialize`` must identify the server,
+    ``notifications/initialized`` completes the handshake, and
+    ``tools/list`` must return exactly the nine-tool surface. Liveness
+    alone is never the pass criterion for a running MCP service.
+    """
+
+    def send(obj: dict) -> None:
+        stdin_pipe.write((json.dumps(obj) + "\n").encode("utf-8"))
+        stdin_pipe.flush()
+
+    def recv(expect_id: int) -> dict:
+        for _ in range(20):
+            line = stdout_pipe.readline()
+            assert line, "server closed stdout during the handshake"
+            message = json.loads(line)
+            if message.get("id") == expect_id:
+                assert "result" in message, message
+                return message["result"]
+        raise AssertionError(f"no response with id {expect_id} within 20 messages")
+
+    send(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "watchdog-probe", "version": "0"},
+            },
+        }
+    )
+    init_result = recv(1)
+    assert init_result["serverInfo"]["name"] == "vaultspec-mcp", init_result
+    send({"jsonrpc": "2.0", "method": "notifications/initialized"})
+    send({"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+    tools_result = recv(2)
+    names = {tool["name"] for tool in tools_result["tools"]}
+    assert names == _EXPECTED_TOOLS, names
+
 
 def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
     """Wait until the process identified by *pid* exits (Windows only).
@@ -271,13 +332,13 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
     (tmp_path / ".vault").mkdir()
     client_code = textwrap.dedent(
         f"""
-        import os, subprocess, sys, time
+        import json, os, subprocess, sys, time
         r, w = os.pipe()
         os.set_inheritable(w, True)
         server = subprocess.Popen(
             [sys.executable, "-m", "vaultspec_core.mcp_server.app"],
             stdin=r,
-            stdout=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
             stderr=subprocess.DEVNULL,
             cwd={str(tmp_path)!r},
         )
@@ -290,6 +351,36 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
         )
         print(server.pid, flush=True)
         print(sleeper.pid, flush=True)
+
+        def send(obj):
+            os.write(w, (json.dumps(obj) + "\\n").encode("utf-8"))
+
+        def recv(expect_id):
+            for _ in range(20):
+                line = server.stdout.readline()
+                if not line:
+                    return None
+                message = json.loads(line)
+                if message.get("id") == expect_id:
+                    return message.get("result")
+            return None
+
+        # Prove the server SERVES over this very pipe before the kill:
+        # initialize, complete the handshake, and list the tool surface.
+        send({{
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": {{
+                "protocolVersion": "2025-03-26", "capabilities": {{}},
+                "clientInfo": {{"name": "leak-client", "version": "0"}},
+            }},
+        }})
+        init_result = recv(1)
+        send({{"jsonrpc": "2.0", "method": "notifications/initialized"}})
+        send({{"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {{}}}})
+        tools_result = recv(2)
+        name = (init_result or {{}}).get("serverInfo", {{}}).get("name")
+        tools = sorted(t["name"] for t in (tools_result or {{}}).get("tools", []))
+        print(f"SERVING name={{name}} tools={{','.join(tools)}}", flush=True)
         time.sleep(3600)
         """
     )
@@ -303,13 +394,13 @@ def test_real_server_exits_when_client_dies_despite_leaked_pipe(
         server_pid = int(client.stdout.readline())
         sleeper_pid = int(client.stdout.readline())
 
-        # Give the server a moment to boot and arm before the client dies,
-        # and prove it actually booted: a server that crashed at startup
-        # would make the post-kill exit assertion pass vacuously.
-        time.sleep(5)
-        assert not _wait_for_pid_exit(server_pid, timeout=0.1), (
-            "server was already dead before its client was killed"
-        )
+        # Functional floor: the server must prove it serves MCP through
+        # this exact pipe before the lifecycle assertion means anything.
+        serving_line = client.stdout.readline().strip()
+        assert serving_line.startswith("SERVING name=vaultspec-mcp "), serving_line
+        served_tools = set(serving_line.split("tools=", 1)[1].split(","))
+        assert served_tools == _EXPECTED_TOOLS, served_tools
+
         client.kill()
         client.wait(timeout=60)
 
@@ -537,12 +628,15 @@ def test_real_server_parent_pid_flag_reaps_on_override_death(
             str(sleeper.pid),
         ],
         stdin=subprocess.PIPE,
-        stdout=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         cwd=tmp_path,
     )
     try:
-        time.sleep(5)
+        # Functional floor: prove the server serves MCP over its own pipes
+        # (handshake identifies it; tools/list is the exact nine-tool
+        # surface) before the override-death lifecycle assertion counts.
+        _assert_server_serves(server.stdin, server.stdout)
         assert server.poll() is None, "server exited before the override died"
         sleeper.kill()
         sleeper.wait(timeout=60)


### PR DESCRIPTION
Refs #220. Recreates #225 (auto-closed when its stacked base merged as #223); identical content rebased onto main. Sibling half: nevenincs/vaultspec-rag#232.

Every test that spawns the real stdio MCP server now proves served capability (initialize identity, the exact nine-tool surface, or a measurable payload) before any lifecycle assertion counts, codified as the functional assertion floor amendment to the testing ADR. The leaked-pipe orphan e2e handshakes through the very pipe it later leaks; EOF exit is proven from a serving session, with zero-input EOF as the documented exception.

Verification: 14/14 suites green on this base; review PASS-with-notes with both actionable findings resolved.