### PR TITLE
fix(vault): recognize the stash/restore two-date mtime signature (#235)

### DIFF
--- a/src/vaultspec_core/vaultcore/checks/modified_stamp.py
+++ b/src/vaultspec_core/vaultcore/checks/modified_stamp.py
@@ -23,16 +23,24 @@ Finding semantics (D3b):
   date) -> finding; the fix refreshes the stamp to the file's mtime date,
   surfacing hand edits the CLI mutators did not stamp.
 
-Clone-signature guard. File mtime does not survive ``git clone``: a fresh
-checkout rewrites every tracked file to one wall-clock instant, so every
-document would falsely read as "modified today" and the staleness branch
-would flag the entire vault. To avoid that noise, before emitting any
-staleness finding this checker computes the modal mtime date across all
-scanned documents; when 80 percent or more of the documents share a single
-mtime date the run is treated as carrying the fresh-clone signature, every
-staleness finding is suppressed for that run, and a single informational
-diagnostic explains why. The missing, non-canonical, and unparseable
-branches are unaffected by the guard - they read frontmatter, not mtime.
+Git-operation guard. File mtime does not survive git operations: a fresh
+checkout rewrites every tracked file to one wall-clock instant, and a
+pre-commit stash/restore cycle rewrites the reverted files to a second
+instant, so the affected documents would falsely read as "modified today"
+and the staleness branch would flag the whole vault. That last case is the
+sharp one: prek stashes unstaged changes before running hooks, and when the
+restore lands on a different calendar day from the working tree's checkout,
+the vault's mtimes collapse onto two dates rather than one - defeating a
+guard that only recognises a single dominant date. To avoid that noise,
+before emitting any staleness finding this checker tallies the mtime date of
+every scanned document; when the largest few mtime dates (a fresh clone is
+one such wall-clock instant, a stash/restore cycle is two;
+:data:`_GIT_SIGNATURE_MAX_INSTANTS`) together account for at least
+:data:`_GIT_SIGNATURE_RATIO` of the documents, the run is treated as
+carrying a git-operation signature, every staleness finding is suppressed
+for that run, and a single informational diagnostic explains why. The
+missing, non-canonical, and unparseable branches are unaffected by the
+guard - they read frontmatter, not mtime.
 """
 
 from __future__ import annotations
@@ -58,9 +66,17 @@ if TYPE_CHECKING:
 
 __all__ = ["check_modified_stamp"]
 
-#: Threshold at or above which a shared mtime date is read as the
-#: fresh-clone signature and staleness findings are suppressed.
-_CLONE_SIGNATURE_RATIO = 0.8
+#: Fraction of documents which, once concentrated on the largest few mtime
+#: dates, is read as a git-operation signature and suppresses staleness.
+_GIT_SIGNATURE_RATIO = 0.8
+
+#: Number of largest mtime-date buckets whose combined share is measured
+#: against :data:`_GIT_SIGNATURE_RATIO`. A fresh clone collapses every file
+#: onto one wall-clock instant; a pre-commit stash/restore cycle spanning a
+#: calendar day adds a second. Two buckets model both without treating a
+#: vault of genuinely diverse hand-edit dates (many small buckets) as an
+#: artifact, so localized staleness still surfaces.
+_GIT_SIGNATURE_MAX_INSTANTS = 2
 
 #: Leading ``yyyy-mm-dd`` prefix on a vault filename, the scaffold-time
 #: date anchor used when ``date:`` is absent or unparseable.
@@ -221,10 +237,12 @@ def check_modified_stamp(
     module docstring describes. The unparseable case is reported but
     never rewritten so a hand-entered value is never silently lost.
 
-    Staleness findings are guarded against the fresh-clone signature:
-    when at least :data:`_CLONE_SIGNATURE_RATIO` of the scanned documents
-    share one mtime date the staleness branch is skipped for the whole
-    run and a single informational diagnostic explains why.
+    Staleness findings are guarded against git-operation mtime rewrites:
+    when the largest few mtime dates (:data:`_GIT_SIGNATURE_MAX_INSTANTS`)
+    together cover at least :data:`_GIT_SIGNATURE_RATIO` of the scanned
+    documents the staleness branch is skipped for the whole run and a
+    single informational diagnostic explains why. This covers both a fresh
+    clone (one instant) and a pre-commit stash/restore cycle (two).
 
     Args:
         root_dir: Project root directory.
@@ -250,8 +268,9 @@ def check_modified_stamp(
                 continue
         docs.append((doc_path, metadata))
 
-    # Clone-signature detection: tally mtime dates across the documents in
-    # scope and suppress staleness findings when one date dominates.
+    # Git-operation detection: tally mtime dates across the documents in
+    # scope and suppress staleness findings when the largest few dates -
+    # the wall-clock instants git operations rewrite files to - dominate.
     mtime_dates: dict[datetime.date, int] = {}
     mtime_by_path: dict[Path, datetime.date | None] = {}
     for doc_path, _metadata in docs:
@@ -261,20 +280,24 @@ def check_modified_stamp(
             mtime_dates[md] = mtime_dates.get(md, 0) + 1
 
     total_with_mtime = sum(mtime_dates.values())
-    clone_signature = False
+    git_signature = False
+    concentrated = 0
     if total_with_mtime:
-        dominant = max(mtime_dates.values())
-        clone_signature = dominant / total_with_mtime >= _CLONE_SIGNATURE_RATIO
+        ranked = sorted(mtime_dates.values(), reverse=True)
+        concentrated = sum(ranked[:_GIT_SIGNATURE_MAX_INSTANTS])
+        git_signature = concentrated / total_with_mtime >= _GIT_SIGNATURE_RATIO
 
-    if clone_signature:
+    if git_signature:
+        instants = min(_GIT_SIGNATURE_MAX_INSTANTS, len(mtime_dates))
         result.diagnostics.append(
             CheckDiagnostic(
                 path=None,
                 message=(
                     "Skipping staleness checks: "
-                    f"{dominant} of {total_with_mtime} documents share one mtime "
-                    "date (fresh-clone signature; file mtime does not survive "
-                    "git clone, so staleness cannot be inferred this run)."
+                    f"{concentrated} of {total_with_mtime} documents cluster on "
+                    f"{instants} mtime date(s) (git-operation signature; file mtime "
+                    "does not survive clone, checkout, or a stash/restore cycle, so "
+                    "staleness cannot be inferred this run)."
                 ),
                 severity=Severity.INFO,
             )
@@ -355,8 +378,8 @@ def check_modified_stamp(
             )
             continue
 
-        # Staleness: only when the run does not carry the clone signature.
-        if clone_signature:
+        # Staleness: only when the run does not carry the git-operation signature.
+        if git_signature:
             continue
         mtime_date = mtime_by_path.get(doc_path)
         if mtime_date is not None and mtime_date > parsed:

--- a/src/vaultspec_core/vaultcore/checks/tests/test_modified_stamp.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_modified_stamp.py
@@ -11,8 +11,9 @@ against real on-disk documents (vault-orientation ADR decisions D3, D3b):
 - an unparseable stamp is flagged as an error and never rewritten;
 - a stale stamp (file mtime newer than the stamp) is flagged and
   refreshed under fix;
-- the fresh-clone signature suppresses staleness findings and emits a
-  single informational diagnostic.
+- the git-operation signature - a fresh clone (one mtime instant) or a
+  pre-commit stash/restore cycle (two) - suppresses staleness findings
+  and emits a single informational diagnostic.
 
 All fixtures are real files; mtimes are set with :func:`os.utime`. No
 mocks, patches, or skips.
@@ -308,7 +309,46 @@ class TestCloneSignatureGuard:
         ]
         assert len(infos) == 1
         assert infos[0].path is None
-        assert "fresh-clone signature" in infos[0].message
+        assert "git-operation signature" in infos[0].message
+
+    def test_stash_restore_two_date_clusters_suppresses_staleness(self, tmp_path: Path):
+        # Regression for the archive-under-prek cascade (issue #235). prek
+        # stashes unstaged changes before running the vault-fix hook; the
+        # restore rewrites the reverted documents to today's mtime while the
+        # rest keep the working tree's earlier checkout date. The vault's
+        # mtimes then collapse onto TWO calendar dates rather than one. A
+        # guard that only recognised a single dominant date let every
+        # document read as stale and the fix rewrote the whole vault. The
+        # two-instant guard must recognise the cluster and suppress.
+        _skeleton(tmp_path)
+        docs = [
+            _write_doc(
+                tmp_path,
+                f"2026-01-{(i % 28) + 1:02d}-doc-{i}-adr",
+                date_line=f"date: '2026-01-{(i % 28) + 1:02d}'",
+                modified_line=f"modified: '2026-01-{(i % 28) + 1:02d}'",
+            )
+            for i in range(20)
+        ]
+        # Baseline checkout instant for the untouched majority.
+        checkout = datetime.date(2026, 7, 20)
+        for doc in docs:
+            _set_mtime(doc, checkout)
+        # Stash restore bumps a minority (5/20 = 25%) to a second date. The
+        # dominant single date holds only 75 percent - under the old guard's
+        # threshold - but the top two dates together cover 100 percent.
+        restore = datetime.date(2026, 7, 23)
+        for doc in docs[:5]:
+            _set_mtime(doc, restore)
+
+        result = _check(tmp_path, fix=True)
+
+        stale_findings = [d for d in result.diagnostics if "Stale" in d.message]
+        assert stale_findings == []
+        assert result.fixed_count == 0
+        infos = [d for d in result.diagnostics if "Skipping staleness" in d.message]
+        assert len(infos) == 1
+        assert "git-operation signature" in infos[0].message
 
     def test_below_threshold_does_not_trip_guard(self, tmp_path: Path):
         _skeleton(tmp_path)


### PR DESCRIPTION
## Summary

Closes #235. Fixes the root cause of the ~901 spurious `modified:` stamp rewrites that deadlocked the `vault-fix` pre-commit hook when committing alongside a pending `vault feature archive`.

## Root cause

`check_modified_stamp` suppressed staleness findings only when a **single** mtime date dominated the vault (the fresh-clone signature, since file mtime does not survive `git clone`). But prek runs hooks against a **stash** of unstaged changes: a stash/restore cycle spanning a calendar day rewrites the reverted files to a *second* wall-clock instant, so the vault''s mtimes collapse onto **two** dates. The single-date guard did not fire, the staleness branch ran, and it rewrote hundreds of stamps mid-commit -> hook abort.

## Fix

Generalize the guard to the largest few mtime dates (`_GIT_SIGNATURE_MAX_INSTANTS = 2`): one instant models a fresh clone, two models a stash/restore cycle. A vault of genuinely diverse hand-edit dates (many small buckets) is still not mistaken for an artifact, so localized staleness continues to surface. Archive internals are deliberately left unchanged - this keeps vaultspec git-agnostic and fixes the blocker universally (any stash/restore spanning a day), not just the archive path.

## Verification

- New regression test `test_stash_restore_two_date_clusters_suppresses_staleness` - **fails against pre-fix code**, passes with the fix (verified by stashing the fix and running it).
- Full suite: `src/vaultspec_core` **2906 passed**, repo-root `tests/` **330 passed**, 0 failures.
- ruff check + format, ty: clean.

## Note

The complementary hardening from #235 (making `vault feature archive` a tracked move, or excluding `.vault/_archive/**` from checker scope) was intentionally **not** bundled here - modified-stamp was the sole rewriter behind the deadlock, so this is the minimal root-cause fix. Those remain available as follow-ups if wanted.