### PR TITLE
ci: target self-hosted build runner by label + add broad-test job

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,3 +1,4 @@
 self-hosted-runner:
   labels:
     - dev-runner
+    - build

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - name: linux-x86_64
-            runner: [self-hosted, Linux, X64]
+            runner: [self-hosted, Linux, X64, build]
             target: x86_64-unknown-linux-gnu
           - name: windows-x86_64
             runner: [self-hosted, Windows, X64]
@@ -77,7 +77,7 @@ jobs:
   release:
     name: Attach to release
     needs: build
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,39 @@ jobs:
       - name: Run tests
         run: just dev test python
 
+  broad-tests:
+    name: Broad Test Suite (informational)
+    # The required "Tests" gate above is marker-scoped to `unit`, which hides the
+    # much larger integration/behavioural suite. This job runs the full suite
+    # (excluding only the gemini/claude markers, which need external API
+    # credentials) so a green CI no longer implies "every test passed" when only
+    # the unit slice ran. It is non-blocking for now: promote it to a required
+    # check once it is proven consistently green on CI. See the PR for rationale.
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Install dependencies
+        run: just dev deps sync
+
+      - name: Run broad test suite
+        run: uv run pytest src/vaultspec_core -q -m "not gemini and not claude"
+
   windows-vault-repair:
     name: Windows Vault Repair Tests
     runs-on: windows-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build
     # Artifact builds run on the shared self-hosted fleet (hosted
     # multiplatform runners are cost-prohibitive); lint/test CI stays hosted.
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -54,7 +54,7 @@ jobs:
   smoke-test:
     name: Smoke Test
     needs: build
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -84,7 +84,7 @@ jobs:
     needs: smoke-test
     # OIDC trusted publishing works from self-hosted runners: the id-token
     # comes from GitHub's OIDC provider, not from the runner host.
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, Linux, X64, build]
     environment:
       name: pypi
     permissions:


### PR DESCRIPTION
## What
CI/CD gate hardening from the runner audit. Three changes:

### 1. Target the toolchain build runner by label (`build`)
All self-hosted **Linux** release jobs now target `[self-hosted, Linux, X64, build]`:
- `publish.yml`: `build`, `smoke-test`, `publish-pypi`
- `binaries.yml`: `linux-x86_64` compile leg + `release` (attach) job

**Why:** bootstrap dev-runners share the bare `[self-hosted, Linux, X64]` label set, so a compile job could land on a runner with no C toolchain (the `cc not found` failure class). The durable **build-runner** (declared in `nevenincs/dev-runner` compose; C toolchain + gh + jq baked in) carries the extra `build` label; targeting it makes the Linux compile/release legs deterministic. Windows/macOS matrix legs unchanged.

### 2. `.github/actionlint.yaml`: register the `build` label
actionlint's runner-label check rejects unknown custom labels; `build` is registered alongside the existing `dev-runner`. Workflow Lint is green.

### 3. Broad test suite (informational)
New non-blocking `Broad Test Suite (informational)` job runs `pytest src/vaultspec_core -m "not gemini and not claude"` (full suite minus external-API markers). The required `Tests` gate is marker-scoped to `unit`, which deselects the larger integration/behavioural suite — a green CI currently implies more than it verifies.

## Compile proof
Dispatched `binaries.yml` from this branch for `vaultspec-core-v0.1.49`; the `Build linux-x86_64` leg (`[self-hosted, Linux, X64, build]`) **compiled successfully** on the build-runner (only that runner carries `build`, so the success is conclusively attributable to it). The ad-hoc, non-IaC `vsc-runner-1` was then retired (container removed + de-registered); vaultspec-core serves self-hosted Linux jobs only from the durable IaC runners. Both remaining runners still include `self-hosted,Linux,X64`, so main's current publish jobs are unaffected pre-merge; merging just makes the compile legs deterministic.

## ⚠️ Broad Test Suite result — WHAT fails and why (read before trusting the green gates)
Latest broad run: **2 failed, 2979 passed, 1 deselected** (~4.5 min). Both failures are **environment/portability issues in the same file, NOT product breakage**, and both are tests the `unit` gate deselects (which is exactly why this job exists):

- `tests/cli/test_config_editor_safety.py::TestEditorResolution::test_resolution_ladder` — `AssertionError: notepad not found on PATH`. Asserts a Windows editor (`notepad`) is resolvable, but runs on headless **ubuntu-latest**. Platform-specific test, not OS-gated.
- `tests/cli/test_config_editor_safety.py::TestEditorSubprocessSafety::test_editor_failures_exits` — `assert 3 == 2`. Spawns a real interactive editor (`vim`), which on a headless runner exits with `Vim: Error reading input, exiting...` → a different CLI exit code than the test expects.

**Category:** (c) environment/config — the tests assume a local interactive editor environment (an editor binary on PATH, a real TTY) that doesn't hold in headless CI. Not (a) genuine product regressions and not (b) generic flakiness. **Kept informational (`continue-on-error: true`)** so it never blocks; promote to required once these two tests are made portable. **Suggested follow-up issue:** OS-gate `test_resolution_ladder` (or assert the platform's actual default editor) and make `test_editor_failures_exits` use a non-interactive fake editor so it's TTY-independent.

## Merge
Safe to merge: required gates (Workflow Lint, Lint/Type, Tests, Vault Audit, Windows Vault Repair, Dependency Audit) pass; only the intentionally-informational Broad Test Suite is red, characterized above.