### PR TITLE
test(cli): guard that every indexed command has a prose section (#249)

### DIFF
--- a/src/vaultspec_core/tests/cli/reference_contract.py
+++ b/src/vaultspec_core/tests/cli/reference_contract.py
@@ -1,0 +1,281 @@
+"""Shared helpers for the CLI-reference contract guards.
+
+Both reference surfaces are guarded by the same three questions: does every
+command in the live Typer tree appear in the document, does every command have a
+prose section a reader can actually land on, and does that section spell out the
+command's flags. The walk and the parsing behind those questions live here so
+the handbook guard and the bundled-reference guard cannot answer them
+differently.
+
+The section parser models the shape the references already use. A command
+section is a level-three heading naming one or more runnable command forms -
+``### vaultspec-core vault add``, the bare ``### install`` of the workspace
+group, or the slash-joined
+``### vaultspec-core spec rules / vaultspec-core spec skills`` - followed by
+prose that runs until the next level-three or level-two heading. A section whose
+heading names a command *group* (``### vaultspec-core vault check``) covers that
+group's leaf commands, which is how the references consolidate families of
+near-identical verbs instead of repeating a table per leaf.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import typer
+    from typer.testing import CliRunner
+
+# Options carried through the global options table or otherwise inherited on
+# essentially every subcommand. Documenting them once at the top of a reference
+# is sufficient; per-command sections do not need to repeat them.
+GLOBAL_FLAGS: frozenset[str] = frozenset(
+    {"--help", "--target", "-t", "--debug", "-d", "--version", "-V"}
+)
+
+# Matches long (``--flag``) or short (``-f``) option tokens.
+OPTION_TOKEN = re.compile(r"(?<![A-Za-z0-9_])(-{1,2}[A-Za-z][A-Za-z0-9_-]*)")
+
+_ENTRY_POINT = "vaultspec-core"
+_SECTION_HEADING = re.compile(r"^### (.+)$", re.MULTILINE)
+_SECTION_END = re.compile(r"^#{1,3} ", re.MULTILINE)
+
+
+# ---------------------------------------------------------------------------
+# Live command tree
+# ---------------------------------------------------------------------------
+
+
+def collect_leaf_command_paths(typer_app: typer.Typer) -> list[tuple[str, ...]]:
+    """Return the full command path for every visible leaf command."""
+
+    paths: list[tuple[str, ...]] = []
+
+    def _walk(current: typer.Typer, prefix: tuple[str, ...]) -> None:
+        for info in current.registered_commands:
+            if info.hidden:
+                continue
+            name = info.name
+            if not name and info.callback is not None:
+                name = getattr(info.callback, "__name__", None)
+            if name:
+                paths.append((*prefix, name))
+        for group in current.registered_groups:
+            name = group.name
+            if not name or group.hidden:
+                continue
+            group_path = (*prefix, name)
+            if group.typer_instance is not None:
+                _walk(group.typer_instance, group_path)
+
+    _walk(typer_app, ())
+    return paths
+
+
+def collect_group_paths(typer_app: typer.Typer) -> list[tuple[str, ...]]:
+    """Return the path of every visible Typer sub-group (needed for coverage)."""
+
+    paths: list[tuple[str, ...]] = []
+
+    def _walk(current: typer.Typer, prefix: tuple[str, ...]) -> None:
+        for group in current.registered_groups:
+            name = group.name
+            if not name or group.hidden:
+                continue
+            group_path = (*prefix, name)
+            paths.append(group_path)
+            if group.typer_instance is not None:
+                _walk(group.typer_instance, group_path)
+
+    _walk(typer_app, ())
+    return paths
+
+
+def help_output(cli: CliRunner, app: typer.Typer, path: tuple[str, ...]) -> str:
+    """Return the ``--help`` text for *path*, asserting the invocation succeeded."""
+    result = cli.invoke(app, [*path, "--help"])
+    assert result.exit_code == 0, (
+        f"`--help` for {' '.join(path) or '<root>'} exited {result.exit_code}:\n"
+        f"{result.output}"
+    )
+    return result.output
+
+
+def extract_options(help_text: str) -> set[str]:
+    """Extract every option token from a Typer ``--help`` block.
+
+    Typer renders help in two layouts depending on whether Rich is active: a
+    boxed table whose rows begin with ``|``, and the plain two-column listing
+    used when Rich is disabled or unavailable. Both are parsed here. Only the
+    leading option column of each row is read, so an option name quoted inside a
+    help *description* is not mistaken for a flag the command accepts.
+    """
+
+    options: set[str] = set()
+    in_options_block = False
+    for raw in help_text.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("+- Options") or line.startswith("Options:"):
+            in_options_block = True
+            continue
+        if not in_options_block:
+            continue
+        if line.startswith("+-"):
+            # End of a Typer option box.
+            in_options_block = False
+            continue
+        if line.startswith("|"):
+            # Boxed layout: the option column is the first cell.
+            cells = [cell.strip() for cell in line.strip("|").split("|")]
+            head = cells[0] if cells else ""
+        elif raw.startswith("  ") and line.startswith("-"):
+            # Plain layout: the option column is separated from its description
+            # by a run of two or more spaces.
+            head = re.split(r"\s{2,}", line, maxsplit=1)[0]
+        else:
+            # A wrapped description line, or the start of another help block.
+            if raw and not raw.startswith(" "):
+                in_options_block = False
+            continue
+        for match in OPTION_TOKEN.finditer(head):
+            options.add(match.group(1))
+    return options
+
+
+def command_options(
+    cli: CliRunner, app: typer.Typer, path: tuple[str, ...]
+) -> set[str]:
+    """Return the non-global option tokens *path* accepts."""
+    return extract_options(help_output(cli, app, path)) - GLOBAL_FLAGS
+
+
+# ---------------------------------------------------------------------------
+# Reference document structure
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CommandSection:
+    """One ``### `` prose section of a reference document.
+
+    Attributes:
+        heading: The heading text, verbatim.
+        commands: Every command path the heading names. A slash-joined heading
+            names several; a heading that is not a runnable command form names
+            none.
+        text: The section's prose, from the heading to the next ``##``/``###``.
+    """
+
+    heading: str
+    commands: tuple[tuple[str, ...], ...]
+    text: str
+
+    def covers(self, path: tuple[str, ...]) -> bool:
+        """True when this section documents *path* directly."""
+        return path in self.commands
+
+    def group_covers(self, path: tuple[str, ...]) -> bool:
+        """True when this section documents a group *path* belongs to.
+
+        A group section consolidates a family of leaf verbs, so it counts as
+        coverage only when its prose actually names the leaf - otherwise a
+        section heading alone would silently vouch for commands it never
+        mentions.
+        """
+        for command in self.commands:
+            if len(command) >= len(path) or path[: len(command)] != command:
+                continue
+            leaf = " ".join(path[len(command) :])
+            # The leaf is named as a code span, either bare (``` `check` ```) or
+            # carrying its argument shape (``` `add NAME [--force]` ```).
+            named = re.compile(r"`" + re.escape(leaf) + r"(?![A-Za-z0-9_-])")
+            if named.search(self.text) or " ".join(path) in self.text:
+                return True
+        return False
+
+
+def _heading_commands(
+    heading: str, known_roots: frozenset[str]
+) -> tuple[tuple[str, ...], ...]:
+    """Parse the command paths a ``### `` heading names.
+
+    Headings appear in three shapes: the fully qualified
+    ``vaultspec-core vault add``, the bare ``install`` used by the workspace
+    group, and several of either joined by ``/``. Anything that does not
+    resolve to a plausible command path (``Sync output vocabulary``) names no
+    command and is skipped.
+    """
+    commands: list[tuple[str, ...]] = []
+    for candidate in heading.replace("`", "").split("/"):
+        tokens = candidate.split()
+        if not tokens:
+            continue
+        if tokens[0] == _ENTRY_POINT:
+            tokens = tokens[1:]
+        if not tokens:
+            continue
+        if tokens[0] not in known_roots:
+            continue
+        if any(not re.fullmatch(r"[a-z][a-z0-9-]*", token) for token in tokens):
+            continue
+        commands.append(tuple(tokens))
+    return tuple(commands)
+
+
+def parse_command_sections(
+    document_text: str, typer_app: typer.Typer
+) -> list[CommandSection]:
+    """Return every ``### `` command section in *document_text*.
+
+    Sections inside the generator-owned command-inventory region are excluded:
+    that region is a machine-rendered index, not the prose a reader lands on,
+    and treating its group headings as documentation is exactly the blind spot
+    this contract closes.
+    """
+    from vaultspec_core.cli.reference_gen import end_marker
+
+    marker = end_marker("command-inventory")
+    prose_start = document_text.find(marker)
+    prose = (
+        document_text[prose_start + len(marker) :]
+        if prose_start != -1
+        else (document_text)
+    )
+
+    known_roots = frozenset(
+        path[0]
+        for path in collect_leaf_command_paths(typer_app)
+        + collect_group_paths(typer_app)
+    )
+
+    sections: list[CommandSection] = []
+    for match in _SECTION_HEADING.finditer(prose):
+        heading = match.group(1).strip()
+        tail = prose[match.end() :]
+        next_heading = _SECTION_END.search(tail)
+        text = tail[: next_heading.start()] if next_heading else tail
+        sections.append(
+            CommandSection(
+                heading=heading,
+                commands=_heading_commands(heading, known_roots),
+                text=text,
+            )
+        )
+    return sections
+
+
+def covering_section(
+    sections: list[CommandSection], path: tuple[str, ...]
+) -> CommandSection | None:
+    """Return the section documenting *path*, preferring an exact match."""
+    for section in sections:
+        if section.covers(path):
+            return section
+    for section in sections:
+        if section.group_covers(path):
+            return section
+    return None

--- a/src/vaultspec_core/tests/cli/test_cli_handbook_drift.py
+++ b/src/vaultspec_core/tests/cli/test_cli_handbook_drift.py
@@ -1,24 +1,37 @@
 """Guard against drift between the CLI command surface and `docs/CLI.md`.
 
-Walks the Typer app tree, invokes ``--help`` on every visible leaf command, and
-asserts that every command name and every non-global option name appears in
-the handbook. Prevents silent regressions where a new command, subcommand, or
-flag lands without a documentation update.
+Three contracts, in tightening order. Mention: every command name and every
+non-global flag appears somewhere in the handbook. Section: every command in the
+generated Command Index also has a hand-written ``### `` prose section a reader
+can land on, either its own or a group section that names it. Locality: every
+one of a command's flags is explained inside that section, not merely somewhere
+in a two-thousand-line file.
+
+The section contract is the one that catches the drift the mention contract
+cannot see. The Command Index is generated from the live command tree, so a new
+command appears there the moment it is registered - and a reader following the
+index into the body finds nothing. Without this guard that gap is invisible to
+CI.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 from typer.testing import CliRunner
 
 from vaultspec_core.cli import app
-
-if TYPE_CHECKING:
-    import typer
+from vaultspec_core.tests.cli.reference_contract import (
+    GLOBAL_FLAGS,
+    collect_group_paths,
+    collect_leaf_command_paths,
+    command_options,
+    covering_section,
+    extract_options,
+    help_output,
+    parse_command_sections,
+)
 
 pytestmark = [pytest.mark.integration]
 
@@ -26,100 +39,15 @@ pytestmark = [pytest.mark.integration]
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _HANDBOOK = _REPO_ROOT / "docs" / "CLI.md"
 
-# Options carried through the global options table or otherwise inherited on
-# essentially every subcommand. Documenting them once at the top of CLI.md is
-# sufficient; per-command tables do not need to repeat them.
-_GLOBAL_FLAGS: frozenset[str] = frozenset(
-    {"--help", "--target", "-t", "--debug", "-d", "--version", "-V"}
+_REGENERATE_HINT = (
+    "Add a `### ` section for it in docs/CLI.md, in the shape of its "
+    "neighbours: a usage fence, a short narrative, then `#### Arguments`, "
+    "`#### Options`, and `#### Examples` grounded in the command's `--help`."
 )
 
-# Matches long (``--flag``) or short (``-f``) option tokens as they appear in
-# Typer's help output tables.
-_OPTION_TOKEN = re.compile(r"(?<![A-Za-z0-9_])(-{1,2}[A-Za-z][A-Za-z0-9_-]*)")
 
-
-def _collect_leaf_command_paths(typer_app: typer.Typer) -> list[tuple[str, ...]]:
-    """Return the full command path for every visible leaf command."""
-
-    paths: list[tuple[str, ...]] = []
-
-    def _walk(current: typer.Typer, prefix: tuple[str, ...]) -> None:
-        for info in current.registered_commands:
-            if info.hidden:
-                continue
-            name = info.name
-            if not name and info.callback is not None:
-                name = getattr(info.callback, "__name__", None)
-            if name:
-                paths.append((*prefix, name))
-        for group in current.registered_groups:
-            name = group.name
-            if not name or group.hidden:
-                continue
-            group_path = (*prefix, name)
-            if group.typer_instance is not None:
-                _walk(group.typer_instance, group_path)
-
-    _walk(typer_app, ())
-    return paths
-
-
-def _collect_group_paths(typer_app: typer.Typer) -> list[tuple[str, ...]]:
-    """Return the path of every visible Typer sub-group (needed for coverage)."""
-
-    paths: list[tuple[str, ...]] = []
-
-    def _walk(current: typer.Typer, prefix: tuple[str, ...]) -> None:
-        for group in current.registered_groups:
-            name = group.name
-            if not name or group.hidden:
-                continue
-            group_path = (*prefix, name)
-            paths.append(group_path)
-            if group.typer_instance is not None:
-                _walk(group.typer_instance, group_path)
-
-    _walk(typer_app, ())
-    return paths
-
-
-def _help_output(cli: CliRunner, path: tuple[str, ...]) -> str:
-    result = cli.invoke(app, [*path, "--help"])
-    assert result.exit_code == 0, (
-        f"`--help` for {' '.join(path) or '<root>'} exited {result.exit_code}:\n"
-        f"{result.output}"
-    )
-    return result.output
-
-
-def _extract_options(help_text: str) -> set[str]:
-    """Extract every option token from a Typer ``--help`` block."""
-
-    options: set[str] = set()
-    in_options_block = False
-    for raw in help_text.splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        if line.startswith("+- Options") or line.startswith("Options:"):
-            in_options_block = True
-            continue
-        if in_options_block and line.startswith("+-"):
-            # End of a Typer option box.
-            in_options_block = False
-            continue
-        if not in_options_block:
-            continue
-        if not line.startswith("|"):
-            continue
-        # Only the leading option tokens on each row.
-        cells = [cell.strip() for cell in line.strip("|").split("|")]
-        for cell in cells:
-            if not cell.startswith("-"):
-                continue
-            for match in _OPTION_TOKEN.finditer(cell):
-                options.add(match.group(1))
-    return options
+def _runner() -> CliRunner:
+    return CliRunner(env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"})
 
 
 def test_handbook_exists() -> None:
@@ -128,8 +56,8 @@ def test_handbook_exists() -> None:
 
 def test_every_cli_command_is_documented() -> None:
     handbook_text = _HANDBOOK.read_text(encoding="utf-8")
-    leaf_paths = _collect_leaf_command_paths(app)
-    group_paths = _collect_group_paths(app)
+    leaf_paths = collect_leaf_command_paths(app)
+    group_paths = collect_group_paths(app)
     assert leaf_paths, "CLI tree is empty; Typer app failed to register commands"
 
     missing: list[str] = []
@@ -148,13 +76,13 @@ def test_every_cli_command_is_documented() -> None:
 
 def test_every_cli_option_is_documented() -> None:
     handbook_text = _HANDBOOK.read_text(encoding="utf-8")
-    cli = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"})
+    cli = _runner()
 
     missing: list[str] = []
-    for path in _collect_leaf_command_paths(app):
-        help_text = _help_output(cli, path)
-        for option in sorted(_extract_options(help_text)):
-            if option in _GLOBAL_FLAGS:
+    for path in collect_leaf_command_paths(app):
+        help_text = help_output(cli, app, path)
+        for option in sorted(extract_options(help_text)):
+            if option in GLOBAL_FLAGS:
                 continue
             if option in handbook_text:
                 continue
@@ -164,4 +92,64 @@ def test_every_cli_option_is_documented() -> None:
         "The following CLI options appear in `--help` but are not mentioned "
         f"anywhere in {_HANDBOOK.relative_to(_REPO_ROOT)}:\n  - "
         + "\n  - ".join(sorted(missing))
+    )
+
+
+def test_every_indexed_command_has_a_prose_section() -> None:
+    """Every command in the Command Index has a prose section behind it.
+
+    The Command Index is rendered from the live command tree, so every
+    registered command is listed there whether or not anyone wrote about it.
+    This asserts the other half: that following an index entry into the body
+    lands the reader on a `### ` section, either the command's own or a group
+    section whose prose names the command.
+    """
+    handbook_text = _HANDBOOK.read_text(encoding="utf-8")
+    sections = parse_command_sections(handbook_text, app)
+    assert sections, "No `### ` command sections parsed out of the handbook"
+
+    leaf_paths = collect_leaf_command_paths(app)
+    assert leaf_paths, "CLI tree is empty; Typer app failed to register commands"
+
+    missing = [
+        " ".join(path)
+        for path in leaf_paths
+        if covering_section(sections, path) is None
+    ]
+
+    assert not missing, (
+        "The following commands have a Command Index entry in "
+        f"{_HANDBOOK.relative_to(_REPO_ROOT)} but no `### ` prose section:\n  - "
+        + "\n  - ".join(sorted(missing))
+        + f"\n\n{_REGENERATE_HINT}"
+    )
+
+
+def test_every_option_is_documented_in_its_own_section() -> None:
+    """A command's flags are explained where the command is explained.
+
+    The whole-file mention contract passes as soon as a flag name occurs
+    anywhere, including in an unrelated command's section. This asserts the
+    locality a reader actually depends on: the section documenting a command
+    spells out that command's own flags.
+    """
+    handbook_text = _HANDBOOK.read_text(encoding="utf-8")
+    sections = parse_command_sections(handbook_text, app)
+    cli = _runner()
+
+    missing: list[str] = []
+    for path in collect_leaf_command_paths(app):
+        section = covering_section(sections, path)
+        if section is None:
+            # Reported by the section contract above; not double-counted here.
+            continue
+        for option in sorted(command_options(cli, app, path)):
+            if option not in section.text:
+                missing.append(
+                    f"{' '.join(path)}  {option}  (section: {section.heading})"
+                )
+
+    assert not missing, (
+        "The following options are missing from the handbook section that "
+        "documents their command:\n  - " + "\n  - ".join(sorted(missing))
     )

--- a/src/vaultspec_core/tests/cli/test_cli_language_contract.py
+++ b/src/vaultspec_core/tests/cli/test_cli_language_contract.py
@@ -18,9 +18,9 @@ import typer.main
 from typer.testing import CliRunner
 
 from vaultspec_core.cli import app
-from vaultspec_core.tests.cli.test_cli_handbook_drift import (
-    _collect_group_paths,
-    _collect_leaf_command_paths,
+from vaultspec_core.tests.cli.reference_contract import (
+    collect_group_paths,
+    collect_leaf_command_paths,
 )
 
 pytestmark = [pytest.mark.integration]
@@ -111,8 +111,8 @@ def _is_bare_cli_reference(reference: str, top_level_commands: set[str]) -> bool
 
 
 def _registered_command_paths() -> set[tuple[str, ...]]:
-    paths = set(_collect_leaf_command_paths(app))
-    paths.update(_collect_group_paths(app))
+    paths = set(collect_leaf_command_paths(app))
+    paths.update(collect_group_paths(app))
     return paths
 
 
@@ -281,7 +281,7 @@ def test_docs_do_not_describe_command_groups_with_bare_executables() -> None:
 
 def test_markdown_command_references_match_live_cli_surface() -> None:
     command_paths = _registered_command_paths()
-    leaf_paths = set(_collect_leaf_command_paths(app))
+    leaf_paths = set(collect_leaf_command_paths(app))
 
     offenders: list[str] = []
     for path in sorted(_DOC_PATHS):
@@ -306,7 +306,7 @@ def test_markdown_command_references_match_live_cli_surface() -> None:
 
 def test_markdown_command_examples_use_live_cli_options() -> None:
     command_paths = _registered_command_paths()
-    leaf_paths = set(_collect_leaf_command_paths(app))
+    leaf_paths = set(collect_leaf_command_paths(app))
 
     offenders: list[str] = []
     for path in sorted(_DOC_PATHS):
@@ -369,7 +369,7 @@ def test_cli_handbook_documents_every_command() -> None:
 
     missing = [
         f"vaultspec-core {' '.join(command_path)}"
-        for command_path in _collect_leaf_command_paths(app)
+        for command_path in collect_leaf_command_paths(app)
         if f"`vaultspec-core {' '.join(command_path)}`" not in handbook
     ]
 

--- a/src/vaultspec_core/tests/cli/test_cli_reference_contract_helpers.py
+++ b/src/vaultspec_core/tests/cli/test_cli_reference_contract_helpers.py
@@ -1,0 +1,143 @@
+"""Cover the machinery the CLI-reference drift guards are built on.
+
+The drift guards are only as strong as their two primitives: the option
+extractor that reads a command's flags out of ``--help``, and the section parser
+that reads a reference document's prose structure. A primitive that silently
+returns nothing turns every guard built on it into a test that cannot fail, so
+each is asserted here against the real CLI and real reference documents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from vaultspec_core.cli import app
+from vaultspec_core.tests.cli.reference_contract import (
+    collect_leaf_command_paths,
+    command_options,
+    covering_section,
+    extract_options,
+    help_output,
+    parse_command_sections,
+)
+
+pytestmark = [pytest.mark.integration]
+
+_REPO_ROOT = Path(__file__).resolve().parents[4]
+_HANDBOOK = _REPO_ROOT / "docs" / "CLI.md"
+
+
+def _runner() -> CliRunner:
+    return CliRunner(env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"})
+
+
+def test_extractor_reads_flags_from_real_help_output() -> None:
+    """The extractor returns a command's actual flags, not an empty set.
+
+    A parser that matches nothing makes the option-coverage guards vacuous:
+    every flag is trivially "documented" because none is ever collected. This
+    pins the extractor against a command whose flag set is known from its own
+    surface, so a help-rendering change that the parser stops understanding
+    fails here instead of quietly disarming the guards.
+    """
+    cli = _runner()
+    options = extract_options(help_output(cli, app, ("vault", "add")))
+
+    assert {"--feature", "-f", "--tier", "--step", "--all-steps"} <= options
+    assert "--help" in options
+
+
+def test_extractor_reads_every_option_bearing_command() -> None:
+    """No command with flags parses as flagless.
+
+    Sweeps the whole live tree rather than one sample: for every leaf command
+    whose help renders an Options block, the extractor must return at least one
+    token from it.
+    """
+    cli = _runner()
+
+    silent: list[str] = []
+    for path in collect_leaf_command_paths(app):
+        help_text = help_output(cli, app, path)
+        if "Options" not in help_text:
+            continue
+        if not extract_options(help_text):
+            silent.append(" ".join(path))
+
+    assert not silent, (
+        "The option extractor found no flags for these commands, whose `--help` "
+        "renders an Options block:\n  - " + "\n  - ".join(sorted(silent))
+    )
+
+
+def test_extractor_ignores_flags_named_in_help_descriptions() -> None:
+    """Only the option column counts, not flags quoted in a description.
+
+    Several commands describe one flag in another's help text. Treating those
+    mentions as accepted options would credit a command with flags it rejects
+    and weaken the per-section contract into noise.
+    """
+    help_text = (
+        "Usage: root demo [OPTIONS]\n"
+        "\n"
+        "Options:\n"
+        "  --real <str>              Ignored unless --imaginary is also passed\n"
+        "  --help                    Show this message and exit.\n"
+    )
+    assert extract_options(help_text) == {"--real", "--help"}
+
+
+def test_section_parser_finds_the_handbook_command_sections() -> None:
+    """Sections parse out of the real handbook and resolve to real commands."""
+    sections = parse_command_sections(_HANDBOOK.read_text(encoding="utf-8"), app)
+    assert sections, "No `### ` sections parsed out of the handbook"
+
+    headings = {section.heading for section in sections}
+    assert "vaultspec-core vault add" in headings
+    assert "install" in headings
+
+    # The bare workspace heading and the fully qualified heading both resolve.
+    by_heading = {section.heading: section for section in sections}
+    assert by_heading["install"].commands == (("install",),)
+    assert by_heading["vaultspec-core vault add"].commands == (("vault", "add"),)
+
+
+def test_section_parser_excludes_the_generated_command_index() -> None:
+    """Index headings never count as prose sections.
+
+    The generated Command Index carries its own `### ` group headings. Counting
+    those as documentation would make the section contract self-satisfying: the
+    index is rendered from the same command tree the contract checks against.
+    """
+    sections = parse_command_sections(_HANDBOOK.read_text(encoding="utf-8"), app)
+    headings = {section.heading for section in sections}
+    assert "Vault" not in headings
+    assert "Top-level commands" not in headings
+
+
+def test_group_section_only_covers_commands_its_prose_names() -> None:
+    """A group heading alone does not vouch for a leaf it never mentions."""
+    sections = parse_command_sections(_HANDBOOK.read_text(encoding="utf-8"), app)
+    check_section = covering_section(sections, ("vault", "check", "orphans"))
+    assert check_section is not None
+    assert check_section.heading == "vaultspec-core vault check"
+
+    # A leaf the group section does not name is not covered by it.
+    invented = ("vault", "check", "no-such-subcommand-anywhere")
+    assert covering_section(sections, invented) is None
+
+
+@pytest.mark.parametrize(
+    "path",
+    [("vault", "edit"), ("vault", "link", "add"), ("doctor",)],
+)
+def test_command_options_are_scoped_to_the_command(path: tuple[str, ...]) -> None:
+    """`command_options` drops global flags and keeps command-specific ones."""
+    cli = _runner()
+    options = command_options(cli, app, path)
+    assert "--help" not in options
+    assert "--target" not in options
+    assert options, f"{' '.join(path)} reported no command-specific options"

--- a/src/vaultspec_core/tests/cli/test_cli_reference_drift.py
+++ b/src/vaultspec_core/tests/cli/test_cli_reference_drift.py
@@ -1,128 +1,40 @@
 """Guard against drift between the CLI surface and the bundled reference.
 
 The bundled machine-facing reference at
-`src/vaultspec_core/builtins/reference/cli.md` is hand-authored. This test
+`src/vaultspec_core/builtins/reference/cli.md` is hand-authored. This module
 walks the live Typer command tree, invokes ``--help`` on every visible leaf
-command, and asserts that every command name and every non-global option
-name appears in the bundled reference. It mirrors `test_cli_handbook_drift`
-for the bundled reference so a new command, subcommand, or flag cannot land
-without a corresponding reference update.
+command, and asserts that every command name and every non-global option name
+appears in the bundled reference. It mirrors `test_cli_handbook_drift` for the
+bundled reference so a new command, subcommand, or flag cannot land without a
+corresponding reference update.
+
+The bundled reference is a terse agent-facing catalog that consolidates whole
+command families into running prose, so the per-command section contract the
+handbook carries does not apply here; coverage is the contract this surface
+owes.
 """
 
 from __future__ import annotations
 
-import re
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 from typer.testing import CliRunner
 
 from vaultspec_core.cli import app
-
-if TYPE_CHECKING:
-    import typer
+from vaultspec_core.tests.cli.reference_contract import (
+    GLOBAL_FLAGS,
+    collect_group_paths,
+    collect_leaf_command_paths,
+    extract_options,
+    help_output,
+)
 
 pytestmark = [pytest.mark.integration]
 
 
 _REPO_ROOT = Path(__file__).resolve().parents[4]
 _REFERENCE = _REPO_ROOT / "src" / "vaultspec_core" / "builtins" / "reference" / "cli.md"
-
-# Options carried through the global options table or otherwise inherited on
-# essentially every subcommand. Documenting them once at the top of the
-# reference is sufficient; per-command tables do not need to repeat them.
-_GLOBAL_FLAGS: frozenset[str] = frozenset(
-    {"--help", "--target", "-t", "--debug", "-d", "--version", "-V"}
-)
-
-# Matches long (``--flag``) or short (``-f``) option tokens as they appear in
-# Typer's help output tables.
-_OPTION_TOKEN = re.compile(r"(?<![A-Za-z0-9_])(-{1,2}[A-Za-z][A-Za-z0-9_-]*)")
-
-
-def _collect_leaf_command_paths(typer_app: typer.Typer) -> list[tuple[str, ...]]:
-    """Return the full command path for every visible leaf command."""
-
-    paths: list[tuple[str, ...]] = []
-
-    def _walk(current: typer.Typer, prefix: tuple[str, ...]) -> None:
-        for info in current.registered_commands:
-            if info.hidden:
-                continue
-            name = info.name
-            if not name and info.callback is not None:
-                name = getattr(info.callback, "__name__", None)
-            if name:
-                paths.append((*prefix, name))
-        for group in current.registered_groups:
-            name = group.name
-            if not name or group.hidden:
-                continue
-            group_path = (*prefix, name)
-            if group.typer_instance is not None:
-                _walk(group.typer_instance, group_path)
-
-    _walk(typer_app, ())
-    return paths
-
-
-def _collect_group_paths(typer_app: typer.Typer) -> list[tuple[str, ...]]:
-    """Return the path of every visible Typer sub-group (needed for coverage)."""
-
-    paths: list[tuple[str, ...]] = []
-
-    def _walk(current: typer.Typer, prefix: tuple[str, ...]) -> None:
-        for group in current.registered_groups:
-            name = group.name
-            if not name or group.hidden:
-                continue
-            group_path = (*prefix, name)
-            paths.append(group_path)
-            if group.typer_instance is not None:
-                _walk(group.typer_instance, group_path)
-
-    _walk(typer_app, ())
-    return paths
-
-
-def _help_output(cli: CliRunner, path: tuple[str, ...]) -> str:
-    result = cli.invoke(app, [*path, "--help"])
-    assert result.exit_code == 0, (
-        f"`--help` for {' '.join(path) or '<root>'} exited {result.exit_code}:\n"
-        f"{result.output}"
-    )
-    return result.output
-
-
-def _extract_options(help_text: str) -> set[str]:
-    """Extract every option token from a Typer ``--help`` block."""
-
-    options: set[str] = set()
-    in_options_block = False
-    for raw in help_text.splitlines():
-        line = raw.strip()
-        if not line:
-            continue
-        if line.startswith("+- Options") or line.startswith("Options:"):
-            in_options_block = True
-            continue
-        if in_options_block and line.startswith("+-"):
-            # End of a Typer option box.
-            in_options_block = False
-            continue
-        if not in_options_block:
-            continue
-        if not line.startswith("|"):
-            continue
-        # Only the leading option tokens on each row.
-        cells = [cell.strip() for cell in line.strip("|").split("|")]
-        for cell in cells:
-            if not cell.startswith("-"):
-                continue
-            for match in _OPTION_TOKEN.finditer(cell):
-                options.add(match.group(1))
-    return options
 
 
 def test_reference_exists() -> None:
@@ -131,8 +43,8 @@ def test_reference_exists() -> None:
 
 def test_every_cli_command_is_in_reference() -> None:
     reference_text = _REFERENCE.read_text(encoding="utf-8")
-    leaf_paths = _collect_leaf_command_paths(app)
-    group_paths = _collect_group_paths(app)
+    leaf_paths = collect_leaf_command_paths(app)
+    group_paths = collect_group_paths(app)
     assert leaf_paths, "CLI tree is empty; Typer app failed to register commands"
 
     missing: list[str] = []
@@ -155,10 +67,10 @@ def test_every_cli_option_is_in_reference() -> None:
     cli = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"})
 
     missing: list[str] = []
-    for path in _collect_leaf_command_paths(app):
-        help_text = _help_output(cli, path)
-        for option in sorted(_extract_options(help_text)):
-            if option in _GLOBAL_FLAGS:
+    for path in collect_leaf_command_paths(app):
+        help_text = help_output(cli, app, path)
+        for option in sorted(extract_options(help_text)):
+            if option in GLOBAL_FLAGS:
                 continue
             if option in reference_text:
                 continue


### PR DESCRIPTION
Closes #249

Stacked on #262 (the #248 gap fills), which must merge first. Base is `docs/cli-reference-gap-fills`; retarget to `main` after that merges.

## The gap

`docs/CLI.md`'s Command Index is rendered from the live Typer tree, so a new command lands there the moment it is registered. Nothing asserted the other half - that following an index entry into the body reaches a hand-written section. Commands drifted undocumented with no CI signal, which is how #248's backlog accumulated.

## The guard

Two new contracts on `docs/CLI.md`, in `test_cli_handbook_drift.py`:

- **`test_every_indexed_command_has_a_prose_section`** - every leaf command has a covering `### ` section: its own, or a group section (`### vaultspec-core vault check`) whose prose actually names the leaf. A group heading alone does not vouch for a leaf it never mentions.
- **`test_every_option_is_documented_in_its_own_section`** - a command's flags are explained where the command is explained, not merely somewhere in a 2,000-line file.

Both proven to fail on real drift: deleting the `vault link add` section fails the first, and deleting the `--stale-days` bullet fails the second.

## The tautology underneath

Fixing the section contract exposed why the existing option contracts never caught anything. `_extract_options` only understood Typer's Rich-boxed help layout (rows starting with `|`). The test runner renders the *plain* layout, so the parser returned an **empty set for every command** - both `test_every_cli_option_is_documented` and `test_every_cli_option_is_in_reference` passed vacuously, on both surfaces.

It now parses both layouts, and reads only the option column so a flag quoted inside another flag's help description is not counted as accepted. `test_cli_reference_contract_helpers.py` pins this permanently: no command whose help renders an Options block may parse as flagless.

## Shared module

The tree walk, extractor, and section parser move to `src/vaultspec_core/tests/cli/reference_contract.py`. `test_cli_handbook_drift`, `test_cli_reference_drift`, and `test_cli_language_contract` all consume it, so the three cannot answer the same question differently.

## Scope note

The bundled `builtins/reference/cli.md` stays on the coverage contract. It is a terse agent-facing catalog that consolidates whole command families into running prose, so the per-command section shape does not apply to it; its command and option coverage is now genuinely enforced by the de-tautologized sweeps.

## Verification

- 43 passed across `test_cli_{handbook_drift,reference_drift,reference_contract_helpers,language_contract,reference_generated}.py`
- prek: ruff-check, ruff-format, ty, and the doc hooks all pass