### PR TITLE
ci(scoop): deploy-key manifest push + gate flaky network test out of required suites

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -82,11 +82,16 @@ jobs:
       contents: write
     steps:
       # Check out main so the scoop-bump step can rewrite and commit the
-      # in-repo bucket manifest after the assets are attached.
+      # in-repo bucket manifest after the assets are attached. The SSH deploy
+      # key authenticates the manifest push: main is protected by a ruleset
+      # that requires status checks, and a deploy-key push is a bypass actor,
+      # so the automated bump lands without a human-gated PR while every other
+      # push stays gated.
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: main
+          ssh-key: ${{ secrets.SCOOP_DEPLOY_KEY }}
 
       - name: Download binaries
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Run broad test suite
         shell: bash
-        run: uv run pytest src/vaultspec_core -q -m "not gemini and not claude"
+        run: uv run pytest src/vaultspec_core -q -m "not gemini and not claude and not network"
 
   windows-vault-repair:
     name: Windows Vault Repair Tests

--- a/justfile
+++ b/justfile
@@ -231,7 +231,7 @@ _dev-test-help:
   @echo "  all       Run all tests"
 
 _dev-test-python:
-  uv run pytest src/vaultspec_core -x -q --tb=short -m "unit and not gemini and not claude"
+  uv run pytest src/vaultspec_core -x -q --tb=short -m "unit and not gemini and not claude and not network"
 
 _dev-test-all:
   just _dev-test-python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,7 @@ markers = [
   "api: API-level tests covering stable public analysis surfaces",
   "unit: fast tests with no external dependencies",
   "integration: requires CLI tools and network",
+  "network: requires live network access (upstream drift guards); excluded from gating suites",
   "gemini: requires Gemini CLI installed",
   "claude: requires Claude CLI installed",
   "timeout: timeout in seconds for individual tests",

--- a/src/vaultspec_core/tests/cli/test_agents_render.py
+++ b/src/vaultspec_core/tests/cli/test_agents_render.py
@@ -353,9 +353,11 @@ class TestSourceAgentCoverage:
 def _fetch_upstream_base_declarations() -> str:
     """Fetch `base-declarations.ts` from gemini-cli main.
 
-    Hard-fails on any network or HTTP error. The integration marker on
-    the calling test class is the opt-in gate; once selected, the test
-    must reach upstream and verify the constants.
+    Hard-fails on any network or HTTP error. The ``network`` marker on the
+    calling test class keeps it out of the gating suites (which run
+    ``not network``); it is an opt-in drift guard run explicitly with
+    ``-m network``, and once selected must reach upstream and verify the
+    constants.
     """
     req = urllib.request.Request(
         _UPSTREAM_BASE_DECLARATIONS_URL,
@@ -365,6 +367,7 @@ def _fetch_upstream_base_declarations() -> str:
         return resp.read().decode("utf-8")
 
 
+@pytest.mark.network
 @pytest.mark.integration
 class TestUpstreamGeminiToolPin:
     """Live drift guard against `google-gemini/gemini-cli` main.


### PR DESCRIPTION
Two fixes, both toward 'green means green, not churn':

**1. Scoop manifest push vs branch protection (deploy key).** `main` is protected by a ruleset requiring 8 status checks; the release job's `Bump scoop manifest` step does `git push origin main` as `github-actions[bot]` and was rejected (`GH006`). The `Attach to release` checkout now authenticates with a write **deploy key** (`SCOOP_DEPLOY_KEY` secret), a ruleset DeployKey bypass actor, so the automated bump lands while every human push stays gated. (Classic protection was consolidated into the `Protect Main` ruleset with admin + DeployKey bypass.)

**2. Flaky network test gated out of required suites.** `TestUpstreamGeminiToolPin` fetches gemini-cli's `base-declarations.ts` over the network at test time. The module-level `pytestmark = [unit]` blanket also tagged this integration test `unit`, so it ran in the required Tests gate and flaked on `ConnectionReset`. Added a dedicated `network` marker to the class and excluded `network` from both gating suites (unit gate + broad matrix). Still runnable on demand via `-m network`; no longer able to fail a merge on an upstream/network hiccup. No skips, no mocks.