### PR TITLE
fix(plan): preserve sanitized link rules across mutations

### DIFF
--- a/.vault/audit/2026-07-27-template-annotation-sanitization-plan-link-rules-audit.md
+++ b/.vault/audit/2026-07-27-template-annotation-sanitization-plan-link-rules-audit.md
@@ -1,0 +1,22 @@
+---
+tags:
+  - '#audit'
+  - '#template-annotation-sanitization'
+date: '2026-07-27'
+modified: '2026-07-27'
+related: []
+---
+
+# `template-annotation-sanitization` audit: `plan link rules`
+
+## Scope
+
+Reviewed the parser-to-serializer state contract and the real sanitation-plus-structural-mutation regression for issue #267.
+
+## Findings
+
+No critical, high, medium, or low findings. **PASS:** source presence is captured only for the generated guidance block, fresh plan construction retains its existing default, and the regression uses the production sanitizer and CLI command without a fake or mirrored implementation.
+
+## Recommendations
+
+No follow-up required. Merge after the configured lint, type, and plan-suite checks pass.

--- a/.vault/index/template-annotation-sanitization.index.md
+++ b/.vault/index/template-annotation-sanitization.index.md
@@ -3,12 +3,13 @@ generated: true
 tags:
   - '#index'
   - '#template-annotation-sanitization'
-date: '2026-05-15'
-modified: '2026-06-13'
+date: '2026-07-27'
+modified: '2026-07-27'
 related:
   - '[[2026-05-15-template-annotation-sanitization-adr]]'
   - '[[2026-05-15-template-annotation-sanitization-plan]]'
   - '[[2026-05-15-template-annotation-sanitization-research]]'
+  - '[[2026-07-27-template-annotation-sanitization-plan-link-rules-audit]]'
 ---
 
 # `template-annotation-sanitization` feature index
@@ -19,7 +20,11 @@ Auto-generated index of all documents tagged with `#template-annotation-sanitiza
 
 ### adr
 
-- `2026-05-15-template-annotation-sanitization-adr` - template-annotation-sanitization adr: explicit generated annotation sanitation | status: accepted
+- `2026-05-15-template-annotation-sanitization-adr` - template-annotation-sanitization adr: explicit generated annotation sanitation | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-27-template-annotation-sanitization-plan-link-rules-audit` - `template-annotation-sanitization` audit: `plan link rules`
 
 ### plan
 

--- a/src/vaultspec_core/plan/parser.py
+++ b/src/vaultspec_core/plan/parser.py
@@ -165,6 +165,9 @@ class Plan:
             demote; same persistence as ``retired_step_ids``.
         retired_wave_ids: Canonical Wave ids retired via remove or
             demote; same persistence as ``retired_step_ids``.
+        has_link_rules: Whether the source carried the generated ``LINK RULES``
+            guidance block. Structural mutations preserve its absence after an
+            explicit annotation sanitation pass.
     """
 
     frontmatter: PlanFrontmatter
@@ -177,6 +180,7 @@ class Plan:
     retired_phase_ids: set[str] = field(default_factory=set)
     retired_wave_ids: set[str] = field(default_factory=set)
     unknown_blocks: list[UnknownBlock] = field(default_factory=list)
+    has_link_rules: bool = True
 
 
 class PlanParseError(ValueError):
@@ -229,7 +233,7 @@ def parse_plan(source: str | Path) -> Plan:
 
     title = _extract_title(body)
     epic_intent = _extract_epic_intent(body)
-    waves, phases, steps, unknown_blocks = _walk_body(body)
+    waves, phases, steps, unknown_blocks, has_link_rules = _walk_body(body)
     retired_steps, retired_phases, retired_waves = _extract_retirement_ledger(body)
 
     return Plan(
@@ -243,6 +247,7 @@ def parse_plan(source: str | Path) -> Plan:
         retired_phase_ids=retired_phases,
         retired_wave_ids=retired_waves,
         unknown_blocks=unknown_blocks,
+        has_link_rules=has_link_rules,
     )
 
 
@@ -335,7 +340,7 @@ def _extract_epic_intent(body: str) -> EpicIntent | None:
 
 def _walk_body(
     body: str,
-) -> tuple[list[Wave], list[Phase], list[Step], list[UnknownBlock]]:
+) -> tuple[list[Wave], list[Phase], list[Step], list[UnknownBlock], bool]:
     """Walk the body and assemble container chains and unknown blocks."""
     waves: list[Wave] = []
     phases: list[Phase] = []
@@ -350,6 +355,7 @@ def _walk_body(
     buffered_unknown: list[str] = []
     in_epic_intent: bool = False
     in_link_rules_comment: bool = False
+    has_link_rules = False
 
     def _flush_intent() -> None:
         if intent_target is not None and intent_buffer:
@@ -377,6 +383,7 @@ def _walk_body(
 
         # 2. Link rules comment block
         if "<!-- LINK RULES:" in line:
+            has_link_rules = True
             in_link_rules_comment = True
         if in_link_rules_comment:
             if "-->" in line:
@@ -469,7 +476,7 @@ def _walk_body(
     _flush_intent()
     _flush_unknown("after_all")
 
-    return waves, phases, steps, unknown_blocks
+    return waves, phases, steps, unknown_blocks, has_link_rules
 
 
 def _build_step(match: re.Match[str], index: int, raw_line: str) -> Step:

--- a/src/vaultspec_core/plan/serialiser.py
+++ b/src/vaultspec_core/plan/serialiser.py
@@ -103,8 +103,9 @@ def serialise_plan(plan: Plan, canonicalise: bool = False) -> str:
     parts: list[str] = []
     parts.append(_render_frontmatter(plan))
     parts.append("")
-    parts.append(_render_link_rules_comment())
-    parts.append("")
+    if plan.has_link_rules:
+        parts.append(_render_link_rules_comment())
+        parts.append("")
     ledger = _render_retirement_ledger(plan)
     if ledger is not None:
         parts.append(ledger)

--- a/src/vaultspec_core/tests/plan/test_preservation.py
+++ b/src/vaultspec_core/tests/plan/test_preservation.py
@@ -15,6 +15,7 @@ from typer.testing import CliRunner
 from vaultspec_core.cli import app
 from vaultspec_core.plan.parser import parse_plan
 from vaultspec_core.plan.serialiser import serialise_plan
+from vaultspec_core.vaultcore.checks.annotations import check_annotations
 
 L1_SAMPLE = """---
 tags:
@@ -174,6 +175,17 @@ def test_serialise_plan_preserves_unknown_blocks() -> None:
     assert serialise_plan(re_parsed, canonicalise=False) == serialized_l1
 
 
+def test_serialise_plan_preserves_link_rules_when_source_contains_them() -> None:
+    """Keep creation-time link guidance when it is present in the source."""
+    annotated = L1_SAMPLE.replace(
+        "---\n\nGeneral preamble",
+        "---\n\n<!-- LINK RULES:\n     generated guidance. -->\n\nGeneral preamble",
+        1,
+    )
+
+    assert "<!-- LINK RULES:" in serialise_plan(parse_plan(annotated))
+
+
 def test_serialise_plan_canonicalise_strips_unknown_blocks() -> None:
     """Verify that serialise_plan with canonicalise=True strips unknown blocks."""
     plan_l1 = parse_plan(L1_SAMPLE)
@@ -270,6 +282,35 @@ def test_cli_standard_apply_preserves_and_reports_count(
     assert "General preamble" in content
     assert "Prose description" in content
     assert "- [x] `S01`" in content
+
+
+def test_cli_step_check_does_not_restore_sanitized_link_rules(
+    tmp_path, runner: CliRunner
+) -> None:
+    """A structural mutation must not undo the real annotation sanitizer."""
+    plan_path = tmp_path / ".vault" / "plan" / "2026-05-05-demo-plan.md"
+    plan_path.parent.mkdir(parents=True)
+    annotated = L1_SAMPLE.replace(
+        "---\n\nGeneral preamble",
+        "---\n\n<!-- LINK RULES:\n     generated guidance. -->\n\nGeneral preamble",
+        1,
+    )
+    plan_path.write_text(serialise_plan(parse_plan(annotated)), encoding="utf-8")
+
+    sanitation = check_annotations(tmp_path, fix=True)
+
+    assert sanitation.fixed_count == 1
+    assert "<!-- LINK RULES:" not in plan_path.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["vault", "plan", "step", "check", str(plan_path), "S01"],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    content = plan_path.read_text(encoding="utf-8")
+    assert "- [x] `S01`" in content
+    assert "<!-- LINK RULES:" not in content
 
 
 def test_cli_step_add_preservation(tmp_path, runner: CliRunner) -> None:


### PR DESCRIPTION
## Summary
- preserve whether a parsed plan contained generated LINK RULES guidance
- prevent structural plan mutations from restoring guidance removed by annotation sanitation
- add a real sanitation plus plan CLI regression test

## Verification
- uv run pytest src/vaultspec_core/tests/plan -q
- uv run ruff check and ruff format --check on touched Python files
- uv run python -m ty check src/vaultspec_core
- prek run --files on the five committed files

Closes #267