### PR TITLE
ci: repoint add-to-project board URL to nevenincs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/add-to-project@v2
         id: add
         with:
-          project-url: https://github.com/users/wgergely/projects/3
+          project-url: https://github.com/users/nevenincs/projects/3
           github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
 
       - name: Set target date to created_at + 30 days


### PR DESCRIPTION
## What
One-line fix: `project-url` owner `users/wgergely/projects/3` → `users/nevenincs/projects/3` in `add-to-project.yml`.

## Why
The `Add to Development Board` workflow has been failing on **every** issue open since the `wgergely`→`nevenincs` account rename, with `Could not resolve to a User with the login of 'wgergely'`. A perpetual red false-signal on the issues event.

## Verification (via gh, not guessed)
- `gh project list --owner nevenincs` → project **3** "Development Board", node `PVT_kwHOAKyuWc4BS9uc` — the **same** node ID already in the workflow (immutable across the rename).
- `gh api graphql` on field `PVTF_lAHOAKyuWc4BS9uczhAaFWg` → resolves to "Target Date" under the project.
- `nevenincs` is a **user** account (org lookup 404s), so the URL stays `/users/nevenincs/...`.

Only the display owner in the URL was stale; the project/field node IDs are unchanged and valid, so the `item-edit` step keeps working.