### PR TITLE
ci: run Broad Test Suite on ubuntu+windows matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,15 +104,22 @@ jobs:
         run: just dev test python
 
   broad-tests:
-    name: Broad Test Suite (informational)
+    name: broad (${{ matrix.os }})
     # The required "Tests" gate above is marker-scoped to `unit`, which hides the
     # much larger integration/behavioural suite. This job runs the full suite
     # (excluding only the gemini/claude markers, which need external API
-    # credentials) so a green CI no longer implies "every test passed" when only
-    # the unit slice ran. It is non-blocking for now: promote it to a required
-    # check once it is proven consistently green on CI. See the PR for rationale.
+    # credentials) on BOTH Linux and Windows, so a green CI no longer implies
+    # "every test passed" when only the unit slice ran on a single OS - and so
+    # platform-specific test hardcodes are caught automatically. Both hosted
+    # runners are symlink-capable, so the symlink-requiring filesystem tests run
+    # in full. Non-blocking for now (continue-on-error): promote to a required
+    # check once both legs are proven consistently green. See the PR for rationale.
     continue-on-error: true
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -131,9 +138,13 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Install dependencies
+        # bash is available on windows-latest via Git Bash; using it on both
+        # OSes keeps the just invocation and argument quoting identical.
+        shell: bash
         run: just dev deps sync
 
       - name: Run broad test suite
+        shell: bash
         run: uv run pytest src/vaultspec_core -q -m "not gemini and not claude"
 
   windows-vault-repair:


### PR DESCRIPTION
## What
Converts the `Broad Test Suite` job in `ci.yml` into a **matrix over `ubuntu-latest` and `windows-latest`** (both GitHub-hosted), `fail-fast: false`, so the full suite (minus gemini/claude markers) runs on **both** platforms every CI run. Legs appear as **`broad (ubuntu-latest)`** and **`broad (windows-latest)`**.

## Why
The broad suite previously ran only on ubuntu-latest, so Linux-only test hardcodes (and Windows-only ones) slipped past CI. Matrixing it makes platform-specific test breakage a caught-automatically class instead of a manual sweep. This is the enforcement half of the platform-hardcode campaign (#254/#255/#256).

## Design
- **Non-blocking for now** (`continue-on-error: true`) — promote to a required check only after both legs prove consistently green.
- **`shell: bash` on both run steps** — Git Bash is present on windows-latest, so the `just dev deps sync` and `uv run pytest ... -m "not gemini and not claude"` invocations (and their quoting) are identical across OSes.
- **Both runners are GitHub-hosted and symlink-capable**, so `test_audit_coverage.py`'s hard-fail symlink guard and the other symlink-requiring filesystem tests run in full. Deliberately **not** routed onto the self-hosted Windows service runner.
- Same test scope as today (no marker changes).

## Verification (the whole point)
Both legs must go green on this PR. If `broad (windows-latest)` surfaces NEW failures (Linux-assuming hardcodes not yet caught), they'll be inventoried here and fixed the same portable way (real constructs, no skips/mocks) — or surfaced if non-trivial. **Result table appended once the run completes.**

Draft; don't merge until both legs are confirmed green.