### PR TITLE
fix(config): platform-aware editor path resolution + source portability sweep

### DIFF
--- a/src/vaultspec_core/core/local_config.py
+++ b/src/vaultspec_core/core/local_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import shlex
 import shutil
 import tomllib
 from pathlib import Path
@@ -12,6 +13,27 @@ from .exceptions import EditorResolutionError, VaultSpecError
 from .helpers import atomic_write, ensure_dir
 
 KNOWN_KEYS = {"editor"}
+
+
+def _command_first_token_on_path(command: str) -> bool:
+    """Return whether *command*'s leading token resolves on ``PATH``.
+
+    Tokenizes *command* with platform-aware quoting rules, disabling POSIX
+    mode on Windows exactly as :mod:`vaultspec_core.hooks.engine` does, so a
+    Windows editor path containing backslashes (for example
+    ``C:\\tools\\ed.exe``) is not mangled by POSIX escape handling before the
+    :func:`shutil.which` lookup.
+
+    Args:
+        command: Editor command string, optionally including flags such as
+            ``"code --wait"``.
+
+    Returns:
+        ``True`` when the command has a first token that :func:`shutil.which`
+        can locate on the current ``PATH``, ``False`` otherwise.
+    """
+    parts = shlex.split(command, posix=(os.name != "nt"))
+    return bool(parts) and shutil.which(parts[0]) is not None
 
 
 def get_local_config_path(target_dir: Path | None = None) -> Path:
@@ -127,46 +149,31 @@ def resolve_editor(
 
     if editor_override:
         sources_tried.append(f"--editor flag ({editor_override!r})")
-        import shlex
-
-        parts = shlex.split(editor_override)
-        if parts and shutil.which(parts[0]):
+        if _command_first_token_on_path(editor_override):
             return editor_override
 
     local_editor = get_config_value("editor", target_dir)
     if local_editor:
         sources_tried.append(f"local config 'editor' ({local_editor!r})")
-        import shlex
-
-        parts = shlex.split(local_editor)
-        if parts and shutil.which(parts[0]):
+        if _command_first_token_on_path(local_editor):
             return local_editor
 
     vaultspec_editor = os.environ.get("VAULTSPEC_EDITOR")
     if vaultspec_editor:
         sources_tried.append(f"$VAULTSPEC_EDITOR env var ({vaultspec_editor!r})")
-        import shlex
-
-        parts = shlex.split(vaultspec_editor)
-        if parts and shutil.which(parts[0]):
+        if _command_first_token_on_path(vaultspec_editor):
             return vaultspec_editor
 
     visual_env = os.environ.get("VISUAL")
     if visual_env:
         sources_tried.append(f"$VISUAL env var ({visual_env!r})")
-        import shlex
-
-        parts = shlex.split(visual_env)
-        if parts and shutil.which(parts[0]):
+        if _command_first_token_on_path(visual_env):
             return visual_env
 
     editor_env = os.environ.get("EDITOR")
     if editor_env:
         sources_tried.append(f"$EDITOR env var ({editor_env!r})")
-        import shlex
-
-        parts = shlex.split(editor_env)
-        if parts and shutil.which(parts[0]):
+        if _command_first_token_on_path(editor_env):
             return editor_env
 
     sources_tried.append("fallback 'vi'")

--- a/src/vaultspec_core/tests/cli/test_editor_path_portability.py
+++ b/src/vaultspec_core/tests/cli/test_editor_path_portability.py
@@ -1,0 +1,39 @@
+"""Unit tests for platform-aware editor command resolution.
+
+These cover :func:`vaultspec_core.core.local_config._command_first_token_on_path`,
+which must not mangle a Windows editor path (backslash separators) before the
+:func:`shutil.which` lookup.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from vaultspec_core.core.local_config import _command_first_token_on_path
+
+pytestmark = [pytest.mark.unit]
+
+
+def test_native_absolute_path_resolves(tmp_path):
+    """A real editor referenced by its native absolute path resolves.
+
+    On Windows the absolute path uses backslash separators; tokenizing it with
+    POSIX quoting rules would consume the backslashes and break the lookup.
+    The helper disables POSIX mode on Windows so the path reaches
+    :func:`shutil.which` intact.
+    """
+    editor = tmp_path / "myeditor.bat"
+    editor.write_text("@echo off\n", encoding="utf-8")
+    editor.chmod(0o755)
+
+    assert _command_first_token_on_path(str(editor)) is True
+
+
+def test_missing_command_is_rejected():
+    """A command whose first token is not on ``PATH`` is rejected."""
+    assert _command_first_token_on_path("vaultspec-not-a-real-editor-xyz") is False
+
+
+def test_blank_command_is_rejected():
+    """A whitespace-only command yields no token and is rejected."""
+    assert _command_first_token_on_path("   ") is False


### PR DESCRIPTION
## Summary

Comprehensive sweep of `src/vaultspec_core/**` (excluding `**/tests/**`) for platform-specific hardcodes in production code, and a fix for the one genuine cross-platform bug found.

**Headline finding:** the source tree is overwhelmingly clean and portable. Line-ending handling (detect source EOL, normalize to `\n`, restore on write, binary reads to dodge Windows text-mode translation), encoding (`encoding="utf-8"` everywhere), file locking (`msvcrt`/`fcntl` dual-path), process control (`taskkill`/`pkill`), tempfile (TMPDIR/TEMP-aware), and `cmd.exe` usage (all `sys.platform == "win32"`-guarded) are all done correctly. No machine metadata (usernames/hostnames/home paths) is committed in source.

## The one real bug (Windows, the reference platform)

`core/local_config.py::resolve_editor` tokenized every candidate editor with `shlex.split()` using its **POSIX default**. On Windows that consumes the backslashes in an absolute editor path (e.g. `EDITOR=C:\tools\ed.exe`), so `shutil.which` fails to find it and resolution falls through to the `vi` fallback, raising `EditorResolutionError` even though a valid editor was configured.

**Fix:** route all five resolution sources through a `_command_first_token_on_path` helper that disables POSIX mode on Windows (`shlex.split(cmd, posix=(os.name != "nt"))`), matching the existing convention already used in `hooks/engine.py`. POSIX behavior is unchanged; Windows absolute-path editors now resolve. Also removes five duplicated inline `import shlex` blocks.

## Tests

New `tests/cli/test_editor_path_portability.py` (unit-marked, real filesystem, no mocks): native absolute-path resolution + missing-command and blank-command rejection.

## Verification

- `pytest src/vaultspec_core -m unit -q`: **1889 passed, 1096 deselected** (green).
- Existing editor integration tests (`test_config_editor_safety.py`): 3 passed (no regression).
- Pre-commit hooks: Ruff lint + format, Ty type-check all pass.

## Inventory (categorized)

Everything below was **read in context and judged correct** except `resolve_editor`:

| Category | Sites | Verdict |
|---|---|---|
| `sys.platform`/`os.name` branches | cli_common, core/helpers, core/hooks, core/resources, protocol/providers/base, hooks/engine, mcp_server/watchdog | Correct dual-platform |
| Line endings (`\r\n`) | ~20 files under vaultcore/checks, core/adr, core/rules, gitignore, gitattributes | Correct detect/normalize/restore |
| Encoding | all `read_text`/`write_text`/`open` | Explicit `utf-8`; no naked text opens |
| File locking | core/helpers | `msvcrt`/`fcntl` dual-path |
| Subprocess shell | core/helpers, core/hooks, core/resources, protocol/providers/base | `cmd.exe` win32-guarded; no `shell=True` on OS-specific cmds |
| tempfile | core/commands, vaultcore/repair | TMPDIR/TEMP-aware |
| Path display normalization | core/commands | Deliberate `\`->`/` for output keys |
| **Editor tokenization** | **core/local_config** | **FIXED** |

Draft; do not merge.