### PR TITLE
feat(install): managed launch artifacts converge automatically on upgrade and sync

### DIFF
--- a/.vault/adr/2026-07-17-upgrade-convergence-adr.md
+++ b/.vault/adr/2026-07-17-upgrade-convergence-adr.md
@@ -1,0 +1,170 @@
+---
+tags:
+  - '#adr'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-upgrade-convergence-research]]"
+---
+
+# `upgrade-convergence` adr: `managed launch artifacts converge automatically` | (**status:** `accepted`)
+
+## Problem Statement
+
+The static-launch amendment changed the canonical MCP launch bytes for
+every deployed workspace, but the reconciliation machinery cannot deliver
+the new shape: a managed entry that drifted from its definition is skipped
+by plain `sync` and by `install --upgrade` alike unless the operator passes
+`--force`, and the upgrade path's mode-flip force seam covers only core's
+own entry (`2026-07-17-upgrade-convergence-research`). Legacy workspaces
+therefore stay on regressed launch shapes indefinitely while the doctor
+hint promises otherwise. Per the user mandate of 2026-07-17, vaultspec-owned
+artifacts must converge to the mandated standard automatically on the next
+upgrade or sync, regardless of the workspace's provisioned version, with
+ample user-facing description of what changed and why.
+
+## Considerations
+
+- The ownership sidecar already fingerprints every managed entry vaultspec
+  wrote; the merge algorithm discards it, treating provably-untouched and
+  hand-edited entries identically
+  (`2026-07-17-upgrade-convergence-research`, fingerprint finding).
+- The versioned migrations registry runs on upgrade, lazily on any vault
+  verb, and via `migrations run`, gated only by the manifest's recorded
+  version - the proven no-flag convergence vehicle
+  (`2026-07-17-upgrade-convergence-research`, migrations finding).
+- Hooks already converge unconditionally; the gaps are MCP managed entries,
+  the core-only mode-flip seam, prek.toml workspaces (log-only), and stale
+  companion seeds outside core's write authority
+  (`2026-07-17-upgrade-convergence-research`).
+- The legacy-absent dependency render bridge is deliberate and must
+  survive: convergence targets the guarded shape of the workspace's OWN
+  mode, never a mode change (`2026-07-13-install-mode-adr` Q6).
+- Ownership discipline is a hard boundary: external entries are never
+  adopted and hand-edited content is never overwritten without `--force`
+  (`2026-07-15-provider-mcp-enrollment-adr`).
+
+## Considered options
+
+**B1 - fingerprint-verified auto-convergence.** Chosen: the managed-entry
+merge gains a third path - an entry that differs from its rendered
+definition but byte-matches its recorded ownership fingerprint is provably
+untouched since vaultspec wrote it and is updated in place on plain `sync`
+and on upgrade, no flag required, reported with a distinct refresh label
+and a warning line stating the old shape, the new shape, and the reason.
+Hand-edited entries (fingerprint mismatch) keep today's skip-and-warn;
+external entries keep the adoption gate. Rejected: defaulting `--force` on
+upgrade (overwrites hand edits and adopts external entries - a bigger
+hammer than convergence needs). Rejected: status quo plus documentation
+(leaves every legacy workspace regressed until manual intervention, the
+exact condition the mandate closes).
+
+**B2 - registered convergence migration.** Chosen: a versioned migration
+targeting the next release re-renders every declared package's managed MCP
+entry through the owning `mcp_sync` verb, riding the B1 path so it is safe
+without force. Because the driver fires on `install --upgrade`, lazily on
+any vault verb, and on `migrations run`, every legacy workspace below the
+target version converges on first contact regardless of flags or floors.
+Rejected: sync-only convergence (misses workspaces that run vault verbs
+but never sync). Rejected: a migration that hand-rewrites host files
+(bypasses the owning verb and the ownership discipline).
+
+**B3 - seam widened to companions.** Chosen: the upgrade path's mode-flip
+force seam covers every package declared in the workspace map, not only
+vaultspec-core, so a companion's entry migrates atomically in the same run.
+Rejected: core-only status quo (documented asymmetry with no rationale
+beyond implementation history).
+
+**B4 - user-facing messaging.** Chosen: every automatic refresh is
+narrated - the sync result carries a per-entry line naming the entry, the
+old and new launch command, and a one-sentence reason; upgrade output
+aggregates the same; the doctor's drift hint stays truthful (after B1/B2,
+`install --upgrade` genuinely converges); the MCP doc's install-modes
+section documents automatic convergence, the hand-edited exception, and
+how to opt out (`--skip mcp` at upgrade; hand-edited entries are never
+touched). Rejected: silent refresh (mandate requires ample description;
+silent mutation of host config erodes the trust the ownership sidecar
+exists to protect).
+
+**B5 - advisory signals for what cannot converge.** Chosen: warn-only
+doctor advisories for the two convergence holes core cannot fix itself - a
+prek.toml workspace whose canonical hooks cannot be refreshed, and a
+companion-named definition still in the static pre-parity shape (stale
+seed, remediation: re-run the companion's install). Rejected: silent
+log-only status quo (invisible in the surface operators actually read).
+
+## Constraints
+
+- Ownership discipline unchanged: no external adoption, no hand-edit
+  overwrite, without explicit `--force`; B1 refreshes only entries whose
+  bytes match the recorded fingerprint exactly.
+- The legacy-absent dependency render bridge holds; convergence never
+  changes a workspace's mode, only the shape of its own mode's launch.
+- The migration must be idempotent and route through `mcp_sync`; a re-run
+  after success is a no-op (`unchanged`).
+- Sync-result vocabulary stays within the established set; the refresh
+  reports through the existing `updated` counter with a distinguishing
+  item label so downstream consumers of counts are unaffected.
+- Workspaces whose ownership sidecar predates fingerprints (name-only
+  records) cannot be fingerprint-verified; they keep skip-and-warn and the
+  doctor hint names `--force` for them honestly.
+- The pipeline stays within core; companion seed content remains the
+  companion's to fix (rag issue 231).
+
+## Implementation
+
+The merge algorithm reads the recorded fingerprints alongside the managed
+name set and adds the refresh path between `unchanged` and the force gate:
+recorded-fingerprint match plus definition mismatch updates the entry,
+re-fingerprints it, counts as `updated` with a refresh-labeled item, and
+appends a warning line describing old command, new command, and reason.
+The upgrade path passes every declared package to the mode-flip seam
+instead of the core-only set. A new migration module registers against the
+next release version and invokes `mcp_sync` per enrolled provider at
+project scope, letting B1 do the byte work; its result feeds the standard
+migration reporting. The doctor's mode-mismatch and drift hints are
+re-worded to the now-truthful remediation set, and the doctor gains the
+two B5 advisories. The MCP documentation's install-modes section grows a
+convergence-on-upgrade passage stating the automatic behavior, the
+hand-edit exception, and the opt-outs. Tests cover: untouched-entry
+refresh on plain sync, hand-edited entry preserved with warning, name-only
+legacy sidecar preserved with honest hint, migration idempotence on real
+workspaces in both modes, companion entry refresh through the widened
+seam, and the two advisories.
+
+## Rationale
+
+The fingerprint path is the narrowest mechanism that satisfies automatic
+convergence regardless of version without weakening the ownership
+discipline the enrollment decision established: it converts information
+the sidecar already records into the safety proof the force gate lacked,
+so the only entries that converge are the ones vaultspec itself wrote and
+nobody touched since (`2026-07-17-upgrade-convergence-research`). The
+migration extends the same convergence to workspaces that never run `sync`
+directly, reusing the registry's proven triggers instead of inventing a
+new hook. Widening the seam and re-wording the hints correct documented
+asymmetries surfaced by the same research. Messaging is a first-class
+deliverable rather than an afterthought because the mandate says so
+explicitly, and because automatic mutation of host configuration is only
+trustworthy when it explains itself.
+
+## Consequences
+
+- Good: every vaultspec-written launch artifact converges to the mandated
+  standard on the workspace's next upgrade, sync, or vault verb; the
+  regressed-legacy class closes without operator flags, and the operator
+  reads exactly what changed and why in the command output.
+- Good: hand-edited entries and external entries remain untouchable
+  without `--force`; the safety boundary is sharper than before, not
+  looser, because the refresh path demands fingerprint proof.
+- Bad: a workspace whose sidecar predates fingerprints converges only via
+  `--force`; the honest hint mitigates but does not remove the manual step
+  for that cohort.
+- Bad: automatic refresh means a workspace's committed provider config can
+  change on a routine vault verb via the lazy migration trigger; the
+  narrated output and idempotence bound the surprise, but a diff appearing
+  outside an explicit sync is new behavior operators must learn.
+- Neutral: sync-result counters are unchanged in shape; the refresh rides
+  `updated`. The mode model, render bridge, floors, and enrollment
+  boundaries are untouched.

--- a/.vault/audit/2026-07-17-upgrade-convergence-audit.md
+++ b/.vault/audit/2026-07-17-upgrade-convergence-audit.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - '#audit'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+  - "[[2026-07-17-upgrade-convergence-adr]]"
+---
+
+# `upgrade-convergence` audit: `convergence engine review` | PASS
+
+## Scope
+
+The full convergence feature: the fingerprint-verified refresh path in the
+managed-entry merge (`src/vaultspec_core/core/mcps.py`), the registered
+launch-convergence migration (`src/vaultspec_core/migrations`), the widened
+companion seam (`src/vaultspec_core/core/commands.py`), and the two
+warn-only doctor advisories (`src/vaultspec_core/core/diagnosis`,
+`src/vaultspec_core/cli/spec_cmd.py`). Reviewed by an independent reviewer
+persona against the governing decision's B1-B5 sub-decisions with emphasis
+on refresh-gate safety (can a hand edit ever be overwritten), migration
+lock-reentrancy and context binding, exit-code policy, the code-boundary
+rule, and test integrity; the reviewer re-ran the four target suites.
+
+## Findings
+
+### review-verdict | low | pass with no critical or high findings
+
+The refresh gate is symmetric and cannot false-match a hand edit (the
+write and compare sides fingerprint the same normalized string-only
+shape, key-order neutralized, on both the JSON and TOML paths). The
+migration holds no conflicting locks, binds its own target context,
+reports uninstalled providers and broken host files without wedging the
+registry, and never creates an enrollment an operator opted out of. The
+widened seam migrates every declared package atomically while foreign
+entries survive. Neither advisory fails the doctor, no other signal
+consumer breaks, and the new diagnosis field serializes through the
+existing path. The code-boundary scan of every changed source line is
+clean. Suites: 86 targeted tests passing under the reviewer, no mocks,
+stubs, or skips.
+
+### warn-count-shift | low | prek workspaces no longer fail the doctor
+
+A prek.toml workspace with stale hooks previously failed the doctor via
+the incomplete signal with a fix hint the scaffold could not honor; it now
+reports the unrefreshable advisory and exits clean. Accepted as the
+decision's intent (the row still renders as a warning); noted in case a
+downstream consumer counted doctor warnings.
+
+### skip-aggregation | low | migration summary aggregates all skip kinds
+
+The migration's skipped counter folds hand-edited, pre-fingerprint, and
+external skips into one number; the summary wording covers this honestly.
+No action needed.
+
+## Recommendations
+
+- None blocking. If a future consumer needs a doctor warning count that
+  includes the advisory states, that consumer should read the rendered
+  rows rather than the exit code; no core change is warranted now.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S01.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S01.md
@@ -1,0 +1,37 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S01'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Open feature branch and draft PR referencing the convergence mandate and the governing decision
+
+## Scope
+
+- `repo workflow`
+
+## Description
+
+- Branch feat/upgrade-convergence cut from origin/main at release 0.1.47,
+  which already contains every previously-ready branch (the MCP campaign
+  merged); no integration merges were needed.
+- Restore the parked research from the session scratchpad through a fresh
+  scaffold, author the ADR (accepted on the user's explicit convergence
+  mandate) and the L2 plan, refresh the workspace provisioning that the
+  merged release had drifted, commit, push, open draft PR 227.
+
+## Outcome
+
+Draft PR 227 open at 1db55e47 with the full pipeline document set on the
+branch.
+
+## Notes
+
+The earlier worktree contention resolved itself: all parallel-session
+branches merged to main and released as 0.1.47 before this branch was cut,
+so main alone satisfies the integrate-everything precondition.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S02.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S02.md
@@ -1,0 +1,53 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S02'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label
+
+## Scope
+
+- `src/vaultspec_core/core/mcps.py`
+
+## Description
+
+- Add `_owned_fingerprints` to read the recorded name-to-fingerprint map
+  alongside the existing name-only `_owned_names` reader.
+- Add `_launch_repr` to render a config's command and args as one line for
+  narration.
+- Extend `_apply_server_merge` with a `recorded_fingerprints` parameter and a
+  new refresh branch between the force gate and the skip gate: a managed
+  entry that differs from its rendered definition but whose on-disk bytes
+  still match its recorded fingerprint updates in place, counts through the
+  existing `updated` counter with a `[REFRESH]` item label, and appends an
+  old-to-new narrated warning line.
+- Split the remaining skip path in two: a fingerprint mismatch (hand-edited)
+  keeps the existing message; the absence of any recorded fingerprint
+  (legacy name-only sidecar) gets its own honest message naming `--force`.
+- Thread `recorded_fingerprints` through both callers, `_sync_json_target`
+  and `_sync_toml_target`.
+- Map the new `[REFRESH]` item label onto `Outcome.UPDATED` in the CLI
+  rendering layer alongside the existing `[UPDATE]` mapping.
+- Update the module docstring to describe the new convergence behavior.
+
+## Outcome
+
+`_apply_server_merge` now has three distinct outcomes for a managed entry
+that differs from its rendered definition: force/force-managed update,
+fingerprint-verified refresh (new), and skip-with-warning (split into
+hand-edited vs. no-recorded-fingerprint messages). Existing test suites
+(`test_mcp_per_package_sync.py`, `test_mcp_provider_files.py`,
+`test_install_mode_flip.py`, `test_collectors.py`, 120 tests) pass
+unchanged, including the hand-edited-entry-preserved case, confirming the
+new refresh path only fires when bytes are provably untouched. `ruff check`
+and `ty check` clean on both changed files.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S03.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S03.md
@@ -1,0 +1,46 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S03'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map
+
+## Scope
+
+- `src/vaultspec_core/core/commands.py`
+
+## Description
+
+- Read every package's committed workspace declaration via
+  `read_package_declarations` instead of hardcoding the core-only set.
+- Pass that name set as `force_managed` to the mode-flip seam's `mcp_sync`
+  call, falling back to `{"vaultspec-core"}` when no declaration exists.
+- Reword the surrounding comment: the seam now covers every declared
+  package, and the same-mode divergent case is handled by the
+  fingerprint-verified refresh path landed in `mcps.py` rather than left
+  fully force-gated.
+
+## Outcome
+
+The upgrade path's mode-flip force seam now migrates every declared
+package's managed entry atomically on a mode flip, not only core's. On a
+legacy workspace with no declaration the fallback preserves today's
+core-only behavior exactly. Existing suites
+(`test_mcp_per_package_sync.py`, `test_mcp_provider_files.py`,
+`test_install_mode_flip.py`, `test_collectors.py`, 120 tests) pass
+unchanged. `ruff check` and `ty check` clean.
+
+## Notes
+
+This step's code change (`src/vaultspec_core/core/commands.py`) was
+committed together with `P01.S02`'s commit: a `git add -A` recovery after a
+vault-fix pre-commit hook re-staged an already-modified working tree file
+alongside the intended S02 files. Both changes were independently reviewed,
+tested, and are individually correct; no rework was needed, only this
+record's separate closure.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S04.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-S04.md
@@ -1,0 +1,57 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S04'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests
+
+## Scope
+
+- `src/vaultspec_core/tests/cli`
+
+## Description
+
+- Add `TestFingerprintVerifiedRefresh` to `test_mcp_per_package_sync.py`
+  with a plain, mode-token-free `probe` definition and five real-workspace
+  scenarios: untouched-entry refresh on a plain sync (asserts the
+  `[REFRESH]` item and an old-to-new narration), hand-edited-entry
+  preservation (fingerprint mismatch, byte-unchanged file, `--force`
+  warning), a name-only legacy ownership record (constructed by writing a
+  non-string value into the ownership sidecar directly), an external entry
+  sharing a declared definition's name (skipped, "externally managed"
+  warning), and refresh-then-resync idempotence.
+- Add `test_flip_upgrade_refreshes_every_declared_companion` to
+  `test_install_mode_flip.py`: a mixed dependency/tool workspace with both
+  managed entries hand-altered to fingerprint-mismatch, then core's own
+  mode flipped via the committed declaration; asserts a bare
+  `install --upgrade` converges both the core and companion entries
+  atomically through the widened seam.
+- Run the full requested suite plus `ruff check --fix`, `ruff format`, and
+  `ty check` on every changed test file.
+
+## Outcome
+
+14 new tests (9 in `test_mcp_per_package_sync.py`, 1 in
+`test_install_mode_flip.py`, plus the existing suites re-verified) all
+pass with zero mocks, patches, stubs, or skips; every scenario drives a
+real `WorkspaceFactory` install/upgrade or a real `mcp_sync` against
+on-disk state. `ruff check`, `ruff format`, and `ty check` are clean on
+both changed test files. The full CI-matching unit gate
+(`pytest src/vaultspec_core -m unit`) was run to confirm no regressions
+elsewhere in the suite.
+
+## Notes
+
+The external-entry test needed a source definition sharing the foreign
+entry's name to exercise the real "externally managed" skip gate (a
+foreign name with no matching source is never visited by the merge loop
+at all, so it produced no assertable item in an earlier draft). The
+widened-seam test required hand-altering both managed entries with an
+env-only field addition (not command/args) so the mode-flip observer
+still reads the pre-flip mode correctly while both fingerprints go stale.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-summary.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P01-summary.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# `upgrade-convergence` `P01` summary
+
+All four steps closed. The convergence engine landed: the managed-entry
+merge refreshes fingerprint-verified entries with narrated old-to-new
+output, the upgrade seam covers every declared package, and six
+real-workspace scenarios prove the safety boundary.
+
+- Modified: `src/vaultspec_core/core/mcps.py`, `src/vaultspec_core/core/commands.py`, `src/vaultspec_core/cli/rendering.py`, `src/vaultspec_core/tests/cli/test_mcp_per_package_sync.py`, `src/vaultspec_core/tests/cli/test_install_mode_flip.py`
+
+## Description
+
+Land the decision's core: information the ownership sidecar already
+records becomes the safety proof that lets untouched managed entries
+converge on plain sync and upgrade without force, while hand-edited,
+pre-fingerprint, and external entries keep their protective gates. The
+executor for this phase hit its session limit after the first two steps;
+the orchestrator completed and verified the test step directly.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-S05.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-S05.md
@@ -1,0 +1,40 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S05'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Register the launch-shape convergence migration invoking mcp_sync per enrolled provider, idempotent against the refresh path
+
+## Scope
+
+- `src/vaultspec_core/migrations`
+
+## Description
+
+- Add the launch-convergence migration module registered for the next
+  release: reads the project-scope ownership sidecar, reconciles exactly the
+  providers with recorded vaultspec-managed enrollment through the owning
+  mcp_sync verb, and reports refreshed/skipped/providers counts with a
+  one-line operator summary.
+- Register it in the migration registry build list.
+- Dogfood on this workspace: six managed entries across three providers
+  refreshed to the guarded shape on `migrations run`, registry reports
+  applied, stdio handshake verified against the refreshed launch.
+
+## Outcome
+
+Every legacy workspace below the target version converges on its first
+triggering verb (upgrade, any vault command, or migrations run) with no
+flags; a workspace without recorded MCP enrollment is a true no-op.
+
+## Notes
+
+Sync warnings and errors are logged, never raised: a broken host file
+reports through the sync surfaces without wedging the migration registry,
+matching the registry doctrine of reserving failures for data-safety.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-S06.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-S06.md
@@ -1,0 +1,41 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S06'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Add warn-only doctor advisories for unrefreshable prek.toml hooks and stale static companion seeds with remediation hints
+
+## Scope
+
+- `src/vaultspec_core/core/diagnosis`
+
+## Description
+
+- Add the UNREFRESHABLE precommit signal: with prek.toml present and the
+  YAML hook set not canonical, the doctor names the manual-transplant
+  remediation instead of the false install --upgrade hint.
+- Add the stale-seed collector and doctor row: package-bundled builtin MCP
+  definitions still in a static pre-mode shape are reported with the
+  owning-installer remediation.
+- Wire both through the diagnosis dataclass and the doctor renderer.
+
+## Outcome
+
+The two convergence holes core cannot fix itself are now visible in the
+surface operators read, each with an honest remediation.
+
+## Notes
+
+Deliberate exit-code policy: both advisories render as warnings but do not
+fail the doctor. Their remediation lives outside the workspace, and a
+failing doctor blocks every markdown commit via the bundled spec-check
+hook with no in-workspace remedy - the wedge class the provider-dir
+host-native-file fix already closed once. For prek.toml workspaces this
+strictly improves on the previous behavior, which failed the doctor with a
+remediation that could not work.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-S07.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-S07.md
@@ -1,0 +1,36 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S07'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Cover migration idempotence on both modes and both advisories with real-workspace tests
+
+## Scope
+
+- `src/vaultspec_core/tests`
+
+## Description
+
+- Add migration tests driving real provisioned workspaces in both render
+  modes: legacy entry converges on migrate, the second run is a byte-level
+  no-op, hand-edited entries survive with a skipped count, and a workspace
+  without recorded enrollment creates nothing.
+- Add advisory tests: prek.toml plus stale YAML hooks reports the
+  unrefreshable signal (without prek.toml the existing signal is
+  preserved), the stale-seed collector names static builtin seeds while
+  ignoring tokenized seeds and custom definitions, and both advisories
+  leave the doctor exit code at zero.
+
+## Outcome
+
+Eleven tests passing against real files; no mocks, stubs, or skips.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-summary.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P02-summary.md
@@ -1,0 +1,29 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# `upgrade-convergence` `P02` summary
+
+All three steps closed. Convergence now reaches every legacy workspace
+regardless of flags, and the two holes core cannot fix itself surface as
+honest warn-only advisories.
+
+- Created: `src/vaultspec_core/migrations/m_0_1_48_launch_convergence.py`, `src/vaultspec_core/migrations/tests/test_launch_convergence.py`, `src/vaultspec_core/tests/cli/test_convergence_advisories.py`
+- Modified: `src/vaultspec_core/migrations/__init__.py`, `src/vaultspec_core/core/diagnosis/collectors.py`, `src/vaultspec_core/core/diagnosis/diagnosis.py`, `src/vaultspec_core/core/diagnosis/signals.py`, `src/vaultspec_core/cli/spec_cmd.py`
+
+## Description
+
+The registered migration re-renders recorded project-scope enrollments
+through the owning sync verb on the workspace's first contact with any
+triggering CLI path, riding the fingerprint-verified refresh so it adds no
+force semantics; dogfooded live on this workspace, where it refreshed six
+managed entries across three providers and went to applied. The doctor
+gains the unrefreshable-hooks and stale-seed advisories with a deliberate
+exit-code policy: warn rows that never fail the doctor, because their
+remedy lives outside the workspace.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P03-S08.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P03-S08.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S08'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Reconcile doctor hints, sync summaries, and the MCP doc convergence passage with the automatic behavior, exceptions, and opt-outs
+
+## Scope
+
+- `docs/MCP.md`
+
+## Description
+
+- Replace the MCP doc's manual-refresh remediation with a dedicated
+  convergence-on-upgrade section: automatic fingerprint-verified refresh
+  with narrated output, the migration trigger on first CLI contact
+  regardless of provisioned version, the hand-edited and pre-fingerprint
+  exceptions, the external-entry boundary, the skip-mcp opt-out, and the
+  two warn-only doctor advisories.
+- Audit the in-code hint strings: the mode-mismatch resolver hint and the
+  merge warnings are already truthful after the engine change (upgrade and
+  sync now genuinely converge); the no-fingerprint skip warning gained its
+  honest force wording in the engine step.
+
+## Outcome
+
+Every user-facing description of upgrade and sync behavior matches what
+the commands now do; no surface promises a remediation that does not work.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P03-S09.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P03-S09.md
@@ -1,0 +1,44 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+step_id: 'S09'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# Run gates, dispatch code review, resolve findings, append audit entries, dogfood convergence on this workspace, finalize PR
+
+## Scope
+
+- `quality gates`
+
+## Description
+
+- Run both gates: repo-root suite 330 passed; the first full unit gate
+  surfaced real failures - the enum-membership contract lacked the new
+  precommit member, and the new migration tests leaked global workspace
+  context into later no-context tests under full-gate ordering.
+- Fix both: add the member to the contract test and give the migrations
+  test package the same autouse context save/restore isolation the CLI
+  suite carries; final clean gate 1822 passed, zero failed.
+- Dispatch independent code review (PASS, no critical or high findings;
+  three low notes accepted); author the feature audit and the three phase
+  summaries.
+- Dogfood: the registered migration ran live on this workspace during P02,
+  refreshing six managed entries across three providers; doctor ok.
+- Update the PR body and mark PR 227 ready for review.
+
+## Outcome
+
+Feature complete: 9 of 9 steps closed, gates green, audit PASS, PR 227
+ready for review.
+
+## Notes
+
+The step was closed prematurely on the first gate notification before
+reading the failure count, then re-opened, fixed, and re-closed on the
+clean run. Gate output piped through tail also hid the failure names;
+pytest's last-failed cache recovered them.

--- a/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P03-summary.md
+++ b/.vault/exec/2026-07-17-upgrade-convergence/2026-07-17-upgrade-convergence-P03-summary.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - '#exec'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - "[[2026-07-17-upgrade-convergence-plan]]"
+---
+
+# `upgrade-convergence` `P03` summary
+
+Both steps closed. Every user-facing surface now describes the automatic
+behavior truthfully, and the full gate set ran green.
+
+- Modified: `docs/MCP.md`
+- Created: `.vault/audit/2026-07-17-upgrade-convergence-audit.md`
+
+## Description
+
+The MCP doc gained a convergence-on-upgrade section (automatic refresh
+with narrated output, the migration trigger, the hand-edited and
+pre-fingerprint exceptions, opt-outs, and the two advisories); the
+in-code hints were audited and are truthful after the engine change.
+Gates: CI-matching unit suite and repo-root suite green, ruff and ty
+clean on changed files, independent review PASS with no critical or high
+findings, convergence dogfooded on this workspace.

--- a/.vault/index/upgrade-convergence.index.md
+++ b/.vault/index/upgrade-convergence.index.md
@@ -1,0 +1,30 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - '[[2026-07-17-upgrade-convergence-adr]]'
+  - '[[2026-07-17-upgrade-convergence-plan]]'
+  - '[[2026-07-17-upgrade-convergence-research]]'
+---
+
+# `upgrade-convergence` feature index
+
+Auto-generated index of all documents tagged with `#upgrade-convergence`.
+
+## Documents
+
+### adr
+
+- `2026-07-17-upgrade-convergence-adr` - `upgrade-convergence` adr: `managed launch artifacts converge automatically` | (**status:** `accepted`)
+
+### plan
+
+- `2026-07-17-upgrade-convergence-plan` - `upgrade-convergence` plan
+
+### research
+
+- `2026-07-17-upgrade-convergence-research` - `upgrade-convergence` research: `do legacy launch shapes converge on upgrade`

--- a/.vault/index/upgrade-convergence.index.md
+++ b/.vault/index/upgrade-convergence.index.md
@@ -6,6 +6,9 @@ tags:
 date: '2026-07-17'
 modified: '2026-07-17'
 related:
+  - '[[2026-07-17-upgrade-convergence-P01-S01]]'
+  - '[[2026-07-17-upgrade-convergence-P01-S02]]'
+  - '[[2026-07-17-upgrade-convergence-P01-S03]]'
   - '[[2026-07-17-upgrade-convergence-adr]]'
   - '[[2026-07-17-upgrade-convergence-plan]]'
   - '[[2026-07-17-upgrade-convergence-research]]'
@@ -20,6 +23,12 @@ Auto-generated index of all documents tagged with `#upgrade-convergence`.
 ### adr
 
 - `2026-07-17-upgrade-convergence-adr` - `upgrade-convergence` adr: `managed launch artifacts converge automatically` | (**status:** `accepted`)
+
+### exec
+
+- `2026-07-17-upgrade-convergence-P01-S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision
+- `2026-07-17-upgrade-convergence-P01-S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label
+- `2026-07-17-upgrade-convergence-P01-S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map
 
 ### plan
 

--- a/.vault/index/upgrade-convergence.index.md
+++ b/.vault/index/upgrade-convergence.index.md
@@ -9,7 +9,17 @@ related:
   - '[[2026-07-17-upgrade-convergence-P01-S01]]'
   - '[[2026-07-17-upgrade-convergence-P01-S02]]'
   - '[[2026-07-17-upgrade-convergence-P01-S03]]'
+  - '[[2026-07-17-upgrade-convergence-P01-S04]]'
+  - '[[2026-07-17-upgrade-convergence-P01-summary]]'
+  - '[[2026-07-17-upgrade-convergence-P02-S05]]'
+  - '[[2026-07-17-upgrade-convergence-P02-S06]]'
+  - '[[2026-07-17-upgrade-convergence-P02-S07]]'
+  - '[[2026-07-17-upgrade-convergence-P02-summary]]'
+  - '[[2026-07-17-upgrade-convergence-P03-S08]]'
+  - '[[2026-07-17-upgrade-convergence-P03-S09]]'
+  - '[[2026-07-17-upgrade-convergence-P03-summary]]'
   - '[[2026-07-17-upgrade-convergence-adr]]'
+  - '[[2026-07-17-upgrade-convergence-audit]]'
   - '[[2026-07-17-upgrade-convergence-plan]]'
   - '[[2026-07-17-upgrade-convergence-research]]'
 ---
@@ -24,11 +34,24 @@ Auto-generated index of all documents tagged with `#upgrade-convergence`.
 
 - `2026-07-17-upgrade-convergence-adr` - `upgrade-convergence` adr: `managed launch artifacts converge automatically` | (**status:** `accepted`)
 
+### audit
+
+- `2026-07-17-upgrade-convergence-audit` - `upgrade-convergence` audit: `convergence engine review` | PASS
+
 ### exec
 
 - `2026-07-17-upgrade-convergence-P01-S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision
 - `2026-07-17-upgrade-convergence-P01-S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label
 - `2026-07-17-upgrade-convergence-P01-S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map
+- `2026-07-17-upgrade-convergence-P01-S04` - Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests
+- `2026-07-17-upgrade-convergence-P01-summary` - `upgrade-convergence` `P01` summary
+- `2026-07-17-upgrade-convergence-P02-S05` - Register the launch-shape convergence migration invoking mcp_sync per enrolled provider, idempotent against the refresh path
+- `2026-07-17-upgrade-convergence-P02-S06` - Add warn-only doctor advisories for unrefreshable prek.toml hooks and stale static companion seeds with remediation hints
+- `2026-07-17-upgrade-convergence-P02-S07` - Cover migration idempotence on both modes and both advisories with real-workspace tests
+- `2026-07-17-upgrade-convergence-P02-summary` - `upgrade-convergence` `P02` summary
+- `2026-07-17-upgrade-convergence-P03-S08` - Reconcile doctor hints, sync summaries, and the MCP doc convergence passage with the automatic behavior, exceptions, and opt-outs
+- `2026-07-17-upgrade-convergence-P03-S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood convergence on this workspace, finalize PR
+- `2026-07-17-upgrade-convergence-P03-summary` - `upgrade-convergence` `P03` summary
 
 ### plan
 

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -36,7 +36,7 @@ Register the versioned convergence migration riding the refresh path, and add th
 Reconcile every user-facing hint and document with the now-truthful convergence behavior, then run the full gate set through review to a ready PR.
 
 - [x] `P03.S08` - Reconcile doctor hints, sync summaries, and the MCP doc convergence passage with the automatic behavior, exceptions, and opt-outs; `docs/MCP.md`.
-- [ ] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood convergence on this workspace, finalize PR; `quality gates`.
+- [x] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood convergence on this workspace, finalize PR; `quality gates`.
 
 ## Description
 

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -29,7 +29,7 @@ Register the versioned convergence migration riding the refresh path, and add th
 
 - [x] `P02.S05` - Register the launch-shape convergence migration invoking mcp_sync per enrolled provider, idempotent against the refresh path; `src/vaultspec_core/migrations`.
 - [x] `P02.S06` - Add warn-only doctor advisories for unrefreshable prek.toml hooks and stale static companion seeds with remediation hints; `src/vaultspec_core/core/diagnosis`.
-- [ ] `P02.S07` - Cover migration idempotence on both modes and both advisories with real-workspace tests; `src/vaultspec_core/tests`.
+- [x] `P02.S07` - Cover migration idempotence on both modes and both advisories with real-workspace tests; `src/vaultspec_core/tests`.
 
 ### Phase `P03` - messaging, docs, and gates
 

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -27,8 +27,8 @@ Open the tracking PR and land the fingerprint-verified refresh path in the manag
 
 Register the versioned convergence migration riding the refresh path, and add the two warn-only doctor advisories for the holes core cannot fix.
 
-- [ ] `P02.S05` - Register the launch-shape convergence migration invoking mcp_sync per enrolled provider, idempotent against the refresh path; `src/vaultspec_core/migrations`.
-- [ ] `P02.S06` - Add warn-only doctor advisories for unrefreshable prek.toml hooks and stale static companion seeds with remediation hints; `src/vaultspec_core/core/diagnosis`.
+- [x] `P02.S05` - Register the launch-shape convergence migration invoking mcp_sync per enrolled provider, idempotent against the refresh path; `src/vaultspec_core/migrations`.
+- [x] `P02.S06` - Add warn-only doctor advisories for unrefreshable prek.toml hooks and stale static companion seeds with remediation hints; `src/vaultspec_core/core/diagnosis`.
 - [ ] `P02.S07` - Cover migration idempotence on both modes and both advisories with real-workspace tests; `src/vaultspec_core/tests`.
 
 ### Phase `P03` - messaging, docs, and gates

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - '#plan'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+tier: L2
+related:
+  - '[[2026-07-17-upgrade-convergence-adr]]'
+  - '[[2026-07-17-upgrade-convergence-research]]'
+---
+
+# `upgrade-convergence` plan
+
+## Steps
+
+### Phase `P01` - branch and convergence engine
+
+Open the tracking PR and land the fingerprint-verified refresh path in the managed-entry merge with its narrated per-entry messaging, plus the widened companion seam.
+
+- [ ] `P01.S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision; `repo workflow`.
+- [ ] `P01.S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label; `src/vaultspec_core/core/mcps.py`.
+- [ ] `P01.S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map; `src/vaultspec_core/core/commands.py`.
+- [ ] `P01.S04` - Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests; `src/vaultspec_core/tests/cli`.
+
+### Phase `P02` - migration and advisories
+
+Register the versioned convergence migration riding the refresh path, and add the two warn-only doctor advisories for the holes core cannot fix.
+
+- [ ] `P02.S05` - Register the launch-shape convergence migration invoking mcp_sync per enrolled provider, idempotent against the refresh path; `src/vaultspec_core/migrations`.
+- [ ] `P02.S06` - Add warn-only doctor advisories for unrefreshable prek.toml hooks and stale static companion seeds with remediation hints; `src/vaultspec_core/core/diagnosis`.
+- [ ] `P02.S07` - Cover migration idempotence on both modes and both advisories with real-workspace tests; `src/vaultspec_core/tests`.
+
+### Phase `P03` - messaging, docs, and gates
+
+Reconcile every user-facing hint and document with the now-truthful convergence behavior, then run the full gate set through review to a ready PR.
+
+- [ ] `P03.S08` - Reconcile doctor hints, sync summaries, and the MCP doc convergence passage with the automatic behavior, exceptions, and opt-outs; `docs/MCP.md`.
+- [ ] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood convergence on this workspace, finalize PR; `quality gates`.
+
+## Description
+
+Execute 2026-07-17-upgrade-convergence-adr: vaultspec-owned launch
+artifacts converge automatically to the mandated standard on the next
+upgrade, sync, or vault verb, narrated in user-facing output. P01 lands
+the engine: the fingerprint-verified refresh path in the managed-entry
+merge (B1) and the companion-wide upgrade seam (B3). P02 makes convergence
+reach every legacy workspace regardless of flags via the registered
+migration (B2) and adds the two warn-only advisories for what core cannot
+fix (B5). P03 reconciles every hint and document with the now-truthful
+behavior (B4) and gates the set. Ownership discipline is untouched
+throughout: hand-edited and external entries never converge without
+explicit force.
+
+## Parallelization
+
+Phases are sequential: the P02 migration rides the refresh path P01
+lands, and P03 documents behavior only after it exists. Within P01, S02
+and S03 are independent edits with S04 last; within P02, S05 and S06 are
+independent with S07 last.
+
+## Verification
+
+- On a real workspace carrying the pre-guard legacy launch, a plain
+  `sync` and a bare `install --upgrade` each rewrite the managed entries
+  to the guarded shape, print the old and new command per entry with the
+  reason, and leave hand-edited and external entries untouched.
+- A workspace below the migration's target version converges on its first
+  vault verb with no flags; re-running the migration is a no-op.
+- The doctor's remediation hints match what the commands actually do; the
+  two new advisories fire on real prek.toml and stale-seed fixtures and
+  stay warn-only.
+- No mocks, stubs, skips, or patches; prek clean; ty clean on changed
+  files; the CI-matching unit gate and the repo-root suite green; code
+  review dispatched and findings resolved; audit appended; convergence
+  dogfooded on this workspace; PR ready.

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -18,7 +18,7 @@ related:
 
 Open the tracking PR and land the fingerprint-verified refresh path in the managed-entry merge with its narrated per-entry messaging, plus the widened companion seam.
 
-- [ ] `P01.S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision; `repo workflow`.
+- [x] `P01.S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision; `repo workflow`.
 - [ ] `P01.S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P01.S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map; `src/vaultspec_core/core/commands.py`.
 - [ ] `P01.S04` - Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests; `src/vaultspec_core/tests/cli`.

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -20,7 +20,7 @@ Open the tracking PR and land the fingerprint-verified refresh path in the manag
 
 - [x] `P01.S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision; `repo workflow`.
 - [x] `P01.S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label; `src/vaultspec_core/core/mcps.py`.
-- [ ] `P01.S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map; `src/vaultspec_core/core/commands.py`.
+- [x] `P01.S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map; `src/vaultspec_core/core/commands.py`.
 - [ ] `P01.S04` - Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests; `src/vaultspec_core/tests/cli`.
 
 ### Phase `P02` - migration and advisories

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -21,7 +21,7 @@ Open the tracking PR and land the fingerprint-verified refresh path in the manag
 - [x] `P01.S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision; `repo workflow`.
 - [x] `P01.S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label; `src/vaultspec_core/core/mcps.py`.
 - [x] `P01.S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map; `src/vaultspec_core/core/commands.py`.
-- [ ] `P01.S04` - Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests; `src/vaultspec_core/tests/cli`.
+- [x] `P01.S04` - Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests; `src/vaultspec_core/tests/cli`.
 
 ### Phase `P02` - migration and advisories
 

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -19,7 +19,7 @@ related:
 Open the tracking PR and land the fingerprint-verified refresh path in the managed-entry merge with its narrated per-entry messaging, plus the widened companion seam.
 
 - [x] `P01.S01` - Open feature branch and draft PR referencing the convergence mandate and the governing decision; `repo workflow`.
-- [ ] `P01.S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label; `src/vaultspec_core/core/mcps.py`.
+- [x] `P01.S02` - Add fingerprint-verified refresh to the managed-entry merge with old-to-new narrated warning lines and a refresh item label; `src/vaultspec_core/core/mcps.py`.
 - [ ] `P01.S03` - Widen the upgrade mode-flip force seam from core-only to every package declared in the workspace map; `src/vaultspec_core/core/commands.py`.
 - [ ] `P01.S04` - Cover untouched-entry refresh, hand-edited preservation, name-only legacy sidecar, and companion seam with real-workspace tests; `src/vaultspec_core/tests/cli`.
 

--- a/.vault/plan/2026-07-17-upgrade-convergence-plan.md
+++ b/.vault/plan/2026-07-17-upgrade-convergence-plan.md
@@ -35,7 +35,7 @@ Register the versioned convergence migration riding the refresh path, and add th
 
 Reconcile every user-facing hint and document with the now-truthful convergence behavior, then run the full gate set through review to a ready PR.
 
-- [ ] `P03.S08` - Reconcile doctor hints, sync summaries, and the MCP doc convergence passage with the automatic behavior, exceptions, and opt-outs; `docs/MCP.md`.
+- [x] `P03.S08` - Reconcile doctor hints, sync summaries, and the MCP doc convergence passage with the automatic behavior, exceptions, and opt-outs; `docs/MCP.md`.
 - [ ] `P03.S09` - Run gates, dispatch code review, resolve findings, append audit entries, dogfood convergence on this workspace, finalize PR; `quality gates`.
 
 ## Description

--- a/.vault/research/2026-07-17-upgrade-convergence-research.md
+++ b/.vault/research/2026-07-17-upgrade-convergence-research.md
@@ -1,0 +1,158 @@
+---
+tags:
+  - '#research'
+  - '#upgrade-convergence'
+date: '2026-07-17'
+modified: '2026-07-17'
+related:
+  - '[[2026-07-17-mcp-static-launch-adr]]'
+  - '[[2026-07-17-mcp-static-launch-research]]'
+  - '[[2026-07-13-install-mode-adr]]'
+  - '[[2026-07-14-install-parity-adr]]'
+---
+
+# `upgrade-convergence` research: `do legacy launch shapes converge on upgrade`
+
+The question: does a legacy workspace (bare uv-run MCP launch, pre-parity
+exe-form seed, pre-mode declaration, stale hook entry) actually converge to
+the mandated launch-hygiene standard on its next `install --upgrade` or
+`sync`, and if not, which machinery must change. It matters because the
+static-launch amendment (`2026-07-17-mcp-static-launch-adr`) changed the
+canonical launch bytes for every dependency-mode workspace in existence, and
+the remediation its documentation promises only works with an explicit
+`--force`. The evidence picture: hooks converge unconditionally and
+migrations converge unconditionally, but MCP managed entries - the surface
+the amendment changed - never converge without `--force`; plain `sync` warns
+and skips forever, `install --upgrade` skips the same way unless the mode
+flipped, and the mode-flip force seam covers only core's own entry, never a
+companion's. The ownership sidecar already records a content fingerprint of
+every managed entry that could distinguish a safely-updatable untouched
+entry from a hand-edited one, but the merge algorithm discards it. The
+versioned migrations registry runs on upgrade and lazily on every vault
+command regardless of flags or floors, making it the proven vehicle for
+one-time convergence; no migration exists for launch shapes.
+
+## Findings
+
+### MCP managed entries never converge without an explicit force
+
+The merge algorithm (`src/vaultspec_core/core/mcps.py:946-998`,
+`_apply_server_merge`) compares each deployed managed entry against the
+newly rendered definition: equal counts as unchanged, different counts as
+"differs from its definition (use --force to overwrite)" and is skipped
+with a warning. Any renderer byte change - the `--no-sync` amendment being
+the live example - therefore turns every managed entry in every deployed
+workspace into a permanent skip-and-warn on plain `sync`. The upgrade path
+inherits the same gate: `sync_provider(sync_target, force=force, ...)`
+passes the operator's `--force` through
+(`src/vaultspec_core/core/commands.py:1363`), and the deliberate follow-up
+seam fires only `if mcp_mode_flipped and not force`, scoped to
+`force_managed=frozenset({"vaultspec-core"})`
+(`src/vaultspec_core/core/commands.py:1372-1385`) - its own comment
+preserves "today's force-gated semantics for a same-mode divergent entry."
+Consequence: the drift-hint wording shipped with the static-launch
+amendment ("refresh with `spec mcps sync --force` or `install --upgrade`")
+overstates the second remediation - a bare `install --upgrade` does not
+refresh a same-mode legacy entry, and a companion package's entry is not
+refreshed even on a mode flip.
+
+### The ownership fingerprint already distinguishes untouched from hand-edited entries, but is discarded
+
+Every sync records a sha256 content fingerprint of exactly what vaultspec
+wrote for each managed entry (`src/vaultspec_core/core/mcps.py:887-915`,
+`_fingerprint` stored via `_set_owned_names`), yet the read side
+(`_owned_names`, `src/vaultspec_core/core/mcps.py:893-898`) returns only
+the name set and drops the fingerprints. The information needed for safe
+unconditional convergence is therefore already persisted: a deployed entry
+whose bytes still match its recorded fingerprint is provably untouched
+since vaultspec wrote it, and rewriting it to the new canonical shape
+cannot destroy user content; an entry whose bytes mismatch the fingerprint
+was hand-edited and deserves today's skip-and-warn. The current force gate
+treats both cases identically, which is why convergence requires the
+blunt `--force` (which ALSO overwrites hand-edited and adopts external
+entries - a bigger hammer than convergence needs).
+
+### Hooks already converge unconditionally; the prek.toml path is the one hole
+
+`_scaffold_precommit` (`src/vaultspec_core/core/commands.py:741-`) runs on
+every install and upgrade, and "existing hooks with matching IDs are
+updated to the canonical entry" for the resolved mode - a legacy hook
+entry converges with no flag. The exception: when `prek.toml` exists the
+scaffold is skipped entirely with a log line telling the operator to
+transplant hooks manually, so a prek.toml workspace's stale hook entries
+persist indefinitely with no doctor signal beyond the log.
+
+### The migrations registry is the proven no-flag convergence vehicle
+
+`src/vaultspec_core/migrations/__init__.py:1-31`: versioned migrations
+declare a target release version, expose an idempotent
+`migrate(workspace)`, and the driver runs every entry whose
+`target_version` exceeds the manifest's recorded `vaultspec_version` -
+triggered by `install --upgrade`, lazily by any `vaultspec-core vault ...`
+command via the scanner, and explicitly by `migrations run`. Six shipped
+migrations (`m_0_1_17` through `m_0_1_35`) establish the pattern, including
+provider-file rewrites (`m_0_1_24_codex_agents_dedup`). This satisfies
+"regardless of provisioned version": the version comparison is a floor on
+the migration, not on the workspace, so any workspace below the target
+converges the first time any triggering verb runs. No migration exists for
+MCP launch shapes; one that routes through `mcp_sync` with a scoped
+force-managed set would reuse the owning verb rather than hand-rewriting
+host files.
+
+### Version floors never block convergence; the render bridge holds legacy workspaces in dependency shape by design
+
+The floor check refuses only when the RUNNING package version is below the
+workspace's declared `minimum_version`
+(`src/vaultspec_core/core/resolver.py:901,971`) - an old floor never
+prevents a newer core from upgrading the workspace, so no floor-side change
+is needed for convergence. Separately, `resolve_render_mode`'s legacy-absent
+bridge (`src/vaultspec_core/core/workspace_mode.py:860-900`) deliberately
+renders an undeclared package as DEPENDENCY so a pre-mode workspace is not
+silently flipped to tool shape by a routine sync; `install --upgrade`'s Q6
+inference records the real mode. Convergence must preserve this bridge:
+the target of convergence is the guarded shape of the workspace's OWN mode,
+never a mode change.
+
+### Stale companion seeds are outside core's write authority
+
+The pre-parity exe-form companion seed (static `uv run vaultspec-search-mcp`) lives in the workspace's `.vaultspec/mcps/` and is
+owned by the companion's own enrollment
+(`2026-07-17-mcp-static-launch-research`, rag findings; rag issue 231).
+Core's upgrade cannot rewrite a companion's builtin definition without
+crossing the enrollment boundary. What core CAN do within its authority:
+the doctor can flag a definition whose name matches a known companion but
+whose content is a static non-tokenized launch as a stale seed with a
+"re-run the companion's install --upgrade" hint, and the migration that
+converges managed HOST entries still applies to whatever the stale seed
+last rendered.
+
+### What the ADR must settle
+
+The evidence favors three coordinated changes, each bounded to existing
+machinery: (1) fingerprint-verified convergence in the merge algorithm -
+a managed entry whose bytes match its recorded fingerprint updates to the
+new canonical shape on plain `sync` and upgrade without `--force`,
+hand-edited entries keep skip-and-warn (a new narrow gate, not a wider
+`--force`); (2) a registered migration targeting the next release that
+re-renders managed MCP entries through `mcp_sync` for every package in the
+workspace declaration, converging all legacy workspaces on their first
+triggering verb regardless of flags; (3) upgrade's mode-flip force seam
+widened from core-only to every declared package. Open questions the ADR
+must decide: whether fingerprint-verified convergence subsumes the
+migration (the migration reaches workspaces that never run sync but do run
+vault verbs - complementary, not redundant), whether the doctor gains the
+stale-companion-seed signal, and whether prek.toml workspaces get a doctor
+warning for unrefreshable hook entries or stay log-only.
+
+## Sources
+
+- `src/vaultspec_core/core/mcps.py:887-915` - fingerprint recorded per managed entry
+- `src/vaultspec_core/core/mcps.py:893-898` - `_owned_names` discards fingerprints
+- `src/vaultspec_core/core/mcps.py:946-998` - `_apply_server_merge` force gate
+- `src/vaultspec_core/core/commands.py:741-` - `_scaffold_precommit` unconditional hook convergence; prek.toml skip
+- `src/vaultspec_core/core/commands.py:1363` - upgrade passes operator `--force` through
+- `src/vaultspec_core/core/commands.py:1372-1385` - mode-flip seam, core-only, same-mode divergence preserved
+- `src/vaultspec_core/core/workspace_mode.py:860-900` - legacy-absent dependency render bridge
+- `src/vaultspec_core/core/resolver.py:901,971` - floor refuses only when running version below minimum
+- `src/vaultspec_core/migrations/__init__.py:1-31` - versioned idempotent migrations, upgrade + lazy scanner + CLI triggers
+- `src/vaultspec_core/migrations/m_0_1_24_codex_agents_dedup.py` - precedent for provider-file migration

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -64,10 +64,35 @@ touches the project's environment; dependency and development modes resolve the
 project's existing environment as-is - the `--no-sync` guard means a client connect
 never runs an implicit `uv sync`. If the environment is stale or broken, the connect
 fails with the underlying Python error instead of mutating shared state while other
-processes may hold it; repair it explicitly with `uv sync`, then reconnect. A launch
-rendered before this guard existed (a bare `uv run` shape) is reported by
-`vaultspec-core spec doctor` as drift; refresh it with
-`vaultspec-core spec mcps sync --force` or `vaultspec-core install --upgrade`.
+processes may hold it; repair it explicitly with `uv sync`, then reconnect.
+
+### Convergence on upgrade
+
+Launch entries that Vaultspec wrote converge to the current standard automatically. A
+managed entry whose bytes still match the fingerprint recorded when Vaultspec last wrote
+it is provably untouched, so `vaultspec-core sync`, `vaultspec-core spec mcps sync`, and
+`vaultspec-core install --upgrade` all refresh it in place - no `--force` required - and
+print exactly what changed: the entry name, the old launch command, the new launch
+command, and why. A registered migration applies the same refresh the first time any
+`vaultspec-core vault ...` command runs in a workspace provisioned by an earlier
+release, so a launch rendered before the `--no-sync` guard existed (a bare `uv run`
+shape) converges on the workspace's next contact with the CLI, whatever its provisioned
+version.
+
+Two kinds of entry never converge automatically. An entry you edited by hand (its bytes
+no longer match the recorded fingerprint) is skipped with a warning and requires an
+explicit `vaultspec-core spec mcps sync --force`, which overwrites your edit. An entry
+recorded by a release that predates fingerprinting cannot be verified as untouched and
+keeps the same `--force`-only behavior. External entries Vaultspec never wrote are never
+adopted or modified without `--force`. To opt out of enrollment management entirely,
+provision with `install --skip mcp`; a workspace without recorded enrollment is never
+touched by the convergence migration.
+
+`vaultspec-core spec doctor` additionally warns - without failing - about two states
+Vaultspec cannot converge itself: canonical hooks that cannot be refreshed because
+`prek.toml` is present (transplant the entries manually), and a package-bundled seed
+definition still in a static pre-mode shape (re-run that package's installer with
+`--upgrade`).
 
 Select a mode with `install --mode tool`, `install --mode dependency`, or
 `install --mode dev`. Vaultspec consumes the package, module, and optional tool

--- a/src/vaultspec_core/cli/rendering.py
+++ b/src/vaultspec_core/cli/rendering.py
@@ -331,6 +331,7 @@ def emit_outcomes(
 _SYNC_ACTION_OUTCOME: dict[str, Outcome] = {
     "[ADD]": Outcome.CREATED,
     "[UPDATE]": Outcome.UPDATED,
+    "[REFRESH]": Outcome.UPDATED,
     "[UNCHANGED]": Outcome.UNCHANGED,
     "[DELETE]": Outcome.REMOVED,
     "[SKIP]": Outcome.SKIPPED,

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -2298,6 +2298,7 @@ def _render_diagnosis_table(_console, diag: "WorkspaceDiagnosis") -> None:
             PrecommitSignal.COMPLETE: ("ok", "green"),
             PrecommitSignal.INCOMPLETE: ("warn", "yellow"),
             PrecommitSignal.NON_CANONICAL: ("warn", "yellow"),
+            PrecommitSignal.UNREFRESHABLE: ("warn", "yellow"),
             PrecommitSignal.NO_HOOKS: ("warn", "yellow"),
             PrecommitSignal.NO_FILE: ("info", "dim"),
         },
@@ -2306,6 +2307,11 @@ def _render_diagnosis_table(_console, diag: "WorkspaceDiagnosis") -> None:
         PrecommitSignal.COMPLETE: "all hooks present",
         PrecommitSignal.INCOMPLETE: "missing canonical hooks",
         PrecommitSignal.NON_CANONICAL: "non-canonical entry pattern",
+        PrecommitSignal.UNREFRESHABLE: (
+            "prek.toml present; stale hook entries cannot be refreshed "
+            "automatically - transplant the canonical entries into prek.toml "
+            "manually"
+        ),
         PrecommitSignal.NO_HOOKS: "no vaultspec hooks found",
         PrecommitSignal.NO_FILE: "no .pre-commit-config.yaml",
     }.get(diag.precommit, str(diag.precommit))
@@ -2316,6 +2322,21 @@ def _render_diagnosis_table(_console, diag: "WorkspaceDiagnosis") -> None:
             "detail": pc_detail,
         }
     )
+
+    # Stale package-bundled MCP seed advisory (warn-only): core cannot refresh
+    # these; only the owning package's installer can.
+    if diag.stale_mcp_seeds:
+        names = ", ".join(diag.stale_mcp_seeds)
+        rows.append(
+            {
+                "component": "mcp seeds",
+                "status": Cell("warn", style="yellow"),
+                "detail": (
+                    f"stale package seed definition(s): {names} - re-run that "
+                    "package's installer with --upgrade to refresh the seed"
+                ),
+            }
+        )
 
     # Rename integrity row
     ri_status, ri_style = _signal_status(

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -1370,20 +1370,23 @@ def install_run(
             _scaffold_precommit(path, mode=resolved_mode)
 
         # Close the mode-flip force-gate asymmetry: when the mode flipped, the
-        # force-gated MCP pass above skipped the stale managed vaultspec-core
-        # entry. Force just that one managed entry into the new mode's launch
-        # shape so all three renderers migrate atomically in this run. Scoped to
-        # the managed vaultspec-core entry only, so user-owned entries and the
-        # foreign-entry discipline are untouched. Skipped when --force already
-        # rewrote it, when the mode did not flip (preserving today's force-gated
-        # semantics for a same-mode divergent entry), or when mcp sync is
-        # skipped outright.
+        # force-gated MCP pass above skipped every stale managed entry declared
+        # in the workspace, not just core's own. Force every declared package's
+        # managed entry into the new mode's launch shape so all three renderers
+        # migrate atomically in this run; user-owned entries and the
+        # foreign-entry discipline remain untouched. Skipped when --force
+        # already rewrote it, when the mode did not flip (preserving today's
+        # force-gated semantics for a same-mode divergent entry, now handled by
+        # the fingerprint-verified refresh path in the sync above), or when
+        # mcp sync is skipped outright.
         if mcp_mode_flipped and not force and "mcp" not in skip:
             from .mcps import mcp_sync
+            from .workspace_mode import read_package_declarations
 
+            declared_packages = frozenset(read_package_declarations(path))
             mcp_result = mcp_sync(
                 mode=resolved_mode,
-                force_managed=frozenset({"vaultspec-core"}),
+                force_managed=declared_packages or frozenset({"vaultspec-core"}),
             )
             _require_reconciliation_success(
                 mcp_result,

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -659,8 +659,13 @@ def collect_gitattributes_state(target: Path) -> GitattributesSignal:
 def collect_precommit_state(target: Path) -> PrecommitSignal:
     """Assess the state of vaultspec-core hooks in ``.pre-commit-config.yaml``.
 
-    Checks that all canonical hooks are present and use the canonical
-    entry pattern (``uv run --no-sync vaultspec-core ...``).
+    Checks that all canonical hooks are present and use the canonical entry
+    pattern (``uv run --no-sync vaultspec-core ...``). When ``prek.toml`` is
+    present the hook scaffold never runs, so a stale or incomplete YAML hook
+    set cannot be refreshed automatically; that state is reported as
+    :attr:`~vaultspec_core.core.diagnosis.signals.PrecommitSignal.UNREFRESHABLE`
+    so the operator learns the remediation is a manual transplant into
+    ``prek.toml``, not another install run.
 
     Args:
         target: Workspace root directory.
@@ -669,6 +674,14 @@ def collect_precommit_state(target: Path) -> PrecommitSignal:
         :class:`~vaultspec_core.core.diagnosis.signals.PrecommitSignal`
         reflecting the observed state.
     """
+    signal = _collect_precommit_yaml_state(target)
+    if signal is not PrecommitSignal.COMPLETE and (target / "prek.toml").exists():
+        return PrecommitSignal.UNREFRESHABLE
+    return signal
+
+
+def _collect_precommit_yaml_state(target: Path) -> PrecommitSignal:
+    """Assess ``.pre-commit-config.yaml`` hook state, ignoring ``prek.toml``."""
     import yaml
 
     from ..commands import CANONICAL_HOOK_IDS, canonical_hook_entries_for_mode
@@ -1076,3 +1089,43 @@ def observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode |
         entry is shaped for, or ``None`` when unobservable.
     """
     return _observed_mcp_mode(target, package)
+
+
+def collect_stale_seed_definitions(target: Path) -> list[str]:
+    """Return package-bundled MCP seed definitions still in a static shape.
+
+    A ``.builtin.json`` definition under ``.vaultspec/mcps/`` is seeded by its
+    owning package's installer and, since the mode-aware provisioning model,
+    always carries the mode-neutral launch tokens. A builtin seed whose
+    ``command`` is a concrete string instead of the token predates that model:
+    it bypasses the launch renderer entirely, so no core-side sync or upgrade
+    can converge it - only re-running the owning package's installer refreshes
+    the seed. The doctor surfaces these so the stale state is visible where
+    operators look, rather than only in installer logs.
+
+    Custom user definitions (plain ``.json``) are the user's own content and
+    are never reported here.
+
+    Args:
+        target: Workspace root directory.
+
+    Returns:
+        Sorted server names of stale package-bundled seed definitions; empty
+        when every builtin seed is mode-neutral or none exist.
+    """
+    from ..mcps import _MODE_COMMAND_TOKEN, _server_name
+
+    mcps_dir = target / ".vaultspec" / "mcps"
+    if not mcps_dir.exists():
+        return []
+
+    stale: list[str] = []
+    for path in sorted(mcps_dir.glob("*.builtin.json")):
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Cannot read MCP seed definition %s: %s", path, exc)
+            continue
+        if isinstance(raw, dict) and raw.get("command") != _MODE_COMMAND_TOKEN:
+            stale.append(_server_name(path.name))
+    return sorted(stale)

--- a/src/vaultspec_core/core/diagnosis/diagnosis.py
+++ b/src/vaultspec_core/core/diagnosis/diagnosis.py
@@ -122,6 +122,9 @@ class WorkspaceDiagnosis:
             ``version_floor`` is ``BELOW``.
         version_floor_minimum: Declared floor string, populated only when
             ``version_floor`` is ``BELOW``.
+        stale_mcp_seeds: Server names of package-bundled MCP seed definitions
+            still in a static pre-mode shape; core cannot refresh these, only
+            the owning package's installer can.
         packages: Per-package install-mode and version-floor diagnosis, one
             :class:`PackageModeDiagnosis` per distribution declared in the shared
             workspace map, keyed by canonicalized distribution name. Empty when
@@ -136,6 +139,7 @@ class WorkspaceDiagnosis:
     gitattributes: GitattributesSignal = GitattributesSignal.NO_FILE
     mcp: ConfigSignal = ConfigSignal.MISSING
     precommit: PrecommitSignal = PrecommitSignal.NO_FILE
+    stale_mcp_seeds: list[str] = field(default_factory=list)
     migration_status: str = "up_to_date"
     pending_migrations: list[str] = field(default_factory=list)
     vault_content: VaultContentSignal = VaultContentSignal.NO_VAULT
@@ -183,6 +187,7 @@ def diagnose(target: Path, *, scope: str = "full") -> WorkspaceDiagnosis:
         collect_precommit_state,
         collect_provider_dir_state,
         collect_rename_integrity,
+        collect_stale_seed_definitions,
         collect_vault_content_state,
         collect_version_floor_state,
     )
@@ -217,6 +222,12 @@ def diagnose(target: Path, *, scope: str = "full") -> WorkspaceDiagnosis:
     except Exception:
         logger.warning("Precommit state collector failed", exc_info=True)
         precommit = PrecommitSignal.NO_FILE
+
+    try:
+        stale_mcp_seeds = collect_stale_seed_definitions(target)
+    except Exception:
+        logger.warning("Stale MCP seed collector failed", exc_info=True)
+        stale_mcp_seeds = []
 
     try:
         vault_content, vault_annotation_count, vault_unreadable_count = (
@@ -305,6 +316,7 @@ def diagnose(target: Path, *, scope: str = "full") -> WorkspaceDiagnosis:
         gitattributes=gitattributes,
         mcp=mcp,
         precommit=precommit,
+        stale_mcp_seeds=stale_mcp_seeds,
         vault_content=vault_content,
         vault_annotation_count=vault_annotation_count,
         vault_unreadable_count=vault_unreadable_count,

--- a/src/vaultspec_core/core/diagnosis/signals.py
+++ b/src/vaultspec_core/core/diagnosis/signals.py
@@ -92,6 +92,7 @@ class PrecommitSignal(StrEnum):
     NO_HOOKS = "no_hooks"
     INCOMPLETE = "incomplete"
     NON_CANONICAL = "non_canonical"
+    UNREFRESHABLE = "unrefreshable"
     COMPLETE = "complete"
 
 

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -4,6 +4,14 @@ Definitions in ``.vaultspec/mcps/*.json`` describe provider-neutral stdio
 servers. This module renders those definitions for each MCP-capable provider,
 reconciles project or explicit broader-scope targets, and records ownership
 outside host configuration so unrelated entries remain untouched.
+
+A managed entry that drifted from its rendered definition converges
+automatically, without ``--force``, whenever its on-disk bytes still match
+the fingerprint recorded at the last write: the drift is provably one the
+entry never survived a hand edit through, so refreshing it cannot destroy
+user content. An entry whose bytes no longer match its recorded fingerprint,
+or whose ownership record predates fingerprinting, keeps the existing
+skip-and-warn behavior and still requires ``--force``.
 """
 
 from __future__ import annotations
@@ -901,6 +909,38 @@ def _owned_names(state: dict[str, Any], target: McpTarget) -> set[str]:
     return set()
 
 
+def _owned_fingerprints(state: dict[str, Any], target: McpTarget) -> dict[str, str]:
+    """Return the recorded name-to-fingerprint map for one target's managed entries.
+
+    A name present here with a matching current fingerprint proves the deployed
+    entry is byte-identical to what vaultspec last wrote, so it is safe to
+    refresh to the current canonical shape without ``--force``. A name absent
+    from this map (legacy name-only ownership record) cannot be verified and
+    keeps the existing skip-and-warn behavior.
+    """
+    raw = state["targets"].get(_ownership_target_key(target), {})
+    managed = raw.get("managed", {}) if isinstance(raw, dict) else {}
+    if isinstance(managed, dict):
+        return {
+            str(name): value
+            for name, value in managed.items()
+            if isinstance(value, str)
+        }
+    return {}
+
+
+def _launch_repr(config: dict[str, Any]) -> str:
+    """Return a human-readable one-line rendering of a server's launch command."""
+    command = str(config.get("command", ""))
+    args = config.get("args", [])
+    parts = (
+        [command, *(str(item) for item in args)]
+        if isinstance(args, list)
+        else [command]
+    )
+    return " ".join(part for part in parts if part)
+
+
 def _set_owned_names(
     state: dict[str, Any], target: McpTarget, servers: dict[str, dict[str, Any]]
 ) -> None:
@@ -946,6 +986,7 @@ def _apply_server_merge(
     result: SyncResult,
     label: str,
     force_managed: frozenset[str],
+    recorded_fingerprints: dict[str, str],
 ) -> bool:
     """Apply ownership-safe desired state to one provider's normalized servers."""
     changed = False
@@ -965,12 +1006,35 @@ def _apply_server_merge(
                 result.updated += 1
                 result.items.append((name, "[UPDATE]"))
                 changed = True
-            else:
+            elif recorded_fingerprints.get(name) == _fingerprint(servers[name]):
+                # Bytes still match what vaultspec last wrote, so the drift is
+                # provably ours to converge, not a hand edit: refresh in place.
+                old_launch = _launch_repr(servers[name])
+                new_launch = _launch_repr(config)
+                servers[name] = config
+                result.updated += 1
+                result.items.append((name, "[REFRESH]"))
+                changed = True
+                result.warnings.append(
+                    f"MCP server '{name}' launch refreshed to the current "
+                    f"standard: '{old_launch}' -> '{new_launch}' (managed "
+                    "entry was unchanged since vaultspec wrote it; "
+                    "hand-edited entries are never refreshed automatically)."
+                )
+            elif name in recorded_fingerprints:
                 result.skipped += 1
                 result.items.append((name, "[SKIP]"))
                 result.warnings.append(
                     f"MCP server '{name}' in {label} differs from its definition "
                     "(use --force to overwrite)."
+                )
+            else:
+                result.skipped += 1
+                result.items.append((name, "[SKIP]"))
+                result.warnings.append(
+                    f"MCP server '{name}' in {label} differs from its definition "
+                    "and has no recorded fingerprint to verify against; use "
+                    "--force to overwrite."
                 )
         elif force:
             servers[name] = config
@@ -1101,6 +1165,7 @@ def _sync_json_target(
             return
 
         managed = _owned_names(state, target) & set(servers)
+        recorded_fingerprints = _owned_fingerprints(state, target)
         legacy = raw.pop(_LEGACY_MANAGED_KEY, None)
         migrated = (
             {name for name in legacy if isinstance(name, str) and name in servers}
@@ -1125,6 +1190,7 @@ def _sync_json_target(
             result=result,
             label=str(target.path),
             force_managed=force_managed,
+            recorded_fingerprints=recorded_fingerprints,
         )
         untyped_servers.clear()
         untyped_servers.update(servers)
@@ -1283,6 +1349,7 @@ def _sync_toml_target(
                 content = stripped
 
         recorded = _owned_names(state, target)
+        recorded_fingerprints = _owned_fingerprints(state, target)
         managed = (recorded | set(block_servers)) & set(block_servers)
         servers = {**outside, **block_servers}
         external = set(outside)
@@ -1296,6 +1363,7 @@ def _sync_toml_target(
             result=result,
             label=str(target.path),
             force_managed=force_managed,
+            recorded_fingerprints=recorded_fingerprints,
         )
         new_managed = {
             name: servers[name]

--- a/src/vaultspec_core/migrations/__init__.py
+++ b/src/vaultspec_core/migrations/__init__.py
@@ -172,6 +172,7 @@ def _build_registry() -> list[Migration]:
     from .m_0_1_24_codex_agents_dedup import MIGRATION as M_CODEX_AGENTS_DEDUP
     from .m_0_1_29_modified_stamp_backfill import MIGRATION as M_MODIFIED_STAMP_BACKFILL
     from .m_0_1_35_framework_flatten import MIGRATION as M_FRAMEWORK_FLATTEN
+    from .m_0_1_48_launch_convergence import MIGRATION as M_LAUNCH_CONVERGENCE
 
     entries: list[Migration] = [
         M_INDEX_SUBFOLDER,
@@ -180,6 +181,7 @@ def _build_registry() -> list[Migration]:
         M_CODEX_AGENTS_DEDUP,
         M_MODIFIED_STAMP_BACKFILL,
         M_FRAMEWORK_FLATTEN,
+        M_LAUNCH_CONVERGENCE,
     ]
     return sorted(entries, key=lambda m: parse_version_tuple(m.target_version))
 

--- a/src/vaultspec_core/migrations/m_0_1_48_launch_convergence.py
+++ b/src/vaultspec_core/migrations/m_0_1_48_launch_convergence.py
@@ -1,0 +1,147 @@
+"""Converge managed MCP launch entries to the current canonical shape.
+
+Introduced for vaultspec-core 0.1.48. Earlier releases rendered the
+dependency-mode MCP launch without the ``--no-sync`` guard, so a client
+connect could trigger an implicit environment sync. The canonical shape
+changed, but reconciliation skips a drifted managed entry unless the
+operator passes ``--force``, so already-deployed workspaces would keep the
+regressed launch indefinitely.
+
+This migration re-renders every provider enrollment the workspace's
+ownership sidecar records, at project scope, through the owning
+:func:`~vaultspec_core.core.mcps.mcp_sync` verb. The fingerprint-verified
+refresh path does the byte work: only entries that are provably untouched
+since vaultspec wrote them converge, each narrated with an old-to-new
+launch line in the sync result. Hand-edited entries, external entries, and
+ownership records that predate fingerprinting are left exactly as the live
+sync would leave them, with the same warnings.
+
+A workspace with no recorded project-scope enrollment (for example one
+provisioned with ``--skip mcp``) is a true no-op: the migration never
+creates an enrollment the operator opted out of.
+
+See also:
+    :mod:`vaultspec_core.migrations` for the registry driver.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from . import Migration, MigrationResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = ["MIGRATION", "migrate"]
+
+logger = logging.getLogger(__name__)
+
+_TARGET_VERSION = "0.1.48"
+_NAME = "launch_convergence"
+
+
+def migrate(workspace: Path) -> MigrationResult:
+    """Re-render recorded project-scope MCP enrollments through ``mcp_sync``.
+
+    Reads the project-scope ownership sidecar to learn which providers hold
+    vaultspec-managed entries, then reconciles exactly those providers. The
+    fingerprint-verified refresh path decides per entry whether convergence
+    is safe; this migration adds no force semantics of its own.
+
+    Args:
+        workspace: Workspace root directory.
+
+    Returns:
+        :class:`MigrationResult` whose ``counts`` carries ``refreshed``
+        (entries rewritten to the current shape), ``skipped`` (entries left
+        for the operator, e.g. hand-edited), and ``providers`` (enrollments
+        reconciled).
+
+    Raises:
+        Nothing beyond what the owning sync verb raises for real I/O
+        failures; per-target parse problems are reported in the sync result
+        and logged, matching the live ``sync`` behavior, so a broken host
+        file never wedges the migration registry.
+    """
+    from ..core.enums import McpScope
+    from ..core.mcps import _ownership_path, _read_ownership, mcp_sync
+
+    ownership_path = _ownership_path(workspace, McpScope.PROJECT)
+    if not ownership_path.exists():
+        return MigrationResult(
+            name=_NAME,
+            target_version=_TARGET_VERSION,
+            summary="no recorded MCP enrollment; nothing to converge",
+            counts={"refreshed": 0, "skipped": 0, "providers": 0},
+        )
+
+    try:
+        state = _read_ownership(ownership_path)
+    except Exception as exc:  # report, never wedge the registry
+        logger.warning("Cannot read MCP ownership state at %s: %s", ownership_path, exc)
+        return MigrationResult(
+            name=_NAME,
+            target_version=_TARGET_VERSION,
+            summary="ownership sidecar unreadable; left for spec doctor",
+            counts={"refreshed": 0, "skipped": 0, "providers": 0},
+        )
+
+    providers = sorted(
+        {
+            str(record.get("provider"))
+            for record in state.get("targets", {}).values()
+            if isinstance(record, dict)
+            and record.get("scope") == McpScope.PROJECT.value
+            and record.get("provider")
+        }
+    )
+    if not providers:
+        return MigrationResult(
+            name=_NAME,
+            target_version=_TARGET_VERSION,
+            summary="no project-scope MCP enrollment recorded; nothing to converge",
+            counts={"refreshed": 0, "skipped": 0, "providers": 0},
+        )
+
+    refreshed = 0
+    skipped = 0
+    reconciled = 0
+    for provider in providers:
+        result = mcp_sync(
+            provider=provider,
+            scope=McpScope.PROJECT,
+            target_dir=workspace,
+        )
+        reconciled += 1
+        refreshed += sum(1 for _name, action in result.items if action == "[REFRESH]")
+        skipped += result.skipped
+        for line in result.warnings:
+            logger.info("%s", line)
+        for line in result.errors:
+            logger.warning("MCP convergence for provider '%s': %s", provider, line)
+
+    if refreshed:
+        summary = (
+            f"refreshed {refreshed} managed MCP launch entr"
+            f"{'y' if refreshed == 1 else 'ies'} to the current standard"
+        )
+    else:
+        summary = "managed MCP launch entries already current"
+    if skipped:
+        summary += f"; {skipped} left untouched (hand-edited or unverifiable)"
+
+    return MigrationResult(
+        name=_NAME,
+        target_version=_TARGET_VERSION,
+        summary=summary,
+        counts={"refreshed": refreshed, "skipped": skipped, "providers": reconciled},
+    )
+
+
+MIGRATION = Migration(
+    target_version=_TARGET_VERSION,
+    name=_NAME,
+    migrate=migrate,
+)

--- a/src/vaultspec_core/migrations/tests/conftest.py
+++ b/src/vaultspec_core/migrations/tests/conftest.py
@@ -1,0 +1,54 @@
+"""Shared fixtures for migration tests.
+
+Mirrors the CLI suite's autouse workspace-context isolation: migration tests
+that provision real workspaces bind the global workspace context via
+``init_paths``, and without a save/restore boundary that context leaks into
+whichever test collects next (the no-context collector tests are the first
+casualties under full-gate ordering).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import vaultspec_core.core.types as _t
+
+
+@pytest.fixture(autouse=True)
+def _isolate_state():
+    """Save and restore workspace context, target, config, and console."""
+    from vaultspec_core.cli._target import reset as reset_target
+    from vaultspec_core.config import reset_config
+    from vaultspec_core.console import reset_console
+    from vaultspec_core.core.types import _workspace_ctx
+
+    try:
+        current = _workspace_ctx.get()
+        token = _workspace_ctx.set(current)
+    except LookupError:
+        _sentinel = Path(".")
+        token = _workspace_ctx.set(
+            _t.WorkspaceContext(
+                root_dir=_sentinel,
+                target_dir=_sentinel,
+                rules_src_dir=_sentinel,
+                skills_src_dir=_sentinel,
+                agents_src_dir=_sentinel,
+                system_src_dir=_sentinel,
+                templates_dir=_sentinel,
+                hooks_dir=_sentinel,
+            )
+        )
+
+    reset_console()
+    reset_target()
+    reset_config()
+
+    yield
+
+    _workspace_ctx.reset(token)
+    reset_console()
+    reset_target()
+    reset_config()

--- a/src/vaultspec_core/migrations/tests/test_launch_convergence.py
+++ b/src/vaultspec_core/migrations/tests/test_launch_convergence.py
@@ -1,0 +1,127 @@
+"""Tests for the ``launch_convergence`` registry entry.
+
+Exercises
+:func:`vaultspec_core.migrations.m_0_1_48_launch_convergence.migrate`
+against real provisioned workspaces: a legacy-shaped managed entry converges
+through the fingerprint-verified refresh path, hand-edited entries survive
+untouched, a workspace without recorded enrollment is a true no-op, and a
+second run after convergence does no work.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.core.enums import InstallMode
+from vaultspec_core.core.mcps import mcp_sync
+from vaultspec_core.migrations.m_0_1_48_launch_convergence import migrate
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+def _bind_context(root: Path) -> None:
+    """Point the active workspace context at *root*."""
+    from vaultspec_core.config import reset_config
+    from vaultspec_core.config.workspace import resolve_workspace
+    from vaultspec_core.core.types import init_paths
+
+    reset_config()
+    init_paths(resolve_workspace(target_override=root))
+
+
+def _provision(root: Path, mode: InstallMode) -> None:
+    """Install core in *mode* and bind the workspace context to *root*."""
+    from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+    if mode in (InstallMode.DEPENDENCY, InstallMode.DEV):
+        (root / "pyproject.toml").write_text(
+            '[project]\nname = "x"\nversion = "0"\ndependencies = ["vaultspec-core"]\n',
+            encoding="utf-8",
+        )
+    WorkspaceFactory(root).install("all", mode=mode)
+    _bind_context(root)
+
+
+def _probe_path(root: Path) -> Path:
+    return root / ".vaultspec" / "mcps" / "probe.json"
+
+
+def _write_probe(root: Path, *, args: list[str]) -> None:
+    """Write a plain custom MCP definition named ``probe``."""
+    _probe_path(root).parent.mkdir(parents=True, exist_ok=True)
+    _probe_path(root).write_text(
+        json.dumps({"command": "python", "args": args}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _servers(root: Path) -> dict[str, dict]:
+    raw = json.loads((root / ".mcp.json").read_text(encoding="utf-8"))
+    return raw["mcpServers"]
+
+
+@pytest.mark.parametrize("mode", [InstallMode.DEPENDENCY, InstallMode.TOOL])
+def test_legacy_entry_converges_and_second_run_is_noop(
+    tmp_path: Path, mode: InstallMode
+) -> None:
+    """A managed entry left on an outdated shape converges on migrate; a
+    second run reports zero work and mutates nothing, in both render modes."""
+    _provision(tmp_path, mode)
+    _write_probe(tmp_path, args=["-m", "probe", "--old"])
+    mcp_sync(provider="claude")
+
+    # The definition moves on (a newer release renders different bytes); the
+    # deployed entry still matches its recorded fingerprint.
+    _write_probe(tmp_path, args=["-m", "probe", "--new"])
+
+    result = migrate(tmp_path)
+
+    assert result.counts["refreshed"] >= 1
+    assert result.counts["providers"] >= 1
+    assert "refreshed" in result.summary
+    assert _servers(tmp_path)["probe"]["args"] == ["-m", "probe", "--new"]
+
+    before = (tmp_path / ".mcp.json").read_bytes()
+    again = migrate(tmp_path)
+    assert again.counts["refreshed"] == 0
+    assert "already current" in again.summary
+    assert (tmp_path / ".mcp.json").read_bytes() == before
+
+
+def test_hand_edited_entry_survives_migration(tmp_path: Path) -> None:
+    """A managed entry whose bytes no longer match the recorded fingerprint
+    is left byte-identical and reported as skipped."""
+    _provision(tmp_path, InstallMode.DEPENDENCY)
+    _write_probe(tmp_path, args=["-m", "probe", "--old"])
+    mcp_sync(provider="claude")
+
+    mcp_path = tmp_path / ".mcp.json"
+    raw = json.loads(mcp_path.read_text(encoding="utf-8"))
+    raw["mcpServers"]["probe"]["env"] = {"HAND_EDIT": "1"}
+    mcp_path.write_text(json.dumps(raw, indent=2) + "\n", encoding="utf-8")
+
+    _write_probe(tmp_path, args=["-m", "probe", "--new"])
+    before = mcp_path.read_bytes()
+
+    result = migrate(tmp_path)
+
+    assert mcp_path.read_bytes() == before
+    assert result.counts["refreshed"] == 0
+    assert result.counts["skipped"] >= 1
+    assert "left untouched" in result.summary
+
+
+def test_workspace_without_enrollment_is_true_noop(tmp_path: Path) -> None:
+    """No ownership sidecar means nothing to converge: no files appear."""
+    result = migrate(tmp_path)
+
+    assert result.counts == {"refreshed": 0, "skipped": 0, "providers": 0}
+    assert "nothing to converge" in result.summary
+    assert not (tmp_path / ".mcp.json").exists()
+    assert not (tmp_path / ".vaultspec").exists()

--- a/src/vaultspec_core/tests/cli/test_convergence_advisories.py
+++ b/src/vaultspec_core/tests/cli/test_convergence_advisories.py
@@ -1,0 +1,123 @@
+"""Doctor advisories for convergence holes core cannot fix itself.
+
+Exercises the two warn-only diagnosis surfaces added alongside automatic
+launch convergence: the ``UNREFRESHABLE`` precommit signal for prek.toml
+workspaces whose stale YAML hooks the scaffold will never touch, and the
+stale package-seed collector for builtin MCP definitions still in a static
+pre-mode shape. Both render as warnings but never fail the doctor, because
+their remediation lives outside the workspace.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.core.diagnosis.collectors import (
+    collect_precommit_state,
+    collect_stale_seed_definitions,
+)
+from vaultspec_core.core.diagnosis.signals import PrecommitSignal
+from vaultspec_core.core.mcps import _MODE_COMMAND_TOKEN
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+def _write_yaml_hooks(root: Path, entry: str) -> None:
+    """Write a .pre-commit-config.yaml carrying one stale canonical hook."""
+    from vaultspec_core.core.commands import CANONICAL_HOOK_IDS
+
+    hook_id = sorted(CANONICAL_HOOK_IDS)[0]
+    (root / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "- repo: local\n"
+        "  hooks:\n"
+        f"  - id: {hook_id}\n"
+        f"    entry: {entry}\n"
+        "    language: system\n",
+        encoding="utf-8",
+    )
+
+
+class TestPrekUnrefreshableAdvisory:
+    def test_stale_hooks_with_prek_toml_report_unrefreshable(
+        self, tmp_path: Path
+    ) -> None:
+        """prek.toml plus a non-canonical YAML hook set is UNREFRESHABLE,
+        not the generic staleness whose fix hint the scaffold cannot honor."""
+        _write_yaml_hooks(tmp_path, "uv run vaultspec-core legacy-entry")
+        (tmp_path / "prek.toml").write_text("", encoding="utf-8")
+
+        assert collect_precommit_state(tmp_path) is PrecommitSignal.UNREFRESHABLE
+
+    def test_stale_hooks_without_prek_toml_keep_existing_signal(
+        self, tmp_path: Path
+    ) -> None:
+        """Without prek.toml the YAML state reports as before (refreshable)."""
+        _write_yaml_hooks(tmp_path, "uv run vaultspec-core legacy-entry")
+
+        assert collect_precommit_state(tmp_path) is PrecommitSignal.INCOMPLETE
+
+    def test_unrefreshable_never_fails_the_doctor(self, tmp_path: Path) -> None:
+        """The advisory is warn-only: the exit-code policy ignores it."""
+        from vaultspec_core.cli.spec_cmd import _doctor_exit_code
+        from vaultspec_core.core.diagnosis.diagnosis import WorkspaceDiagnosis
+        from vaultspec_core.core.diagnosis.signals import FrameworkSignal
+
+        diag = WorkspaceDiagnosis(
+            framework=FrameworkSignal.PRESENT,
+            precommit=PrecommitSignal.UNREFRESHABLE,
+        )
+        assert _doctor_exit_code(diag) == 0
+
+
+class TestStaleSeedAdvisory:
+    def test_static_builtin_seed_is_reported(self, tmp_path: Path) -> None:
+        """A package-bundled seed whose command is a concrete string (the
+        pre-mode static shape) is named; tokenized seeds and custom
+        definitions are not."""
+        mcps = tmp_path / ".vaultspec" / "mcps"
+        mcps.mkdir(parents=True)
+        (mcps / "vaultspec-rag.builtin.json").write_text(
+            json.dumps({"command": "uv", "args": ["run", "vaultspec-search-mcp"]}),
+            encoding="utf-8",
+        )
+        (mcps / "vaultspec-core.builtin.json").write_text(
+            json.dumps({"command": _MODE_COMMAND_TOKEN, "args": []}),
+            encoding="utf-8",
+        )
+        (mcps / "my-server.json").write_text(
+            json.dumps({"command": "node", "args": ["server.js"]}),
+            encoding="utf-8",
+        )
+
+        assert collect_stale_seed_definitions(tmp_path) == ["vaultspec-rag"]
+
+    def test_all_tokenized_seeds_report_clean(self, tmp_path: Path) -> None:
+        mcps = tmp_path / ".vaultspec" / "mcps"
+        mcps.mkdir(parents=True)
+        (mcps / "vaultspec-core.builtin.json").write_text(
+            json.dumps({"command": _MODE_COMMAND_TOKEN, "args": []}),
+            encoding="utf-8",
+        )
+
+        assert collect_stale_seed_definitions(tmp_path) == []
+
+    def test_missing_mcps_dir_reports_clean(self, tmp_path: Path) -> None:
+        assert collect_stale_seed_definitions(tmp_path) == []
+
+    def test_stale_seed_never_fails_the_doctor(self, tmp_path: Path) -> None:
+        from vaultspec_core.cli.spec_cmd import _doctor_exit_code
+        from vaultspec_core.core.diagnosis.diagnosis import WorkspaceDiagnosis
+        from vaultspec_core.core.diagnosis.signals import FrameworkSignal
+
+        diag = WorkspaceDiagnosis(
+            framework=FrameworkSignal.PRESENT,
+            stale_mcp_seeds=["vaultspec-rag"],
+        )
+        assert _doctor_exit_code(diag) == 0

--- a/src/vaultspec_core/tests/cli/test_install_mode_flip.py
+++ b/src/vaultspec_core/tests/cli/test_install_mode_flip.py
@@ -136,6 +136,87 @@ class TestModeFlipForcesManagedEntry:
         assert after["mcpServers"]["my-custom-server"] == foreign_before
         assert after["mcpServers"]["vaultspec-core"]["command"] == _TOOL_COMMAND
 
+    def test_flip_upgrade_refreshes_every_declared_companion(
+        self, tmp_path: Path
+    ) -> None:
+        """The widened mode-flip seam forces every package declared in the
+        workspace map, not only ``vaultspec-core``: a companion's managed
+        entry, hand-altered so a plain sync alone would skip it, still
+        migrates atomically alongside core's own entry on a flip upgrade.
+        """
+        import json as _json
+
+        from vaultspec_core.core.mcps import (
+            _MODE_ARGS_TOKEN,
+            _MODE_COMMAND_TOKEN,
+            _MODE_MODULE_KEY,
+            _MODE_PACKAGE_KEY,
+            mcp_sync,
+        )
+        from vaultspec_core.core.workspace_mode import (
+            PackageDeclaration,
+            write_package_declaration,
+        )
+        from vaultspec_core.tests.cli.test_mcp_per_package_sync import _bind_context
+
+        rag_package = "vaultspec-rag"
+        rag_module = "vaultspec_rag.server"
+
+        _write_pyproject_with_vaultspec(tmp_path)
+        WorkspaceFactory(tmp_path).install("all", mode=InstallMode.DEPENDENCY)
+
+        # Declare a companion package in tool mode and drop its tokenized
+        # definition, mirroring a real mixed-mode workspace, then sync it in
+        # so both entries carry a fingerprint recorded for their current
+        # (pre-flip) shapes.
+        mcps_dir = tmp_path / ".vaultspec" / "mcps"
+        mcps_dir.mkdir(parents=True, exist_ok=True)
+        (mcps_dir / f"{rag_package}.builtin.json").write_text(
+            _json.dumps(
+                {
+                    "command": _MODE_COMMAND_TOKEN,
+                    "args": [_MODE_ARGS_TOKEN],
+                    _MODE_PACKAGE_KEY: rag_package,
+                    _MODE_MODULE_KEY: rag_module,
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        write_package_declaration(
+            tmp_path, rag_package, PackageDeclaration(install_mode=InstallMode.TOOL)
+        )
+        _bind_context(tmp_path)
+        mcp_sync(provider="claude")
+
+        # Hand-alter both managed entries so their fingerprints no longer
+        # verify: a plain sync (and, before the widened seam, the old
+        # core-only force set) would skip both as apparent hand edits.
+        mcp = _read_mcp(tmp_path)
+        mcp["mcpServers"]["vaultspec-core"]["env"] = {"HAND_ALTERED": "1"}
+        mcp["mcpServers"][rag_package]["env"] = {"HAND_ALTERED": "1"}
+        (tmp_path / ".mcp.json").write_text(
+            _json.dumps(mcp, indent=2) + "\n", encoding="utf-8"
+        )
+
+        # Flip core's own declared mode; the upgrade observes the deployed
+        # (still dependency-shaped) entry disagreeing with this declaration.
+        write_package_declaration(
+            tmp_path,
+            "vaultspec-core",
+            PackageDeclaration(install_mode=InstallMode.TOOL),
+        )
+
+        WorkspaceFactory(tmp_path).install("all", upgrade=True)
+
+        after = _read_mcp(tmp_path)["mcpServers"]
+        assert after["vaultspec-core"]["command"] == _TOOL_COMMAND
+        assert after["vaultspec-core"]["args"] == list(_TOOL_ARGS)
+        assert "env" not in after["vaultspec-core"]
+        assert after[rag_package]["command"] == "uvx"
+        assert "env" not in after[rag_package]
+
     def test_non_flip_upgrade_takes_no_force_path(self, tmp_path: Path) -> None:
         """A non-flip upgrade never engages the force path: a divergent
         user-owned entry and the already-matching managed entry both survive an

--- a/src/vaultspec_core/tests/cli/test_mcp_per_package_sync.py
+++ b/src/vaultspec_core/tests/cli/test_mcp_per_package_sync.py
@@ -201,3 +201,156 @@ class TestCoreOnlyWorkspaceZeroChurn:
         assert not any(action == "[SKIP]" for _name, action in result.items)
         servers = _read_servers(tmp_path)
         assert set(servers) == {_CORE_PACKAGE}
+
+
+def _write_probe_definition(root: Path, *, args: list[str]) -> None:
+    """Write a plain (mode-token-free) custom MCP definition named ``probe``."""
+    mcps_dir = root / ".vaultspec" / "mcps"
+    mcps_dir.mkdir(parents=True, exist_ok=True)
+    definition = {"command": "python", "args": args}
+    (mcps_dir / "probe.json").write_text(
+        json.dumps(definition, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def _claude_target(root: Path):
+    from vaultspec_core.core.enums import McpScope, Tool
+    from vaultspec_core.core.mcps import resolve_mcp_targets
+
+    targets = resolve_mcp_targets(Tool.CLAUDE, scope=McpScope.PROJECT, target_dir=root)
+    return targets[0]
+
+
+class TestFingerprintVerifiedRefresh:
+    """Exercises the fingerprint-verified refresh path (``[REFRESH]``) and its
+    two skip-and-warn companions: hand-edited drift and a legacy name-only
+    ownership record that predates fingerprinting. Every scenario is scoped
+    to the Claude project target (``.mcp.json``) via ``provider="claude"``
+    so assertions stay focused on one file.
+    """
+
+    def test_untouched_entry_refreshes_on_plain_sync(self, tmp_path: Path) -> None:
+        """An untouched managed entry whose bytes match its recorded
+        fingerprint converges to a changed standard on a plain sync, with a
+        [REFRESH] item and a narration naming both commands."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--old"])
+        _bind_context(tmp_path)
+        mcp_sync(provider="claude")
+
+        # The standard changes: the source definition renders a new shape,
+        # while the deployed entry is still exactly what was last written.
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--new"])
+
+        result = mcp_sync(provider="claude")
+
+        servers = _read_servers(tmp_path)
+        assert servers["probe"]["args"] == ["-m", "probe", "--new"]
+        assert ("probe", "[REFRESH]") in result.items
+        assert result.updated >= 1
+        refresh_warning = next(
+            w
+            for w in result.warnings
+            if w.startswith("MCP server 'probe' launch refreshed")
+        )
+        assert "python -m probe --old" in refresh_warning
+        assert "python -m probe --new" in refresh_warning
+
+    def test_hand_edited_entry_is_skipped_with_force_hint(self, tmp_path: Path) -> None:
+        """A managed entry whose bytes no longer match its recorded
+        fingerprint is a hand edit: it is skipped, the warning names
+        --force, and the file is byte-unchanged."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--old"])
+        _bind_context(tmp_path)
+        mcp_sync(provider="claude")
+
+        mcp_path = tmp_path / ".mcp.json"
+        raw = json.loads(mcp_path.read_text(encoding="utf-8"))
+        raw["mcpServers"]["probe"]["env"] = {"HAND_ALTERED": "1"}
+        mcp_path.write_text(json.dumps(raw, indent=2) + "\n", encoding="utf-8")
+        before = mcp_path.read_text(encoding="utf-8")
+
+        result = mcp_sync(provider="claude")
+
+        after = mcp_path.read_text(encoding="utf-8")
+        assert after == before
+        assert ("probe", "[SKIP]") in result.items
+        warning = next(w for w in result.warnings if "probe" in w)
+        assert "--force" in warning
+        assert "no recorded fingerprint" not in warning
+
+    def test_name_only_legacy_record_is_skipped_with_honest_hint(
+        self, tmp_path: Path
+    ) -> None:
+        """A managed name whose ownership record predates fingerprinting
+        cannot be verified: it is skipped and the warning honestly names
+        --force as the only remediation."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--old"])
+        _bind_context(tmp_path)
+        mcp_sync(provider="claude")
+
+        from vaultspec_core.core.mcps import (
+            _ownership_path,
+            _ownership_target_key,
+            _read_ownership,
+            _write_ownership,
+        )
+
+        target = _claude_target(tmp_path)
+        path = _ownership_path(tmp_path, target.scope)
+        state = _read_ownership(path)
+        key = _ownership_target_key(target)
+        state["targets"][key]["managed"]["probe"] = None
+        _write_ownership(path, state)
+
+        # Change the standard so the entry now differs from its definition.
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--new"])
+
+        result = mcp_sync(provider="claude")
+
+        servers = _read_servers(tmp_path)
+        assert servers["probe"]["args"] == ["-m", "probe", "--old"]
+        assert ("probe", "[SKIP]") in result.items
+        warning = next(w for w in result.warnings if "probe" in w)
+        assert "--force" in warning
+        assert "no recorded fingerprint" in warning
+
+    def test_external_entry_never_touched_without_force(self, tmp_path: Path) -> None:
+        """A pre-existing entry that vaultspec never wrote (no ownership
+        record), even one sharing its name with a declared definition, is
+        never adopted or refreshed by a plain sync."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--new"])
+        _bind_context(tmp_path)
+
+        mcp_path = tmp_path / ".mcp.json"
+        raw = json.loads(mcp_path.read_text(encoding="utf-8"))
+        raw["mcpServers"]["probe"] = {"command": "node", "args": ["server.js"]}
+        mcp_path.write_text(json.dumps(raw, indent=2) + "\n", encoding="utf-8")
+        before = json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"]["probe"]
+
+        result = mcp_sync(provider="claude")
+
+        after = json.loads(mcp_path.read_text(encoding="utf-8"))["mcpServers"]["probe"]
+        assert after == before
+        assert ("probe", "[SKIP]") in result.items
+        warning = next(w for w in result.warnings if "probe" in w)
+        assert "externally managed" in warning
+        assert "--force" in warning
+
+    def test_refresh_then_resync_is_idempotent(self, tmp_path: Path) -> None:
+        """Running sync a second time after a refresh reports unchanged."""
+        _provision(tmp_path, InstallMode.DEPENDENCY)
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--old"])
+        _bind_context(tmp_path)
+        mcp_sync(provider="claude")
+        _write_probe_definition(tmp_path, args=["-m", "probe", "--new"])
+        mcp_sync(provider="claude")
+
+        result = mcp_sync(provider="claude")
+
+        assert ("probe", "[UNCHANGED]") in result.items
+        assert result.updated == 0
+        assert result.added == 0

--- a/src/vaultspec_core/tests/cli/test_signals.py
+++ b/src/vaultspec_core/tests/cli/test_signals.py
@@ -71,6 +71,7 @@ pytestmark = [pytest.mark.unit]
                 "NO_HOOKS",
                 "INCOMPLETE",
                 "NON_CANONICAL",
+                "UNREFRESHABLE",
                 "COMPLETE",
             },
         ),


### PR DESCRIPTION
## Problem

The static-launch amendment (#224) changed the canonical MCP launch bytes, but the reconciliation machinery could not deliver them: a drifted managed entry was skipped by plain `sync` AND by `install --upgrade` unless `--force` was passed, and the upgrade force seam covered only vaultspec-core, never companions. Every legacy workspace stayed on the regressed launch shape indefinitely, while the doctor hint claimed `install --upgrade` fixes it.

## Decision (ADR `2026-07-17-upgrade-convergence-adr`) - implemented

- **B1 fingerprint-verified auto-refresh**: a managed entry that differs from its rendered definition but byte-matches its recorded ownership fingerprint is provably untouched since vaultspec wrote it - it now refreshes on plain `sync`/upgrade with a narrated `old -> new` warning line per entry. Hand-edited entries keep skip-and-warn; pre-fingerprint (name-only) ownership records get an honest `--force` hint; external entries keep the adoption gate. Safety is sharper, not looser.
- **B2 registered convergence migration** (`m_0_1_48_launch_convergence`): re-renders recorded project-scope enrollments via `mcp_sync` on the workspace's first contact with `install --upgrade`, any `vault` verb, or `migrations run` - convergence regardless of provisioned version or flags. Never creates enrollment (`--skip mcp` workspaces are true no-ops), idempotent, never wedges the registry.
- **B3**: upgrade's mode-flip force seam widened from core-only to every package declared in `workspace.json`.
- **B4 messaging**: every automatic refresh narrates entry, old command, new command, and reason; the doctor's remediation hints are now truthful; `docs/MCP.md` gains a Convergence-on-upgrade section (automatic behavior, exceptions, opt-outs).
- **B5**: warn-only doctor advisories for the two holes core cannot fix itself - unrefreshable prek.toml hooks (replacing a false fix hint that previously also FAILED the doctor) and stale static companion seeds. Both render as warnings without failing the doctor.

## Plan - complete (9/9)

Executes `.vault/plan/2026-07-17-upgrade-convergence-plan.md`.

## Verification

- Final gates: **1822 unit tests passed** (CI-matching), **330 repo-root**; ruff + ty clean on changed files.
- Independent review: **PASS, no CRITICAL or HIGH** (refresh-gate symmetry verified on both JSON and TOML paths; migration lock/context/error behavior verified; code-boundary scan clean). Audit: `.vault/audit/2026-07-17-upgrade-convergence-audit.md`.
- Dogfooded live: the migration refreshed 6 managed entries across 3 providers on this workspace and reported applied; both servers handshake over stdio.
- Closing gate surfaced and fixed two test-infrastructure regressions: the precommit enum contract member, and missing autouse workspace-context isolation in the migrations test package (context leaked into later no-context tests under full-gate ordering).