### PR TITLE
fix: scope markdown repairs before migrations

### DIFF
--- a/src/vaultspec_core/tests/cli/test_migration_triggers.py
+++ b/src/vaultspec_core/tests/cli/test_migration_triggers.py
@@ -308,6 +308,48 @@ class TestVaultCheckWarnsWithoutMutation:
         assert "Pending schema migration" in result.stdout
 
 
+class TestFeatureScopedMarkdownRepair:
+    def test_fix_does_not_migrate_unselected_documents(self, tmp_path: Path) -> None:
+        """A selected markdown repair must not trigger global schema convergence."""
+        factory = WorkspaceFactory(tmp_path).install("core")
+        research_dir = tmp_path / ".vault" / "research"
+        research_dir.mkdir(parents=True, exist_ok=True)
+        selected = research_dir / "2026-07-27-alpha-research.md"
+        selected_before = (
+            b"---\n"
+            b"tags:\n"
+            b"  - '#research'\n"
+            b"  - '#alpha'\n"
+            b"date: '2026-07-27'\n"
+            b"related: []\n"
+            b"---\n\n"
+            b"# alpha research   \n"
+        )
+        selected.write_bytes(selected_before)
+        unselected = research_dir / "2026-07-27-beta-research.md"
+        unselected.write_text(
+            "---\n"
+            "tags:\n"
+            "  - '#research'\n"
+            "  - '#beta'\n"
+            "date: '2026-07-27'\n"
+            "related: []\n"
+            "---\n\n"
+            "# beta research\n",
+            encoding="utf-8",
+        )
+        before = unselected.read_bytes()
+        _rewind_manifest(tmp_path, "0.1.28")
+
+        result = factory.run(
+            "vault", "check", "markdown", "--fix", "--feature", "alpha"
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert selected.read_bytes() != selected_before
+        assert unselected.read_bytes() == before
+
+
 class TestMigrationsCli:
     def test_status_lists_pending(self, tmp_path: Path):
         factory = WorkspaceFactory(tmp_path).install("core")

--- a/src/vaultspec_core/vaultcore/checks/markdown.py
+++ b/src/vaultspec_core/vaultcore/checks/markdown.py
@@ -166,7 +166,10 @@ def check_markdown(
     result = CheckResult(check_name="markdown", supports_fix=True)
     wanted_feature = feature.lstrip("#") if feature else None
 
-    for doc_path in scan_vault(root_dir):
+    for doc_path in scan_vault(
+        root_dir,
+        run_migrations=not bool(wanted_feature),
+    ):
         try:
             raw_content = doc_path.read_bytes().decode("utf-8")
         except (OSError, UnicodeDecodeError):

--- a/src/vaultspec_core/vaultcore/scanner.py
+++ b/src/vaultspec_core/vaultcore/scanner.py
@@ -31,19 +31,27 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
 
 
-def scan_vault(root_dir: pathlib.Path) -> Iterator[pathlib.Path]:
+def scan_vault(
+    root_dir: pathlib.Path,
+    *,
+    run_migrations: bool = True,
+) -> Iterator[pathlib.Path]:
     """Yield all markdown files under the configured docs directory.
 
-    Skips hidden ``.obsidian`` subtrees. Runs the lazy migration
-    trigger before walking the tree: any registered schema migration
-    whose target version exceeds the manifest's ``vaultspec_version``
-    is applied first, so callers always observe the post-migration
-    layout. The trigger short-circuits via a per-process workspace
-    cache, so the manifest read happens once per workspace per CLI
-    invocation rather than once per scan.
+    Skips hidden ``.obsidian`` subtrees. By default, runs the lazy
+    migration trigger before walking the tree: any registered schema
+    migration whose target version exceeds the manifest's
+    ``vaultspec_version`` is applied first, so callers observe the
+    post-migration layout. The trigger short-circuits via a per-process
+    workspace cache, so the manifest read happens once per workspace per
+    CLI invocation rather than once per scan. Callers with an explicit
+    no-unrelated-mutation boundary may opt out.
 
     Args:
         root_dir: Project root that contains the docs directory.
+        run_migrations: Whether to run pending schema migrations before
+            scanning. Defaults to ``True`` to preserve lazy migration
+            behavior for existing callers.
 
     Yields:
         Absolute paths to each ``.md`` file found.
@@ -51,13 +59,14 @@ def scan_vault(root_dir: pathlib.Path) -> Iterator[pathlib.Path]:
     from ..config import get_config
     from ..migrations import run_pending_migrations
 
-    try:
-        run_pending_migrations(root_dir, use_cache=True)
-    except Exception:
-        # A migration failure must not silently corrupt the scan; log
-        # and propagate so the surrounding command surfaces it.
-        logger.exception("Pending migration failed for %s", root_dir)
-        raise
+    if run_migrations:
+        try:
+            run_pending_migrations(root_dir, use_cache=True)
+        except Exception:
+            # A migration failure must not silently corrupt the scan; log
+            # and propagate so the surrounding command surfaces it.
+            logger.exception("Pending migration failed for %s", root_dir)
+            raise
 
     docs_dir = root_dir / get_config().docs_dir
     if not docs_dir.exists():


### PR DESCRIPTION
## Summary

- prevent feature-scoped Markdown repair from triggering workspace-wide lazy migrations
- preserve default migration behavior for every existing scanner caller
- add a real stale-workspace CLI regression that proves unselected records remain byte-identical

Closes #268

## Verification

- `uv run --no-sync pytest src/vaultspec_core/tests/cli/test_migration_triggers.py -q`
- `just dev lint python`
- `just dev lint type`