### PR TITLE
fix(sync): self-gating spec-check hook so warnings do not deadlock commits (#236)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
     pass_filenames: false
   - id: spec-check
     name: Vault Doctor (Check)
-    entry: uv run --no-sync vaultspec-core spec doctor
+    entry: uv run --no-sync vaultspec-core spec doctor --gate-errors
     language: system
     types:
     - markdown

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -574,9 +574,12 @@ management.
 Run diagnostic collectors across the framework, providers, builtins, `.gitignore`, vault
 content, and configuration files.
 
-| Option | Short | Default | Description | | -------------- | ----- | ------- |
+| Option | Short | Default | Description | | ---------------- | ----- | ------- |
 --------------------------- | | `--target DIR` | `-t` | cwd | Diagnose another
-directory. | | `--json` | - | off | Emit the diagnosis as JSON. |
+directory. | | `--json` | - | off | Emit the diagnosis as JSON. | | `--gate-errors` | -
+| off | Fold the warning exit (1) to 0 so only errors (exit 2) fail; used by the
+`spec-check` pre-commit hook so expected provider-mirror lag does not deadlock commits.
+|
 
 ### vaultspec-core spec rules
 
@@ -648,10 +651,11 @@ order and bumps the manifest version.
 ------------------------------------------------------ | | `vaultspec-core vault check`
 | `0` clean, `1` errors found. | | `vaultspec-core vault plan check` | `0` clean, `1` at
 least one ERROR-severity finding. | | `vaultspec-core spec doctor` | `0` all ok, `1`
-warnings, `2` errors. | | `vaultspec-core spec mcps status` | `0` config status ok, `1`
-otherwise. | | `vaultspec-core migrations status` | `0` up to date or no manifest, `1`
-migrations pending. | | `vaultspec-core migrations run` | `0` success (including no-op),
-`1` a migration failed. |
+warnings, `2` errors (`--gate-errors` folds `1` to `0`). | |
+`vaultspec-core spec mcps status` | `0` config status ok, `1` otherwise. | |
+`vaultspec-core migrations status` | `0` up to date or no manifest, `1` migrations
+pending. | | `vaultspec-core migrations run` | `0` success (including no-op), `1` a
+migration failed. |
 
 ## Environment variables
 

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -1905,13 +1905,26 @@ def cmd_doctor(
     json_output: Annotated[
         bool, typer.Option("--json", help="Output diagnosis as JSON")
     ] = False,
+    gate_errors: Annotated[
+        bool,
+        typer.Option(
+            "--gate-errors",
+            help=(
+                "Exit 0 on warnings; fail (exit 2) only on errors. For the "
+                "pre-commit gate, where warning-level provider-mirror lag is an "
+                "expected steady state that must not block commits."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Diagnose workspace health and report issues.
 
     Runs all diagnostic collectors and reports the state of the framework,
     providers, builtins, gitignore, and configuration files.
 
-    Exit codes: 0 = all ok, 1 = warnings, 2 = errors.
+    Exit codes: 0 = all ok, 1 = warnings, 2 = errors. With ``--gate-errors``
+    the warning exit is folded to 0 so only errors (exit 2) fail; the report
+    is unchanged and still lists every warning.
     """
     import dataclasses
 
@@ -1951,8 +1964,9 @@ def cmd_doctor(
     if json_output:
         data = dataclasses.asdict(diag)
         exit_code = _doctor_exit_code(diag)
-        _emit_json("spec.doctor", "failed" if exit_code else "unchanged", data)
-        raise typer.Exit(code=exit_code)
+        gated = _gate(exit_code, gate_errors=gate_errors)
+        _emit_json("spec.doctor", "failed" if gated else "unchanged", data)
+        raise typer.Exit(code=gated)
 
     from vaultspec_core.console import get_console
 
@@ -1960,7 +1974,7 @@ def cmd_doctor(
     _render_diagnosis_table(console, diag)
 
     exit_code = _doctor_exit_code(diag)
-    raise typer.Exit(code=exit_code)
+    raise typer.Exit(code=_gate(exit_code, gate_errors=gate_errors))
 
 
 # =============================================================================
@@ -2615,6 +2629,28 @@ def _doctor_exit_code(
     if has_warn:
         return 1
     return 0
+
+
+def _gate(exit_code: int, *, gate_errors: bool) -> int:
+    """Fold the warning exit to 0 when *gate_errors* is set.
+
+    The doctor's native contract is 0/1/2 for ok/warnings/errors. The
+    pre-commit gate opts into error-only blocking with ``--gate-errors``:
+    warning-level provider-mirror lag is the expected steady state after any
+    builtins change (``check-provider-artifacts`` forbids committing the
+    regenerated mirror), so a warning-strict gate would deadlock every commit.
+    Errors (exit 2) still fail; a clean run (0) is unaffected.
+
+    Args:
+        exit_code: The native doctor exit code (0, 1, or 2).
+        gate_errors: When ``True``, map the warning code (1) to 0.
+
+    Returns:
+        The gated exit code.
+    """
+    if gate_errors and exit_code < 2:
+        return 0
+    return exit_code
 
 
 def _run_edit_command(

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -655,7 +655,13 @@ _HOOK_SUBCOMMAND: dict[PrecommitHook, str] = {
     PrecommitHook.VAULT_FIX: "vault check all --fix",
     PrecommitHook.VAULT_SANITIZE_ANNOTATIONS: "vault sanitize annotations",
     PrecommitHook.CHECK_PROVIDER_ARTIFACTS: "check-providers",
-    PrecommitHook.SPEC_CHECK: "spec doctor",
+    # ``--gate-errors`` folds the doctor's warning exit (1) to 0 so the gate
+    # blocks only on errors. Warning-level provider-mirror lag is the expected
+    # steady state after any builtins change - check-provider-artifacts forbids
+    # committing the regenerated mirror - so a warning-strict gate would
+    # deadlock every commit. This is the canonical entry, not a hand-hardened
+    # local override, so sync renders it directly rather than clobbering it.
+    PrecommitHook.SPEC_CHECK: "spec doctor --gate-errors",
 }
 _HOOK_META: dict[PrecommitHook, dict[str, object]] = {
     PrecommitHook.VAULT_FIX: {"name": "Vault fix", "types": ["markdown"]},

--- a/src/vaultspec_core/tests/cli/test_doctor.py
+++ b/src/vaultspec_core/tests/cli/test_doctor.py
@@ -255,3 +255,49 @@ class TestTopLevelDoctorCommand:
         factory = WorkspaceFactory(tmp_path)
         result = factory.run("doctor")
         assert result.exit_code == 2
+
+
+class TestDoctorGateErrors:
+    """``spec doctor --gate-errors`` folds the warning exit to 0.
+
+    The ``spec-check`` pre-commit hook opts into this so warning-level
+    provider-mirror lag - the expected steady state after any builtins
+    change - never deadlocks commits, while real errors still fail the gate.
+    Each test drives the real CLI against an on-disk workspace built by the
+    factory; no doubles.
+    """
+
+    def test_warning_state_fails_without_flag(self, tmp_path: Path) -> None:
+        # Stale synced provider content is a warning (exit 1) - the bare hook
+        # form that deadlocks commits.
+        factory = WorkspaceFactory(tmp_path)
+        factory.install().outdated_vaultspec_rules("claude")
+        result = factory.run("spec", "doctor")
+        assert result.exit_code == 1, result.output
+
+    def test_gate_errors_folds_warning_to_zero(self, tmp_path: Path) -> None:
+        factory = WorkspaceFactory(tmp_path)
+        factory.install().outdated_vaultspec_rules("claude")
+        result = factory.run("spec", "doctor", "--gate-errors")
+        assert result.exit_code == 0, result.output
+
+    def test_gate_errors_still_fails_on_error(self, tmp_path: Path) -> None:
+        # A corrupted manifest is an error (exit 2); the gate must still fail.
+        factory = WorkspaceFactory(tmp_path)
+        factory.install().corrupt_manifest()
+        result = factory.run("spec", "doctor", "--gate-errors")
+        assert result.exit_code == 2, result.output
+
+    def test_gate_errors_clean_is_zero(self, tmp_path: Path) -> None:
+        factory = WorkspaceFactory(tmp_path)
+        factory.install()
+        result = factory.run("spec", "doctor", "--gate-errors")
+        assert result.exit_code == 0, result.output
+
+    def test_gate_errors_json_folds_warning(self, tmp_path: Path) -> None:
+        factory = WorkspaceFactory(tmp_path)
+        factory.install().outdated_vaultspec_rules("claude")
+        result = factory.run("spec", "doctor", "--gate-errors", "--json")
+        assert result.exit_code == 0, result.output
+        # The report still records the warning; only the exit code is folded.
+        assert json.loads(result.output)["data"]["providers"]

--- a/src/vaultspec_core/tests/cli/test_flow_bugs.py
+++ b/src/vaultspec_core/tests/cli/test_flow_bugs.py
@@ -346,6 +346,76 @@ class TestPrekShortCircuit:
         assert (tmp_path / ".pre-commit-config.yaml").exists()
 
 
+class TestSpecCheckGateEntry:
+    """Regression: the canonical ``spec-check`` entry is the error-gating form.
+
+    Warning-strict ``spec doctor`` deadlocks commits because provider-mirror
+    lag is a warning-level steady state. The canonical hook must carry
+    ``--gate-errors`` so ``sync`` renders the non-deadlocking form directly,
+    and a config already on that form must be a no-op (no clobber, no diff).
+    """
+
+    def _spec_check_entry(self, root: Path) -> str:
+        import yaml
+
+        data = yaml.safe_load(
+            (root / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+        )
+        local = next(r for r in data["repos"] if r.get("repo") == "local")
+        return next(h["entry"] for h in local["hooks"] if h["id"] == "spec-check")
+
+    def test_scaffold_emits_gate_errors_form(self, tmp_path: Path) -> None:
+        _scaffold_precommit(tmp_path)
+        assert self._spec_check_entry(tmp_path).endswith("spec doctor --gate-errors")
+
+    def test_bare_entry_is_upgraded_to_gate_form(self, tmp_path: Path) -> None:
+        import yaml
+
+        # A repo carrying the old warning-strict bare form.
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            yaml.dump(
+                {
+                    "repos": [
+                        {
+                            "repo": "local",
+                            "hooks": [
+                                {
+                                    "id": "spec-check",
+                                    "name": "Spec check",
+                                    "entry": "uv run --no-sync vaultspec-core "
+                                    "spec doctor",
+                                    "language": "system",
+                                    "types": ["markdown"],
+                                    "pass_filenames": False,
+                                }
+                            ],
+                        }
+                    ]
+                },
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+        changed = _scaffold_precommit(tmp_path)
+
+        assert changed == [(".pre-commit-config.yaml", "precommit")]
+        assert self._spec_check_entry(tmp_path).endswith("spec doctor --gate-errors")
+
+    def test_gate_form_entry_is_noop(self, tmp_path: Path) -> None:
+        # First scaffold renders the canonical gating form; a second pass over
+        # the identical config must make no change (no clobber loop).
+        _scaffold_precommit(tmp_path)
+        before = (tmp_path / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+        second = _scaffold_precommit(tmp_path)
+
+        assert second == []
+        assert (tmp_path / ".pre-commit-config.yaml").read_text(
+            encoding="utf-8"
+        ) == before
+
+
 # ---- Domain 2 + domain 1 end-to-end: install leaves a clean tree -------------
 
 
@@ -1210,7 +1280,7 @@ _HOOK_SUBCOMMANDS = {
     "vault-fix": "vault check all --fix",
     "vault-sanitize-annotations": "vault sanitize annotations",
     "check-provider-artifacts": "check-providers",
-    "spec-check": "spec doctor",
+    "spec-check": "spec doctor --gate-errors",
 }
 _DEPENDENCY_HOOK_PREFIX = "uv run --no-sync vaultspec-core"
 _TOOL_HOOK_PREFIX = "uvx --from vaultspec-core vaultspec-core"


### PR DESCRIPTION
## Summary

Refs #236. Fixes the commit-deadlock root cause: a bare `spec doctor` spec-check hook exits 1 on warnings, and warning-level provider-mirror lag is the expected steady state after any builtins change (`check-provider-artifacts` forbids committing the regenerated mirror). So the gate blocked every commit - previously worked around with `--no-verify`, and any full `sync` that rewrote a hand-hardened local override reintroduced the deadlock.

## Fix

- New first-class `spec doctor --gate-errors` flag: folds the warning exit (1) to 0, still fails on errors (exit 2). The report is unchanged and still lists every warning.
- Canonical spec-check hook entry becomes `spec doctor --gate-errors`, so `sync` renders the self-gating form directly - no fragile hand-authored wrapper to preserve or clobber. A bare entry is upgraded to the gate form on the next full sync.
- The doctor now flags a non-canonical spec-check entry so drift is visible.
- This repo''s own `.pre-commit-config.yaml` adopts the gated entry (dogfoods the fix; the spec-check hook on this very PR passed as a result).

## Verification

- `spec doctor` exits 1 on the current warning state; `spec doctor --gate-errors` exits 0; errors still exit 2 (covered by new `TestDoctorGateErrors`).
- `TestSpecCheckGateEntry`: scaffold emits the gate form, a bare entry is upgraded to it, the gate form is a no-op on re-render.
- Full suite: `src/vaultspec_core` **2914 passed**, repo-root `tests/` **330 passed**, 0 failures. ruff check + format, ty, cli-reference --check, check-providers: clean.

## Scope note (deliberately not `Closes`)

#236 also mentions full-sync YAML assembly stripping two explanatory comments and unquoting two mdformat/pymarkdown exclude regexes. That is a separate concern on the config-assembly path and is **not** addressed here. I''ve left #236 open for a maintainer decision on whether that sub-item warrants a follow-up, rather than auto-closing.