### PR TITLE
chore(scoop): bump manifest to v0.1.50

### DIFF
--- a/bucket/vaultspec-core.json
+++ b/bucket/vaultspec-core.json
@@ -7,17 +7,23 @@
     "The hash field is intentionally absent: the assets do not exist yet, so no",
     "real digest can be committed - autoupdate reads it from SHA256SUMS."
   ],
-  "version": "0.0.0",
+  "version": "0.1.50",
   "description": "Spec-driven development framework - vaultspec-core CLI and MCP server",
   "homepage": "https://github.com/nevenincs/vaultspec-core",
   "license": "MIT",
   "url": [
-    "https://github.com/nevenincs/vaultspec-core/releases/download/vaultspec-core-v0.0.0/vaultspec-core-x86_64-pc-windows-msvc.exe",
-    "https://github.com/nevenincs/vaultspec-core/releases/download/vaultspec-core-v0.0.0/vaultspec-mcp-x86_64-pc-windows-msvc.exe"
+    "https://github.com/nevenincs/vaultspec-core/releases/download/vaultspec-core-v0.1.50/vaultspec-core-x86_64-pc-windows-msvc.exe",
+    "https://github.com/nevenincs/vaultspec-core/releases/download/vaultspec-core-v0.1.50/vaultspec-mcp-x86_64-pc-windows-msvc.exe"
   ],
   "bin": [
-    ["vaultspec-core-x86_64-pc-windows-msvc.exe", "vaultspec-core"],
-    ["vaultspec-mcp-x86_64-pc-windows-msvc.exe", "vaultspec-mcp"]
+    [
+      "vaultspec-core-x86_64-pc-windows-msvc.exe",
+      "vaultspec-core"
+    ],
+    [
+      "vaultspec-mcp-x86_64-pc-windows-msvc.exe",
+      "vaultspec-mcp"
+    ]
   ],
   "checkver": {
     "github": "https://github.com/nevenincs/vaultspec-core",
@@ -32,5 +38,9 @@
       "url": "https://github.com/nevenincs/vaultspec-core/releases/download/vaultspec-core-v$version/SHA256SUMS",
       "regex": "$sha256\\s+$basename"
     }
-  }
+  },
+  "hash": [
+    "3fcbefcf382c042260b16813f74515d1e07f89de63706cde6e9df05d4a77250e",
+    "e5bd7401a08779d2f1c9c42caee02154265b508f1a320c16a4561ed9fe9f951c"
+  ]
 }


### PR DESCRIPTION
Manually bump the in-repo scoop manifest to 0.1.50 with the released Windows asset URLs + SHA256 hashes (read from the v0.1.50 release SHA256SUMS).

The automated `Bump scoop manifest` step in binaries.yml failed to push directly to `main` (now branch-protected: `GH006 Protected branch update failed`), so the manifest was still at 0.0.0. This lands it through the gated PR flow. A durable fix for the workflow's direct-push-to-main is tracked separately.