### PR TITLE
ci: promote broad test suite to a required gate on both OS legs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,8 @@ jobs:
     # "every test passed" when only the unit slice ran on a single OS - and so
     # platform-specific test hardcodes are caught automatically. Both hosted
     # runners are symlink-capable, so the symlink-requiring filesystem tests run
-    # in full. Non-blocking for now (continue-on-error): promote to a required
-    # check once both legs are proven consistently green. See the PR for rationale.
-    continue-on-error: true
+    # in full. This is a required status check on both legs: a failure on either
+    # OS blocks the merge, so "green" means green on every platform.
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Removes `continue-on-error: true` from the `broad-tests` matrix now that both `broad (ubuntu-latest)` and `broad (windows-latest)` are proven green (#258).

**Why:** a `continue-on-error` job reports its status check as *success* even when steps fail, so it can't gate a merge. With both legs now registered as required status checks on `main` branch protection, dropping `continue-on-error` gives the gate real teeth: a platform-specific failure on either OS now blocks the merge, so green means green on every platform.

Closes the platform-hardcode campaign: #254 (editor tests), #255 (real Windows path bug + source sweep), #256 (symlink capability guard), #258 (OS matrix), and this promotion.