### PR TITLE
fix: recognize unrefreshable prek sync state

### DIFF
--- a/src/vaultspec_core/core/resolver.py
+++ b/src/vaultspec_core/core/resolver.py
@@ -855,6 +855,12 @@ def _resolve_precommit(
             )
         return
 
+    if signal == PrecommitSignal.UNREFRESHABLE:
+        # ``prek.toml`` owns this boundary, so sync cannot repair the stale
+        # YAML hooks. The doctor surface already renders the actionable
+        # advisory; resolution must leave the workspace unchanged.
+        return
+
     logger.warning("Unknown PrecommitSignal member: %s (action=%s)", signal, action)
 
 

--- a/src/vaultspec_core/tests/cli/test_resolver.py
+++ b/src/vaultspec_core/tests/cli/test_resolver.py
@@ -20,7 +20,7 @@ from vaultspec_core.core.diagnosis.signals import (
     ResolutionAction,
 )
 from vaultspec_core.core.enums import CliAction, Tool
-from vaultspec_core.core.resolver import ResolutionPlan, resolve
+from vaultspec_core.core.resolver import ResolutionPlan, _resolve_precommit, resolve
 
 pytestmark = [pytest.mark.unit]
 
@@ -374,6 +374,28 @@ class TestGitignoreRules:
             s for s in plan.steps if s.action == ResolutionAction.REPAIR_GITIGNORE
         ]
         assert gitignore_steps == []
+
+
+# ---------------------------------------------------------------------------
+# Pre-commit rules
+# ---------------------------------------------------------------------------
+
+
+class TestPrecommitRules:
+    def test_repeated_sync_ignores_unrefreshable_prek_boundary(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING", logger="vaultspec_core.core.resolver")
+
+        for _ in range(2):
+            _resolve_precommit(
+                ResolutionPlan(),
+                PrecommitSignal.UNREFRESHABLE,
+                CliAction.SYNC,
+                force=False,
+            )
+
+        assert "Unknown PrecommitSignal member" not in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #231

Treat `PrecommitSignal.UNREFRESHABLE` as an intentional no-op when `prek.toml` owns the hook boundary, instead of logging a healthy repeated sync as an unknown signal. The regression fails twice on the previous warning path and passes after the resolver handles the state; 53 focused tests and changed-file Ruff checks pass.
