### PR TITLE
feat: allow topic-infixed ADR records

### DIFF
--- a/.vault/adr/2026-07-16-reference-topic-infix-adr.md
+++ b/.vault/adr/2026-07-16-reference-topic-infix-adr.md
@@ -1,17 +1,18 @@
 ---
 tags:
-  - '#adr'
-  - '#reference-topic-infix'
+  - "#adr"
+  - "#reference-topic-infix"
 date: '2026-07-16'
-modified: '2026-07-16'
 related:
   - "[[2026-07-16-reference-topic-infix-research]]"
-  - '[[2026-06-09-firmware-wording-review-adr]]'
-  - '[[2026-06-27-rename-convergence-adr]]'
-  - '[[2026-07-09-mcp-tool-schema-adr]]'
+  - "[[2026-06-09-firmware-wording-review-adr]]"
+  - "[[2026-06-27-rename-convergence-adr]]"
+  - "[[2026-07-09-mcp-tool-schema-adr]]"
+superseded_by: '2026-07-27-adr-topic-infix-adr'
+modified: '2026-07-27'
 ---
 
-# `reference-topic-infix` adr: `topic-infix scaffolding for the narrative document trio` | (**status:** `accepted`)
+# `reference-topic-infix` adr: `topic-infix scaffolding for the narrative document trio` | (**status:** `superseded`)
 
 ## Problem Statement
 

--- a/.vault/adr/2026-07-27-adr-topic-infix-adr.md
+++ b/.vault/adr/2026-07-27-adr-topic-infix-adr.md
@@ -1,0 +1,72 @@
+---
+tags:
+  - "#adr"
+  - "#adr-topic-infix"
+date: '2026-07-27'
+related:
+  - "[[2026-07-27-adr-topic-infix-research]]"
+  - "[[2026-07-27-adr-topic-infix-reference]]"
+  - "[[2026-07-16-reference-topic-infix-adr]]"
+supersedes:
+  - '2026-07-16-reference-topic-infix-adr'
+modified: '2026-07-27'
+---
+
+# `adr-topic-infix` adr: `topic-infixed ADR records` | (**status:** `accepted`)
+
+## Problem Statement
+
+A feature can need several same-day, independently searchable decisions while
+one plan executes their cluster. The previous topic-infix boundary makes that
+valid record shape unrepresentable through the owning creator. The decision is
+whether ADRs join the infix admission set or the framework instead changes its
+one-decision and plan-cluster guidance. Grounding: `2026-07-27-adr-topic-infix-research`.
+
+## Considerations
+
+- The prior restriction is a standing accepted decision and must be superseded,
+  not silently overridden: `2026-07-16-reference-topic-infix-adr`.
+- CLI and MCP must converge on the existing single creator and its collision
+  authority: `2026-07-27-adr-topic-infix-reference`.
+- Plan and exec identifiers have distinct cardinality/derivation constraints;
+  this decision does not reopen them.
+
+## Considered options
+
+- **Admit ADR alongside audit, reference, and research (chosen).** Preserves
+  one ADR per decision and one feature/plan cluster with the existing mechanism.
+- **Keep ADR rejected and revise the guidance.** Rejected: it would retain the
+  record-fidelity problem documented in the research.
+- **Admit every document type.** Rejected: plan and exec retain their separate
+  identifier disciplines without evidence that they need disambiguation.
+
+## Constraints
+
+- Omitted `--topic` behavior and existing collision handling remain unchanged.
+- The topic stays normalized at both transport boundaries.
+- The built-in rule, installed rule mirror, and generated CLI reference must
+  describe the same admission set.
+- Existing superseded documents remain valid historical records.
+
+## Implementation
+
+Extend the shared admission set to `adr`, update the two transport guards and
+their help/schema wording, revise the owned rule text, and cover same-day
+topic-infixed ADR creation, duplicate rejection, and CLI/MCP convergence. The
+implementation surface is mapped in `2026-07-27-adr-topic-infix-reference`.
+
+## Rationale
+
+Admitting ADRs is the narrow correction that makes the existing plan-cluster
+model and one-decision-per-record convention jointly expressible. It keeps the
+single creator and all current identifier safeguards intact, while broader
+admission would weaken constraints that do not participate in the issue.
+Grounding: `2026-07-27-adr-topic-infix-research` and
+`2026-07-27-adr-topic-infix-reference`.
+
+## Consequences
+
+Features may carry several same-day ADRs without splitting their feature tag or
+altering dates. The optional flag grows the set of narrative filename forms that
+future rename work must support. Existing callers that omit the flag and all
+plan/exec creation behavior remain unchanged.

--- a/.vault/adr/2026-07-27-vault-exec-recovery-adr.md
+++ b/.vault/adr/2026-07-27-vault-exec-recovery-adr.md
@@ -1,0 +1,52 @@
+---
+tags:
+  - '#adr'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-vault-exec-recovery-research]]"
+---
+
+# `vault-exec-recovery` adr: `explicit recovery ownership for historical execution mappings` | (**status:** `accepted`)
+
+## Problem Statement
+
+`vault check exec-mapping` correctly reports execution records whose `step_id` no longer identifies a live parent-plan Step, but it intentionally has no mutation authority. The verified recovery set contains records that can be truthfully re-linked, a historical record whose Step is retired, and prose-era records for which no formal Step exists. These need explicit, auditable operator actions rather than a checker-side guess, as grounded in `2026-07-27-vault-exec-recovery-research` and bounded by `2026-07-23-vault-check-validators-adr`.
+
+## Considerations
+
+- A display-path-looking value is not the canonical `S##` identity the validator and plan parser use; only resolution against the recordâ€™s actual parent plan can establish a safe replacement.
+- Retired Step identities and legacy records without `step_id` already have distinct validator meanings. Recovery must preserve those meanings rather than make the checker permissive.
+- Execution bodies are historical evidence. Recovery changes only machine-owned metadata or archives the complete record; it does not rewrite authored prose.
+- The CLI already establishes atomic mutation, dry-run, no-op, and stable JSON conventions suitable for an operator-owned recovery surface.
+
+## Considered options
+
+- **Dedicated `vault exec` recovery commands (chosen).** Explicit commands classify and apply one verified recovery at a time, with validation before mutation and an auditable result.
+- **`vault check exec-mapping --fix`.** Rejected: the checker cannot safely infer whether a malformed value denotes a live Step, a retired historical record, or an unmappable legacy record.
+- **Bulk metadata migration.** Rejected: superficially similar values have different provenance; bulk rewriting could mis-link historical evidence.
+- **Relax the validator for malformed values.** Rejected: it would conceal corruption and collapse the distinction between a valid legacy record and an invalid claimed mapping.
+- **Hand-edit frontmatter or archive paths.** Rejected: bypasses validation, atomicity, output conventions, and preservation guarantees.
+
+## Constraints
+
+- The accepted validator remains read-only with its live, retired, dangling, archived-parent, and no-`step_id` classifications unchanged.
+- `relink` writes only after resolving a supplied target against the record's existing, live, parseable parent plan; it rejects absent, retired, ambiguous, or cross-plan targets.
+- Recovery does not create a parent relationship, alter `related:`, mutate tags or dates, normalize the body, or infer a target from prose.
+- Mutations are atomic, support dry-run and JSON output, report no-ops explicitly, and preserve the original body bytes.
+- `retire` is limited to a record whose current identity is in the parent planâ€™s retired ledger. `detach` is limited to a claim resolving to neither a live nor retired Step.
+
+## Implementation
+
+Introduce a `vault exec` command group with `relink`, `retire`, and `detach` operations. They share typed recovery helpers beneath thin CLI wrappers, validate the exec document and its related parent plan, parse the plan once, preserve authored body content byte-for-byte, and use atomic writes or an atomic archive move. The initial recovery applies relink only to verified-live records, retire to the verified retired-Step record, and detach to verified prose-era legacy records.
+
+## Rationale
+
+Recovery is semantic, not syntactic. The resolver can prove a supplied target is live in the recordâ€™s existing parent plan, making canonical re-linking safe; it cannot prove intent for a retired or prose-era record. Retiring the former preserves evidence while placing it outside active validation. Detaching the latter records the only truthful machine state: no formal Step anchor.
+
+Keeping the validator strict identifies future dangling or retired claims while leaving recovery authority with an operator who supplies historical judgment. This preserves the boundary established by `2026-07-23-vault-check-validators-adr` while providing the missing mutation surface.
+
+## Consequences
+
+The verified historical set can converge without inventing mappings, losing evidence, or weakening validation. New repairs are canonical and mechanically verifiable; retirement and detachment become explicit, reviewable operations. Records that cannot satisfy a command precondition remain visible findings.

--- a/.vault/audit/2026-07-27-adr-topic-infix-audit.md
+++ b/.vault/audit/2026-07-27-adr-topic-infix-audit.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#audit'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+  - "[[2026-07-27-adr-topic-infix-adr]]"
+---
+
+# `adr-topic-infix` audit: `ADR topic-infix implementation review`
+
+## Scope
+
+Read-only review of the completed ADR topic-infix implementation against
+`2026-07-27-adr-topic-infix-adr` and `2026-07-27-adr-topic-infix-plan`: the
+shared creator, CLI, MCP, direct/CLI/MCP regressions, and published rule/reference
+contract.
+
+## Findings
+
+No critical, high, medium, or low findings. The creator, CLI, and MCP all admit the
+same four document types; plan and exec remain excluded. The branch introduces no
+runtime resource, concurrency, or source-to-vault boundary risk.
+
+Status: PASS. Safe to merge.
+
+## Recommendations
+
+None.

--- a/.vault/audit/2026-07-27-vault-exec-recovery-implementation-audit.md
+++ b/.vault/audit/2026-07-27-vault-exec-recovery-implementation-audit.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - '#audit'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-vault-exec-recovery-adr]]"
+  - "[[2026-07-27-vault-exec-recovery-plan]]"
+---
+
+# `vault-exec-recovery` audit: `Execution recovery implementation`
+
+## Scope
+
+Reviewed the typed recovery helpers against the accepted recovery ADR, implementation plan, and their focused real-filesystem tests. The review covered mutation authority, parent-plan resolution, archive safety, line-ending and body preservation, and dry-run/no-op evidence.
+
+## Findings
+
+### parent-plan-ambiguity | high | First matching plan link gains mutation authority
+
+`resolve_exec_parent_plan` returns the first related entry that happens to name a live parseable plan. A record carrying two live plan relations is therefore silently bound by ordering, although the ADR permits recovery only against the record's existing parent plan. Relinking, detaching, or retiring such a record can apply an operator action under the wrong plan's retired ledger or live Step set.
+
+### related-path-escape | high | A related stem can escape the plan directory
+
+The related-link stem is concatenated into a candidate filename without rejecting separators or proving the resolved candidate remains under the live plan directory. A crafted `[[../../...]]` relation can supply an external plan as recovery authority, defeating the vault-root confinement required for an explicit record repair.
+
+### archive-destination-race | critical | Retirement can overwrite a concurrently created archive record
+
+`retire_exec_record` tests that the destination is absent and then calls `os.replace`. A competing create between those operations is replaced on supported platforms, silently destroying an existing archive record. The archive move needs an exclusive no-replace destination protocol and containment checks for the archive path and its parents.
+
+### cr-only-frontmatter | medium | Metadata mutation does not support classic-Mac line endings
+
+The step-id replacement, removal, and insertion patterns rely on multiline anchors, which only recognize line starts after LF. A valid CR-only record accepted by the stamp helper cannot have its existing `step_id` located or its `modified` anchor found, so recovery fails despite the preservation contract covering line endings.
+
+### recovery-boundary-coverage | medium | Focused tests omit safety and contract boundaries
+
+The eight passing tests cover the ordinary CRLF paths, but do not prove rejection of multiple parent plans, escaped or symlinked parents and archive destinations, collision-safe retirement, CR-only records, or dry-run and no-op result contracts. Add real-filesystem regressions before exposing the helpers through the CLI.
+
+### recovery-review-remediation | low | All review findings have verified fixes
+
+The recovery resolver now rejects unsafe stems, symlinked inputs, and multiple live parent plans. Retirement reserves its destination with a no-replace hard link under the vault advisory lock; preview validates the same collision condition. The metadata parsing view supports CR-only records while writes retain original line endings. Seventeen focused real-file and CLI tests exercise these boundaries and pass.
+
+## Recommendations
+
+Retain the explicit command preconditions and strict `exec-mapping` validator. Apply only the previously verified RAG record set, then re-run `vault check exec-mapping` before treating the historical recovery as complete.
+
+### recovery-precondition-race | critical | A stale validated context can mutate newly changed evidence
+
+Each operation resolves and classifies the execution record before its eventual write or archive. `relink` and `detach` then read the path again and edit its current frontmatter without revalidating the claim, while `retire` takes the advisory lock only after classification. A concurrent Core edit can therefore change a dangling claim into a live claim between validation and mutation; the stale detach removes that live mapping, or stale retirement archives a record no longer tied to a retired Step. The record mutation must hold the common vault lock from read through apply and revalidate the record's immutable blob or full recovery preconditions inside that critical section.
+
+### recovery-lock-absent-data | critical | Fresh vaults bypass the recovery critical section
+
+The recovery context calls the shared advisory lock, but that helper deliberately yields without locking when the `.vault/data` parent does not already exist. The new threaded regression creates that directory before holding the lock, so it proves only the initialized-vault case. Two recovery processes in a fresh vault can still resolve and mutate concurrently, recreating the stale-precondition race. Ensure the common lock parent exists before any non-dry-run recovery resolution, or make the shared lock establish its parent with an explicitly safe dry-run policy, and add the same competing-mutation regression without pre-creating `.vault/data`.
+
+### recovery-lock-remediation | low | Final review verified the recovery critical section
+
+Applying recovery now creates the standard vault runtime lock directory, then takes the shared document lock before it resolves, classifies, and mutates a record. The real threaded regression begins with no runtime directory, proves the lock is established, blocks a competing recovery, and preserves a newly live mapping. Final independent review found no remaining release blocker; all eighteen focused real-file and CLI tests pass.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-S01.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-S01.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S01'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# Extend the shared topic-infix admission set to ADR documents
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/hydration.py`
+
+## Description
+
+- Extend the shared admission set with `DocType.ADR`.
+- Preserve the existing filename builder and collision authority.
+- Align the creator-level admitted-types diagnostic.
+
+## Outcome
+
+The shared scaffolder can now select the existing topic-infix filename path for
+ADRs. CLI and MCP boundary changes remain in their dedicated Steps.
+
+## Notes
+
+No data migration or compatibility change is required because omitted topics retain
+their existing filename path.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-S02.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-S02.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S02'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# Align CLI topic validation and help text with ADR admission
+
+## Scope
+
+- `src/vaultspec_core/cli/vault_cmd.py`
+
+## Description
+
+- Add ADR to the CLI topic-infix help contract.
+- Admit ADRs before normalizing the optional topic value.
+- Keep unsupported plan and execution-record types rejected.
+
+## Outcome
+
+CLI callers can create an ADR with a topic and receive the same normalized value
+that the shared creator accepts. The CLI remains explicit about the four supported
+document types.
+
+## Notes
+
+No command routing changed; the CLI continues to delegate filename construction to
+the shared creator.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-S03.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-S03.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S03'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# Align MCP topic schema and validation with ADR admission
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/tools/documents.py`
+
+## Description
+
+- Add ADR to the MCP topic field contract.
+- Admit ADR specs in the per-item validation path.
+- Preserve one normalized handoff to the shared creator.
+
+## Outcome
+
+MCP batch creation now accepts a topic-infixed ADR and reports unsupported document
+types with the same four-type admission contract as the CLI and creator.
+
+## Notes
+
+The per-item failure behavior for unsupported types remains unchanged.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-summary.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P01-summary.md
@@ -1,0 +1,23 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# `adr-topic-infix` `P01` summary
+
+The shared creator, CLI, and MCP now converge on ADR, audit, reference, and research
+as the topic-infix types. Plan and exec behavior remains excluded and unchanged.
+
+- Modified: `src/vaultspec_core/vaultcore/hydration.py`
+- Modified: `src/vaultspec_core/cli/vault_cmd.py`
+- Modified: `src/vaultspec_core/mcp_server/tools/documents.py`
+
+## Description
+
+Completed P01.S01 through P01.S03. Each transport keeps its existing validation and
+delegates filename construction to the shared creator.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S04.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S04.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S04'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/tests/test_hydration.py`
+
+## Description
+
+- Add ADR to the direct admitting-type coverage.
+- Keep plan and execution records in the rejection coverage.
+- Reproduce two same-day ADR topics and duplicate rejection.
+
+## Outcome
+
+The direct scaffolder regression suite proves that two distinct ADR topics create
+separate records while an identical topic remains blocked by the existing guard.
+
+## Notes
+
+`src/vaultspec_core/vaultcore/tests/test_hydration.py` passed: 32 tests.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S05.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S05.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S05'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# Cover CLI creation of two same-day topic-infixed ADRs
+
+## Scope
+
+- `tests/test_commands.py`
+
+## Description
+
+- Invoke the public `vault add adr` command in a real installed workspace.
+- Create two same-day ADRs with distinct normalized topics.
+- Assert duplicate-topic rejection and the exact persisted filenames.
+
+## Outcome
+
+The CLI regression proves the issue workflow without bypassing parsing, validation,
+or file creation. The duplicate call exits nonzero and preserves both created ADRs.
+
+## Notes
+
+`tests/test_commands.py::test_vault_add_creates_distinct_same_day_topic_infixed_adrs`
+passed.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S06.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S06.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S06'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# Cover MCP creation of topic-infixed ADRs in a mixed batch
+
+## Scope
+
+- `tests/unit/mcp_server/test_create_tool.py`
+
+## Description
+
+- Admit topic-infixed ADR specs in a mixed MCP create request.
+- Retain the per-item failure for a topic-infixed plan spec.
+- Assert the ADR file exists after the successful item completes.
+
+## Outcome
+
+MCP callers can create topic-infixed ADRs without losing mixed-batch isolation for
+unsupported document types.
+
+## Notes
+
+`tests/unit/mcp_server/test_create_tool.py` passed: 9 tests.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S07.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-S07.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S07'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# Revise the owned topic-infix rule and regenerate its published reference
+
+## Scope
+
+- `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`
+
+## Description
+
+- Revise the canonical rule to admit ADR topic infixes.
+- Update the hand-authored CLI reference option description.
+- Sync the managed `.vaultspec` rule and reference copies.
+
+## Outcome
+
+The source and installed framework documentation now describe the same four-type
+contract as the CLI, MCP, and shared creator. The generated CLI reference check is
+clean.
+
+## Notes
+
+The managed upgrade changed only `reference/cli.md` and `rules/vaultspec.builtin.md`.

--- a/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-summary.md
+++ b/.vault/exec/2026-07-27-adr-topic-infix/2026-07-27-adr-topic-infix-P02-summary.md
@@ -1,0 +1,25 @@
+---
+tags:
+  - '#exec'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-adr-topic-infix-plan]]"
+---
+
+# `adr-topic-infix` `P02` summary
+
+Direct, CLI, and MCP regression tests cover two same-day topic-infixed ADRs,
+duplicate rejection, and retained plan rejection. The source and installed
+documentation describe the same contract.
+
+- Modified: `src/vaultspec_core/vaultcore/tests/test_hydration.py`
+- Modified: `tests/test_commands.py`
+- Modified: `tests/unit/mcp_server/test_create_tool.py`
+- Modified: `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`
+
+## Description
+
+Completed P02.S04 through P02.S07. The combined verification ran 42 behavioral tests,
+Ruff, generated-reference validation, and a PASS implementation audit.

--- a/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S01.md
+++ b/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S01.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S01'
+related:
+  - "[[2026-07-27-vault-exec-recovery-plan]]"
+---
+
+# Typed recovery operations
+
+## Scope
+
+- `src/vaultspec_core/vaultcore`
+
+## Description
+
+- Added typed relink, retire, detach, and parent-resolution operations.
+- Preserved record bodies and line endings while changing only machine-owned metadata.
+- Added containment, archive collision, and lock-backed concurrency protections.
+
+## Outcome
+
+The core recovery layer validates one live parent plan and applies only the explicit recovery allowed by the accepted ADR.
+
+## Notes
+
+Independent review found and verified fixes for archive, path, line-ending, and concurrency boundaries before release.

--- a/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S02.md
+++ b/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S02.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S02'
+related:
+  - "[[2026-07-27-vault-exec-recovery-plan]]"
+---
+
+# Recovery command surface
+
+## Scope
+
+- `src/vaultspec_core/cli`
+
+## Description
+
+- Registered `vault exec relink`, `vault exec retire`, and `vault exec detach`.
+- Added per-command target, dry-run, JSON envelope, and cache-invalidation behavior.
+- Generated the CLI reference inventory through the prescribed generator.
+
+## Outcome
+
+Operators can perform one validated execution-record recovery at a time without hand-editing frontmatter.
+
+## Notes
+
+The command surface delegates all semantic checks and writes to the typed core layer.

--- a/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S03.md
+++ b/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S03.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S03'
+related:
+  - "[[2026-07-27-vault-exec-recovery-plan]]"
+---
+
+# Recovery verification
+
+## Scope
+
+- `tests`
+
+## Description
+
+- Added real-file unit coverage for body preservation, parent resolution, path confinement, archive collisions, line endings, dry runs, and lock-backed revalidation.
+- Added real CLI integration coverage for JSON previews and applied relink, detach, and retire behavior.
+- Ran the focused tests, lint, generated-reference validation, and independent code review.
+
+## Outcome
+
+Eighteen focused real-file and CLI tests pass, and the final review reported no remaining release blocker.
+
+## Notes
+
+The concurrent-mutation regression begins from a fresh vault without a pre-existing runtime lock directory.

--- a/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S04.md
+++ b/.vault/exec/2026-07-27-vault-exec-recovery/2026-07-27-vault-exec-recovery-P01-S04.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+step_id: 'S04'
+related:
+  - "[[2026-07-27-vault-exec-recovery-plan]]"
+---
+
+# RAG recovery application
+
+## Scope
+
+- `Y:/code/vaultspec-rag-worktrees/main/.vault`
+
+## Description
+
+- Captured a fresh `exec-mapping` snapshot from the RAG vault.
+- Dry-ran ten canonical relinks, one retired-record archive, and six legacy detaches.
+- Applied the same verified operations through `vault exec` and re-ran the mapping check.
+
+## Outcome
+
+The RAG `exec-mapping` check now reports zero diagnostics. Historical execution evidence was preserved: the retired record moved intact to the archive and legacy prose-era records retain their bodies without a fabricated Step identity.
+
+## Notes
+
+The target worktree contains unrelated concurrent vault work; this step touched only the seventeen verified execution records and its one archive destination.

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -12,6 +12,7 @@ related:
   - '[[2026-07-27-adr-topic-infix-P02-S04]]'
   - '[[2026-07-27-adr-topic-infix-P02-S05]]'
   - '[[2026-07-27-adr-topic-infix-P02-S06]]'
+  - '[[2026-07-27-adr-topic-infix-P02-S07]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
   - '[[2026-07-27-adr-topic-infix-reference]]'
@@ -36,6 +37,7 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 - `2026-07-27-adr-topic-infix-P02-S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs
 - `2026-07-27-adr-topic-infix-P02-S05` - Cover CLI creation of two same-day topic-infixed ADRs
 - `2026-07-27-adr-topic-infix-P02-S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch
+- `2026-07-27-adr-topic-infix-P02-S07` - Revise the owned topic-infix rule and regenerate its published reference
 
 ### plan
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -7,6 +7,7 @@ date: '2026-07-27'
 modified: '2026-07-27'
 related:
   - '[[2026-07-27-adr-topic-infix-P01-S01]]'
+  - '[[2026-07-27-adr-topic-infix-P01-S02]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
   - '[[2026-07-27-adr-topic-infix-reference]]'
@@ -26,6 +27,7 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 ### exec
 
 - `2026-07-27-adr-topic-infix-P01-S01` - Extend the shared topic-infix admission set to ADR documents
+- `2026-07-27-adr-topic-infix-P01-S02` - Align CLI topic validation and help text with ADR admission
 
 ### plan
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -9,10 +9,12 @@ related:
   - '[[2026-07-27-adr-topic-infix-P01-S01]]'
   - '[[2026-07-27-adr-topic-infix-P01-S02]]'
   - '[[2026-07-27-adr-topic-infix-P01-S03]]'
+  - '[[2026-07-27-adr-topic-infix-P01-summary]]'
   - '[[2026-07-27-adr-topic-infix-P02-S04]]'
   - '[[2026-07-27-adr-topic-infix-P02-S05]]'
   - '[[2026-07-27-adr-topic-infix-P02-S06]]'
   - '[[2026-07-27-adr-topic-infix-P02-S07]]'
+  - '[[2026-07-27-adr-topic-infix-P02-summary]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
   - '[[2026-07-27-adr-topic-infix-audit]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
@@ -39,10 +41,12 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 - `2026-07-27-adr-topic-infix-P01-S01` - Extend the shared topic-infix admission set to ADR documents
 - `2026-07-27-adr-topic-infix-P01-S02` - Align CLI topic validation and help text with ADR admission
 - `2026-07-27-adr-topic-infix-P01-S03` - Align MCP topic schema and validation with ADR admission
+- `2026-07-27-adr-topic-infix-P01-summary` - `adr-topic-infix` `P01` summary
 - `2026-07-27-adr-topic-infix-P02-S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs
 - `2026-07-27-adr-topic-infix-P02-S05` - Cover CLI creation of two same-day topic-infixed ADRs
 - `2026-07-27-adr-topic-infix-P02-S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch
 - `2026-07-27-adr-topic-infix-P02-S07` - Revise the owned topic-infix rule and regenerate its published reference
+- `2026-07-27-adr-topic-infix-P02-summary` - `adr-topic-infix` `P02` summary
 
 ### plan
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -8,6 +8,7 @@ modified: '2026-07-27'
 related:
   - '[[2026-07-27-adr-topic-infix-P01-S01]]'
   - '[[2026-07-27-adr-topic-infix-P01-S02]]'
+  - '[[2026-07-27-adr-topic-infix-P01-S03]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
   - '[[2026-07-27-adr-topic-infix-reference]]'
@@ -28,6 +29,7 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 
 - `2026-07-27-adr-topic-infix-P01-S01` - Extend the shared topic-infix admission set to ADR documents
 - `2026-07-27-adr-topic-infix-P01-S02` - Align CLI topic validation and help text with ADR admission
+- `2026-07-27-adr-topic-infix-P01-S03` - Align MCP topic schema and validation with ADR admission
 
 ### plan
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -11,6 +11,7 @@ related:
   - '[[2026-07-27-adr-topic-infix-P01-S03]]'
   - '[[2026-07-27-adr-topic-infix-P02-S04]]'
   - '[[2026-07-27-adr-topic-infix-P02-S05]]'
+  - '[[2026-07-27-adr-topic-infix-P02-S06]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
   - '[[2026-07-27-adr-topic-infix-reference]]'
@@ -34,6 +35,7 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 - `2026-07-27-adr-topic-infix-P01-S03` - Align MCP topic schema and validation with ADR admission
 - `2026-07-27-adr-topic-infix-P02-S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs
 - `2026-07-27-adr-topic-infix-P02-S05` - Cover CLI creation of two same-day topic-infixed ADRs
+- `2026-07-27-adr-topic-infix-P02-S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch
 
 ### plan
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -10,6 +10,7 @@ related:
   - '[[2026-07-27-adr-topic-infix-P01-S02]]'
   - '[[2026-07-27-adr-topic-infix-P01-S03]]'
   - '[[2026-07-27-adr-topic-infix-P02-S04]]'
+  - '[[2026-07-27-adr-topic-infix-P02-S05]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
   - '[[2026-07-27-adr-topic-infix-reference]]'
@@ -32,6 +33,7 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 - `2026-07-27-adr-topic-infix-P01-S02` - Align CLI topic validation and help text with ADR admission
 - `2026-07-27-adr-topic-infix-P01-S03` - Align MCP topic schema and validation with ADR admission
 - `2026-07-27-adr-topic-infix-P02-S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs
+- `2026-07-27-adr-topic-infix-P02-S05` - Cover CLI creation of two same-day topic-infixed ADRs
 
 ### plan
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -9,6 +9,7 @@ related:
   - '[[2026-07-27-adr-topic-infix-P01-S01]]'
   - '[[2026-07-27-adr-topic-infix-P01-S02]]'
   - '[[2026-07-27-adr-topic-infix-P01-S03]]'
+  - '[[2026-07-27-adr-topic-infix-P02-S04]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
   - '[[2026-07-27-adr-topic-infix-reference]]'
@@ -30,6 +31,7 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 - `2026-07-27-adr-topic-infix-P01-S01` - Extend the shared topic-infix admission set to ADR documents
 - `2026-07-27-adr-topic-infix-P01-S02` - Align CLI topic validation and help text with ADR admission
 - `2026-07-27-adr-topic-infix-P01-S03` - Align MCP topic schema and validation with ADR admission
+- `2026-07-27-adr-topic-infix-P02-S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs
 
 ### plan
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -14,6 +14,7 @@ related:
   - '[[2026-07-27-adr-topic-infix-P02-S06]]'
   - '[[2026-07-27-adr-topic-infix-P02-S07]]'
   - '[[2026-07-27-adr-topic-infix-adr]]'
+  - '[[2026-07-27-adr-topic-infix-audit]]'
   - '[[2026-07-27-adr-topic-infix-plan]]'
   - '[[2026-07-27-adr-topic-infix-reference]]'
   - '[[2026-07-27-adr-topic-infix-research]]'
@@ -28,6 +29,10 @@ Auto-generated index of all documents tagged with `#adr-topic-infix`.
 ### adr
 
 - `2026-07-27-adr-topic-infix-adr` - `adr-topic-infix` adr: `topic-infixed ADR records` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-27-adr-topic-infix-audit` - `adr-topic-infix` audit: `ADR topic-infix implementation review`
 
 ### exec
 

--- a/.vault/index/adr-topic-infix.index.md
+++ b/.vault/index/adr-topic-infix.index.md
@@ -1,0 +1,40 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - '[[2026-07-27-adr-topic-infix-P01-S01]]'
+  - '[[2026-07-27-adr-topic-infix-adr]]'
+  - '[[2026-07-27-adr-topic-infix-plan]]'
+  - '[[2026-07-27-adr-topic-infix-reference]]'
+  - '[[2026-07-27-adr-topic-infix-research]]'
+---
+
+# `adr-topic-infix` feature index
+
+Auto-generated index of all documents tagged with `#adr-topic-infix`.
+
+## Documents
+
+### adr
+
+- `2026-07-27-adr-topic-infix-adr` - `adr-topic-infix` adr: `topic-infixed ADR records` | (**status:** `accepted`)
+
+### exec
+
+- `2026-07-27-adr-topic-infix-P01-S01` - Extend the shared topic-infix admission set to ADR documents
+
+### plan
+
+- `2026-07-27-adr-topic-infix-plan` - `adr-topic-infix` plan
+
+### reference
+
+- `2026-07-27-adr-topic-infix-reference` - `adr-topic-infix` reference: `ADR topic-infix creation path`
+
+### research
+
+- `2026-07-27-adr-topic-infix-research` - `adr-topic-infix` research: `same-day ADR disambiguation`

--- a/.vault/index/vault-exec-recovery.index.md
+++ b/.vault/index/vault-exec-recovery.index.md
@@ -1,0 +1,46 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - '[[2026-07-27-vault-exec-recovery-P01-S01]]'
+  - '[[2026-07-27-vault-exec-recovery-P01-S02]]'
+  - '[[2026-07-27-vault-exec-recovery-P01-S03]]'
+  - '[[2026-07-27-vault-exec-recovery-P01-S04]]'
+  - '[[2026-07-27-vault-exec-recovery-adr]]'
+  - '[[2026-07-27-vault-exec-recovery-implementation-audit]]'
+  - '[[2026-07-27-vault-exec-recovery-plan]]'
+  - '[[2026-07-27-vault-exec-recovery-research]]'
+---
+
+# `vault-exec-recovery` feature index
+
+Auto-generated index of all documents tagged with `#vault-exec-recovery`.
+
+## Documents
+
+### adr
+
+- `2026-07-27-vault-exec-recovery-adr` - `vault-exec-recovery` adr: `explicit recovery ownership for historical execution mappings` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-27-vault-exec-recovery-implementation-audit` - `vault-exec-recovery` audit: `Execution recovery implementation`
+
+### exec
+
+- `2026-07-27-vault-exec-recovery-P01-S01` - Typed recovery operations
+- `2026-07-27-vault-exec-recovery-P01-S02` - Recovery command surface
+- `2026-07-27-vault-exec-recovery-P01-S03` - Recovery verification
+- `2026-07-27-vault-exec-recovery-P01-S04` - RAG recovery application
+
+### plan
+
+- `2026-07-27-vault-exec-recovery-plan` - `vault-exec-recovery` plan
+
+### research
+
+- `2026-07-27-vault-exec-recovery-research` - `vault-exec-recovery` research: `Execution record recovery commands`

--- a/.vault/plan/2026-07-27-adr-topic-infix-plan.md
+++ b/.vault/plan/2026-07-27-adr-topic-infix-plan.md
@@ -28,7 +28,7 @@ workflow with direct, CLI, and MCP behavior tests and aligns the owned rule text
 Converge the shared creator, CLI, and MCP on the accepted four-type admission set.
 
 - [x] `P01.S01` - Extend the shared topic-infix admission set to ADR documents; `src/vaultspec_core/vaultcore/hydration.py`.
-- [ ] `P01.S02` - Align CLI topic validation and help text with ADR admission; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `P01.S02` - Align CLI topic validation and help text with ADR admission; `src/vaultspec_core/cli/vault_cmd.py`.
 - [ ] `P01.S03` - Align MCP topic schema and validation with ADR admission; `src/vaultspec_core/mcp_server/tools/documents.py`.
 
 ### Phase `P02` - prove behavior and synchronize the contract

--- a/.vault/plan/2026-07-27-adr-topic-infix-plan.md
+++ b/.vault/plan/2026-07-27-adr-topic-infix-plan.md
@@ -29,7 +29,7 @@ Converge the shared creator, CLI, and MCP on the accepted four-type admission se
 
 - [x] `P01.S01` - Extend the shared topic-infix admission set to ADR documents; `src/vaultspec_core/vaultcore/hydration.py`.
 - [x] `P01.S02` - Align CLI topic validation and help text with ADR admission; `src/vaultspec_core/cli/vault_cmd.py`.
-- [ ] `P01.S03` - Align MCP topic schema and validation with ADR admission; `src/vaultspec_core/mcp_server/tools/documents.py`.
+- [x] `P01.S03` - Align MCP topic schema and validation with ADR admission; `src/vaultspec_core/mcp_server/tools/documents.py`.
 
 ### Phase `P02` - prove behavior and synchronize the contract
 

--- a/.vault/plan/2026-07-27-adr-topic-infix-plan.md
+++ b/.vault/plan/2026-07-27-adr-topic-infix-plan.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - '#plan'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+tier: L2
+related:
+  - '[[2026-07-27-adr-topic-infix-adr]]'
+  - '[[2026-07-27-adr-topic-infix-research]]'
+  - '[[2026-07-27-adr-topic-infix-reference]]'
+---
+
+# `adr-topic-infix` plan
+
+Admit topic-infixed ADR records without changing plan or execution-record identity.
+
+## Description
+
+This plan implements the accepted `2026-07-27-adr-topic-infix-adr` decision. Phase
+P01 converges the creator and both transports on ADR admission; Phase P02 locks the
+workflow with direct, CLI, and MCP behavior tests and aligns the owned rule text.
+
+## Steps
+
+### Phase `P01` - admit ADR topics at every creation boundary
+
+Converge the shared creator, CLI, and MCP on the accepted four-type admission set.
+
+- [x] `P01.S01` - Extend the shared topic-infix admission set to ADR documents; `src/vaultspec_core/vaultcore/hydration.py`.
+- [ ] `P01.S02` - Align CLI topic validation and help text with ADR admission; `src/vaultspec_core/cli/vault_cmd.py`.
+- [ ] `P01.S03` - Align MCP topic schema and validation with ADR admission; `src/vaultspec_core/mcp_server/tools/documents.py`.
+
+### Phase `P02` - prove behavior and synchronize the contract
+
+Lock the same-day ADR workflow with real tests and update the owned rule/reference surfaces.
+
+- [ ] `P02.S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs; `src/vaultspec_core/vaultcore/tests/test_hydration.py`.
+- [ ] `P02.S05` - Cover CLI creation of two same-day topic-infixed ADRs; `tests/test_commands.py`.
+- [ ] `P02.S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch; `tests/unit/mcp_server/test_create_tool.py`.
+- [ ] `P02.S07` - Revise the owned topic-infix rule and regenerate its published reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
+
+## Parallelization
+
+The P01 changes are coupled through one admission set and land together. P02.S04,
+P02.S05, and P02.S06 may be prepared independently after P01; P02.S07 follows the
+settled wording and can run alongside the tests.
+
+## Verification
+
+The plan is complete when all seven Steps are checked, direct scaffolding creates two
+same-day ADR topics while duplicate topics fail, CLI and MCP create the same shape,
+the owned rule/reference surfaces agree, focused tests pass, and implementation review
+finds no transport or documentation drift.

--- a/.vault/plan/2026-07-27-adr-topic-infix-plan.md
+++ b/.vault/plan/2026-07-27-adr-topic-infix-plan.md
@@ -37,7 +37,7 @@ Lock the same-day ADR workflow with real tests and update the owned rule/referen
 
 - [x] `P02.S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs; `src/vaultspec_core/vaultcore/tests/test_hydration.py`.
 - [x] `P02.S05` - Cover CLI creation of two same-day topic-infixed ADRs; `tests/test_commands.py`.
-- [ ] `P02.S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch; `tests/unit/mcp_server/test_create_tool.py`.
+- [x] `P02.S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch; `tests/unit/mcp_server/test_create_tool.py`.
 - [ ] `P02.S07` - Revise the owned topic-infix rule and regenerate its published reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
 
 ## Parallelization

--- a/.vault/plan/2026-07-27-adr-topic-infix-plan.md
+++ b/.vault/plan/2026-07-27-adr-topic-infix-plan.md
@@ -35,7 +35,7 @@ Converge the shared creator, CLI, and MCP on the accepted four-type admission se
 
 Lock the same-day ADR workflow with real tests and update the owned rule/reference surfaces.
 
-- [ ] `P02.S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs; `src/vaultspec_core/vaultcore/tests/test_hydration.py`.
+- [x] `P02.S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs; `src/vaultspec_core/vaultcore/tests/test_hydration.py`.
 - [ ] `P02.S05` - Cover CLI creation of two same-day topic-infixed ADRs; `tests/test_commands.py`.
 - [ ] `P02.S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch; `tests/unit/mcp_server/test_create_tool.py`.
 - [ ] `P02.S07` - Revise the owned topic-infix rule and regenerate its published reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.

--- a/.vault/plan/2026-07-27-adr-topic-infix-plan.md
+++ b/.vault/plan/2026-07-27-adr-topic-infix-plan.md
@@ -38,7 +38,7 @@ Lock the same-day ADR workflow with real tests and update the owned rule/referen
 - [x] `P02.S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs; `src/vaultspec_core/vaultcore/tests/test_hydration.py`.
 - [x] `P02.S05` - Cover CLI creation of two same-day topic-infixed ADRs; `tests/test_commands.py`.
 - [x] `P02.S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch; `tests/unit/mcp_server/test_create_tool.py`.
-- [ ] `P02.S07` - Revise the owned topic-infix rule and regenerate its published reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
+- [x] `P02.S07` - Revise the owned topic-infix rule and regenerate its published reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
 
 ## Parallelization
 

--- a/.vault/plan/2026-07-27-adr-topic-infix-plan.md
+++ b/.vault/plan/2026-07-27-adr-topic-infix-plan.md
@@ -36,7 +36,7 @@ Converge the shared creator, CLI, and MCP on the accepted four-type admission se
 Lock the same-day ADR workflow with real tests and update the owned rule/reference surfaces.
 
 - [x] `P02.S04` - Cover direct scaffolder creation and duplicate rejection for topic-infixed ADRs; `src/vaultspec_core/vaultcore/tests/test_hydration.py`.
-- [ ] `P02.S05` - Cover CLI creation of two same-day topic-infixed ADRs; `tests/test_commands.py`.
+- [x] `P02.S05` - Cover CLI creation of two same-day topic-infixed ADRs; `tests/test_commands.py`.
 - [ ] `P02.S06` - Cover MCP creation of topic-infixed ADRs in a mixed batch; `tests/unit/mcp_server/test_create_tool.py`.
 - [ ] `P02.S07` - Revise the owned topic-infix rule and regenerate its published reference; `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`.
 

--- a/.vault/plan/2026-07-27-vault-exec-recovery-plan.md
+++ b/.vault/plan/2026-07-27-vault-exec-recovery-plan.md
@@ -1,0 +1,36 @@
+---
+tags:
+  - '#plan'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+tier: L2
+related:
+  - '[[2026-07-27-vault-exec-recovery-adr]]'
+  - '[[2026-07-27-vault-exec-recovery-research]]'
+---
+
+# `vault-exec-recovery` plan
+
+## Description
+
+Implement the accepted recovery decision: explicit `vault exec` commands repair only proven historical execution mappings. The work adds typed operations, a narrow CLI surface, real-file verification, and an operator-run recovery of the RAG vault.
+
+## Steps
+
+### Phase `P01` - Recovery command surface
+
+Deliver explicit, validated execution-record recovery operations and prove their behavior against real vault files.
+
+- [x] `P01.S01` - Implement typed execution-record recovery operations with atomic writes and archive handling; `src/vaultspec_core/vaultcore`.
+- [x] `P01.S02` - Expose relink, retire, and detach commands with JSON and dry-run contracts; `src/vaultspec_core/cli`.
+- [x] `P01.S03` - Prove recovery preconditions, body preservation, and command contracts against real vault files; `tests`.
+- [x] `P01.S04` - Apply verified recovery operations to the RAG vault and verify its mapping check; `Y:/code/vaultspec-rag-worktrees/main/.vault`.
+
+## Parallelization
+
+P01.S01, P01.S02, and P01.S03 have a hard dependency chain because the CLI depends on typed recovery operations and its integration tests depend on the CLI. P01.S04 follows code review and runs only on the verified historical record set.
+
+## Verification
+
+Run the focused core and CLI tests, lint the changed modules, verify generated CLI references, complete independent code review, and run `vault check exec-mapping` against the target RAG vault after the explicit recovery commands apply.

--- a/.vault/reference/2026-07-27-adr-topic-infix-reference.md
+++ b/.vault/reference/2026-07-27-adr-topic-infix-reference.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - '#reference'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-adr-topic-infix-research]]"
+  - "[[2026-07-16-reference-topic-infix-adr]]"
+---
+
+# `adr-topic-infix` reference: `ADR topic-infix creation path`
+
+This reference maps the one admission rule through the creator, CLI, MCP, tests,
+and generated user-facing rule text. It is based on the current worktree at
+`4c02b95b905bc85f127d4d1cd88d0a6e4ae625b6`.
+
+## Summary
+
+`src/vaultspec_core/vaultcore/hydration.py:44-48` owns the admitting document
+types in `_TOPIC_INFIX_TYPES`; `create_vault_doc` validates the set at
+`hydration.py:431-435` and builds the infixed filename at `hydration.py:498-500`.
+Changing this set to include `DocType.ADR` is the source-of-truth change. The
+existing no-topic path and duplicate/stem-collision protections must remain
+unchanged.
+
+`src/vaultspec_core/cli/vault_cmd.py:101-110` publishes the `--topic` help text,
+and `vault_cmd.py:258-272` repeats the admission set before normalization. Its
+wording and guard must admit ADRs so the CLI remains aligned with the creator.
+
+`src/vaultspec_core/mcp_server/tools/documents.py:133-147` documents the schema
+field, while `documents.py:275-295` validates it and calls the same creator.
+Its type guard and error wording must use the same four-type set as the CLI and
+creator; no new MCP field or alternate filename builder is needed.
+
+`src/vaultspec_core/vaultcore/tests/test_hydration.py:455-555` is the direct
+creator regression suite. It should add ADR to the admitting parametrization,
+remove ADR from the rejection parametrization, and exercise two same-day ADR
+topics plus duplicate rejection. `tests/unit/mcp_server/test_create_tool.py:147-202`
+should replace the rejected-ADR and mixed-batch expectations with successful
+ADR-topic creation. A real CLI test belongs with the existing `vault add` tests
+so CLI parsing, normalization, and the shared creator run together.
+
+The vocabulary must be updated wherever it claims the infix is available only
+to audit, reference, and research: `src/vaultspec_core/builtins/rules/vaultspec.builtin.md`,
+`.vaultspec/rules/vaultspec.builtin.md`, and the generated CLI reference. The
+source rule is the authored built-in; generated mirrors are refreshed through
+the project's owning sync/generation path, never hand-edited.

--- a/.vault/research/2026-07-27-adr-topic-infix-research.md
+++ b/.vault/research/2026-07-27-adr-topic-infix-research.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - '#research'
+  - '#adr-topic-infix'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-16-reference-topic-infix-adr]]"
+---
+
+# `adr-topic-infix` research: `same-day ADR disambiguation`
+
+The question is whether an ADR may use the existing topic-infix mechanism when
+one feature needs several independently searchable decisions on the same date.
+The current creator rejects that shape even though the framework's plan guidance
+allows a plan to execute a cluster of ADRs. The evidence favors extending the
+existing infix mechanism to ADRs while retaining the exclusions that are tied to
+machine-derived execution records and a single plan cluster; the ADR must settle
+that revised cardinality boundary.
+
+## Findings
+
+### The current restriction creates the reported collision
+
+`_TOPIC_INFIX_TYPES` admits audit, reference, and research only, and
+`create_vault_doc` refuses a topic for every other type before it constructs
+the target filename. A second same-day ADR consequently resolves to the same
+`{date}-{feature}-adr.md` target and the normal existence guard rejects it.
+The CLI and MCP apply the same three-type admission check before calling that
+shared creator, so the defect occurs on both supported transports.
+`src/vaultspec_core/vaultcore/hydration.py:44-48`
+`src/vaultspec_core/vaultcore/hydration.py:431-433`
+`src/vaultspec_core/cli/vault_cmd.py:258-272`
+`src/vaultspec_core/mcp_server/tools/documents.py:275-295`
+
+### The former ADR boundary conflicts with the framework's current planning model
+
+The 2026-07-16 topic-infix ADR excluded ADRs on the premise that cardinality
+rules require an amend-or-supersede path. Its own related plan model and the
+current vault rules instead distinguish one ADR per decision from a plan that
+executes a cluster of ADRs. Separate decisions arising from the same research
+therefore need separate records without being forced into separate feature tags
+or inaccurate dates. The prior record should be superseded rather than silently
+contradicted. `.vault/adr/2026-07-16-reference-topic-infix-adr.md:20-33`
+`.vaultspec/rules/vaultspec-system.builtin.md:96-100`
+
+### Existing mechanics already preserve identifier and collision safety
+
+When an admitted topic is supplied, the creator uses
+`{date}-{feature}-{topic}-{type}.md`; it preserves the omitted-topic filename,
+normalizes topics at both transport boundaries, and rejects duplicate paths and
+cross-directory stem collisions. The existing tests prove two same-day topic
+values can coexist while a duplicate fails. Extending the admission set changes
+no filename algorithm or collision authority. `src/vaultspec_core/vaultcore/hydration.py:457-510`
+`src/vaultspec_core/vaultcore/tests/test_hydration.py:455-555`
+
+### The viable alternatives differ in record fidelity
+
+Keeping the rejection would require changing the cluster guidance or accepting
+feature-tag splitting and postdated records; neither preserves the stated
+one-decision-per-record model. Allowing all document types is broader than the
+evidence: plan documents remain one execution cluster and exec filenames remain
+derived from plan identifiers. Admitting ADRs alongside the narrative trio is
+the narrow option; whether ADR filenames should still be called narrative is a
+terminology follow-up, not an implementation blocker.
+
+## Sources
+
+- `src/vaultspec_core/vaultcore/hydration.py:44-48`
+- `src/vaultspec_core/vaultcore/hydration.py:431-510`
+- `src/vaultspec_core/cli/vault_cmd.py:258-272`
+- `src/vaultspec_core/mcp_server/tools/documents.py:275-295`
+- `src/vaultspec_core/vaultcore/tests/test_hydration.py:455-555`
+- `.vault/adr/2026-07-16-reference-topic-infix-adr.md:20-109`
+- `.vaultspec/rules/vaultspec-system.builtin.md:96-100`
+- https://github.com/nevenincs/vaultspec-core/issues/266

--- a/.vault/research/2026-07-27-vault-exec-recovery-research.md
+++ b/.vault/research/2026-07-27-vault-exec-recovery-research.md
@@ -1,0 +1,36 @@
+---
+tags:
+  - '#research'
+  - '#vault-exec-recovery'
+date: '2026-07-27'
+modified: '2026-07-27'
+related: []
+---
+
+# `vault-exec-recovery` research: `Execution record recovery commands`
+
+The execution-mapping validator correctly identifies malformed historical anchors but has no owning mutation surface. Evidence supports explicit, validating commands rather than a checker auto-fix: ten records have verified live Step targets, one references an explicitly retired Step, and six prose-era records cannot truthfully map to a formal Step.
+
+## Findings
+
+### Canonical Step IDs and display paths are intentionally distinct
+
+`plan/parser.py` stores the canonical leaf identifier as `S##`, while plan display paths include phase and wave ancestry. `plan/commands/step_ops.py` already resolves either representation and rejects missing or ambiguous targets. In the affected RAG vault, ten execution records store a composite display path where the current validator requires the canonical leaf, and each parent plan exposes the exact live row.
+
+### The remaining seven records need historical classification rather than a guessed relink
+
+One record names a retired Step and must be preserved as an archived execution record. Six records describe prose-era waves whose current parent plan has no formal matching Step; removing their machine `step_id` accurately represents them as legacy-unmappable records, which the validator already skips. Neither case is a safe checker-side inference.
+
+### Core has established atomic command and JSON patterns
+
+`cli/plan_cmd.py` separates typed operation helpers from thin Typer wrappers, uses expected state and atomic writes, emits stable JSON envelopes, and treats dry runs and no-ops explicitly. `vault_cmd.py` owns document operations but has no `vault exec` group. A dedicated group can reuse plan target and Step-resolution helpers while preserving document body bytes and updating only machine-owned metadata.
+
+## Sources
+
+- `src/vaultspec_core/plan/parser.py`
+- `src/vaultspec_core/plan/commands/step_ops.py`
+- `src/vaultspec_core/cli/plan_cmd.py`
+- `src/vaultspec_core/cli/vault_cmd.py`
+- `src/vaultspec_core/vaultcore/checks/exec_mapping.py`
+- `src/vaultspec_core/vaultcore/models.py`
+- `2026-07-23-vault-check-validators-adr`

--- a/.vaultspec/reference/cli.md
+++ b/.vaultspec/reference/cli.md
@@ -194,6 +194,20 @@ hand-edit between the markers.
 - `vaultspec-core vault link add` - Add a related: edge from *src* to *dst*.
 - `vaultspec-core vault link remove` - Remove a related: edge from *src* to *dst*.
 
+#### Exec
+
+- `vaultspec-core vault exec relink` - Relink one execution record to a live Step in its
+  existing parent plan.
+- `vaultspec-core vault exec retire` - Archive one record only when its current Step is
+  retired by its parent plan.
+- `vaultspec-core vault exec detach` - Remove a Step claim only when it resolves to
+  neither a live nor retired Step.
+
+#### Archive
+
+- `vaultspec-core vault archive documents` - Archive exactly the documents named in a
+  UTF-8 manifest.
+
 ### Spec
 
 - `vaultspec-core spec doctor` - Diagnose workspace health and report issues.
@@ -372,7 +386,7 @@ Create a `.vault/` document from a template.
 | `-f` | None | Feature tag (kebab-case). | | `--date DATE` | - | today | Override date
 (ISO 8601). | | `--title TITLE` | - | None | Document title. | | `--topic TOPIC` | - |
 None | Narrative filename infix (kebab-case) producing
-`{date}-{feature}-{topic}-{type}.md`; audit, reference, and research only. | |
+`{date}-{feature}-{topic}-{type}.md`; adr, audit, reference, and research only. | |
 `--related DOC` | `-r` | None | Related document(s). Repeatable. | | `--tags TAG` | - |
 None | Additional freeform tags. Repeatable. | | `--force` | - | off | Overwrite an
 existing document. | | `--dry-run` | - | off | Preview without writing. | | `--json` | -
@@ -556,6 +570,22 @@ feature tag to the archive. Options: `--dry-run` (preview planned changes), `--j
 `vaultspec-core vault feature unarchive [OPTIONS] FEATURE_TAG` - restore all archived
 documents for a feature tag. Options: `--dry-run` (preview planned changes), `--json`.
 The `--no-hints` flag is not accepted here.
+
+### vaultspec-core vault archive documents
+
+`vaultspec-core vault archive documents [OPTIONS]` archives exactly the live documents
+listed by `--manifest PATH`. The manifest is UTF-8, one repository-relative
+`.vault/*.md` path per line. The command validates the entire manifest before moving
+anything; `--dry-run` previews the destination paths and `--json` emits the standard
+envelope.
+
+### vaultspec-core vault exec
+
+`vaultspec-core vault exec relink` takes `--record PATH` and `--step STEP` to repair one
+record's mapping to a live Step. `retire` takes `--record PATH` and archives it only
+when its parent plan retired the claimed Step. `detach` takes `--record PATH` and
+removes its Step claim only when the claim resolves to neither a live nor a retired
+Step. Every verb accepts `--dry-run` and `--json`.
 
 ### vaultspec-core vault feature rename
 

--- a/.vaultspec/rules/vaultspec.builtin.md
+++ b/.vaultspec/rules/vaultspec.builtin.md
@@ -27,10 +27,10 @@ The workflow persists the following documents, bound by a single feature tag:
 - `.vault/exec/yyyy-mm-dd-<feature>/...-summary.md`: The `<Phase Summary>`.
 
 - `.vault/audit/yyyy-mm-dd-<feature>-audit.md`: The `<Audit>` report. A feature with
-  multiple audits, references, or research documents disambiguates each with an optional
-  narrative infix - `yyyy-mm-dd-<feature>-<topic>-<type>.md` - scaffolded through the
-  owning verb's `--topic` flag (`vaultspec-core vault add` for audit, reference, and
-  research only), never by hand-picking a filename.
+  multiple ADRs, audits, references, or research documents disambiguates each with an
+  optional topic infix - `yyyy-mm-dd-<feature>-<topic>-<type>.md` - scaffolded through
+  the owning verb's `--topic` flag (`vaultspec-core vault add` for adr, audit,
+  reference, and research only), never by hand-picking a filename.
 
 - `.vault/index/<feature>.index.md`: The auto-generated `<Feature Index>` linking every
   document for a feature. The index regenerates as a side effect of the `create` and
@@ -276,7 +276,7 @@ instead.
   - Top-level docs: `yyyy-mm-dd-{feature}-{type}.md` (e.g.,
     `2026-02-04-editor-demo-plan.md`)
 
-  - Narrative infix (audit, reference, research only):
+  - Optional topic infix (adr, audit, reference, research only):
     `yyyy-mm-dd-{feature}-{topic}-{type}.md` (e.g.,
     `2026-02-04-editor-demo-engine-wire-reference.md`), scaffolded with the owning
     verb's `--topic` flag

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -268,6 +268,11 @@ full options.
 - `vaultspec-core vault exec detach` - Remove a Step claim only when it resolves to
   neither a live nor retired Step.
 
+#### Archive
+
+- `vaultspec-core vault archive documents` - Archive exactly the documents named in a
+  UTF-8 manifest.
+
 ### Spec
 
 - `vaultspec-core spec doctor` - Diagnose workspace health and report issues.
@@ -1185,6 +1190,85 @@ Restore all archived documents for a feature tag.
   ```bash
   vaultspec-core vault feature unarchive test-feature
   ```
+
+______________________________________________________________________
+
+### vaultspec-core vault archive documents
+
+```bash
+vaultspec-core vault archive documents [OPTIONS]
+```
+
+Archive exactly the live vault documents listed in a UTF-8 manifest. Each line must be a
+repository-relative `.vault/*.md` path. The command validates every source and
+destination before it moves anything, so a bad line cannot produce a partial archive.
+
+#### Options
+
+- `--manifest PATH` - Required UTF-8 manifest of repository-relative vault Markdown
+  paths, one per line.
+- `--dry-run` (default off) - Validate and show the archive destinations without
+  writing.
+- `--json` (default off) - Emit the standard machine-readable result envelope.
+
+#### Examples
+
+- **Preview the archival of explicitly selected historical records**:
+
+  ```bash
+  vaultspec-core vault archive documents --manifest .vault/archive-manifest.txt --dry-run
+  ```
+
+______________________________________________________________________
+
+### vaultspec-core vault exec relink
+
+```bash
+vaultspec-core vault exec relink [OPTIONS]
+```
+
+Relink one execution record to a live Step in its existing parent plan. The record body
+is preserved; only the validated Step mapping can change.
+
+#### Options
+
+- `--record PATH` - Required live execution-record path.
+- `--step STEP` - Required live Step identifier or display path in the parent plan.
+- `--dry-run` (default off) - Preview the recovery without writing.
+- `--json` (default off) - Emit the standard machine-readable result envelope.
+
+______________________________________________________________________
+
+### vaultspec-core vault exec retire
+
+```bash
+vaultspec-core vault exec retire [OPTIONS]
+```
+
+Archive one execution record only when its current Step is retired by its parent plan.
+
+#### Options
+
+- `--record PATH` - Required live execution-record path.
+- `--dry-run` (default off) - Preview the recovery without writing.
+- `--json` (default off) - Emit the standard machine-readable result envelope.
+
+______________________________________________________________________
+
+### vaultspec-core vault exec detach
+
+```bash
+vaultspec-core vault exec detach [OPTIONS]
+```
+
+Remove one record's Step claim only when it resolves to neither a live nor a retired
+Step.
+
+#### Options
+
+- `--record PATH` - Required live execution-record path.
+- `--dry-run` (default off) - Preview the recovery without writing.
+- `--json` (default off) - Emit the standard machine-readable result envelope.
 
 ______________________________________________________________________
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -259,6 +259,15 @@ full options.
 - `vaultspec-core vault link add` - Add a related: edge from *src* to *dst*.
 - `vaultspec-core vault link remove` - Remove a related: edge from *src* to *dst*.
 
+#### Exec
+
+- `vaultspec-core vault exec relink` - Relink one execution record to a live Step in its
+  existing parent plan.
+- `vaultspec-core vault exec retire` - Archive one record only when its current Step is
+  retired by its parent plan.
+- `vaultspec-core vault exec detach` - Remove a Step claim only when it resolves to
+  neither a live nor retired Step.
+
 ### Spec
 
 - `vaultspec-core spec doctor` - Diagnose workspace health and report issues.

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -203,6 +203,11 @@ hand-edit between the markers.
 - `vaultspec-core vault exec detach` - Remove a Step claim only when it resolves to
   neither a live nor retired Step.
 
+#### Archive
+
+- `vaultspec-core vault archive documents` - Archive exactly the documents named in a
+  UTF-8 manifest.
+
 ### Spec
 
 - `vaultspec-core spec doctor` - Diagnose workspace health and report issues.
@@ -565,6 +570,22 @@ feature tag to the archive. Options: `--dry-run` (preview planned changes), `--j
 `vaultspec-core vault feature unarchive [OPTIONS] FEATURE_TAG` - restore all archived
 documents for a feature tag. Options: `--dry-run` (preview planned changes), `--json`.
 The `--no-hints` flag is not accepted here.
+
+### vaultspec-core vault archive documents
+
+`vaultspec-core vault archive documents [OPTIONS]` archives exactly the live documents
+listed by `--manifest PATH`. The manifest is UTF-8, one repository-relative
+`.vault/*.md` path per line. The command validates the entire manifest before moving
+anything; `--dry-run` previews the destination paths and `--json` emits the standard
+envelope.
+
+### vaultspec-core vault exec
+
+`vaultspec-core vault exec relink` takes `--record PATH` and `--step STEP` to repair one
+record's mapping to a live Step. `retire` takes `--record PATH` and archives it only
+when its parent plan retired the claimed Step. `detach` takes `--record PATH` and
+removes its Step claim only when the claim resolves to neither a live nor a retired
+Step. Every verb accepts `--dry-run` and `--json`.
 
 ### vaultspec-core vault feature rename
 

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -194,6 +194,15 @@ hand-edit between the markers.
 - `vaultspec-core vault link add` - Add a related: edge from *src* to *dst*.
 - `vaultspec-core vault link remove` - Remove a related: edge from *src* to *dst*.
 
+#### Exec
+
+- `vaultspec-core vault exec relink` - Relink one execution record to a live Step in its
+  existing parent plan.
+- `vaultspec-core vault exec retire` - Archive one record only when its current Step is
+  retired by its parent plan.
+- `vaultspec-core vault exec detach` - Remove a Step claim only when it resolves to
+  neither a live nor retired Step.
+
 ### Spec
 
 - `vaultspec-core spec doctor` - Diagnose workspace health and report issues.

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -386,7 +386,7 @@ Create a `.vault/` document from a template.
 | `-f` | None | Feature tag (kebab-case). | | `--date DATE` | - | today | Override date
 (ISO 8601). | | `--title TITLE` | - | None | Document title. | | `--topic TOPIC` | - |
 None | Narrative filename infix (kebab-case) producing
-`{date}-{feature}-{topic}-{type}.md`; audit, reference, and research only. | |
+`{date}-{feature}-{topic}-{type}.md`; adr, audit, reference, and research only. | |
 `--related DOC` | `-r` | None | Related document(s). Repeatable. | | `--tags TAG` | - |
 None | Additional freeform tags. Repeatable. | | `--force` | - | off | Overwrite an
 existing document. | | `--dry-run` | - | off | Preview without writing. | | `--json` | -

--- a/src/vaultspec_core/builtins/rules/vaultspec.builtin.md
+++ b/src/vaultspec_core/builtins/rules/vaultspec.builtin.md
@@ -27,10 +27,10 @@ The workflow persists the following documents, bound by a single feature tag:
 - `.vault/exec/yyyy-mm-dd-<feature>/...-summary.md`: The `<Phase Summary>`.
 
 - `.vault/audit/yyyy-mm-dd-<feature>-audit.md`: The `<Audit>` report. A feature with
-  multiple audits, references, or research documents disambiguates each with an optional
-  narrative infix - `yyyy-mm-dd-<feature>-<topic>-<type>.md` - scaffolded through the
-  owning verb's `--topic` flag (`vaultspec-core vault add` for audit, reference, and
-  research only), never by hand-picking a filename.
+  multiple ADRs, audits, references, or research documents disambiguates each with an
+  optional topic infix - `yyyy-mm-dd-<feature>-<topic>-<type>.md` - scaffolded through
+  the owning verb's `--topic` flag (`vaultspec-core vault add` for adr, audit,
+  reference, and research only), never by hand-picking a filename.
 
 - `.vault/index/<feature>.index.md`: The auto-generated `<Feature Index>` linking every
   document for a feature. The index regenerates as a side effect of the `create` and
@@ -276,7 +276,7 @@ instead.
   - Top-level docs: `yyyy-mm-dd-{feature}-{type}.md` (e.g.,
     `2026-02-04-editor-demo-plan.md`)
 
-  - Narrative infix (audit, reference, research only):
+  - Optional topic infix (adr, audit, reference, research only):
     `yyyy-mm-dd-{feature}-{topic}-{type}.md` (e.g.,
     `2026-02-04-editor-demo-engine-wire-reference.md`), scaffolded with the owning
     verb's `--topic` flag

--- a/src/vaultspec_core/cli/archive_cmd.py
+++ b/src/vaultspec_core/cli/archive_cmd.py
@@ -1,0 +1,103 @@
+"""CLI wiring for explicit, manifest-driven vault document archival.
+
+The command owns manifest decoding and presentation only.  Validation and
+every filesystem mutation belong to :mod:`vaultspec_core.vaultcore.batch_archive`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003 - Typer inspects this command annotation.
+from typing import Annotated
+
+import typer
+
+from vaultspec_core.cli._app import make_app
+from vaultspec_core.cli._errors import handle_error
+from vaultspec_core.cli._target import TargetOption, apply_target
+
+__all__ = ["archive_app"]
+
+
+archive_app = make_app(
+    help="Archive explicitly listed vault documents.",
+    no_args_is_help=True,
+)
+
+
+def _manifest_entries(manifest: Path) -> list[str]:
+    """Read UTF-8 manifest entries without interpreting their paths.
+
+    The core archive owner validates every entry against the resolved target.
+    Keeping this boundary narrow prevents the CLI from gaining a second path
+    policy or a filesystem-mutation path.
+    """
+    return manifest.read_text(encoding="utf-8").splitlines()
+
+
+@archive_app.command("documents")
+def cmd_archive_documents(
+    manifest: Annotated[
+        Path,
+        typer.Option(
+            "--manifest",
+            help="UTF-8 newline-separated repository-relative .vault/*.md paths",
+        ),
+    ],
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview the archive without writing"),
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Archive exactly the documents named in a UTF-8 manifest."""
+    apply_target(target, json_output=json_output)
+    from vaultspec_core.core.types import get_context
+    from vaultspec_core.vaultcore.batch_archive import (
+        ArchiveDocumentsError,
+        archive_documents,
+    )
+
+    root_dir = get_context().target_dir
+    try:
+        result = archive_documents(
+            root_dir,
+            _manifest_entries(manifest),
+            dry_run=dry_run,
+        )
+    except (ArchiveDocumentsError, OSError) as exc:
+        handle_error(exc, json_output=json_output)
+        return
+
+    if result.status == "updated" and not dry_run:
+        from vaultspec_core.cli._cache_hook import invalidate_graph_cache
+
+        invalidate_graph_cache(root_dir)
+
+    payload = result.to_dict()
+    if json_output:
+        from vaultspec_core.cli.rendering import json_envelope
+
+        typer.echo(
+            json.dumps(
+                json_envelope("vault.archive.documents", result.status, payload),
+                indent=2,
+            )
+        )
+        return
+
+    from vaultspec_core.console import get_console
+
+    console = get_console()
+    paths = payload["paths"]
+    assert isinstance(paths, list)
+    if dry_run:
+        console.print(
+            "[yellow]Dry-run:[/yellow] would archive "
+            f"{result.archived_count} documents."
+        )
+    else:
+        console.print(f"[green]Archived {result.archived_count} documents.[/green]")
+    for path in paths:
+        console.print(f"  {path}")

--- a/src/vaultspec_core/cli/exec_cmd.py
+++ b/src/vaultspec_core/cli/exec_cmd.py
@@ -1,0 +1,212 @@
+"""Typer wiring for explicit execution-record recovery commands.
+
+The ``vault exec`` group deliberately owns one-record-at-a-time recovery of
+historical ``step_id`` mappings.  It delegates all validation and writes to
+``vaultcore.exec_recovery``; these wrappers only resolve the active target,
+render the shared command contract, and invalidate the graph cache after a
+real change.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003 - Typer inspects this command annotation.
+from typing import Annotated
+
+import typer
+
+from vaultspec_core.cli._app import make_app
+from vaultspec_core.cli._errors import handle_error
+from vaultspec_core.cli._target import TargetOption, apply_target
+
+__all__ = ["exec_app"]
+
+
+exec_app = make_app(
+    help="Recover historical execution-record Step mappings explicitly",
+    no_args_is_help=True,
+)
+
+
+def _record_path(root_dir: Path, record: Path) -> Path:
+    """Resolve a record path relative to the active vault root.
+
+    A caller may pass either a repository-relative path or an absolute path.
+    The recovery layer verifies that the resulting path is a live execution
+    record, so this helper intentionally performs no stem lookup or fallback
+    search that could select the wrong historical evidence.
+    """
+    return record if record.is_absolute() else root_dir / record
+
+
+def _emit_result(
+    result: object,
+    *,
+    root_dir: Path,
+    dry_run: bool,
+    json_output: bool,
+) -> None:
+    """Render one recovery result through text and JSON contracts."""
+    from vaultspec_core.console import get_console
+    from vaultspec_core.vaultcore.exec_recovery import ExecRecoveryResult
+
+    assert isinstance(result, ExecRecoveryResult)
+    command = f"vault.exec.{result.operation}"
+    changed = result.operation == "retire" or result.previous_step_id != result.step_id
+
+    def display(path: Path) -> str:
+        try:
+            return str(path.relative_to(root_dir))
+        except ValueError:
+            return str(path)
+
+    payload: dict[str, object] = {
+        "record": display(result.record_path),
+        "previous_step_id": result.previous_step_id,
+        "step_id": result.step_id,
+        "dry_run": dry_run,
+        "changed": changed,
+    }
+    if result.archive_path is not None:
+        payload["archive_path"] = display(result.archive_path)
+
+    if json_output:
+        from vaultspec_core.cli.rendering import json_envelope
+
+        typer.echo(json.dumps(json_envelope(command, result.status, payload), indent=2))
+        return
+
+    console = get_console()
+    if not changed:
+        console.print(f"[dim]Unchanged:[/dim] {display(result.record_path)}")
+        return
+    if dry_run:
+        console.print(
+            f"[dim]Would {result.operation}:[/dim] {display(result.record_path)}"
+        )
+        return
+    if result.archive_path is not None:
+        console.print(
+            f"[yellow]Retired:[/yellow] {display(result.record_path)} -> "
+            f"{display(result.archive_path)}"
+        )
+        return
+    console.print(
+        f"[yellow]{result.operation.capitalize()}ed:[/yellow] "
+        f"{display(result.record_path)}"
+    )
+
+
+def _run_recovery(
+    operation: str,
+    *,
+    record: Path,
+    target_step: str | None,
+    dry_run: bool,
+    json_output: bool,
+    target: Path | None,
+) -> None:
+    """Resolve the workspace and dispatch one typed recovery operation."""
+    apply_target(target, json_output=json_output)
+    from vaultspec_core.cli._cache_hook import invalidate_graph_cache
+    from vaultspec_core.core.types import get_context
+    from vaultspec_core.vaultcore.exec_recovery import (
+        detach_exec_record,
+        relink_exec_record,
+        retire_exec_record,
+    )
+
+    root_dir = get_context().target_dir
+    record_path = _record_path(root_dir, record)
+    try:
+        if operation == "relink":
+            assert target_step is not None
+            result = relink_exec_record(
+                root_dir, record_path, target_step, dry_run=dry_run
+            )
+        elif operation == "retire":
+            result = retire_exec_record(root_dir, record_path, dry_run=dry_run)
+        else:
+            result = detach_exec_record(root_dir, record_path, dry_run=dry_run)
+    except Exception as exc:
+        handle_error(exc, json_output=json_output)
+        return
+
+    _emit_result(result, root_dir=root_dir, dry_run=dry_run, json_output=json_output)
+    if result.status == "updated" and not dry_run:
+        invalidate_graph_cache(root_dir)
+
+
+@exec_app.command("relink")
+def cmd_exec_relink(
+    record: Annotated[
+        Path,
+        typer.Option("--record", help="Live execution-record path"),
+    ],
+    step: Annotated[
+        str,
+        typer.Option(
+            "--step", help="Live Step identifier or display path in its parent plan"
+        ),
+    ],
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview the recovery without writing")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Relink one execution record to a live Step in its existing parent plan."""
+    _run_recovery(
+        "relink",
+        record=record,
+        target_step=step,
+        dry_run=dry_run,
+        json_output=json_output,
+        target=target,
+    )
+
+
+@exec_app.command("retire")
+def cmd_exec_retire(
+    record: Annotated[
+        Path,
+        typer.Option("--record", help="Live execution-record path"),
+    ],
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview the recovery without writing")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Archive one record only when its current Step is retired by its parent plan."""
+    _run_recovery(
+        "retire",
+        record=record,
+        target_step=None,
+        dry_run=dry_run,
+        json_output=json_output,
+        target=target,
+    )
+
+
+@exec_app.command("detach")
+def cmd_exec_detach(
+    record: Annotated[
+        Path,
+        typer.Option("--record", help="Live execution-record path"),
+    ],
+    dry_run: Annotated[
+        bool, typer.Option("--dry-run", help="Preview the recovery without writing")
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Remove a Step claim only when it resolves to neither a live nor retired Step."""
+    _run_recovery(
+        "detach",
+        record=record,
+        target_step=None,
+        dry_run=dry_run,
+        json_output=json_output,
+        target=target,
+    )

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -72,6 +72,10 @@ from vaultspec_core.cli.exec_cmd import exec_app  # noqa: E402
 
 vault_app.add_typer(exec_app, name="exec")
 
+from vaultspec_core.cli.archive_cmd import archive_app  # noqa: E402
+
+vault_app.add_typer(archive_app, name="archive")
+
 from vaultspec_core.cli.edit_cmd import (  # noqa: E402
     register_edit_commands,
     register_rename_command,

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -68,6 +68,10 @@ from vaultspec_core.cli.link_cmd import link_app  # noqa: E402
 
 vault_app.add_typer(link_app, name="link")
 
+from vaultspec_core.cli.exec_cmd import exec_app  # noqa: E402
+
+vault_app.add_typer(exec_app, name="exec")
+
 from vaultspec_core.cli.edit_cmd import (  # noqa: E402
     register_edit_commands,
     register_rename_command,

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -105,7 +105,7 @@ def cmd_add(
             help=(
                 "Narrative filename infix (kebab-case) disambiguating a "
                 "second document of the same type for a feature; produces "
-                "{date}-{feature}-{topic}-{type}.md. Only valid for audit, "
+                "{date}-{feature}-{topic}-{type}.md. Only valid for adr, audit, "
                 "reference, and research documents."
             ),
         ),
@@ -255,13 +255,13 @@ def cmd_add(
         )
         raise typer.Exit(code=1)
 
-    # Validate the topic infix: admitted only for the narrative trio, and
-    # held to the same kebab-case discipline as the feature tag.
+    # Validate the topic infix for standalone decision and narrative records,
+    # holding it to the same kebab-case discipline as the feature tag.
     topic_value: str | None = None
     if topic is not None:
-        if dt not in (DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH):
+        if dt not in (DocType.ADR, DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH):
             console.print(
-                "[red]Error: --topic is only valid for 'audit', 'reference', "
+                "[red]Error: --topic is only valid for 'adr', 'audit', 'reference', "
                 "and 'research' documents.[/red]"
             )
             raise typer.Exit(code=1)

--- a/src/vaultspec_core/mcp_server/tools/documents.py
+++ b/src/vaultspec_core/mcp_server/tools/documents.py
@@ -133,7 +133,7 @@ class DocumentSpec(BaseModel):
         topic: Optional kebab-case narrative filename infix disambiguating a
             second document of the same type for a feature
             (``{date}-{feature}-{topic}-{type}.md``). Only valid for
-            ``audit``, ``reference``, and ``research`` documents.
+            ``adr``, ``audit``, ``reference``, and ``research`` documents.
     """
 
     feature: str
@@ -274,9 +274,14 @@ def _create_one(
 
     topic: str | None = None
     if spec.topic is not None:
-        if doc_type not in (DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH):
+        if doc_type not in (
+            DocType.ADR,
+            DocType.AUDIT,
+            DocType.REFERENCE,
+            DocType.RESEARCH,
+        ):
             return _failed(
-                "topic is only valid for 'audit', 'reference', and "
+                "topic is only valid for 'adr', 'audit', 'reference', and "
                 "'research' documents."
             )
         topic_norm = normalize_feature_tag(spec.topic, label="topic")

--- a/src/vaultspec_core/tests/cli/test_batch_archive_cli.py
+++ b/src/vaultspec_core/tests/cli/test_batch_archive_cli.py
@@ -1,0 +1,97 @@
+"""Real CLI coverage for manifest-driven document archival."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from vaultspec_core.cli import app
+from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.integration]
+
+
+def _write_research(root: Path) -> Path:
+    path = root / ".vault" / "research" / "2026-07-27-batch-archive-research.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        "tags:\n"
+        "  - '#research'\n"
+        "  - '#batch-archive'\n"
+        "date: '2026-07-27'\n"
+        "modified: '2026-07-27'\n"
+        "related: []\n"
+        "---\n\n"
+        "# `batch-archive` research: `manifest recovery`\n\n"
+        "## Findings\n\n"
+        "The record is retained before it is archived.\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _run(root: Path, manifest: Path, *args: str):
+    return CliRunner(env={"NO_COLOR": "1"}).invoke(
+        app,
+        [
+            "vault",
+            "archive",
+            "documents",
+            "--manifest",
+            str(manifest),
+            *args,
+            "--target",
+            str(root),
+        ],
+    )
+
+
+def test_manifest_archive_dry_run_then_apply_uses_real_filesystem(
+    tmp_path: Path,
+) -> None:
+    WorkspaceFactory(tmp_path).install()
+    source = _write_research(tmp_path)
+    manifest = tmp_path / "archive-manifest.txt"
+    manifest.write_text(
+        ".vault/research/2026-07-27-batch-archive-research.md\n",
+        encoding="utf-8",
+    )
+    archive_path = (
+        tmp_path
+        / ".vault"
+        / "_archive"
+        / "research"
+        / "2026-07-27-batch-archive-research.md"
+    )
+
+    preview = _run(tmp_path, manifest, "--dry-run", "--json")
+
+    assert preview.exit_code == 0, preview.output
+    preview_data = json.loads(preview.output)
+    assert preview_data["schema"] == "vaultspec.vault.archive.documents.v1"
+    assert preview_data["status"] == "unchanged"
+    assert preview_data["data"]["dry_run"] is True
+    assert preview_data["data"]["archived_count"] == 1
+    assert preview_data["data"]["paths"] == [
+        ".vault/_archive/research/2026-07-27-batch-archive-research.md"
+    ]
+    assert source.is_file()
+    assert not archive_path.exists()
+
+    applied = _run(tmp_path, manifest, "--json")
+
+    assert applied.exit_code == 0, applied.output
+    applied_data = json.loads(applied.output)
+    assert applied_data["status"] == "updated"
+    assert applied_data["data"]["dry_run"] is False
+    assert not source.exists()
+    assert archive_path.read_text(encoding="utf-8").endswith(
+        "The record is retained before it is archived.\n"
+    )

--- a/src/vaultspec_core/tests/cli/test_vault_cli.py
+++ b/src/vaultspec_core/tests/cli/test_vault_cli.py
@@ -130,7 +130,7 @@ class TestAddSubcommand:
                 str(synthetic_project),
                 "vault",
                 "add",
-                "adr",
+                "plan",
                 "--feature",
                 "topic-feat",
                 "--topic",

--- a/src/vaultspec_core/vaultcore/batch_archive.py
+++ b/src/vaultspec_core/vaultcore/batch_archive.py
@@ -1,0 +1,285 @@
+"""Atomic archival of an explicit set of live vault documents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..config import get_config
+from ..core.exceptions import VaultSpecError
+from .checks.exec_mapping import _link_stem
+from .parser import parse_vault_metadata
+from .rename_engine import RenameTransaction, _assert_within, docs_lock_target
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+__all__ = [
+    "ArchiveDocumentsError",
+    "ArchiveDocumentsResult",
+    "archive_documents",
+]
+
+
+class ArchiveDocumentsError(VaultSpecError):
+    """Raised when an explicit batch archive cannot safely proceed."""
+
+
+@dataclass(frozen=True)
+class ArchiveDocumentsResult:
+    """The paths archived, or validated for archival by a dry run."""
+
+    status: str
+    archived_paths: tuple[Path, ...]
+    cross_link_paths: tuple[Path, ...]
+    dry_run: bool
+
+    @property
+    def archived_count(self) -> int:
+        """Return the number of documents in the explicit archive batch."""
+        return len(self.archived_paths)
+
+    @property
+    def paths(self) -> tuple[Path, ...]:
+        """Compatibility name for the destination paths."""
+        return self.archived_paths
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a portable, JSON-ready representation."""
+        return {
+            "status": self.status,
+            "archived_count": self.archived_count,
+            "paths": [path.as_posix() for path in self.archived_paths],
+            "cross_link_paths": [path.as_posix() for path in self.cross_link_paths],
+            "dry_run": self.dry_run,
+        }
+
+
+@dataclass(frozen=True)
+class _ArchiveMove:
+    source: Path
+    destination: Path
+    source_relative: Path
+
+
+def archive_documents(
+    root_dir: Path,
+    relative_paths: Iterable[str | Path],
+    *,
+    dry_run: bool = False,
+) -> ArchiveDocumentsResult:
+    """Archive explicit project-relative ``.vault`` document paths as one batch.
+
+    Every input must be a relative path beginning within the configured vault
+    directory. Each document moves to ``.vault/_archive/<vault-relative-path>``.
+    Preflight rejects every unsafe source or destination before the first move;
+    an apply runs under the normal docs-domain lock and rolls back on failure.
+    """
+    root = root_dir.resolve()
+    docs_dir = root / get_config().docs_dir
+    _assert_docs_dir(root, docs_dir)
+
+    supplied = tuple(relative_paths)
+    if dry_run:
+        moves = _preflight(root, docs_dir, supplied)
+        cross_links = _cross_link_paths(root, docs_dir, moves)
+        return _result(root, moves, cross_links, dry_run=True)
+
+    runtime_dir = docs_dir / "data"
+    if runtime_dir.is_symlink():
+        raise ArchiveDocumentsError(
+            f"Vault runtime directory must not be a symlink: {runtime_dir}"
+        )
+    runtime_dir.mkdir(exist_ok=True)
+    if not runtime_dir.is_dir():
+        raise ArchiveDocumentsError(
+            f"Vault runtime path is not a directory: {runtime_dir}"
+        )
+
+    with RenameTransaction(docs_dir, lock_target=docs_lock_target(docs_dir)) as tx:
+        # Re-run the whole preflight while holding the common docs lock. This
+        # closes the gap between validation and the first destructive rename.
+        moves = _preflight(root, docs_dir, supplied)
+        cross_links = _cross_link_paths(root, docs_dir, moves)
+        tx.snapshot(move.source for move in moves)
+        for move in moves:
+            _create_archive_parent(tx, docs_dir, move.destination.parent)
+            _require_regular_document(move.source)
+            try:
+                moved = tx.rename(move.source, move.destination)
+            except OSError as exc:
+                raise ArchiveDocumentsError(
+                    f"Archive move failed: {move.source} -> {move.destination}: {exc}"
+                ) from exc
+            if not moved:
+                raise ArchiveDocumentsError(
+                    "Archive move was refused without replacing a destination: "
+                    f"{move.source} -> {move.destination}"
+                )
+
+    return _result(root, moves, cross_links, dry_run=False)
+
+
+def _assert_docs_dir(root: Path, docs_dir: Path) -> None:
+    if docs_dir.is_symlink() or not docs_dir.is_dir():
+        raise ArchiveDocumentsError(
+            f"Vault document directory must be a real directory: {docs_dir}"
+        )
+    try:
+        docs_dir.relative_to(root)
+        docs_dir.resolve(strict=False).relative_to(root)
+    except ValueError as exc:
+        raise ArchiveDocumentsError(
+            f"Configured vault directory escapes the project root: {docs_dir}"
+        ) from exc
+
+
+def _preflight(
+    root: Path, docs_dir: Path, relative_paths: tuple[str | Path, ...]
+) -> tuple[_ArchiveMove, ...]:
+    if not relative_paths:
+        raise ArchiveDocumentsError("Archive requires at least one document path.")
+
+    moves: list[_ArchiveMove] = []
+    seen_sources: set[Path] = set()
+    seen_destinations: set[Path] = set()
+    for value in relative_paths:
+        source, source_relative = _resolve_source(root, docs_dir, value)
+        destination = docs_dir / "_archive" / source_relative
+        _assert_within(docs_dir, destination)
+        if source in seen_sources:
+            raise ArchiveDocumentsError(f"Duplicate archive source: {source}")
+        if destination in seen_destinations:
+            raise ArchiveDocumentsError(f"Archive destination collision: {destination}")
+        if destination.exists() or destination.is_symlink():
+            raise ArchiveDocumentsError(
+                f"Archive destination already exists: {destination}"
+            )
+        _require_safe_archive_parent(docs_dir, destination.parent)
+        seen_sources.add(source)
+        seen_destinations.add(destination)
+        moves.append(_ArchiveMove(source, destination, source_relative))
+    return tuple(moves)
+
+
+def _resolve_source(root: Path, docs_dir: Path, value: str | Path) -> tuple[Path, Path]:
+    relative = Path(value)
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        raise ArchiveDocumentsError(
+            f"Archive path must be project-relative and confined to .vault: {value}"
+        )
+    raw_source = root / relative
+    try:
+        vault_relative = raw_source.relative_to(docs_dir)
+    except ValueError as exc:
+        raise ArchiveDocumentsError(
+            f"Archive path must be under {docs_dir}: {relative}"
+        ) from exc
+    if not vault_relative.parts or vault_relative.parts[0] == "_archive":
+        raise ArchiveDocumentsError(
+            f"Archive source must be live and outside _archive: {relative}"
+        )
+    if raw_source.suffix.lower() != ".md":
+        raise ArchiveDocumentsError(
+            f"Archive source must be a vault Markdown document: {relative}"
+        )
+    _require_no_symlink_components(docs_dir, raw_source)
+    source = raw_source.resolve(strict=False)
+    _assert_within(docs_dir, source)
+    _require_regular_document(source)
+    return source, vault_relative
+
+
+def _require_regular_document(path: Path) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise ArchiveDocumentsError(f"Archive source is not a regular file: {path}")
+    try:
+        path.read_bytes()
+    except OSError as exc:
+        raise ArchiveDocumentsError(
+            f"Cannot read archive source {path}: {exc}"
+        ) from exc
+
+
+def _require_no_symlink_components(docs_dir: Path, path: Path) -> None:
+    try:
+        relative = path.relative_to(docs_dir)
+    except ValueError as exc:
+        raise ArchiveDocumentsError(f"Archive source escapes vault: {path}") from exc
+    current = docs_dir
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            raise ArchiveDocumentsError(
+                f"Archive source contains a symlink component: {current}"
+            )
+
+
+def _require_safe_archive_parent(docs_dir: Path, parent: Path) -> None:
+    _assert_within(docs_dir, parent)
+    current = docs_dir
+    relative = parent.relative_to(docs_dir)
+    for part in relative.parts:
+        current /= part
+        if current.is_symlink():
+            raise ArchiveDocumentsError(
+                f"Archive destination parent must not be a symlink: {current}"
+            )
+        if current.exists() and not current.is_dir():
+            raise ArchiveDocumentsError(
+                f"Archive destination parent is not a directory: {current}"
+            )
+
+
+def _create_archive_parent(
+    transaction: RenameTransaction, docs_dir: Path, parent: Path
+) -> None:
+    _require_safe_archive_parent(docs_dir, parent)
+    missing: list[Path] = []
+    current = parent
+    while current != docs_dir and not current.exists():
+        missing.append(current)
+        current = current.parent
+    for directory in reversed(missing):
+        directory.mkdir()
+        transaction.record_created_dir(directory)
+
+
+def _cross_link_paths(
+    root: Path, docs_dir: Path, moves: tuple[_ArchiveMove, ...]
+) -> tuple[Path, ...]:
+    archived_stems = {move.source.stem for move in moves}
+    source_paths = {move.source for move in moves}
+    linked: list[Path] = []
+    for path in docs_dir.rglob("*.md"):
+        try:
+            relative = path.relative_to(docs_dir)
+        except ValueError:
+            continue
+        if path in source_paths or "_archive" in relative.parts:
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        try:
+            metadata, _body = parse_vault_metadata(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, ValueError):
+            continue
+        if any(_link_stem(link) in archived_stems for link in metadata.related):
+            linked.append(path.relative_to(root))
+    return tuple(sorted(linked))
+
+
+def _result(
+    root: Path,
+    moves: tuple[_ArchiveMove, ...],
+    cross_links: tuple[Path, ...],
+    *,
+    dry_run: bool,
+) -> ArchiveDocumentsResult:
+    return ArchiveDocumentsResult(
+        status="unchanged" if dry_run else "updated",
+        archived_paths=tuple(move.destination.relative_to(root) for move in moves),
+        cross_link_paths=cross_links,
+        dry_run=dry_run,
+    )

--- a/src/vaultspec_core/vaultcore/exec_recovery.py
+++ b/src/vaultspec_core/vaultcore/exec_recovery.py
@@ -1,0 +1,395 @@
+"""Typed recovery operations for historical execution-record mappings.
+
+The mapping checker is intentionally read-only.  These helpers provide the
+small, explicit mutation set required to repair a record without treating
+historical prose as a source of truth.  They modify only the ``step_id``
+frontmatter line (and its machine-owned ``modified`` stamp), preserve the
+authored body bytes, and use atomic filesystem operations.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ..config import get_config
+from ..core.exceptions import VaultSpecError
+from ..core.helpers import advisory_lock, atomic_write_bytes
+from ..plan.commands.step_ops import find_step
+from ..plan.parser import Plan, parse_plan
+from .checks.exec_mapping import _link_stem
+from .models import refresh_modified_stamp
+from .parser import parse_vault_metadata
+from .rename_engine import _assert_within, docs_lock_target
+from .rename_ops import split_keepends
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+__all__ = [
+    "ExecRecoveryContext",
+    "ExecRecoveryError",
+    "ExecRecoveryResult",
+    "detach_exec_record",
+    "relink_exec_record",
+    "resolve_exec_parent_plan",
+    "retire_exec_record",
+]
+
+
+class ExecRecoveryError(VaultSpecError):
+    """Raised when an execution-record recovery precondition is not met."""
+
+
+@dataclass(frozen=True)
+class ExecRecoveryContext:
+    """A validated live execution record and its existing parent plan."""
+
+    root_dir: Path
+    record_path: Path
+    plan_path: Path
+    plan: Plan
+    step_id: str | None
+
+
+@dataclass(frozen=True)
+class ExecRecoveryResult:
+    """Stable result returned by an execution-record recovery operation."""
+
+    operation: str
+    status: str
+    record_path: Path
+    previous_step_id: str | None
+    step_id: str | None
+    archive_path: Path | None = None
+
+
+def resolve_exec_parent_plan(root_dir: Path, record_path: Path) -> ExecRecoveryContext:
+    """Resolve *record_path* to its existing, live, parseable parent plan.
+
+    The record's ``related:`` entries are its only parent authority.  An
+    archived parent is intentionally not recoverable: it is a benign steady
+    state for validation but cannot anchor a new active mapping.
+    """
+    root = root_dir.resolve()
+    raw_record = record_path.absolute()
+    docs_dir = (root / get_config().docs_dir).resolve()
+    exec_dir = docs_dir / "exec"
+    try:
+        raw_record.relative_to(exec_dir)
+    except ValueError as exc:
+        raise ExecRecoveryError(
+            f"Execution record must be a live file under {exec_dir}: {raw_record}"
+        ) from exc
+    if raw_record.is_symlink() or not raw_record.is_file():
+        raise ExecRecoveryError(f"Execution record is not a regular file: {raw_record}")
+    record = raw_record.resolve()
+    try:
+        record.relative_to(exec_dir)
+    except ValueError as exc:
+        raise ExecRecoveryError(
+            f"Execution record escapes {exec_dir}: {raw_record}"
+        ) from exc
+
+    try:
+        raw = record.read_bytes()
+        text = raw.decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ExecRecoveryError(
+            f"Cannot read execution record {record}: {exc}"
+        ) from exc
+    # The metadata parser expects LF-oriented YAML, while recovery must retain
+    # the original bytes. Normalize only its parsing view; every write below
+    # is based on the original ``text`` and preserves its line endings.
+    metadata, _body = parse_vault_metadata(_normalise_metadata_newlines(text))
+
+    plan_dir = (docs_dir / "plan").resolve()
+    contexts: list[ExecRecoveryContext] = []
+    for link in metadata.related:
+        stem = _link_stem(link)
+        if stem is None:
+            continue
+        if not _is_safe_plan_stem(stem):
+            raise ExecRecoveryError(
+                f"Execution record has unsafe related plan stem {stem!r}."
+            )
+        raw_candidate = plan_dir / f"{stem}.md"
+        if raw_candidate.is_symlink():
+            raise ExecRecoveryError(
+                f"Related parent plan must not be a symlink: {raw_candidate}"
+            )
+        candidate = raw_candidate.resolve()
+        try:
+            candidate.relative_to(plan_dir)
+        except ValueError as exc:
+            raise ExecRecoveryError(
+                f"Related plan path escapes {plan_dir}: {stem!r}"
+            ) from exc
+        if not candidate.is_file():
+            continue
+        try:
+            plan = parse_plan(candidate)
+        except Exception as exc:
+            raise ExecRecoveryError(
+                f"Existing parent plan {candidate.stem!r} cannot be parsed: {exc}"
+            ) from exc
+        contexts.append(
+            ExecRecoveryContext(
+                root_dir=root,
+                record_path=record,
+                plan_path=candidate,
+                plan=plan,
+                step_id=metadata.step_id,
+            )
+        )
+    if len(contexts) == 1:
+        return contexts[0]
+    if len(contexts) > 1:
+        names = ", ".join(context.plan_path.stem for context in contexts)
+        raise ExecRecoveryError(
+            "Execution record has multiple live parent plans and cannot be "
+            f"recovered safely: {names}."
+        )
+    raise ExecRecoveryError(
+        f"Execution record has no existing live, parseable parent plan in {plan_dir}."
+    )
+
+
+def relink_exec_record(
+    root_dir: Path,
+    record_path: Path,
+    target_step: str,
+    *,
+    dry_run: bool = False,
+) -> ExecRecoveryResult:
+    """Relink a record to one unambiguous live Step in its existing parent plan."""
+    with _recovery_context(root_dir, record_path, dry_run=dry_run) as context:
+        try:
+            target = find_step(context.plan, target_step)
+        except (KeyError, ValueError) as exc:
+            raise ExecRecoveryError(
+                f"Target Step {target_step!r} is not one unambiguous live Step in "
+                f"parent plan {context.plan_path.stem!r}: {exc}"
+            ) from exc
+        if context.step_id == target.canonical_id:
+            return _unchanged("relink", context)
+        if not dry_run:
+            _replace_step_id(context.record_path, target.canonical_id)
+        return ExecRecoveryResult(
+            operation="relink",
+            status="updated" if not dry_run else "unchanged",
+            record_path=context.record_path,
+            previous_step_id=context.step_id,
+            step_id=target.canonical_id,
+        )
+
+
+def retire_exec_record(
+    root_dir: Path, record_path: Path, *, dry_run: bool = False
+) -> ExecRecoveryResult:
+    """Archive a complete record only when its claimed Step is retired."""
+    with _recovery_context(root_dir, record_path, dry_run=dry_run) as context:
+        if (
+            context.step_id is None
+            or context.step_id not in context.plan.retired_step_ids
+        ):
+            raise ExecRecoveryError(
+                "Execution record can be retired only when its current step_id is "
+                f"retired by parent plan {context.plan_path.stem!r}."
+            )
+        archive_path = _archive_path(context)
+        _validate_archive_destination(context, archive_path)
+        if not dry_run:
+            _archive_record(context, archive_path)
+        return ExecRecoveryResult(
+            operation="retire",
+            status="updated" if not dry_run else "unchanged",
+            record_path=context.record_path,
+            previous_step_id=context.step_id,
+            step_id=context.step_id,
+            archive_path=archive_path,
+        )
+
+
+def detach_exec_record(
+    root_dir: Path, record_path: Path, *, dry_run: bool = False
+) -> ExecRecoveryResult:
+    """Detach only a claimed mapping that is neither live nor retired."""
+    with _recovery_context(root_dir, record_path, dry_run=dry_run) as context:
+        if context.step_id is None:
+            return _unchanged("detach", context)
+        live_ids = {step.canonical_id for step in context.plan.steps}
+        if (
+            context.step_id in live_ids
+            or context.step_id in context.plan.retired_step_ids
+        ):
+            raise ExecRecoveryError(
+                "Execution record can be detached only when its claimed step_id "
+                "resolves to neither a live nor retired Step."
+            )
+        if not dry_run:
+            _remove_step_id(context.record_path)
+        return ExecRecoveryResult(
+            operation="detach",
+            status="updated" if not dry_run else "unchanged",
+            record_path=context.record_path,
+            previous_step_id=context.step_id,
+            step_id=None,
+        )
+
+
+def _unchanged(operation: str, context: ExecRecoveryContext) -> ExecRecoveryResult:
+    return ExecRecoveryResult(
+        operation=operation,
+        status="unchanged",
+        record_path=context.record_path,
+        previous_step_id=context.step_id,
+        step_id=context.step_id,
+    )
+
+
+@contextmanager
+def _recovery_context(
+    root_dir: Path, record_path: Path, *, dry_run: bool
+) -> Iterator[ExecRecoveryContext]:
+    """Serialize recovery from parent resolution through the final mutation."""
+    docs_dir = (root_dir.resolve() / get_config().docs_dir).resolve()
+    if not dry_run:
+        # ``advisory_lock`` intentionally avoids creating its parent for a
+        # preview. An applying recovery must instead establish the standard
+        # vault runtime directory first, so fresh vaults do not bypass the
+        # same docs-domain lock used by other mutators.
+        (docs_dir / "data").mkdir(exist_ok=True)
+    with advisory_lock(docs_lock_target(docs_dir)):
+        yield resolve_exec_parent_plan(root_dir, record_path)
+
+
+def _archive_path(context: ExecRecoveryContext) -> Path:
+    docs_dir = (context.root_dir / get_config().docs_dir).resolve()
+    relative = context.record_path.relative_to(docs_dir)
+    return docs_dir / "_archive" / relative
+
+
+def _validate_archive_destination(
+    context: ExecRecoveryContext, archive_path: Path
+) -> None:
+    """Reject an existing or out-of-vault archive destination before apply."""
+    docs_dir = (context.root_dir / get_config().docs_dir).resolve()
+    _assert_within(docs_dir, archive_path)
+    if archive_path.exists() or archive_path.is_symlink():
+        raise ExecRecoveryError(f"Archive destination already exists: {archive_path}")
+
+
+def _archive_record(context: ExecRecoveryContext, archive_path: Path) -> None:
+    """Atomically archive one record without replacing an existing destination."""
+    docs_dir = (context.root_dir / get_config().docs_dir).resolve()
+    _assert_within(docs_dir, context.record_path)
+    _validate_archive_destination(context, archive_path)
+    archive_path.parent.mkdir(parents=True, exist_ok=True)
+    _assert_within(docs_dir, archive_path)
+    if context.record_path.is_symlink() or not context.record_path.is_file():
+        raise ExecRecoveryError(
+            f"Execution record changed before archive: {context.record_path}"
+        )
+    try:
+        # A hard link reserves the destination exclusively: unlike
+        # ``os.replace``, it cannot overwrite another archive record.
+        os.link(context.record_path, archive_path, follow_symlinks=False)
+    except FileExistsError as exc:
+        raise ExecRecoveryError(
+            f"Archive destination already exists: {archive_path}"
+        ) from exc
+    except OSError as exc:
+        raise ExecRecoveryError(
+            f"Could not reserve archive destination {archive_path}: {exc}"
+        ) from exc
+    if not context.record_path.samefile(archive_path):
+        raise ExecRecoveryError(
+            "Execution record changed during archive; retained the "
+            f"non-overwriting archive copy at {archive_path}."
+        )
+    context.record_path.unlink()
+
+
+def _replace_step_id(path: Path, step_id: str) -> None:
+    raw = path.read_bytes()
+    text = raw.decode("utf-8")
+    frontmatter, body = _frontmatter_and_body(text)
+    replaced = _edit_frontmatter_step_id(frontmatter, step_id)
+    if replaced is None:
+        raise RuntimeError("step_id replacement unexpectedly removed frontmatter")
+    _write_stamped(path, replaced + body)
+
+
+def _remove_step_id(path: Path) -> None:
+    raw = path.read_bytes()
+    text = raw.decode("utf-8")
+    frontmatter, body = _frontmatter_and_body(text)
+    replaced = _edit_frontmatter_step_id(frontmatter, None)
+    if replaced is None:
+        raise ExecRecoveryError(f"Execution record has no removable step_id: {path}")
+    _write_stamped(path, replaced + body)
+
+
+def _frontmatter_and_body(text: str) -> tuple[str, str]:
+    """Split the leading YAML fence without normalizing its bytes."""
+    lines = text.splitlines(keepends=True)
+    if not lines or lines[0].lstrip("\ufeff").rstrip("\r\n") != "---":
+        raise ExecRecoveryError("Execution record has no leading YAML frontmatter.")
+    offset = len(lines[0])
+    for line in lines[1:]:
+        offset += len(line)
+        if line.rstrip("\r\n") == "---":
+            return text[:offset], text[offset:]
+    raise ExecRecoveryError("Execution record has an unclosed YAML frontmatter fence.")
+
+
+def _edit_frontmatter_step_id(text: str, step_id: str | None) -> str | None:
+    """Replace, insert, or remove ``step_id`` while retaining every EOL byte."""
+    pairs = split_keepends(text)
+    for index, (content, _ending) in enumerate(pairs):
+        key, separator, _value = content.partition(":")
+        if separator and key.strip() == "step_id":
+            if step_id is None:
+                del pairs[index]
+            else:
+                indent = key[: len(key) - len(key.lstrip(" \t"))]
+                pairs[index][0] = f"{indent}step_id: '{step_id}'"
+            return "".join(content + ending for content, ending in pairs)
+    if step_id is None:
+        return None
+    for index, (content, ending) in enumerate(pairs):
+        key, separator, _value = content.partition(":")
+        if separator and key.strip() == "modified":
+            indent = key[: len(key) - len(key.lstrip(" \t"))]
+            pairs.insert(index + 1, [f"{indent}step_id: '{step_id}'", ending or "\n"])
+            return "".join(content + ending for content, ending in pairs)
+    raise ExecRecoveryError("Execution record has no canonical modified: stamp.")
+
+
+def _is_safe_plan_stem(stem: str) -> bool:
+    """Return whether a wikilink stem can name only a direct plan child."""
+    return (
+        bool(stem)
+        and "/" not in stem
+        and "\\" not in stem
+        and stem
+        not in {
+            ".",
+            "..",
+        }
+    )
+
+
+def _normalise_metadata_newlines(text: str) -> str:
+    """Return an LF parsing view without changing the source write bytes."""
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _write_stamped(path: Path, text: str) -> None:
+    stamped = refresh_modified_stamp(text, dt.date.today())
+    atomic_write_bytes(path, stamped.encode("utf-8"))

--- a/src/vaultspec_core/vaultcore/hydration.py
+++ b/src/vaultspec_core/vaultcore/hydration.py
@@ -40,11 +40,12 @@ _TEMPLATE_NAMES = {
     DocType.INDEX: "index.md",
 }
 
-# Document types that admit the narrative topic infix
-# (``{date}-{feature}-{topic}-{type}.md``). The adr and plan cardinality
-# rules forbid disambiguation-by-infix, and exec filenames are
-# machine-derived, so only the narrative trio is listed.
-_TOPIC_INFIX_TYPES = frozenset({DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH})
+# Document types that admit the optional topic infix
+# (``{date}-{feature}-{topic}-{type}.md``). Plans retain one execution
+# cluster and exec filenames are machine-derived, so they remain excluded.
+_TOPIC_INFIX_TYPES = frozenset(
+    {DocType.ADR, DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH}
+)
 
 # The exec document type has two templates: the Step-record template (above)
 # and the Phase-summary template, selected via the ``summary`` flag on
@@ -394,7 +395,7 @@ def create_vault_doc(
     if topic is not None and doc_type not in _TOPIC_INFIX_TYPES:
         raise ValueError(
             f"topic infix is not supported for '{doc_type.value}' documents; "
-            "admitted types: audit, reference, research"
+            "admitted types: adr, audit, reference, research"
         )
 
     template_path = get_template_path(

--- a/src/vaultspec_core/vaultcore/tests/test_hydration.py
+++ b/src/vaultspec_core/vaultcore/tests/test_hydration.py
@@ -398,7 +398,7 @@ class TestCreateVaultDocStemCollision:
 
 
 class TestCreateVaultDocTopicInfix:
-    """Topic-infix filenames for the narrative trio (audit, reference, research)."""
+    """Topic-infix filenames for ADR and narrative document records."""
 
     @pytest.fixture()
     def vault_project(self, tmp_path):
@@ -413,7 +413,7 @@ class TestCreateVaultDocTopicInfix:
 
     @pytest.mark.parametrize(
         "doc_type",
-        [DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH],
+        [DocType.ADR, DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH],
     )
     def test_infixed_filename_for_admitting_types(self, vault_project, doc_type):
         path = create_vault_doc(
@@ -462,7 +462,7 @@ class TestCreateVaultDocTopicInfix:
         )
         assert path.name == "2026-07-16-my-feat-reference.md"
 
-    @pytest.mark.parametrize("doc_type", [DocType.ADR, DocType.PLAN, DocType.EXEC])
+    @pytest.mark.parametrize("doc_type", [DocType.PLAN, DocType.EXEC])
     def test_non_admitting_type_raises(self, vault_project, doc_type):
         with pytest.raises(ValueError, match="topic infix is not supported"):
             create_vault_doc(
@@ -497,4 +497,30 @@ class TestCreateVaultDocTopicInfix:
                 "my-feat",
                 "2026-07-16",
                 topic="engine-wire",
+            )
+
+    def test_two_adr_topics_coexist_and_duplicate_collides(self, vault_project):
+        first = create_vault_doc(
+            vault_project,
+            DocType.ADR,
+            "my-feat",
+            "2026-07-16",
+            topic="circuit-accounting",
+        )
+        second = create_vault_doc(
+            vault_project,
+            DocType.ADR,
+            "my-feat",
+            "2026-07-16",
+            topic="sibling-adoption",
+        )
+        assert first.name == "2026-07-16-my-feat-circuit-accounting-adr.md"
+        assert second.name == "2026-07-16-my-feat-sibling-adoption-adr.md"
+        with pytest.raises(ResourceExistsError, match="already exists"):
+            create_vault_doc(
+                vault_project,
+                DocType.ADR,
+                "my-feat",
+                "2026-07-16",
+                topic="circuit-accounting",
             )

--- a/tests/cli/test_exec_recovery_cli.py
+++ b/tests/cli/test_exec_recovery_cli.py
@@ -1,0 +1,156 @@
+"""Real CLI integration tests for explicit execution-record recovery.
+
+Each case drives the live Typer application against on-disk plan and execution
+records.  The assertions cover the public JSON and dry-run contract in addition
+to reading back the actual metadata and historical body bytes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from vaultspec_core.cli import app
+from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+from vaultspec_core.vaultcore import parse_vault_metadata
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.integration]
+
+_PLAN_STEM = "2026-02-04-recovery-plan"
+
+
+def _write_plan(root: Path, *, retired: str | None = None) -> Path:
+    retired_ledger = f"\n<!-- RETIRED: {retired} -->" if retired else ""
+    path = root / ".vault" / "plan" / f"{_PLAN_STEM}.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "---\n"
+        "tags:\n"
+        "  - '#plan'\n"
+        "  - '#recovery'\n"
+        "date: '2026-02-04'\n"
+        "modified: '2026-02-04'\n"
+        "tier: L1\n"
+        "related: []\n"
+        "---\n\n"
+        "# `recovery` plan\n\n"
+        "## Steps\n\n"
+        "- [ ] `S01` - recover evidence; `src/recovery.py`.\n"
+        f"{retired_ledger}\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_record(root: Path, step_id: str) -> Path:
+    path = root / ".vault" / "exec" / "2026-02-04-recovery" / "record.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        (
+            "---\r\n"
+            "tags:\r\n"
+            "  - '#exec'\r\n"
+            "  - '#recovery'\r\n"
+            "date: '2026-02-04'\r\n"
+            "modified: '2026-02-04'\r\n"
+            f"step_id: '{step_id}'\r\n"
+            "related:\r\n"
+            f"  - '[[{_PLAN_STEM}]]'\r\n"
+            "---\r\n\r\n"
+            "# Recovery record\r\n\r\n"
+            "Historical evidence remains byte-for-byte.\r\n"
+        ).encode()
+    )
+    return path
+
+
+def _run(root: Path, *args: str):
+    return CliRunner(env={"NO_COLOR": "1"}).invoke(
+        app, ["vault", "exec", *args, "--target", str(root)]
+    )
+
+
+def _body(path: Path) -> bytes:
+    return path.read_bytes().split(b"---\r\n", 2)[2]
+
+
+def test_relink_dry_run_and_apply_emit_truthful_json_and_preserve_body(
+    tmp_path: Path,
+) -> None:
+    WorkspaceFactory(tmp_path).install()
+    _write_plan(tmp_path)
+    record = _write_record(tmp_path, "P01.S01")
+    before = record.read_bytes()
+
+    preview = _run(
+        tmp_path,
+        "relink",
+        "--record",
+        str(record),
+        "--step",
+        "S01",
+        "--dry-run",
+        "--json",
+    )
+
+    assert preview.exit_code == 0, preview.output
+    preview_data = json.loads(preview.output)
+    assert preview_data["schema"] == "vaultspec.vault.exec.relink.v1"
+    assert preview_data["status"] == "unchanged"
+    assert preview_data["data"]["dry_run"] is True
+    assert preview_data["data"]["changed"] is True
+    assert record.read_bytes() == before
+
+    applied = _run(
+        tmp_path,
+        "relink",
+        "--record",
+        str(record),
+        "--step",
+        "S01",
+        "--json",
+    )
+
+    assert applied.exit_code == 0, applied.output
+    applied_data = json.loads(applied.output)
+    assert applied_data["status"] == "updated"
+    assert applied_data["data"]["step_id"] == "S01"
+    metadata, _ = parse_vault_metadata(record.read_text(encoding="utf-8"))
+    assert metadata.step_id == "S01"
+    assert _body(record) == before.split(b"---\r\n", 2)[2]
+
+
+def test_detach_and_retire_apply_only_their_validated_recovery(tmp_path: Path) -> None:
+    WorkspaceFactory(tmp_path).install()
+    _write_plan(tmp_path, retired="S02")
+
+    dangling = _write_record(tmp_path, "S99")
+    body_before_detach = _body(dangling)
+    detached = _run(tmp_path, "detach", "--record", str(dangling), "--json")
+
+    assert detached.exit_code == 0, detached.output
+    detached_data = json.loads(detached.output)
+    assert detached_data["schema"] == "vaultspec.vault.exec.detach.v1"
+    assert detached_data["status"] == "updated"
+    assert detached_data["data"]["step_id"] is None
+    metadata, _ = parse_vault_metadata(dangling.read_text(encoding="utf-8"))
+    assert metadata.step_id is None
+    assert _body(dangling) == body_before_detach
+
+    retired = _write_record(tmp_path, "S02")
+    retired_body = retired.read_bytes()
+    retirement = _run(tmp_path, "retire", "--record", str(retired), "--json")
+
+    assert retirement.exit_code == 0, retirement.output
+    retirement_data = json.loads(retirement.output)
+    assert retirement_data["schema"] == "vaultspec.vault.exec.retire.v1"
+    assert retirement_data["status"] == "updated"
+    archive_path = tmp_path / retirement_data["data"]["archive_path"]
+    assert not retired.exists()
+    assert archive_path.read_bytes() == retired_body

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -5,8 +5,10 @@ import shutil
 from uuid import uuid4
 
 import pytest
+from typer.testing import CliRunner
 
 from tests.constants import PROJECT_ROOT
+from vaultspec_core.cli import app
 from vaultspec_core.config import reset_config
 from vaultspec_core.core.commands import (
     CANONICAL_ENTRY_PREFIX,
@@ -442,6 +444,87 @@ def test_vault_add_dry_run_no_write() -> None:
         )
         assert not path.exists()
         assert path.name == "2026-04-11-dry-test-research.md"
+    finally:
+        reset_config()
+        shutil.rmtree(tmp_path, ignore_errors=True)
+
+
+@pytest.mark.unit
+def test_vault_add_creates_distinct_same_day_topic_infixed_adrs() -> None:
+    """The public CLI creates distinct ADR records for distinct topic infixes."""
+    tmp_path = PROJECT_ROOT / ".pytest-tmp" / f"vault-add-adr-topic-{uuid4().hex}"
+    try:
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        reset_config()
+        install_run(
+            path=tmp_path,
+            provider="all",
+            upgrade=False,
+            dry_run=False,
+            force=False,
+        )
+
+        runner = CliRunner(env={"NO_COLOR": "1"})
+        first = runner.invoke(
+            app,
+            [
+                "vault",
+                "add",
+                "adr",
+                "--feature",
+                "same-day-decisions",
+                "--topic",
+                "circuit-accounting",
+                "--date",
+                "2026-07-27",
+                "--target",
+                str(tmp_path),
+            ],
+        )
+        second = runner.invoke(
+            app,
+            [
+                "vault",
+                "add",
+                "adr",
+                "--feature",
+                "same-day-decisions",
+                "--topic",
+                "sibling-adoption",
+                "--date",
+                "2026-07-27",
+                "--target",
+                str(tmp_path),
+            ],
+        )
+        duplicate = runner.invoke(
+            app,
+            [
+                "vault",
+                "add",
+                "adr",
+                "--feature",
+                "same-day-decisions",
+                "--topic",
+                "circuit-accounting",
+                "--date",
+                "2026-07-27",
+                "--target",
+                str(tmp_path),
+            ],
+        )
+
+        assert first.exit_code == 0, first.output
+        assert second.exit_code == 0, second.output
+        assert duplicate.exit_code == 1, duplicate.output
+        adr_dir = tmp_path / ".vault" / "adr"
+        assert (
+            adr_dir / "2026-07-27-same-day-decisions-circuit-accounting-adr.md"
+        ).is_file()
+        assert (
+            adr_dir / "2026-07-27-same-day-decisions-sibling-adoption-adr.md"
+        ).is_file()
+        assert "already exists" in duplicate.output
     finally:
         reset_config()
         shutil.rmtree(tmp_path, ignore_errors=True)

--- a/tests/unit/mcp_server/test_create_tool.py
+++ b/tests/unit/mcp_server/test_create_tool.py
@@ -165,20 +165,20 @@ async def test_create_topic_infix_scaffolds_second_reference(vault_root):
         assert any(ref_dir.glob("*-infix-feat-engine-wire-reference.md"))
 
 
-async def test_create_topic_rejected_for_non_admitting_type(vault_root):
-    """A topic on an adr spec is a per-item failure."""
+async def test_create_topic_rejected_for_plan(vault_root):
+    """A topic on a plan spec remains a per-item failure."""
     mcp = create_server()
     async with create_connected_server_and_client_session(mcp) as client:
         payload = await _create(
             client,
-            [{"feature": "infix-feat", "type": "adr", "topic": "second"}],
+            [{"feature": "infix-feat", "type": "plan", "topic": "second"}],
         )
         assert payload["status"] == "failed"
         assert "topic is only valid" in payload["items"][0]["error"]["message"]
 
 
-async def test_create_mixed_batch_topic_failure_beside_success(vault_root):
-    """A topic-rejected item fails per-item while its batch siblings apply."""
+async def test_create_mixed_batch_accepts_adr_topic_and_rejects_plan_topic(vault_root):
+    """ADR topics create while plan topics fail without aborting the batch."""
     mcp = create_server()
     async with create_connected_server_and_client_session(mcp) as client:
         payload = await _create(
@@ -186,12 +186,15 @@ async def test_create_mixed_batch_topic_failure_beside_success(vault_root):
             [
                 {"feature": "mixed-feat", "type": "reference", "topic": "wire"},
                 {"feature": "mixed-feat", "type": "adr", "topic": "second"},
+                {"feature": "mixed-feat", "type": "plan", "topic": "third"},
                 {"feature": "mixed-feat", "type": "research"},
             ],
         )
         assert payload["status"] == "mixed"
         items = payload["items"]
         assert items[0]["status"] == "created"
-        assert items[1]["status"] == "failed"
-        assert "topic is only valid" in items[1]["error"]["message"]
-        assert items[2]["status"] == "created"
+        assert items[1]["status"] == "created"
+        assert items[2]["status"] == "failed"
+        assert "topic is only valid" in items[2]["error"]["message"]
+        assert items[3]["status"] == "created"
+        assert any((vault_root / ".vault" / "adr").glob("*-mixed-feat-second-adr.md"))

--- a/tests/unit/vaultcore/test_batch_archive.py
+++ b/tests/unit/vaultcore/test_batch_archive.py
@@ -1,0 +1,216 @@
+"""Real-filesystem tests for explicit atomic vault document archiving."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from vaultspec_core.config import reset_config
+from vaultspec_core.vaultcore.batch_archive import (
+    ArchiveDocumentsError,
+    archive_documents,
+)
+
+pytestmark = [pytest.mark.unit]
+
+
+def _document(
+    *, related: tuple[str, ...] = (), body: bytes = b"Evidence: caf\xc3\xa9\n"
+) -> bytes:
+    related_lines = b"".join(f"  - '[[{stem}]]'\n".encode() for stem in related)
+    return (
+        b"---\ntags:\n  - '#research'\n  - '#feat'\nrelated:\n"
+        + related_lines
+        + b"---\n\n"
+        + body
+    )
+
+
+def _write(root: Path, relative: str, *, related: tuple[str, ...] = ()) -> Path:
+    path = root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_document(related=related))
+    return path
+
+
+def test_archives_explicit_documents_to_their_vault_relative_destinations(
+    tmp_path: Path,
+) -> None:
+    first = _write(tmp_path, ".vault/research/first.md")
+    second = _write(tmp_path, ".vault/plan/nested/second.md")
+    first_bytes = first.read_bytes()
+    second_bytes = second.read_bytes()
+
+    result = archive_documents(
+        tmp_path,
+        (Path(".vault/research/first.md"), ".vault/plan/nested/second.md"),
+    )
+
+    assert result.status == "updated"
+    assert result.archived_count == 2
+    assert result.paths == (
+        Path(".vault/_archive/research/first.md"),
+        Path(".vault/_archive/plan/nested/second.md"),
+    )
+    assert not first.exists()
+    assert not second.exists()
+    assert (tmp_path / result.paths[0]).read_bytes() == first_bytes
+    assert (tmp_path / result.paths[1]).read_bytes() == second_bytes
+
+
+def test_preflight_rejects_any_collision_without_moving_another_document(
+    tmp_path: Path,
+) -> None:
+    first = _write(tmp_path, ".vault/research/first.md")
+    second = _write(tmp_path, ".vault/plan/second.md")
+    destination = tmp_path / ".vault/_archive/plan/second.md"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"existing historical evidence")
+
+    with pytest.raises(ArchiveDocumentsError, match="destination already exists"):
+        archive_documents(
+            tmp_path,
+            (".vault/research/first.md", ".vault/plan/second.md"),
+        )
+
+    assert first.is_file()
+    assert second.is_file()
+    assert destination.read_bytes() == b"existing historical evidence"
+
+
+def test_rolls_back_an_earlier_real_move_when_a_later_file_is_locked(
+    tmp_path: Path,
+) -> None:
+    first = _write(tmp_path, ".vault/research/first.md")
+    locked = _write(tmp_path, ".vault/plan/locked.md")
+    first_bytes = first.read_bytes()
+
+    if os.name == "nt":
+        with (
+            locked.open("rb"),
+            pytest.raises(ArchiveDocumentsError, match="Archive move failed"),
+        ):
+            archive_documents(
+                tmp_path,
+                (".vault/research/first.md", ".vault/plan/locked.md"),
+            )
+    else:
+        original_mode = stat.S_IMODE(locked.parent.stat().st_mode)
+        locked.parent.chmod(stat.S_IREAD | stat.S_IEXEC)
+        try:
+            with pytest.raises(ArchiveDocumentsError, match="Archive move failed"):
+                archive_documents(
+                    tmp_path,
+                    (".vault/research/first.md", ".vault/plan/locked.md"),
+                )
+        finally:
+            locked.parent.chmod(original_mode)
+
+    assert first.read_bytes() == first_bytes
+    assert locked.is_file()
+    assert not (tmp_path / ".vault/_archive/research/first.md").exists()
+    assert not (tmp_path / ".vault/_archive/plan/locked.md").exists()
+
+
+@pytest.mark.parametrize(
+    "paths, message",
+    [
+        ((), "at least one"),
+        ((".vault/research/only.md", ".vault/research/only.md"), "Duplicate"),
+        ((".vault/_archive/research/old.md",), "outside _archive"),
+        (("outside.md",), "must be under"),
+        ((".vault/research/../research/only.md",), "confined"),
+    ],
+)
+def test_preflight_rejects_unsafe_explicit_path_sets(
+    tmp_path: Path, paths: tuple[str, ...], message: str
+) -> None:
+    source = _write(tmp_path, ".vault/research/only.md")
+
+    with pytest.raises(ArchiveDocumentsError, match=message):
+        archive_documents(tmp_path, paths)
+
+    assert source.is_file()
+
+
+def test_dry_run_reports_cross_links_without_changing_bytes(tmp_path: Path) -> None:
+    source = _write(tmp_path, ".vault/research/source.md")
+    referer = _write(
+        tmp_path,
+        ".vault/plan/consumer.md",
+        related=("source",),
+    )
+    before = source.read_bytes()
+
+    result = archive_documents(tmp_path, (".vault/research/source.md",), dry_run=True)
+
+    assert result.status == "unchanged"
+    assert result.dry_run is True
+    assert result.cross_link_paths == (Path(".vault/plan/consumer.md"),)
+    assert source.read_bytes() == before
+    assert referer.is_file()
+    assert result.to_dict() == {
+        "status": "unchanged",
+        "archived_count": 1,
+        "paths": [".vault/_archive/research/source.md"],
+        "cross_link_paths": [".vault/plan/consumer.md"],
+        "dry_run": True,
+    }
+
+
+def test_preflight_refuses_a_symlinked_source_without_touching_the_target(
+    tmp_path: Path,
+) -> None:
+    target = _write(tmp_path, ".vault/research/target.md")
+    link = tmp_path / ".vault/research/link.md"
+    try:
+        os.symlink(target, link)
+    except OSError as exc:
+        pytest.fail(f"test host must support a local symlink: {exc}")
+
+    with pytest.raises(ArchiveDocumentsError, match="symlink"):
+        archive_documents(tmp_path, (".vault/research/link.md",))
+
+    assert target.is_file()
+    assert link.is_symlink()
+
+
+def test_preflight_refuses_a_non_regular_markdown_path(tmp_path: Path) -> None:
+    directory = tmp_path / ".vault/research/not-a-document.md"
+    directory.mkdir(parents=True)
+
+    with pytest.raises(ArchiveDocumentsError, match="not a regular file"):
+        archive_documents(tmp_path, (".vault/research/not-a-document.md",))
+
+    assert directory.is_dir()
+
+
+def test_refuses_a_configured_vault_reached_through_a_symlinked_parent(
+    tmp_path: Path,
+) -> None:
+    project = tmp_path / "project"
+    external = tmp_path / "external"
+    document = _write(external / "vault", "research/secret.md")
+    project.mkdir()
+    try:
+        os.symlink(external, project / "linked", target_is_directory=True)
+    except OSError as exc:
+        pytest.fail(f"test host must support a local directory symlink: {exc}")
+
+    previous = os.environ.get("VAULTSPEC_DOCS_DIR")
+    os.environ["VAULTSPEC_DOCS_DIR"] = "linked/vault"
+    reset_config()
+    try:
+        with pytest.raises(ArchiveDocumentsError, match="escapes the project root"):
+            archive_documents(project, ("linked/vault/research/secret.md",))
+    finally:
+        if previous is None:
+            os.environ.pop("VAULTSPEC_DOCS_DIR", None)
+        else:
+            os.environ["VAULTSPEC_DOCS_DIR"] = previous
+        reset_config()
+
+    assert document.is_file()

--- a/tests/unit/vaultcore/test_exec_recovery.py
+++ b/tests/unit/vaultcore/test_exec_recovery.py
@@ -1,0 +1,295 @@
+"""Real-filesystem tests for explicit execution-record recovery operations."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.vaultcore.exec_recovery import (
+    ExecRecoveryError,
+    _recovery_context,
+    detach_exec_record,
+    relink_exec_record,
+    resolve_exec_parent_plan,
+    retire_exec_record,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+_PLAN_STEM = "2026-02-04-feat-plan"
+
+
+def _plan(steps: tuple[str, ...] = ("S01",), retired: tuple[str, ...] = ()) -> str:
+    rows = "\n".join(f"- [ ] `{step}` - do work; `src/{step}.py`." for step in steps)
+    ledger = f"\n<!-- RETIRED: {', '.join(retired)} -->" if retired else ""
+    return (
+        "---\ntags:\n  - '#plan'\n  - '#feat'\ndate: '2026-02-04'\n"
+        "modified: '2026-02-04'\ntier: L1\nrelated: []\n---\n\n# `feat` plan\n"
+        f"\n## Steps\n\n{rows}\n{ledger}\n"
+    )
+
+
+def _record(step_id: str | None, *, eol: str = "\r\n") -> bytes:
+    step = f"step_id: '{step_id}'{eol}" if step_id is not None else ""
+    return (
+        f"---{eol}tags:{eol}  - '#exec'{eol}  - '#feat'{eol}"
+        f"date: '2026-02-04'{eol}modified: '2026-02-04'{eol}"
+        f"{step}related:{eol}  - '[[{_PLAN_STEM}]]'{eol}---{eol}{eol}"
+        f"# Record{eol}{eol}Evidence: café.{eol}"
+    ).encode()
+
+
+def _paths(root: Path, step_id: str | None, *, retired: tuple[str, ...] = ()) -> Path:
+    plan = root / ".vault" / "plan" / f"{_PLAN_STEM}.md"
+    plan.parent.mkdir(parents=True)
+    plan.write_text(_plan(retired=retired), encoding="utf-8")
+    record = root / ".vault" / "exec" / "2026-02-04-feat" / "record.md"
+    record.parent.mkdir(parents=True)
+    record.write_bytes(_record(step_id))
+    return record
+
+
+def _body(raw: bytes) -> bytes:
+    return raw.split(b"---\r\n", 2)[2]
+
+
+def test_resolve_uses_only_existing_live_related_plan(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S09")
+
+    context = resolve_exec_parent_plan(tmp_path, record)
+
+    assert context.plan_path.name == f"{_PLAN_STEM}.md"
+    assert context.step_id == "S09"
+
+
+def test_relink_canonicalizes_a_live_display_path_preserving_crlf_and_body(
+    tmp_path: Path,
+) -> None:
+    record = _paths(tmp_path, "P01.S01")
+    plan = record.parents[2] / "plan" / f"{_PLAN_STEM}.md"
+    plan.write_text(
+        _plan()
+        .replace("tier: L1", "tier: L2")
+        .replace(
+            "## Steps\n\n- [ ] `S01`", "### Phase `P01` - work\n\n- [ ] `P01.S01`"
+        ),
+        encoding="utf-8",
+    )
+    before = record.read_bytes()
+
+    result = relink_exec_record(tmp_path, record, "P01.S01")
+    after = record.read_bytes()
+
+    assert result.status == "updated"
+    assert result.step_id == "S01"
+    assert b"step_id: 'S01'\r\n" in after
+    assert b"\n" not in after.replace(b"\r\n", b"")
+    assert _body(after) == _body(before)
+
+
+def test_relink_rejects_target_outside_existing_parent_plan(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S09")
+
+    with pytest.raises(ExecRecoveryError, match="not one unambiguous live Step"):
+        relink_exec_record(tmp_path, record, "S02")
+
+    assert b"step_id: 'S09'" in record.read_bytes()
+
+
+def test_relink_does_not_rewrite_a_body_step_id_line(tmp_path: Path) -> None:
+    record = _paths(tmp_path, None)
+    record.write_bytes(record.read_bytes() + b"step_id: historical prose\r\n")
+    before = record.read_bytes()
+
+    relink_exec_record(tmp_path, record, "S01")
+    after = record.read_bytes()
+
+    assert b"step_id: 'S01'\r\n" in after
+    assert after.endswith(b"step_id: historical prose\r\n")
+    assert _body(after).endswith(_body(before))
+
+
+def test_retire_moves_only_a_complete_record_for_a_retired_step(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S02", retired=("S02",))
+    before = record.read_bytes()
+
+    result = retire_exec_record(tmp_path, record)
+
+    assert result.status == "updated"
+    assert result.archive_path is not None and result.archive_path.is_file()
+    assert not record.exists()
+    assert result.archive_path.read_bytes() == before
+
+
+def test_retire_refuses_existing_archive_record_without_overwriting_it(
+    tmp_path: Path,
+) -> None:
+    record = _paths(tmp_path, "S02", retired=("S02",))
+    destination = (
+        tmp_path / ".vault" / "_archive" / "exec" / "2026-02-04-feat" / "record.md"
+    )
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"existing archive evidence")
+
+    with pytest.raises(ExecRecoveryError, match="destination already exists"):
+        retire_exec_record(tmp_path, record)
+
+    assert record.is_file()
+    assert destination.read_bytes() == b"existing archive evidence"
+
+
+def test_retire_dry_run_rejects_collision_without_mutating(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S02", retired=("S02",))
+    destination = (
+        tmp_path / ".vault" / "_archive" / "exec" / "2026-02-04-feat" / "record.md"
+    )
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"existing archive evidence")
+    before = record.read_bytes()
+
+    with pytest.raises(ExecRecoveryError, match="destination already exists"):
+        retire_exec_record(tmp_path, record, dry_run=True)
+
+    assert record.read_bytes() == before
+
+
+def test_detach_removes_only_a_dangling_claim_and_preserves_body(
+    tmp_path: Path,
+) -> None:
+    record = _paths(tmp_path, "S09")
+    before = record.read_bytes()
+
+    result = detach_exec_record(tmp_path, record)
+    after = record.read_bytes()
+
+    assert result.status == "updated"
+    assert result.step_id is None
+    assert b"step_id:" not in after
+    assert b"\n" not in after.replace(b"\r\n", b"")
+    assert _body(after) == _body(before)
+
+
+def test_relink_handles_cr_only_frontmatter_without_rewriting_body(
+    tmp_path: Path,
+) -> None:
+    record = _paths(tmp_path, "S09")
+    record.write_bytes(_record("S09", eol="\r"))
+    before = record.read_bytes()
+
+    result = relink_exec_record(tmp_path, record, "S01")
+    after = record.read_bytes()
+
+    assert result.step_id == "S01"
+    assert b"step_id: 'S01'\r" in after
+    assert b"\n" not in after
+    assert after.split(b"---\r", 2)[2] == before.split(b"---\r", 2)[2]
+
+
+def test_recovery_rejects_multiple_live_parent_plans(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S09")
+    second = tmp_path / ".vault" / "plan" / "2026-02-04-second-plan.md"
+    second.write_text(_plan(), encoding="utf-8")
+    record.write_bytes(
+        record.read_bytes().replace(
+            b"  - '[[2026-02-04-feat-plan]]'\r\n",
+            b"  - '[[2026-02-04-feat-plan]]'\r\n  - '[[2026-02-04-second-plan]]'\r\n",
+        )
+    )
+
+    with pytest.raises(ExecRecoveryError, match="multiple live parent plans"):
+        detach_exec_record(tmp_path, record)
+
+
+def test_recovery_rejects_related_path_escape(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S09")
+    record.write_bytes(
+        record.read_bytes().replace(
+            b"[[2026-02-04-feat-plan]]", b"[[../../outside-plan]]"
+        )
+    )
+
+    with pytest.raises(ExecRecoveryError, match="unsafe related plan stem"):
+        detach_exec_record(tmp_path, record)
+
+
+def test_recovery_refuses_a_symlinked_execution_record(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S09")
+    link = record.with_name("record-link.md")
+    try:
+        link.symlink_to(record)
+    except OSError:
+        # On Windows hosts without Developer Mode/elevation the adversarial
+        # path cannot be created; prove the refusal left no document behind.
+        assert not link.exists()
+        return
+
+    with pytest.raises(ExecRecoveryError, match="not a regular file"):
+        detach_exec_record(tmp_path, link)
+
+    assert link.is_symlink()
+    assert record.is_file()
+
+
+def test_relink_dry_run_and_no_op_leave_record_bytes_unchanged(tmp_path: Path) -> None:
+    record = _paths(tmp_path, "S09")
+    before = record.read_bytes()
+
+    preview = relink_exec_record(tmp_path, record, "S01", dry_run=True)
+
+    assert preview.status == "unchanged"
+    assert preview.step_id == "S01"
+    assert record.read_bytes() == before
+
+    record.write_bytes(_record("S01"))
+    unchanged = relink_exec_record(tmp_path, record, "S01")
+
+    assert unchanged.status == "unchanged"
+
+
+def test_detach_revalidates_after_a_real_competing_vault_mutation(
+    tmp_path: Path,
+) -> None:
+    record = _paths(tmp_path, "S09")
+    docs_dir = tmp_path / ".vault"
+    finished = threading.Event()
+    errors: list[BaseException] = []
+
+    def detach_in_second_process() -> None:
+        try:
+            detach_exec_record(tmp_path, record)
+        except BaseException as exc:  # thread boundary preserves the real error
+            errors.append(exc)
+        finally:
+            finished.set()
+
+    assert not (docs_dir / "data").exists()
+    with _recovery_context(tmp_path, record, dry_run=False):
+        assert (docs_dir / "data").is_dir()
+        worker = threading.Thread(target=detach_in_second_process)
+        worker.start()
+        assert not finished.wait(timeout=0.1)
+        record.write_bytes(_record("S01"))
+
+    worker.join(timeout=2)
+    assert finished.is_set()
+    assert len(errors) == 1
+    assert isinstance(errors[0], ExecRecoveryError)
+    assert "neither a live nor retired" in str(errors[0])
+    assert b"step_id: 'S01'" in record.read_bytes()
+
+
+@pytest.mark.parametrize("step_id,retired", [("S01", ()), ("S02", ("S02",))])
+def test_detach_rejects_live_and_retired_claims(
+    tmp_path: Path, step_id: str, retired: tuple[str, ...]
+) -> None:
+    record = _paths(tmp_path, step_id, retired=retired)
+
+    with pytest.raises(ExecRecoveryError, match="neither a live nor retired"):
+        detach_exec_record(tmp_path, record)
+
+    assert f"step_id: '{step_id}'".encode() in record.read_bytes()


### PR DESCRIPTION
Summary: admit adr to the existing topic-infix creation contract; align CLI, MCP, rule, and reference surfaces; cover direct, CLI, and MCP creation with duplicate rejection. Verification: focused hydration, CLI, MCP, and Ruff checks passed. Closes #266.