### PR TITLE
feat(vault): exec-mapping and body-sections check validators (#233, #234)

### DIFF
--- a/.vault/adr/2026-07-23-vault-check-validators-adr.md
+++ b/.vault/adr/2026-07-23-vault-check-validators-adr.md
@@ -1,0 +1,154 @@
+---
+tags:
+  - '#adr'
+  - '#vault-check-validators'
+date: '2026-07-23'
+modified: '2026-07-23'
+related:
+  - "[[2026-07-23-vault-check-validators-research]]"
+---
+
+# `vault-check-validators` adr: `two read-only vault-check validators` | (**status:** `accepted`)
+
+## Problem Statement
+
+The `vault check` suite has two blind spots, both traced in
+`2026-07-23-vault-check-validators-research` and both descended from the
+unimplemented Phase 3 of the `vault-api` plan. An execution record can declare a
+`step_id` and parent plan that resolve to nothing - a retired id, a renamed plan,
+or a typo - and the vault reports clean (#233). A document body can be missing a
+section its template mandates - an ADR with no `Consequences`, a plan with no
+`Verification` - and every current checker passes it (#234). Both are silent
+integrity gaps in the corpus the whole pipeline depends on, and both need a
+decision now on checker shape, severity, and edge-case policy before any code is
+written.
+
+## Considerations
+
+- Both validators plug into one integration seam: `run_all_checks` registration,
+  `CheckResult`/`CheckDiagnostic` emission, snapshot/graph threading, feature
+  filtering (`2026-07-23-vault-check-validators-research`).
+- The plan parser already exposes live and retired Step ids
+  (`Plan.steps[].canonical_id`, `Plan.retired_step_ids`), so #233 needs no new
+  parsing infrastructure.
+- The shipped templates already carry per-type `##` section sets and resolve
+  through one existing seam (`get_template_path`), so #234 can keep templates as
+  the single source of truth with no hardcoded list.
+- The scanner hides `_archive`, which is both a benefit (archived docs are out of
+  scope for free) and the sharpest #233 trap (an archived parent plan looks
+  "missing" unless probed on disk).
+- Neither gap has an unambiguous auto-repair, unlike `check_schema`'s
+  add-a-`related:`-link fix.
+
+## Considered options
+
+- **One ADR, two read-only checkers (chosen).** Both validators share every
+  integration concern and descend from the same plan phase; one ADR decides both,
+  landing as two checker functions. Cons: a single record covers two behaviors -
+  mitigated by delineating the two decisions explicitly below.
+- **Two separate ADRs.** Rejected: duplicates the identical integration,
+  severity, registration, and test-strategy reasoning across two records that
+  would have to cross-reference each other constantly; fragments one coherent
+  decision.
+- **Extend an existing checker** (fold back-mapping into `check_features`,
+  headings into `check_schema`). Rejected: `check_features` is feature-level
+  presence and `check_schema` is cross-reference edges
+  (`2026-07-23-vault-check-validators-research`); overloading either blurs a clean
+  single-responsibility surface and complicates their existing `--fix` paths.
+- **Make either checker `--fix`-capable.** Rejected: no safe unambiguous repair
+  exists (the correct `step_id` target is unknown; a section's position/ordering/
+  content is the author's). A fix that inserts an empty heading adds noise without
+  resolving the defect.
+- **#234 from a hardcoded section list.** Rejected by the issue and the research:
+  the templates must stay the single source of truth so the two never drift.
+
+## Constraints
+
+- No new dependencies; both checkers use existing modules (`plan.parser`,
+  `vaultcore.hydration`, `vaultcore.parser`, the graph/snapshot). No frontier or
+  maturity risk.
+- Parent-feature stability: #233 depends on `Plan.retired_step_ids` and
+  `parse_plan`, which are mature and covered by the plan test suite; #234 depends
+  on `_TEMPLATE_NAMES` and `get_template_path`, mature since the templates
+  shipped. Both are stable seams, not in-flight features.
+- No-Crash policy: a missing/unreadable template, an unparseable plan, or a legacy
+  exec record without `step_id` must degrade to a skip or a finding, never an
+  exception that aborts `vault check all`.
+
+## Implementation
+
+Two new modules under `src/vaultspec_core/vaultcore/checks/`, each a read-only
+`CheckResult`-returning function, both registered in `run_all_checks` (identical
+call in the fix and non-fix branches, following the `check_encoding` precedent)
+and added to `__all__`.
+
+**`step_id` becomes a first-class field.** `step_id` is added to
+`DocumentMetadata` and parsed by a one-line branch beside `modified` and
+`archived`, so exec back-mapping reads it from the snapshot rather than
+re-parsing each file. This is the ratified decision, not an option.
+
+**Checker one - `exec-mapping` (#233).** Iterates snapshot documents of type
+`exec` (via `get_doc_type`), skipping generated indexes. For each, reads the
+first-class `step_id` and the parent-plan reference. The parent plan is resolved
+from the exec record's `related:` plan-stem link, falling back to locating
+`.vault/plan/<stem>.md`. It then `parse_plan`s the plan and classifies:
+`step_id` present in the live `canonical_id` set -> clean; present only in
+`retired_step_ids` -> WARNING (references a retired Step); absent entirely ->
+WARNING (dangling Step id); parent plan file absent from `.vault/plan/` ->
+before flagging, probe `.vault/_archive/plan/<stem>.md`: if the plan is archived,
+treat as expected (silent, no finding); if truly gone, WARNING. An exec record
+with no `step_id` (legacy, pre-field) is skipped, not flagged. An unparseable
+plan yields a single WARNING against that plan rather than a crash.
+
+**Checker two - `body-sections` (#234).** For each snapshot document whose
+`DocType` is in `_TEMPLATE_NAMES` (excluding `index`, which is generated), loads
+the corresponding template via `get_template_path`, extracts the ordered set of
+`##` headings from the template body as the required sections (no hardcoding),
+and verifies the document body contains each required heading with real authored
+content up to the next `##` or EOF. Absent heading -> finding; present-but-empty
+heading -> finding. A section holding only a scaffold hint-comment (an HTML
+comment block) or only an unreplaced `{placeholder}` counts as **empty** ->
+finding, so a scaffolded-but-unauthored document does not pass. Author-added
+extra sections are ignored. Exec documents select between `exec-step.md` and
+`exec-summary.md` by the summary-filename convention. A missing or unreadable
+template for a type degrades to a skip (no finding), never a crash.
+
+Severity: both checkers emit **WARNING** for their defects (ratified). Both are
+read-only (`supports_fix=False`, ratified); each finding's `fix_description`
+names the manual remedy (correct or retire the `step_id`; add or fill the named
+section).
+
+## Rationale
+
+WARNING, not ERROR, because both defects are corpus-hygiene signals that the
+existing large vault and legacy records would surface in volume, and an ERROR
+fails the doctor exit code and can gate commits (mirroring the #236 reasoning that
+warning-level lag must not deadlock). `check_features` sets the precedent of
+WARNING for structural-completeness gaps
+(`2026-07-23-vault-check-validators-research`), whereas `check_schema` reserves
+ERROR for a hard missing-grounding edge with an auto-fix. Read-only wins because
+neither defect has a safe unambiguous repair, and an inserted empty section or a
+guessed `step_id` would degrade signal. One ADR wins because the two validators
+are one integration decision with two leaves, exactly as `references.py` already
+co-locates two sibling checkers. Deriving #234's sections from the templates wins
+on the single-source-of-truth criterion the issue makes binding: any future
+template edit updates the contract with zero checker change.
+
+## Consequences
+
+Gains: every exec record is provably anchored to a live Step, and every document
+body is provably section-complete against its template, closing two silent
+integrity gaps and completing the stalled `vault-api` Phase 3. The template-derived
+approach means #234 never drifts from the templates.
+
+Difficulties and pitfalls: the first `vault check` run on an established vault may
+surface a burst of pre-existing WARNINGs (legacy docs missing newer sections, old
+exec records) - acceptable as advisory and non-blocking, but the plan must note
+it so it is not mistaken for a regression. The `_archive` probe in #233 is the
+one correctness-critical edge; its regression test is mandatory. Plans are the
+tier-conditional #234 case - the four plan H2s are present at every tier, so
+heading-presence holds; implementation must confirm `Parallelization` is genuinely
+required at `L1` rather than tier-gated. Empty-section detection treats a
+hint-comment-only or `{placeholder}`-only required section as empty (ratified), so
+it is robust to the scaffold comments a fresh document carries before authoring
+and cannot be satisfied by an unedited scaffold.

--- a/.vault/audit/2026-07-23-vault-check-validators-audit.md
+++ b/.vault/audit/2026-07-23-vault-check-validators-audit.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#audit'
+  - '#vault-check-validators'
+date: '2026-07-23'
+modified: '2026-07-23'
+related:
+  - '[[2026-07-23-vault-check-validators-adr]]'
+  - '[[2026-07-23-vault-check-validators-plan]]'
+---
+
+# `vault-check-validators` audit: `verify-phase review of two read-only validators`
+
+## Scope
+
+The exec-mapping and body-sections validators implemented against the accepted decision and executed through the fifteen-step plan. This is the verify phase run before merge to the main branch, covering correctness, decision adherence, test integrity, and the volume of findings each checker surfaces on the established corpus.
+
+## Findings
+
+### verification-gates | low | All static and test gates pass with no regressions
+
+Ruff, ruff-format, and the type checker are clean. The full unit suite reports 2951 passing and the repository-root suite 330 passing, 3281 in total with zero failures. Adding `step_id` to the document metadata did not regress the message-server or metadata-parser paths.
+
+### body-sections-volume | low | The 749 body-sections warnings are legitimate pre-existing debt, not false positives
+
+Sampled flagged documents confirm genuine misses. An older decision record lacks the template-mandated Considered-options section; a free-form decision record predating the current template lacks four mandated sections. 385 of roughly 1100 documents carry section debt accumulated before the templates were standardized. The warning severity keeps this advisory and non-blocking, exactly as the decision intended.
+
+### exec-mapping-behaviour | low | The single exec-mapping warning is a genuine dangling reference and the archive probe is correct
+
+The one finding flags an execution record declaring a Step that does not exist in its parent plan. The mandatory archived-parent regression test writes a plan under the archive path and asserts the probe treats an archived parent as the expected steady state, producing no finding.
+
+### review-process | medium | The dispatched review agent returned no report; independent verification substituted
+
+The verify-phase reviewer ran but surfaced no findings message. Independent verification covered its full scope: decision adherence (both checkers warning-level and read-only), exec-mapping classification and the archive probe, body-sections legitimacy, the step-id metadata field, test integrity (real filesystem, no mocks), and registration in both the fix and non-fix check branches.
+
+## Recommendations
+
+Backfill the body-section debt over time; the warning severity makes this optional and non-blocking as intended, so it need not gate any release. No architectural follow-on is required - ship the two validators.

--- a/.vault/index/vault-check-validators.index.md
+++ b/.vault/index/vault-check-validators.index.md
@@ -1,0 +1,35 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#vault-check-validators'
+date: '2026-07-23'
+modified: '2026-07-23'
+related:
+  - '[[2026-07-23-vault-check-validators-adr]]'
+  - '[[2026-07-23-vault-check-validators-audit]]'
+  - '[[2026-07-23-vault-check-validators-plan]]'
+  - '[[2026-07-23-vault-check-validators-research]]'
+---
+
+# `vault-check-validators` feature index
+
+Auto-generated index of all documents tagged with `#vault-check-validators`.
+
+## Documents
+
+### adr
+
+- `2026-07-23-vault-check-validators-adr` - `vault-check-validators` adr: `two read-only vault-check validators` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-23-vault-check-validators-audit` - `vault-check-validators` audit: `verify-phase review of two read-only validators`
+
+### plan
+
+- `2026-07-23-vault-check-validators-plan` - `vault-check-validators` plan
+
+### research
+
+- `2026-07-23-vault-check-validators-research` - `vault-check-validators` research: `two missing vault-check validators`

--- a/.vault/plan/2026-07-23-vault-check-validators-plan.md
+++ b/.vault/plan/2026-07-23-vault-check-validators-plan.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - '#plan'
+  - '#vault-check-validators'
+date: '2026-07-23'
+modified: '2026-07-23'
+tier: L2
+related:
+  - '[[2026-07-23-vault-check-validators-adr]]'
+  - '[[2026-07-23-vault-check-validators-research]]'
+---
+
+# `vault-check-validators` plan
+
+## Description
+
+Implement the two read-only `vault check` validators decided in the accepted
+ADR: `exec-mapping` (#233), which confirms every execution record maps back to a
+live Step in its parent plan, and `body-sections` (#234), which confirms every
+document body carries the sections its template mandates. Both emit WARNING, both
+are read-only, and both wire into `run_all_checks` behind one integration seam.
+The work proceeds in dependency order: the `step_id` frontmatter field first
+(P01), then each checker with its tests (P02, P03), then suite registration
+(P04). Note for execution and review: the first `vault check` run against the
+established vault will surface a burst of pre-existing WARNINGs (legacy documents
+missing newer sections, older exec records) - this is the expected, non-blocking
+steady state the ADR anticipated, not a regression introduced by these checkers.
+
+## Steps
+
+### Phase `P01` - step_id first-class field
+
+Make the originating Step id a parsed frontmatter field so exec back-mapping reads it from the snapshot.
+
+- [x] `P01.S01` - Add a step_id field to DocumentMetadata and parse it in parse_vault_metadata beside modified and archived; `src/vaultspec_core/vaultcore/models.py, src/vaultspec_core/vaultcore/parser.py`.
+- [x] `P01.S02` - Add a unit test asserting step_id parses from exec-record frontmatter and is None when absent; `src/vaultspec_core/vaultcore/tests/test_parser.py`.
+
+### Phase `P02` - exec-mapping checker (#233)
+
+Validate every execution record maps back to a live Step in its parent plan, distinguishing archived parents from dangling references.
+
+- [x] `P02.S03` - Implement the exec-mapping checker classifying each exec record step_id as live, retired, or dangling against its parse_plan-resolved parent plan, resolving the plan from the related link with a plan-stem filename fallback under the plan directory and skipping legacy records that carry no step_id; `src/vaultspec_core/vaultcore/checks/exec_mapping.py`.
+- [x] `P02.S04` - Add the archived-parent probe so a parent plan found under .vault/\_archive/plan/ yields no finding while a truly-absent plan yields a warning; `src/vaultspec_core/vaultcore/checks/exec_mapping.py`.
+- [x] `P02.S05` - Degrade an unparseable parent plan to a single warning against that plan rather than raising, honouring the no-crash policy; `src/vaultspec_core/vaultcore/checks/exec_mapping.py`.
+- [x] `P02.S06` - Add real-filesystem tests for valid mapping, retired step id, dangling step id, and truly-missing parent plan; `src/vaultspec_core/vaultcore/checks/tests/test_exec_mapping.py`.
+- [x] `P02.S07` - Add the mandatory archived-parent regression test asserting an exec record whose plan is archived produces no finding; `src/vaultspec_core/vaultcore/checks/tests/test_exec_mapping.py`.
+- [x] `P02.S08` - Add a test that an unparseable parent plan degrades to a warning and does not crash the checker; `src/vaultspec_core/vaultcore/checks/tests/test_exec_mapping.py`.
+
+### Phase `P03` - body-sections checker (#234)
+
+Validate every document body carries the sections its template mandates, treating comment-only or placeholder-only sections as empty.
+
+- [x] `P03.S09` - Implement the body-sections checker deriving required sections from each document type's template via get_template_path and \_TEMPLATE_NAMES, flagging any required heading that is absent or holds only a hint comment or unreplaced placeholder, and selecting the exec-step or exec-summary template by the summary-filename convention; `src/vaultspec_core/vaultcore/checks/body_sections.py`.
+- [x] `P03.S10` - Degrade a missing or unreadable template for a document type to a skip with no finding rather than raising; `src/vaultspec_core/vaultcore/checks/body_sections.py`.
+- [x] `P03.S11` - Add real-filesystem tests covering present, absent, and empty required sections for the adr, plan, research, reference, audit, and exec document types; `src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py`.
+- [x] `P03.S12` - Add a tier-conditional test asserting the four plan sections are required across plan tiers; `src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py`.
+- [x] `P03.S13` - Add an empty-section detection test asserting a comment-only section and a placeholder-only section are each flagged as empty; `src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py`.
+
+### Phase `P04` - registration and suite integration
+
+Wire both checkers into the run_all_checks suite read-only and confirm they surface through the aggregate check.
+
+- [x] `P04.S14` - Register both checkers in run_all_checks in the fix and non-fix branches following the read-only check_encoding precedent and add them to __all__; `src/vaultspec_core/vaultcore/checks/__init__.py`.
+- [x] `P04.S15` - Add an integration test asserting both checkers appear in run_all_checks output and report fixed_count zero in the fix branch; `src/vaultspec_core/vaultcore/checks/tests/test_run_all.py`.
+
+## Parallelization
+
+P01 must land first: both checkers and their tests depend on the `step_id`
+field. P02 (exec-mapping) and P03 (body-sections) are independent of each other
+and may be executed in parallel once P01 is closed. Within P02 and P03 the
+implementation Steps precede their test Steps. P04 (registration) is last: it
+depends on both checker modules existing, and its integration test depends on
+both being registered.
+
+## Verification
+
+The plan is complete when every Step is closed. Each checker is verified by its
+own real-filesystem tests (no doubles): exec-mapping proves the valid, retired,
+dangling, and truly-missing-plan classifications plus the mandatory
+archived-parent probe and the unparseable-plan degradation; body-sections proves
+present, absent, and empty-section detection across every document type, the
+tier-conditional plan sections, and comment-only or placeholder-only sections
+reading as empty. Both checkers must surface in `run_all_checks` with
+`fixed_count` zero (read-only). The full suite (`pytest src/vaultspec_core`), the
+repo-root tree (`pytest tests`), `ruff check`, `ruff format --check`, and `ty`
+must all pass, and a `vaultspec-code-review` audit signs off before close.

--- a/.vault/research/2026-07-23-vault-check-validators-research.md
+++ b/.vault/research/2026-07-23-vault-check-validators-research.md
@@ -1,0 +1,183 @@
+---
+tags:
+  - '#research'
+  - '#vault-check-validators'
+date: '2026-07-23'
+modified: '2026-07-23'
+related: []
+---
+
+# `vault-check-validators` research: `two missing vault-check validators`
+
+Two gaps in the `vault check` suite were originally scoped as Phase 3 of the
+stalled `vault-api` plan and never implemented. The first: no checker confirms
+that an execution record maps back to a live Step row in its parent plan, so a
+retired id, renamed plan, or typo in an exec record reports clean. The second:
+no checker confirms a document body carries the sections its template mandates,
+so an ADR missing `Consequences` passes every check. This document grounds both
+in the real checker architecture, the exec/plan/template data structures, and
+frames the design space the ADR must settle. The evidence favors two sibling
+read-only checkers sharing one integration seam; the ADR decides names,
+severity, template-derivation mechanics, and the edge-case policy.
+
+## Findings
+
+### The checker contract is a uniform, snapshot-fed function returning `CheckResult`
+
+Every checker is a module-level function that returns a
+`CheckResult(check_name=..., supports_fix=bool)` carrying a list of
+`CheckDiagnostic(path, message, severity, fixable, fix_description)`
+(`src/vaultspec_core/vaultcore/checks/_base.py:46-64`). Severity is one of
+`Severity.ERROR | WARNING | INFO` (`_base.py:38-43`); the exit code and the
+`--fix` machinery read `fixed_count` and the severity tallies. Checkers are
+registered by being called in order inside `run_all_checks`
+(`src/vaultspec_core/vaultcore/checks/__init__.py:74-210`), which builds one
+`VaultGraph` and its `to_snapshot()` once and threads either the `graph` or the
+`snapshot` into each checker, refreshing the graph only after a mutating checker
+reports `fixed_count` (`__init__.py:130-134`). A new checker is added by
+importing it, appending it to both the non-fix and fix branches, and adding it
+to `__all__`. Read-only checkers (`check_encoding`, `check_feature_rename_integrity`)
+run identically in both branches (`__init__.py:191,209`), which is the precedent
+both new checkers follow.
+
+### The snapshot is `path -> (DocumentMetadata, body)`; `step_id` is not yet parsed
+
+`VaultSnapshot` is `dict[Path, tuple[DocumentMetadata, str]]` (`_base.py:20-24`),
+the body being the post-frontmatter text. `check_features` and
+`check_modified_stamp` consume it directly. Crucially, the vaultcore parser does
+NOT surface `step_id`: `parse_vault_metadata` populates `date`, `modified`,
+`superseded_by`, `archived`, `tags`, `related`, etc. (`parser.py:177-194`) but has
+no `step_id` branch, and `DocumentMetadata` (`models.py:295`) has no such field.
+The dict-returning `parse_frontmatter(content) -> (dict, body)` (`parser.py:91`)
+does expose arbitrary keys including `step_id`. So the exec checker either reads
+`step_id` via `parse_frontmatter` per exec doc, or the model gains a first-class
+`step_id` field. The exec template confirms the two anchoring fields:
+`step_id: '{step_id}'` in frontmatter and the parent plan as a
+`related: ['[[{plan_stem}]]']` wiki-link (`.vaultspec/templates/exec-step.md`),
+both machine-filled by `vaultspec-core vault add exec`.
+
+### Exec-to-plan back-mapping (#233) has a ready data path via `parse_plan`
+
+A plan document parses to a `Plan` model exposing every live Step id and every
+retired id: `Plan.steps[].canonical_id` (`src/vaultspec_core/plan/parser.py:61`,
+`138-178`) and `Plan.retired_step_ids: set[str]` (`parser.py:176`), the latter
+persisted in a hidden comment ledger so retirement survives round-trips. The
+`Step.canonical_id` is the leaf `S##`. `parse_plan(source)` accepts a path or
+text (`parser.py:209`). So #233 resolves, per exec record: the parent plan (from
+the `related:` plan-stem link, or by locating `.vault/plan/<stem>.md`), then
+`parse_plan` it, then classify `step_id` as live (in `canonical_id` set),
+retired (in `retired_step_ids` -> finding), or absent (dangling -> finding);
+a missing plan file is its own finding. `get_doc_type` (`scanner.py:111`)
+classifies exec docs by their `.vault/exec/` location.
+
+### Archived parents are the sharp #233 edge: the scanner hides `_archive`
+
+`scan_vault` skips any path containing `_archive` (`scanner.py:70`), so the graph
+and snapshot never contain an archived plan. A naive "plan not in snapshot ->
+missing" rule would therefore misreport every exec record whose plan was archived
+(the expected, benign steady state) as a dangling defect. #233 must probe
+`.vault/_archive/plan/<stem>.md` on disk before emitting a missing-plan finding,
+distinguishing an archived parent (expected; INFO or silent) from a truly-absent
+one (defect). Archived exec records themselves are already out of scope because
+the scanner hides them.
+
+### Legacy exec records without `step_id` are unmappable, not defective
+
+Exec records created before the `step_id` field existed carry no canonical id to
+resolve. The checker cannot back-map them and must skip them (no finding, or at
+most INFO) rather than flag absence as a dangling reference; flagging would flood
+legacy corpora. This mirrors how `check_modified_stamp` treats a fresh-clone
+signature as a systemic condition to suppress rather than a per-doc defect
+(`checks/modified_stamp.py`).
+
+### Template-mandated sections (#234) are derivable H2 headings, per doc type
+
+Each shipped template carries a fixed set of `##` section headings that
+constitute its body contract. Enumerated from `src/vaultspec_core/builtins/templates/`:
+adr -> Problem Statement, Considerations, Considered options, Constraints,
+Implementation, Rationale, Consequences (`adr.md:51-90`); plan -> Description,
+Steps, Parallelization, Verification (`plan.md:102-172`); research -> Findings,
+Sources (`research.md:42-51`); reference -> Summary (`reference.md:37`); audit ->
+Scope, Findings, Recommendations (`audit.md:32-47`); exec-step -> Description,
+Outcome, Notes (`exec-step.md:47-53`); exec-summary -> Description
+(`exec-summary.md:45`); index -> Documents (`index.md:27`, auto-generated, out of
+scope). The H1 lines carry placeholders (`# {feature} adr: {title}`) but the H2
+section titles are literal, so a template-driven checker derives the required set
+by extracting `##` headings from the template body with no hardcoding.
+
+### #234 reuses the existing template-resolution seam
+
+Templates resolve at runtime from `root_dir / framework_dir / "templates"` (i.e.
+`.vaultspec/templates/`) via `get_template_path` (`hydration.py:553-593`), and the
+`DocType -> filename` map already exists as `_TEMPLATE_NAMES`
+(`hydration.py:33-41`), with exec's second template (`exec-summary.md`) handled by
+a `summary` selector (`hydration.py:52`). #234 reuses this map and resolution so
+the templates remain the single source of truth. A missing or unreadable template
+(uninstalled or corrupted `.vaultspec/`) must degrade gracefully (skip that doc
+type, optional INFO), never crash - consistent with the "No-Crash" policy.
+
+### #234 must detect empty sections, not just absent headings
+
+The acceptance criterion is "absent OR empty." A present `## Consequences` with no
+prose before the next heading is still a defect. So the checker parses the doc
+body into heading-delimited sections and, for each required heading, verifies both
+presence and non-whitespace content up to the next `##` (or EOF). Author-added
+extra sections are tolerated; only the absence or emptiness of a required section
+is a finding. Plans are the tier-conditional case: the four plan H2s are present
+at every tier (only their content shape varies), so heading-presence still holds,
+but the ADR should confirm whether `Parallelization` is required at `L1`.
+
+### Nearest analogues confirm the shape and that neither gap is covered
+
+`check_features` (`features.py:67`) is feature-level presence (exec-without-plan,
+plan-without-ADR) - not per-record step resolution. `check_schema`
+(`references.py:217`) enforces cross-reference edges (ADR grounded by research,
+plan governed by ADR) - it inspects `related:` links, never Step ids or body
+headings. `check_structure` (`structure.py:338`) enforces directory and filename
+conventions only. Both new checkers are genuinely new surface. `check_schema`
+also demonstrates the read-only-vs-fix boundary: it offers `--fix` only because a
+missing `related:` link has an unambiguous auto-repair (add the wiki-link). No such
+unambiguous repair exists for a dangling `step_id` (the correct target is unknown)
+or a missing body section (position, ordering, and content are the author's), so
+both new checkers are read-only, which the ADR should ratify.
+
+### One integration seam, two validators: a single ADR is the natural unit
+
+Both validators share every integration concern - registration in
+`run_all_checks`, `CheckResult`/`CheckDiagnostic` emission, snapshot/graph
+consumption, feature filtering, read-only status, archived-doc handling, and a
+real-filesystem per-doc-type test strategy - and both descend from the same
+Phase 3 of the `vault-api` plan. They differ only in data source (plan parser vs
+templates) and locus (cross-document vs in-document). The codebase already
+co-locates sibling checkers in one module (`references.py` holds both
+`check_references` and `check_schema`). The evidence favors one ADR deciding both,
+with two clearly-delineated validator decisions, over two ADRs duplicating the
+integration boilerplate; the ADR should confirm this and may still land them as
+two separate checker functions/modules.
+
+## Sources
+
+- `src/vaultspec_core/vaultcore/checks/_base.py:20,38-64` - `CheckResult`,
+  `CheckDiagnostic`, `Severity`, `VaultSnapshot` contract.
+- `src/vaultspec_core/vaultcore/checks/__init__.py:74-210` - `run_all_checks`
+  registration, graph/snapshot threading, read-only checker precedent.
+- `src/vaultspec_core/vaultcore/checks/features.py:67,122-154` - feature-level
+  presence checker (nearest analogue, not back-mapping).
+- `src/vaultspec_core/vaultcore/checks/references.py:217-425` - `check_schema`
+  cross-reference rules and `--fix` boundary.
+- `src/vaultspec_core/vaultcore/checks/structure.py:338` - structure/filename
+  checker (no heading logic).
+- `src/vaultspec_core/vaultcore/parser.py:91,177-194` - `parse_frontmatter` dict
+  vs `parse_vault_metadata`; no `step_id` branch.
+- `src/vaultspec_core/vaultcore/models.py:295` - `DocumentMetadata` fields.
+- `src/vaultspec_core/plan/parser.py:61,176,209` - `Step.canonical_id`,
+  `Plan.retired_step_ids`, `parse_plan`.
+- `src/vaultspec_core/vaultcore/scanner.py:70,111` - `_archive` exclusion,
+  `get_doc_type`.
+- `src/vaultspec_core/vaultcore/hydration.py:33-41,52,553-593` - `_TEMPLATE_NAMES`,
+  exec-summary selector, `get_template_path` resolution.
+- `.vaultspec/templates/` (adr.md:51-90, plan.md:102-172, research.md:42-51,
+  reference.md:37, audit.md:32-47, exec-step.md:47-53, exec-summary.md:45,
+  index.md:27) - the per-type required H2 section sets.
+- Issues #233, #234; provenance `.vault/plan/2026-02-08-vault-api-plan.md`
+  Phase 3.

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -83,6 +83,10 @@ hand-edit between the markers.
 - `vaultspec-core vault check all` - Run all vault health checks.
 - `vaultspec-core vault check body-links` - Find wiki-links and markdown path links in
   document body text.
+- `vaultspec-core vault check exec-mapping` - Check execution records map to a live Step
+  in their parent plan.
+- `vaultspec-core vault check body-sections` - Check document bodies carry the sections
+  their template mandates.
 - `vaultspec-core vault check annotations` - Find generated template annotations in
   vault documents.
 - `vaultspec-core vault check markdown` - Check and optionally fix markdown hygiene
@@ -574,9 +578,12 @@ management.
 Run diagnostic collectors across the framework, providers, builtins, `.gitignore`, vault
 content, and configuration files.
 
-| Option | Short | Default | Description | | -------------- | ----- | ------- |
+| Option | Short | Default | Description | | ---------------- | ----- | ------- |
 --------------------------- | | `--target DIR` | `-t` | cwd | Diagnose another
-directory. | | `--json` | - | off | Emit the diagnosis as JSON. |
+directory. | | `--json` | - | off | Emit the diagnosis as JSON. | | `--gate-errors` | -
+| off | Fold the warning exit (1) to 0 so only errors (exit 2) fail; used by the
+`spec-check` pre-commit hook so expected provider-mirror lag does not deadlock commits.
+|
 
 ### vaultspec-core spec rules
 
@@ -648,10 +655,11 @@ order and bumps the manifest version.
 ------------------------------------------------------ | | `vaultspec-core vault check`
 | `0` clean, `1` errors found. | | `vaultspec-core vault plan check` | `0` clean, `1` at
 least one ERROR-severity finding. | | `vaultspec-core spec doctor` | `0` all ok, `1`
-warnings, `2` errors. | | `vaultspec-core spec mcps status` | `0` config status ok, `1`
-otherwise. | | `vaultspec-core migrations status` | `0` up to date or no manifest, `1`
-migrations pending. | | `vaultspec-core migrations run` | `0` success (including no-op),
-`1` a migration failed. |
+warnings, `2` errors (`--gate-errors` folds `1` to `0`). | |
+`vaultspec-core spec mcps status` | `0` config status ok, `1` otherwise. | |
+`vaultspec-core migrations status` | `0` up to date or no manifest, `1` migrations
+pending. | | `vaultspec-core migrations run` | `0` success (including no-op), `1` a
+migration failed. |
 
 ## Environment variables
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -148,6 +148,10 @@ full options.
 - `vaultspec-core vault check all` - Run all vault health checks.
 - `vaultspec-core vault check body-links` - Find wiki-links and markdown path links in
   document body text.
+- `vaultspec-core vault check exec-mapping` - Check execution records map to a live Step
+  in their parent plan.
+- `vaultspec-core vault check body-sections` - Check document bodies carry the sections
+  their template mandates.
 - `vaultspec-core vault check annotations` - Find generated template annotations in
   vault documents.
 - `vaultspec-core vault check markdown` - Check and optionally fix markdown hygiene

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -83,6 +83,10 @@ hand-edit between the markers.
 - `vaultspec-core vault check all` - Run all vault health checks.
 - `vaultspec-core vault check body-links` - Find wiki-links and markdown path links in
   document body text.
+- `vaultspec-core vault check exec-mapping` - Check execution records map to a live Step
+  in their parent plan.
+- `vaultspec-core vault check body-sections` - Check document bodies carry the sections
+  their template mandates.
 - `vaultspec-core vault check annotations` - Find generated template annotations in
   vault documents.
 - `vaultspec-core vault check markdown` - Check and optionally fix markdown hygiene

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -1440,6 +1440,58 @@ def cmd_check_body_links(
     )
 
 
+@check_app.command("exec-mapping")
+def cmd_check_exec_mapping(
+    feature: Annotated[
+        str | None, typer.Option("--feature", "-f", help="Filter by feature tag")
+    ] = None,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Show INFO-level diagnostics")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Check execution records map to a live Step in their parent plan."""
+    apply_target(target)
+    from vaultspec_core.core.types import get_context as _get_ctx
+    from vaultspec_core.graph import VaultGraph
+    from vaultspec_core.vaultcore.checks import check_exec_mapping
+
+    snapshot = VaultGraph(_get_ctx().target_dir).to_snapshot()
+    result = check_exec_mapping(
+        _get_ctx().target_dir, snapshot=snapshot, feature=feature
+    )
+    _render_and_exit(
+        result, verbose, json_output=json_output, command="vault.check.exec-mapping"
+    )
+
+
+@check_app.command("body-sections")
+def cmd_check_body_sections(
+    feature: Annotated[
+        str | None, typer.Option("--feature", "-f", help="Filter by feature tag")
+    ] = None,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Show INFO-level diagnostics")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Check document bodies carry the sections their template mandates."""
+    apply_target(target)
+    from vaultspec_core.core.types import get_context as _get_ctx
+    from vaultspec_core.graph import VaultGraph
+    from vaultspec_core.vaultcore.checks import check_body_sections
+
+    snapshot = VaultGraph(_get_ctx().target_dir).to_snapshot()
+    result = check_body_sections(
+        _get_ctx().target_dir, snapshot=snapshot, feature=feature
+    )
+    _render_and_exit(
+        result, verbose, json_output=json_output, command="vault.check.body-sections"
+    )
+
+
 @check_app.command("annotations")
 def cmd_check_annotations(
     fix: Annotated[

--- a/src/vaultspec_core/graph/api.py
+++ b/src/vaultspec_core/graph/api.py
@@ -1178,12 +1178,15 @@ class VaultGraph:
             superseded_by = (
                 raw_superseded_by if isinstance(raw_superseded_by, str) else None
             )
+            raw_step_id = node.frontmatter.get("step_id")
+            step_id = raw_step_id if isinstance(raw_step_id, str) else None
             metadata = DocumentMetadata(
                 tags=sorted(node.tags),
                 date=node.date,
                 modified=node.modified,
                 related=related,
                 superseded_by=superseded_by,
+                step_id=step_id,
             )
             snapshot[node.path] = (metadata, node.body)
         return snapshot

--- a/src/vaultspec_core/tests/cli/test_vault_repair.py
+++ b/src/vaultspec_core/tests/cli/test_vault_repair.py
@@ -615,6 +615,8 @@ class TestVaultRepair:
             "placeholders",
             "orphans",
             "features",
+            "exec-mapping",
+            "body-sections",
             "feature-rename-integrity",
             "references",
             "schema",

--- a/src/vaultspec_core/vaultcore/checks/__init__.py
+++ b/src/vaultspec_core/vaultcore/checks/__init__.py
@@ -24,9 +24,11 @@ from ._base import (
 from .adr_status import check_adr_status
 from .annotations import check_annotations
 from .body_links import check_body_links
+from .body_sections import check_body_sections
 from .code_boundary import check_code_boundary
 from .dangling import check_dangling
 from .encoding import check_encoding
+from .exec_mapping import check_exec_mapping
 from .feature_rename_integrity import check_feature_rename_integrity
 from .features import check_features
 from .frontmatter import check_frontmatter
@@ -51,9 +53,11 @@ __all__ = [
     "check_adr_status",
     "check_annotations",
     "check_body_links",
+    "check_body_sections",
     "check_code_boundary",
     "check_dangling",
     "check_encoding",
+    "check_exec_mapping",
     "check_feature_rename_integrity",
     "check_features",
     "check_frontmatter",
@@ -81,8 +85,8 @@ def run_all_checks(
 
     Executes structure, frontmatter, modified-stamp, annotations, markdown,
     links, dangling, body-links, placeholders, orphans, features,
-    feature-rename-integrity, references, schema, adr-status,
-    rename-integrity, and encoding checks in order. Builds a single
+    exec-mapping, body-sections, feature-rename-integrity, references, schema,
+    adr-status, rename-integrity, and encoding checks in order. Builds a single
     :class:`~vaultspec_core.graph.VaultGraph` and shares it across
     graph-consuming checkers to avoid redundant I/O.
 
@@ -114,6 +118,8 @@ def run_all_checks(
             check_placeholders(root_dir, snapshot=snapshot, feature=feature),
             check_orphans(root_dir, graph=graph, feature=feature),
             check_features(root_dir, snapshot=snapshot, feature=feature),
+            check_exec_mapping(root_dir, snapshot=snapshot, feature=feature),
+            check_body_sections(root_dir, snapshot=snapshot, feature=feature),
             check_feature_rename_integrity(root_dir),
             check_references(root_dir, graph=graph, feature=feature, fix=False),
             check_schema(root_dir, graph=graph, feature=feature, fix=False),
@@ -185,6 +191,15 @@ def run_all_checks(
     results.append(check_orphans(root_dir, graph=graph, feature=feature))
     results.append(
         check_features(root_dir, snapshot=graph.to_snapshot(), feature=feature)
+    )
+    # Exec-mapping and body-sections are read-only (no dangling reference or
+    # missing section has an unambiguous auto-repair); they run identically in
+    # both modes, following the check_encoding precedent.
+    results.append(
+        check_exec_mapping(root_dir, snapshot=graph.to_snapshot(), feature=feature)
+    )
+    results.append(
+        check_body_sections(root_dir, snapshot=graph.to_snapshot(), feature=feature)
     )
     # Feature-rename-integrity is read-only (reconciling drift is a feature
     # rename, not a frontmatter rewrite); it runs identically in both modes.

--- a/src/vaultspec_core/vaultcore/checks/body_sections.py
+++ b/src/vaultspec_core/vaultcore/checks/body_sections.py
@@ -1,0 +1,193 @@
+"""Validate a document body against the sections its template mandates.
+
+The shipped templates in ``.vaultspec/templates/`` are the single source of
+truth for a document type's required sections: each template carries a fixed
+set of level-two (``## ``) headings that constitute the body contract. Nothing
+previously confirmed a document actually kept them - an ADR could ship without
+its ``Consequences`` section and pass every check.
+
+This checker derives the required sections per document type by extracting the
+``## `` headings from that type's template (never a hardcoded list), then for
+each document verifies every required heading is present and carries real
+authored content. A required section that is absent, or that holds only a
+scaffold hint-comment or an unreplaced ``{placeholder}``, is reported: a
+scaffolded-but-unauthored document cannot satisfy the contract. Author-added
+extra sections are ignored; only the absence or emptiness of a required
+section is a finding.
+
+Edge handling:
+
+- Execution records select ``exec-step.md`` or ``exec-summary.md`` by the
+  ``-summary`` filename convention.
+- Generated feature indexes are out of scope (their body is machine-authored).
+- A document type with no template, or a template that cannot be read, degrades
+  to a skip (no finding) rather than a crash (No-Crash policy).
+
+The checker is read-only: a section's position, ordering, and content are the
+author's, so no safe automatic repair exists. Each finding's ``fix_description``
+names the manual remedy.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from ._base import (
+    CheckDiagnostic,
+    CheckResult,
+    Severity,
+    extract_feature_tags,
+    is_generated_index,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ._base import VaultSnapshot
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["check_body_sections"]
+
+#: A level-two heading line (``## Title``), excluding deeper ``### `` headings.
+_H2_RE = re.compile(r"^##[ \t]+(?P<title>\S.*?)\s*$", re.MULTILINE)
+
+#: An HTML comment block, stripped before content-emptiness is judged.
+_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+#: Content consisting only of ``{placeholder}`` tokens and whitespace, treated
+#: as empty so an unauthored scaffold section does not satisfy the contract.
+_PLACEHOLDER_ONLY_RE = re.compile(r"^(?:\s*\{[^{}]*\}\s*)+$")
+
+
+def _required_sections(template_text: str) -> list[str]:
+    """Return the ordered ``## `` section titles a template mandates.
+
+    HTML comment blocks (which embed example headings in the scaffold hints)
+    are stripped first so only the template's real headings are extracted.
+    """
+    stripped = _COMMENT_RE.sub("", template_text)
+    return [m.group("title") for m in _H2_RE.finditer(stripped)]
+
+
+def _section_contents(body: str) -> dict[str, str]:
+    """Map each ``## `` heading title in *body* to its raw content.
+
+    Content runs from just after the heading line to the next ``## `` heading
+    or the end of the document. A later duplicate heading overwrites an earlier
+    one; documents do not legitimately repeat a required section.
+    """
+    contents: dict[str, str] = {}
+    matches = list(_H2_RE.finditer(body))
+    for i, match in enumerate(matches):
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        contents[match.group("title")] = body[start:end]
+    return contents
+
+
+def _is_empty(section_body: str) -> bool:
+    """Return ``True`` when a section carries no real authored content.
+
+    A section is empty when, after HTML comments are stripped, nothing but
+    whitespace remains, or when the remainder is only ``{placeholder}`` tokens.
+    """
+    text = _COMMENT_RE.sub("", section_body).strip()
+    if not text:
+        return True
+    return _PLACEHOLDER_ONLY_RE.fullmatch(text) is not None
+
+
+def check_body_sections(
+    root_dir: Path,
+    *,
+    snapshot: VaultSnapshot,
+    feature: str | None = None,
+) -> CheckResult:
+    """Validate every document body carries its template-mandated sections.
+
+    Args:
+        root_dir: Project root directory.
+        snapshot: Pre-built snapshot mapping document paths to parsed
+            ``(metadata, body)`` tuples.
+        feature: Restrict checks to documents carrying this feature tag
+            (without ``#``).
+
+    Returns:
+        :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with check
+        name ``"body-sections"``. Does not support ``--fix``.
+    """
+    from ..hydration import get_template_path
+    from ..scanner import get_doc_type
+
+    result = CheckResult(check_name="body-sections", supports_fix=False)
+
+    # Cache required-section lists per (doc_type, summary) so each template is
+    # read and parsed once per run rather than once per document.
+    required_cache: dict[tuple[str, bool], list[str] | None] = {}
+
+    for doc_path, (metadata, body) in sorted(snapshot.items()):
+        doc_type = get_doc_type(doc_path, root_dir)
+        if doc_type is None:
+            continue
+        if is_generated_index(doc_path):
+            continue
+        if feature:
+            feat = feature.lstrip("#")
+            if feat not in extract_feature_tags(metadata.tags):
+                continue
+
+        is_summary = doc_path.stem.endswith("-summary")
+        cache_key = (doc_type.value, is_summary)
+        if cache_key not in required_cache:
+            template_path = get_template_path(root_dir, doc_type, summary=is_summary)
+            if template_path is None:
+                required_cache[cache_key] = None
+            else:
+                try:
+                    template_text = template_path.read_text(encoding="utf-8")
+                except (OSError, UnicodeDecodeError):
+                    required_cache[cache_key] = None
+                else:
+                    required_cache[cache_key] = _required_sections(template_text)
+
+        required = required_cache[cache_key]
+        if not required:
+            # No template mapping, unreadable template, or a template with no
+            # required sections: nothing to validate against, skip cleanly.
+            continue
+
+        rel_path = doc_path.relative_to(root_dir)
+        contents = _section_contents(body)
+
+        for title in required:
+            if title not in contents:
+                result.diagnostics.append(
+                    CheckDiagnostic(
+                        path=rel_path,
+                        message=(
+                            f"Missing required section '## {title}' mandated by "
+                            f"the {doc_type.value} template."
+                        ),
+                        severity=Severity.WARNING,
+                        fixable=False,
+                        fix_description=f"Add and fill the '## {title}' section.",
+                    )
+                )
+            elif _is_empty(contents[title]):
+                result.diagnostics.append(
+                    CheckDiagnostic(
+                        path=rel_path,
+                        message=(
+                            f"Required section '## {title}' is empty (only "
+                            "scaffold comments or placeholders)."
+                        ),
+                        severity=Severity.WARNING,
+                        fixable=False,
+                        fix_description=f"Author real content under '## {title}'.",
+                    )
+                )
+
+    return result

--- a/src/vaultspec_core/vaultcore/checks/exec_mapping.py
+++ b/src/vaultspec_core/vaultcore/checks/exec_mapping.py
@@ -1,0 +1,206 @@
+"""Back-map every execution record to a live Step in its parent plan.
+
+An execution record carries a ``step_id`` frontmatter stamp and a
+``related:`` wiki-link to its parent plan. Nothing previously confirmed that
+the referenced Step still exists: a retired id, a renamed or deleted plan, or
+a typo left the record pointing at nothing while every check reported clean.
+
+This checker resolves each exec record's parent plan and classifies its
+``step_id`` against the plan's live and retired Step ids:
+
+- ``step_id`` present in the plan's live Step ids -> clean.
+- ``step_id`` present only in the plan's retired ledger -> WARNING (the Step
+  was removed; the record is orphaned).
+- ``step_id`` absent from both -> WARNING (dangling Step id).
+- The parent plan is not found in ``.vault/plan/`` -> before flagging, the
+  ``.vault/_archive/plan/`` tree is probed: an archived parent is the expected,
+  benign steady state and produces no finding, while a truly-absent parent is a
+  WARNING.
+- The parent plan cannot be parsed -> a single WARNING against that plan rather
+  than a crash (No-Crash policy).
+
+A legacy exec record that carries no ``step_id`` (predating the field) cannot
+be back-mapped and is skipped, not flagged. The checker is read-only: no
+dangling reference has an unambiguous automatic repair, so each finding's
+``fix_description`` names the manual remedy instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import TYPE_CHECKING
+
+from ._base import CheckDiagnostic, CheckResult, Severity, extract_feature_tags
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ._base import VaultSnapshot
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["check_exec_mapping"]
+
+#: Strip the ``[[`` / ``]]`` wrapper (and any ``#anchor`` / ``|alias``) from a
+#: ``related:`` wiki-link, yielding the bare document stem.
+_WIKILINK_RE = re.compile(r"^\[\[([^\]#|]+)")
+
+
+def _link_stem(link: str) -> str | None:
+    """Return the bare document stem from a ``[[wiki-link]]`` string."""
+    match = _WIKILINK_RE.match(link.strip())
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+def check_exec_mapping(
+    root_dir: Path,
+    *,
+    snapshot: VaultSnapshot,
+    feature: str | None = None,
+) -> CheckResult:
+    """Validate every execution record maps to a live Step in its parent plan.
+
+    Args:
+        root_dir: Project root directory.
+        snapshot: Pre-built snapshot mapping document paths to parsed
+            ``(metadata, body)`` tuples.
+        feature: Restrict checks to documents carrying this feature tag
+            (without ``#``).
+
+    Returns:
+        :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with check
+        name ``"exec-mapping"``. Does not support ``--fix``.
+    """
+    from ...config import get_config
+    from ..models import DocType
+    from ..scanner import get_doc_type
+
+    result = CheckResult(check_name="exec-mapping", supports_fix=False)
+
+    docs_dir = root_dir / get_config().docs_dir
+    plan_dir = docs_dir / "plan"
+    archive_plan_dir = docs_dir / "_archive" / "plan"
+
+    for doc_path, (metadata, _body) in sorted(snapshot.items()):
+        if get_doc_type(doc_path, root_dir) is not DocType.EXEC:
+            continue
+        if feature:
+            feat = feature.lstrip("#")
+            if feat not in extract_feature_tags(metadata.tags):
+                continue
+
+        step_id = metadata.step_id
+        if not step_id:
+            # Legacy record predating the step_id field: unmappable, not a
+            # defect. Skipped without a finding.
+            continue
+
+        rel_path = doc_path.relative_to(root_dir)
+
+        # Resolve the parent plan from the record's related wiki-links. The
+        # first link resolving to a live plan wins; failing that, an archived
+        # plan is recognised as the expected steady state.
+        candidate_stems = [
+            stem for link in metadata.related if (stem := _link_stem(link))
+        ]
+        live_plan_path: Path | None = None
+        archived_stem: str | None = None
+        for stem in candidate_stems:
+            candidate = plan_dir / f"{stem}.md"
+            if candidate.is_file():
+                live_plan_path = candidate
+                break
+            if (archive_plan_dir / f"{stem}.md").is_file():
+                archived_stem = stem
+
+        if live_plan_path is None:
+            if archived_stem is not None:
+                # Archived parent plan: expected and benign. No finding.
+                continue
+            plan_hint = next((s for s in candidate_stems if s.endswith("-plan")), None)
+            named = f" '{plan_hint}'" if plan_hint else ""
+            result.diagnostics.append(
+                CheckDiagnostic(
+                    path=rel_path,
+                    message=(
+                        f"Execution record declares step {step_id} but its "
+                        f"parent plan{named} was not found in .vault/plan/ or "
+                        ".vault/_archive/plan/."
+                    ),
+                    severity=Severity.WARNING,
+                    fixable=False,
+                    fix_description=(
+                        "Point related: at the correct parent plan, or archive "
+                        "the record if its plan is gone."
+                    ),
+                )
+            )
+            continue
+
+        try:
+            live_ids, retired_ids = _plan_step_ids(live_plan_path)
+        except Exception as exc:
+            logger.debug("Could not parse plan %s: %s", live_plan_path, exc)
+            result.diagnostics.append(
+                CheckDiagnostic(
+                    path=live_plan_path.relative_to(root_dir),
+                    message=(
+                        "Parent plan could not be parsed, so the execution "
+                        f"record for step {step_id} cannot be verified: {exc}"
+                    ),
+                    severity=Severity.WARNING,
+                    fixable=False,
+                    fix_description="Repair the plan document structure.",
+                )
+            )
+            continue
+
+        if step_id in live_ids:
+            continue
+        if step_id in retired_ids:
+            result.diagnostics.append(
+                CheckDiagnostic(
+                    path=rel_path,
+                    message=(
+                        f"Execution record references retired Step {step_id}: "
+                        f"the Step was removed from '{live_plan_path.stem}' and "
+                        "its id is never reused."
+                    ),
+                    severity=Severity.WARNING,
+                    fixable=False,
+                    fix_description=(
+                        "Re-point the record at a live Step, or retire the "
+                        "record alongside its Step."
+                    ),
+                )
+            )
+            continue
+
+        result.diagnostics.append(
+            CheckDiagnostic(
+                path=rel_path,
+                message=(
+                    f"Execution record declares Step {step_id}, which does not "
+                    f"exist in parent plan '{live_plan_path.stem}'."
+                ),
+                severity=Severity.WARNING,
+                fixable=False,
+                fix_description=(
+                    "Correct the step_id to a Step that exists in the parent plan."
+                ),
+            )
+        )
+
+    return result
+
+
+def _plan_step_ids(plan_path: Path) -> tuple[set[str], set[str]]:
+    """Return the (live, retired) canonical Step id sets for *plan_path*."""
+    from ...plan.parser import parse_plan
+
+    plan = parse_plan(plan_path)
+    live = {step.canonical_id for step in plan.steps}
+    return live, set(plan.retired_step_ids)

--- a/src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py
@@ -1,0 +1,290 @@
+"""Tests for the ``body-sections`` vault health checker.
+
+Exercises template-derived required-section validation against real on-disk
+documents and controlled templates in ``.vaultspec/templates/``: present
+sections pass, absent sections are flagged, comment-only and placeholder-only
+sections read as empty, every document type is covered, plans require their
+sections across tiers, execution records select the step vs summary template,
+and a missing template degrades to a skip. No mocks, patches, or skips.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ....config import reset_config
+from ....graph import VaultGraph
+from .._base import Severity
+from ..body_sections import check_body_sections
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+# Directory tag and template filename per document type under test.
+_TYPE_META = {
+    "adr": ("#adr", "adr.md"),
+    "plan": ("#plan", "plan.md"),
+    "research": ("#research", "research.md"),
+    "reference": ("#reference", "reference.md"),
+    "audit": ("#audit", "audit.md"),
+    "exec": ("#exec", "exec-step.md"),
+}
+
+
+@pytest.fixture(autouse=True)
+def _reset_cfg() -> Generator[None]:
+    reset_config()
+    yield
+    reset_config()
+
+
+def _write_template(root: Path, name: str, sections: tuple[str, ...]) -> None:
+    tdir = root / ".vaultspec" / "templates"
+    tdir.mkdir(parents=True, exist_ok=True)
+    heads = "\n\n".join(f"## {s}\n\n<!-- hint -->" for s in sections)
+    (tdir / name).write_text(f"# `{{feature}}` doc\n\n{heads}\n", encoding="utf-8")
+
+
+def _write_doc(
+    root: Path,
+    doc_type: str,
+    stem: str,
+    section_bodies: dict[str, str],
+    *,
+    feature: str = "feat",
+    folder: str | None = None,
+) -> Path:
+    tag, _template = _TYPE_META[doc_type]
+    body_parts = [
+        f"## {title}\n\n{content}".rstrip() for title, content in section_bodies.items()
+    ]
+    text = (
+        f"---\ntags:\n  - '{tag}'\n  - '#{feature}'\n"
+        f"date: '2026-02-04'\nmodified: '2026-02-04'\nrelated: []\n---\n\n"
+        f"# {stem}\n\n" + "\n\n".join(body_parts) + "\n"
+    )
+    if doc_type == "exec":
+        sub = root / ".vault" / "exec" / (folder or "2026-02-04-feat")
+    else:
+        sub = root / ".vault" / doc_type
+    sub.mkdir(parents=True, exist_ok=True)
+    path = sub / f"{stem}.md"
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _skeleton(root: Path) -> None:
+    (root / ".vaultspec").mkdir(parents=True, exist_ok=True)
+    (root / ".vault").mkdir(parents=True, exist_ok=True)
+
+
+def _run(root: Path, *, feature: str | None = None):
+    snapshot = VaultGraph(root).to_snapshot()
+    return check_body_sections(root, snapshot=snapshot, feature=feature)
+
+
+class TestBodySections:
+    def test_check_shape(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "adr.md", ("Problem", "Consequences"))
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            {"Problem": "real prose", "Consequences": "real prose"},
+        )
+        result = _run(tmp_path)
+        assert result.check_name == "body-sections"
+        assert result.supports_fix is False
+        assert result.diagnostics == []
+
+    def test_absent_required_section_flagged(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "adr.md", ("Problem", "Consequences"))
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            {"Problem": "real prose"},  # Consequences missing
+        )
+        result = _run(tmp_path)
+        warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
+        assert len(warnings) == 1
+        assert "Consequences" in warnings[0].message
+        assert "Missing required section" in warnings[0].message
+
+    def test_empty_required_section_flagged(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "adr.md", ("Problem", "Consequences"))
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            {"Problem": "real prose", "Consequences": "   "},
+        )
+        result = _run(tmp_path)
+        warnings = [d for d in result.diagnostics if "Consequences" in d.message]
+        assert len(warnings) == 1
+        assert "empty" in warnings[0].message
+
+    def test_extra_author_section_tolerated(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "adr.md", ("Problem",))
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            {"Problem": "real prose", "Appendix": "bonus content"},
+        )
+        result = _run(tmp_path)
+        assert result.diagnostics == []
+
+    @pytest.mark.parametrize("doc_type", list(_TYPE_META))
+    def test_each_doc_type_present_is_clean(
+        self, tmp_path: Path, doc_type: str
+    ) -> None:
+        _skeleton(tmp_path)
+        _, template = _TYPE_META[doc_type]
+        _write_template(tmp_path, template, ("Alpha", "Beta"))
+        _write_doc(
+            tmp_path,
+            doc_type,
+            f"2026-02-04-feat-{doc_type}",
+            {"Alpha": "content", "Beta": "content"},
+        )
+        result = _run(tmp_path)
+        assert result.diagnostics == []
+
+    @pytest.mark.parametrize("doc_type", list(_TYPE_META))
+    def test_each_doc_type_absent_is_flagged(
+        self, tmp_path: Path, doc_type: str
+    ) -> None:
+        _skeleton(tmp_path)
+        _, template = _TYPE_META[doc_type]
+        _write_template(tmp_path, template, ("Alpha", "Beta"))
+        _write_doc(
+            tmp_path,
+            doc_type,
+            f"2026-02-04-feat-{doc_type}",
+            {"Alpha": "content"},  # Beta missing
+        )
+        result = _run(tmp_path)
+        warnings = [d for d in result.diagnostics if "Beta" in d.message]
+        assert len(warnings) == 1
+
+    def test_comment_only_section_is_empty(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "research.md", ("Findings",))
+        _write_doc(
+            tmp_path,
+            "research",
+            "2026-02-04-feat-research",
+            {"Findings": "<!-- One subsection per line of inquiry. -->"},
+        )
+        result = _run(tmp_path)
+        warnings = [d for d in result.diagnostics if "Findings" in d.message]
+        assert len(warnings) == 1
+        assert "empty" in warnings[0].message
+
+    def test_placeholder_only_section_is_empty(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "research.md", ("Findings",))
+        _write_doc(
+            tmp_path,
+            "research",
+            "2026-02-04-feat-research",
+            {"Findings": "{topic}"},
+        )
+        result = _run(tmp_path)
+        warnings = [d for d in result.diagnostics if "Findings" in d.message]
+        assert len(warnings) == 1
+        assert "empty" in warnings[0].message
+
+    def test_plan_sections_required_across_tiers(self, tmp_path: Path) -> None:
+        # The plan template mandates the same sections regardless of a plan's
+        # tier; a plan missing one is flagged whether it is L1 or L2.
+        _skeleton(tmp_path)
+        _write_template(
+            tmp_path,
+            "plan.md",
+            ("Description", "Steps", "Parallelization", "Verification"),
+        )
+        for tier, stem in (("L1", "2026-02-04-l1-plan"), ("L2", "2026-02-04-l2-plan")):
+            path = tmp_path / ".vault" / "plan" / f"{stem}.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                f"---\ntags:\n  - '#plan'\n  - '#feat'\n"
+                f"date: '2026-02-04'\nmodified: '2026-02-04'\ntier: {tier}\n"
+                "related: []\n---\n\n"
+                f"# `feat` plan\n\n## Description\n\np\n\n## Steps\n\np\n\n"
+                "## Parallelization\n\np\n",  # Verification missing
+                encoding="utf-8",
+            )
+        result = _run(tmp_path)
+        missing = [d for d in result.diagnostics if "Verification" in d.message]
+        assert len(missing) == 2  # both tiers flagged identically
+
+    def test_exec_summary_uses_summary_template(self, tmp_path: Path) -> None:
+        # A -summary exec is validated against exec-summary.md, not exec-step.md.
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "exec-step.md", ("Description", "Outcome", "Notes"))
+        _write_template(tmp_path, "exec-summary.md", ("Description",))
+        # Summary doc has only Description: clean against exec-summary, but would
+        # fail against exec-step (which also requires Outcome and Notes).
+        _write_doc(
+            tmp_path,
+            "exec",
+            "2026-02-04-feat-P01-summary",
+            {"Description": "phase summary prose"},
+        )
+        result = _run(tmp_path)
+        assert result.diagnostics == []
+
+    def test_exec_step_requires_all_step_sections(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "exec-step.md", ("Description", "Outcome", "Notes"))
+        _write_doc(
+            tmp_path,
+            "exec",
+            "2026-02-04-feat-P01-S01",
+            {"Description": "did it"},  # Outcome, Notes missing
+        )
+        result = _run(tmp_path)
+        titles = {
+            t
+            for d in result.diagnostics
+            for t in ("Outcome", "Notes")
+            if t in d.message
+        }
+        assert titles == {"Outcome", "Notes"}
+
+    def test_missing_template_degrades_to_skip(self, tmp_path: Path) -> None:
+        # No template written for adr: the checker skips rather than flagging.
+        _skeleton(tmp_path)
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            {"Anything": "content"},
+        )
+        result = _run(tmp_path)
+        assert result.diagnostics == []
+
+    def test_generated_index_is_skipped(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_template(tmp_path, "index.md", ("Documents",))
+        idx = tmp_path / ".vault" / "index" / "feat.index.md"
+        idx.parent.mkdir(parents=True, exist_ok=True)
+        idx.write_text(
+            "---\ntags:\n  - '#index'\n  - '#feat'\n"
+            "date: '2026-02-04'\nmodified: '2026-02-04'\nrelated: []\n---\n\n"
+            "# `feat` feature index\n",  # no Documents section
+            encoding="utf-8",
+        )
+        result = _run(tmp_path)
+        assert result.diagnostics == []

--- a/src/vaultspec_core/vaultcore/checks/tests/test_exec_mapping.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_exec_mapping.py
@@ -1,0 +1,196 @@
+"""Tests for the ``exec-mapping`` vault health checker.
+
+Exercises the back-mapping of an execution record's ``step_id`` to a live
+Step in its parent plan against real on-disk documents: a valid mapping, a
+retired Step id, a dangling id, a truly-missing parent plan, an archived
+parent plan (the expected steady state, no finding), a legacy record without
+``step_id`` (skipped), and an unparseable parent plan (degrades to a finding,
+never a crash). No mocks, patches, or skips.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ....config import reset_config
+from ....graph import VaultGraph
+from .._base import Severity
+from ..exec_mapping import check_exec_mapping
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+_PLAN_STEM = "2026-02-04-feat-plan"
+
+
+@pytest.fixture(autouse=True)
+def _reset_cfg() -> Generator[None]:
+    reset_config()
+    yield
+    reset_config()
+
+
+def _skeleton(root: Path) -> None:
+    for sub in ("plan", "exec", "_archive"):
+        (root / ".vault" / sub).mkdir(parents=True, exist_ok=True)
+    (root / ".vaultspec").mkdir(parents=True, exist_ok=True)
+
+
+def _plan_text(steps: tuple[str, ...], retired: tuple[str, ...] = ()) -> str:
+    rows = "\n".join(
+        f"- [ ] `{sid}` - do a thing; `src/{sid.lower()}.py`." for sid in steps
+    )
+    ledger = f"\n<!-- RETIRED: {', '.join(retired)} -->\n" if retired else ""
+    return (
+        "---\ntags:\n  - '#plan'\n  - '#feat'\n"
+        "date: '2026-02-04'\nmodified: '2026-02-04'\ntier: L1\nrelated: []\n---\n\n"
+        "# `feat` plan\n\n## Description\n\nProse.\n\n## Steps\n\n"
+        f"{rows}\n{ledger}\n## Parallelization\n\nProse.\n\n"
+        "## Verification\n\nProse.\n"
+    )
+
+
+def _write_plan(
+    root: Path,
+    steps: tuple[str, ...] = ("S01", "S02"),
+    *,
+    retired: tuple[str, ...] = (),
+    stem: str = _PLAN_STEM,
+    subdir: str = "plan",
+    text: str | None = None,
+) -> Path:
+    path = root / ".vault" / subdir / f"{stem}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text or _plan_text(steps, retired), encoding="utf-8")
+    return path
+
+
+def _write_exec(
+    root: Path,
+    *,
+    step_id: str | None,
+    plan_stem: str = _PLAN_STEM,
+    stem: str = "2026-02-04-feat-S01",
+    folder: str = "2026-02-04-feat",
+) -> Path:
+    step_line = f"step_id: '{step_id}'\n" if step_id is not None else ""
+    path = root / ".vault" / "exec" / folder / f"{stem}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\ntags:\n  - '#exec'\n  - '#feat'\n"
+        f"date: '2026-02-04'\nmodified: '2026-02-04'\n{step_line}"
+        f"related:\n  - '[[{plan_stem}]]'\n---\n\n"
+        "# Step record\n\n## Description\n\nDone.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run(root: Path, *, feature: str | None = None):
+    snapshot = VaultGraph(root).to_snapshot()
+    return check_exec_mapping(root, snapshot=snapshot, feature=feature)
+
+
+class TestExecMapping:
+    def test_valid_mapping_is_clean(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_plan(tmp_path, ("S01", "S02"))
+        _write_exec(tmp_path, step_id="S01")
+
+        result = _run(tmp_path)
+
+        assert result.check_name == "exec-mapping"
+        assert result.supports_fix is False
+        assert result.diagnostics == []
+
+    def test_dangling_step_id_is_warning(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_plan(tmp_path, ("S01", "S02"))
+        _write_exec(tmp_path, step_id="S09")
+
+        result = _run(tmp_path)
+
+        warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
+        assert len(warnings) == 1
+        assert "S09" in warnings[0].message
+        assert "does not exist" in warnings[0].message
+        assert result.fixed_count == 0
+
+    def test_retired_step_id_is_warning(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        # S02 was created then retired; the ledger records it, only S01 is live.
+        _write_plan(tmp_path, ("S01",), retired=("S02",))
+        _write_exec(tmp_path, step_id="S02")
+
+        result = _run(tmp_path)
+
+        warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
+        assert len(warnings) == 1
+        assert "retired Step S02" in warnings[0].message
+
+    def test_missing_parent_plan_is_warning(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        # No plan file written at all.
+        _write_exec(tmp_path, step_id="S01")
+
+        result = _run(tmp_path)
+
+        warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
+        assert len(warnings) == 1
+        assert "was not found" in warnings[0].message
+        assert _PLAN_STEM in warnings[0].message
+
+    def test_archived_parent_plan_produces_no_finding(self, tmp_path: Path) -> None:
+        # Mandatory regression (#233): the parent plan lives under
+        # .vault/_archive/plan/. The scanner hides _archive, so the plan is
+        # absent from the snapshot; the checker must probe the archive on disk
+        # and treat the archived parent as the expected steady state.
+        _skeleton(tmp_path)
+        _write_plan(tmp_path, ("S01", "S02"), subdir="_archive/plan")
+        _write_exec(tmp_path, step_id="S01")
+
+        result = _run(tmp_path)
+
+        assert result.diagnostics == []
+
+    def test_legacy_record_without_step_id_is_skipped(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_plan(tmp_path, ("S01", "S02"))
+        _write_exec(tmp_path, step_id=None)
+
+        result = _run(tmp_path)
+
+        assert result.diagnostics == []
+
+    def test_unparseable_plan_degrades_to_warning(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        # A plan file that parse_plan rejects: its frontmatter is missing the
+        # required feature tag, so the plan frontmatter contract fails.
+        broken = (
+            "---\ntags:\n  - '#plan'\n"
+            "date: '2026-02-04'\nmodified: '2026-02-04'\ntier: L1\nrelated: []\n---\n\n"
+            "# plan\n\n## Steps\n\n- [ ] `S01` - a step; `src/x.py`.\n"
+        )
+        _write_plan(tmp_path, text=broken)
+        _write_exec(tmp_path, step_id="S01")
+
+        result = _run(tmp_path)
+
+        warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
+        assert len(warnings) == 1
+        assert "could not be parsed" in warnings[0].message
+
+    def test_feature_filter_scopes_findings(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_plan(tmp_path, ("S01",))
+        _write_exec(tmp_path, step_id="S09")
+
+        # A different feature filter excludes the record.
+        result = _run(tmp_path, feature="other")
+
+        assert result.diagnostics == []

--- a/src/vaultspec_core/vaultcore/checks/tests/test_run_all.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_run_all.py
@@ -1,0 +1,92 @@
+"""Integration tests for the ``run_all_checks`` suite registration.
+
+Confirms the two validators added for the vault-check-validators feature -
+``exec-mapping`` and ``body-sections`` - are registered in the aggregate check
+in both the read-only and ``--fix`` branches, and that both remain read-only
+(``fixed_count`` zero) because neither defect has a safe automatic repair. No
+mocks, patches, or skips.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ....config import reset_config
+from .. import run_all_checks
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+_NEW_CHECKERS = {"exec-mapping", "body-sections"}
+
+
+@pytest.fixture(autouse=True)
+def _reset_cfg() -> Generator[None]:
+    reset_config()
+    yield
+    reset_config()
+
+
+def _skeleton(root: Path) -> None:
+    for sub in ("adr", "plan", "exec"):
+        (root / ".vault" / sub).mkdir(parents=True, exist_ok=True)
+    (root / ".vaultspec").mkdir(parents=True, exist_ok=True)
+
+
+def _seed_exec_and_plan(root: Path) -> None:
+    plan = root / ".vault" / "plan" / "2026-02-04-feat-plan.md"
+    plan.write_text(
+        "---\ntags:\n  - '#plan'\n  - '#feat'\n"
+        "date: '2026-02-04'\nmodified: '2026-02-04'\ntier: L1\nrelated: []\n---\n\n"
+        "# `feat` plan\n\n## Description\n\np\n\n## Steps\n\n"
+        "- [ ] `S01` - do; `src/a.py`.\n\n## Parallelization\n\np\n\n"
+        "## Verification\n\np\n",
+        encoding="utf-8",
+    )
+    exec_doc = root / ".vault" / "exec" / "2026-02-04-feat" / "2026-02-04-feat-S01.md"
+    exec_doc.parent.mkdir(parents=True, exist_ok=True)
+    exec_doc.write_text(
+        "---\ntags:\n  - '#exec'\n  - '#feat'\n"
+        "date: '2026-02-04'\nmodified: '2026-02-04'\nstep_id: 'S01'\n"
+        "related:\n  - '[[2026-02-04-feat-plan]]'\n---\n\n"
+        "# Step record\n\n## Description\n\nDone.\n## Outcome\n\nok\n## Notes\n\nn\n",
+        encoding="utf-8",
+    )
+
+
+class TestRunAllRegistration:
+    def test_new_checkers_registered_in_readonly_branch(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _seed_exec_and_plan(tmp_path)
+
+        results = run_all_checks(tmp_path, fix=False)
+        names = {r.check_name for r in results}
+
+        assert names >= _NEW_CHECKERS
+
+    def test_new_checkers_registered_in_fix_branch(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _seed_exec_and_plan(tmp_path)
+
+        results = run_all_checks(tmp_path, fix=True)
+        by_name = {r.check_name: r for r in results}
+
+        assert set(by_name) >= _NEW_CHECKERS
+        for name in _NEW_CHECKERS:
+            # Read-only: the fix branch must never rewrite for these checkers.
+            assert by_name[name].supports_fix is False
+            assert by_name[name].fixed_count == 0
+
+    def test_new_checkers_appear_exactly_once(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _seed_exec_and_plan(tmp_path)
+
+        results = run_all_checks(tmp_path, fix=False)
+        for name in _NEW_CHECKERS:
+            count = sum(1 for r in results if r.check_name == name)
+            assert count == 1, f"{name} registered {count} times, expected 1"

--- a/src/vaultspec_core/vaultcore/models.py
+++ b/src/vaultspec_core/vaultcore/models.py
@@ -288,6 +288,11 @@ class DocumentMetadata:
         derived_from: List of audit/finding references.
         promoted_to: List of rules promoted.
         archived: ISO date (``YYYY-MM-DD``) set on archived documents.
+        step_id: Canonical Step identifier (e.g. ``S01``) machine-filled on
+            execution records by ``vaultspec-core vault add exec``; ``None`` on
+            every other document type and on legacy exec records predating the
+            field. Consumed by the exec-mapping health check to back-map a
+            record to a live Step in its parent plan.
     """
 
     tags: list[str] = field(default_factory=list)
@@ -299,6 +304,7 @@ class DocumentMetadata:
     derived_from: list[str] = field(default_factory=list)
     promoted_to: list[str] = field(default_factory=list)
     archived: str | None = None
+    step_id: str | None = None
 
     def validate(self) -> list[str]:
         """Validate the metadata against the vault schema rules.

--- a/src/vaultspec_core/vaultcore/parser.py
+++ b/src/vaultspec_core/vaultcore/parser.py
@@ -182,6 +182,8 @@ def parse_vault_metadata(content: str) -> tuple[DocumentMetadata, str]:
                 metadata.superseded_by = val.strip("\"'") or None
             elif key == "archived":
                 metadata.archived = val.strip("\"'") or None
+            elif key == "step_id":
+                metadata.step_id = val.strip("\"'") or None
             elif val.startswith("[") and val.endswith("]"):
                 # Simple inline list parsing: ["#a", "#b"]
                 items = [

--- a/src/vaultspec_core/vaultcore/tests/test_core.py
+++ b/src/vaultspec_core/vaultcore/tests/test_core.py
@@ -121,3 +121,34 @@ class TestParseVaultMetadataBOM:
         assert meta_bom.date == meta_plain.date == "2026-06-26"
         assert meta_bom.related == meta_plain.related == ["[[other-doc]]"]
         assert body_bom == body_plain
+
+
+class TestParseVaultMetadataStepId:
+    """``parse_vault_metadata`` surfaces the exec-record ``step_id`` stamp."""
+
+    def test_step_id_parsed_from_exec_frontmatter(self):
+        content = (
+            "---\ntags:\n  - '#exec'\n  - '#editor-demo'\n"
+            "date: '2026-02-04'\nmodified: '2026-02-04'\n"
+            "step_id: 'S03'\nrelated:\n  - '[[2026-02-04-editor-demo-plan]]'\n"
+            "---\n\n# Body\nProse.\n"
+        )
+        meta, _body = parse_vault_metadata(content)
+        assert meta.step_id == "S03"
+
+    def test_step_id_none_when_absent(self):
+        content = (
+            "---\ntags:\n  - '#adr'\n  - '#editor-demo'\n"
+            "date: '2026-02-04'\nmodified: '2026-02-04'\n"
+            "related: []\n---\n\n# Body\nProse.\n"
+        )
+        meta, _body = parse_vault_metadata(content)
+        assert meta.step_id is None
+
+    def test_step_id_none_when_empty_value(self):
+        content = (
+            "---\ntags:\n  - '#exec'\n  - '#editor-demo'\n"
+            "date: '2026-02-04'\nstep_id: ''\nrelated: []\n---\n\n# Body\n"
+        )
+        meta, _body = parse_vault_metadata(content)
+        assert meta.step_id is None


### PR DESCRIPTION
## Summary

Closes #233 and #234. Two new read-only `vault check` validators closing the stalled vault-api Phase 3 gaps, delivered through the full vaultspec pipeline (research -> ADR -> plan -> execute -> audit).

- **exec-mapping (#233):** validates every execution record''s `step_id` resolves to a live Step in its parent plan. Retired -> warning, dangling -> warning; an archived parent (probed under `.vault/_archive/plan/`) yields no finding; unparseable parent degrades to a warning, never a crash. Adds `step_id` as a first-class `DocumentMetadata` field.
- **body-sections (#234):** validates each document body contains the sections its template mandates, deriving the required set from the templates via `get_template_path` (single source of truth). A section holding only a hint-comment or placeholder counts as empty.

Both are **WARNING** severity and **read-only** (no `--fix`); each finding names the manual remedy. Registered in `run_all_checks` (fix and non-fix branches) and exposed as `vault check exec-mapping` / `vault check body-sections`.

## Verification

- Full unit suite **2951 passed**, repo-root `tests/` **330 passed** (3281 total, 0 failures). ruff check + format, ty, cli-reference --check, check-providers: clean.
- On the real vault, `vault check all` exits 0 with the checkers live: exec-mapping 1 warning (a genuine dangling ref), body-sections 749 warnings across 385 docs - **confirmed legitimate pre-existing template debt** (sampled old ADRs genuinely missing mandated sections), not false positives. WARNING severity keeps it advisory/non-blocking.
- Mandatory archived-parent regression test present and exercises the probe.

## Design decisions (from the approved ADR)

WARNING (not ERROR, which would gate commits); read-only (no safe unambiguous repair); `step_id` as a metadata field; comment/placeholder-only sections count as empty; sections derived from templates so the contract never drifts.