### PR TITLE
perf(vault): scale large-corpus reads to the second domain

### DIFF
--- a/.vault/adr/2026-07-27-markdown-feature-scope-adr.md
+++ b/.vault/adr/2026-07-27-markdown-feature-scope-adr.md
@@ -1,0 +1,77 @@
+---
+tags:
+  - '#adr'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-markdown-feature-scope-research]]"
+---
+
+# `markdown-feature-scope` adr: `feature-scoped markdown repair bypasses lazy migrations` | (**status:** `proposed`)
+
+## Problem Statement
+
+Feature-scoped markdown repair promises to limit mutation to the selected feature,
+but its discovery path can cause unrelated vault records to change before the
+scope filter applies. The command needs a bounded migration policy that restores
+that safety contract without redesigning migration ownership. Grounding:
+`2026-07-27-markdown-feature-scope-research` and
+`2026-07-27-markdown-feature-scope-reference`.
+
+## Considerations
+
+- The feature filter is correct at the markdown writer; the pre-filter scanner
+  side effect is the decision locus (`2026-07-27-markdown-feature-scope-reference`).
+- Existing creation and index paths depend on default lazy convergence, so the
+  correction must preserve that default (`2026-07-27-markdown-feature-scope-research`).
+- Markdown hygiene is deliberately limited to safe whitespace normalization;
+  operating on pending-migration records is acceptable only for the explicitly
+  selected feature (`2026-07-27-markdown-feature-scope-research`).
+
+## Considered options
+
+- **Optional migration-free scan for feature-scoped markdown repair (proposed).**
+  Add an opt-out scanner parameter that preserves migration triggering by default;
+  `check_markdown` uses it only when a feature is supplied.
+- **Make every scanner consumer migration-free.** Rejected for this issue: it is a
+  broader migration-ownership redesign with unknown compatibility impact on mature
+  mutating commands.
+- **Retain unconditional lazy migration.** Rejected: it cannot satisfy the selected
+  feature's byte-preservation contract.
+
+## Constraints
+
+- No dependency or schema migration changes are required.
+- `scan_vault` is a mature shared seam; its migration-triggering default must remain
+  stable for callers that do not explicitly request a non-mutating scan.
+- The regression must exercise the actual CLI with an installed stale workspace;
+  direct checker tests do not observe registry side effects.
+- The separately reported plan-section and UTF-8 corruption is not decided here:
+  current markdown and known migration behavior do not account for it.
+
+## Implementation
+
+`scan_vault` gains an optional migration-control parameter whose default retains
+today's lazy migration behavior. A `check_markdown` call with `--feature` requests
+the non-migrating mode before it reads or repairs documents; unscoped markdown
+checks and every other caller keep the default. A real CLI regression provisions
+a stale workspace with dirty selected and unselected documents and proves the
+unselected document remains byte-identical.
+
+## Rationale
+
+The proposed boundary is the smallest change that makes the explicit scope
+guarantee true. It separates this repair command from global schema convergence
+without changing the established default relied on elsewhere. The evidence and
+alternative analysis are in `2026-07-27-markdown-feature-scope-research`; the
+source-level mutation trace is in `2026-07-27-markdown-feature-scope-reference`.
+
+## Consequences
+
+Feature-scoped markdown repair becomes safe to run in a shared stale workspace:
+only matching documents may be normalized, and pending migrations remain visible
+for explicit operator action. The trade-off is that selected documents may be
+checked before workspace schema convergence; that is intentionally limited to the
+existing pure hygiene transform. A future decision may address migration-free
+reads globally, but it must audit all scanner callers and is not implied here.

--- a/.vault/adr/2026-07-27-vault-scale-performance-adr.md
+++ b/.vault/adr/2026-07-27-vault-scale-performance-adr.md
@@ -1,0 +1,299 @@
+---
+tags:
+  - '#adr'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-vault-scale-performance-audit]]"
+  - '[[2026-06-10-graph-backend-adr]]'
+  - '[[2026-06-13-vault-graph-ref-adr]]'
+  - '[[2026-06-12-vault-orientation-adr]]'
+  - '[[2026-06-13-cli-output-standardization-adr]]'
+  - '[[2026-07-23-vault-check-validators-adr]]'
+---
+
+# `vault-scale-performance` adr: `large-vault performance architecture` | (**status:** `accepted`)
+
+## Problem Statement
+
+At one order of magnitude past the graph design envelope, the read-side verbs
+degrade superlinearly: on a 12k-document production corpus, `vault graph`,
+`doctor`, and `vault check all` are minute-class commands, and one documented
+remediation path arms a further ~90s regression
+(`2026-07-27-vault-scale-performance-audit`). The audit shows the causes are not
+scattered inefficiencies but a small set of recurring architectural patterns: a
+metrics API that conflates cheap counts with expensive analysis, a check pipeline
+that re-ingests a corpus it already holds in memory, cache validation that costs
+more than the cache saves, workspace-global facts recomputed per document, and
+render surfaces with no volume policy. Each validated fix is behaviour-preserving,
+so what needs deciding is not whether to fix them but which standing positions
+prevent the same classes of defect from recurring. The prior graph decision
+(`2026-06-10-graph-backend-adr`) explicitly scoped its performance posture to
+roughly 5,000 documents; production corpora have outgrown that scope, and its
+fingerprint-cache design has drifted in implementation. This record extends the
+performance architecture to the measured 12k-document scale and resolves the
+drift.
+
+## Considerations
+
+- Every optimization named in the grounding audit was validated byte-identical to
+  baseline output, so these are architectural positions over proven refactors,
+  not speculative rewrites (`2026-07-27-vault-scale-performance-audit`).
+- `2026-06-10-graph-backend-adr` specified the fingerprint cache keyed on
+  `(st_size, st_mtime_ns)`; the shipped `fingerprint_vault` hashes every file
+  unconditionally. The implementation drifted stricter and slower than the
+  accepted design; this record must resolve the divergence explicitly rather than
+  leave two contradictory authorities standing.
+- `2026-06-13-vault-graph-ref-adr` codified that ref-scoped reads bypass the
+  worktree cache entirely; any cache policy decided here must leave that boundary
+  untouched.
+- `2026-06-12-vault-orientation-adr` decision D6 already mandates a batched
+  status core (one plan pass, one exec index); the corpus-rescan behaviour the
+  audit measures is drift from that decision, not a gap in it.
+- `2026-06-13-cli-output-standardization-adr` already rules that truncation must
+  be fixed and marked and that `--json` is the machine contract; a report volume
+  policy extends that contract rather than inventing a new one.
+- `2026-07-23-vault-check-validators-adr` ratified `step_id` as a first-class
+  snapshot field precisely so checkers read the snapshot instead of re-parsing
+  files; the single-ingress contract generalizes that ratified direction to the
+  whole check suite.
+- The no-mock testing mandate and the never-commit-fixtures rule constrain how a
+  scale regression gate can be built; `vaultspec_core.testing.synthetic` is the
+  canonical generator for synthetic corpora.
+- Filesystem mtime resolution varies by platform: nanosecond on NTFS and ext4,
+  two seconds on FAT-class filesystems. Any stat-trusting cache policy must state
+  its residual risk in those terms.
+
+## Considered options
+
+- **Cache validation.** (a) Hash-always status quo: strongest soundness, but the
+  validation costs more than the cache saves at scale, and it contradicts the
+  accepted stat-keyed design. Rejected. (b) Pure stat-trust, never hash: cheapest,
+  but silently wrong for a same-size edit inside one mtime tick with no bounded
+  mitigation. Rejected. (c) Stat-trust with a racily-clean window - trust
+  size+mtime, hash only files whose mtime falls within the cache-write tick - the
+  resolution proven by git for the identical problem. Chosen. (d) Drop the cache:
+  simplest, but forfeits the warm path entirely just as corpus scale makes it
+  matter most. Rejected.
+- **Metrics API.** (a) Leave `metrics()` conflated and patch `render_tree` to
+  count directly: fixes one caller, leaves the trap armed for the next. Rejected.
+  (b) Memoize `metrics()`: hides the cost on repeat calls but the first caller
+  still pays O(V\*E) for three numbers. Rejected. (c) Split descriptive counts
+  from graph-theoretic analysis into separate surfaces, analysis strictly opt-in.
+  Chosen.
+- **Check pipeline.** (a) Fix each offending checker ad hoc: addresses today's
+  five, does nothing to stop the sixth. Rejected. (b) Parallelize the check suite:
+  spends cores to mask redundant work and multiplies the I/O storm. Rejected.
+  (c) A single-ingress contract - every checker consumes the shared snapshot,
+  enforced structurally and by test. Chosen.
+- **Workspace-global reads.** (a) Memoize the baseline ledger as a one-off patch:
+  fixes the instance, not the class. Rejected. (b) A standing run-scope rule for
+  all per-workspace facts, with the ledger as its first application. Chosen.
+- **Scale regression gate.** (a) No gate: the audit is proof these regressions
+  land silently. Rejected. (b) Wall-clock CI thresholds on a large corpus: flaky
+  across runners and slow to execute. Rejected. (c) Complexity budgets asserted
+  as operation counts and scaling ratios over generated synthetic corpora under
+  a dedicated marker. Chosen.
+- **Report volume.** (a) Leave unbounded: 4.3MB of terminal output at scale.
+  Rejected. (b) Page interactively: breaks the LLM-first output contract.
+  Rejected. (c) Fixed caps with marked truncation and aggregates, full detail
+  under `--json`. Chosen.
+- **Native acceleration.** (a) A dedicated C calculation engine: rejected -
+  it duplicates actively-evolving semantics (parsers, checkers, the
+  racily-clean rule) into a second implementation that must stay
+  byte-identical, breaks the pure-Python distribution story, and its
+  wall-clock advantage over the accepted architecture plus deferred
+  incremental work falls below human-perceptible CLI latency. (b) Native
+  leaf libraries behind existing seams: the libyaml-backed frontmatter
+  loader (already shipped on the parse hot path with a pure-Python
+  fallback) and a C-backed graph library for the opt-in analysis surface,
+  each falling back to the pure implementation when the wheel is absent.
+  Chosen.
+
+## Constraints
+
+- Behaviour preservation is the hard boundary: every change under this record
+  must keep verb output byte-identical for the human surface and
+  schema-identical for `--json`, except where a decision below explicitly
+  changes a surface (report caps, opt-in analysis) - those follow the codified
+  json-schema-version-discipline rule (bump the schema version, ship the
+  contract test in the same change).
+- Parent features are stable: the graph cache module, the snapshot and hydration
+  seam, the plan parser, and the output contract are all mature, shipped, and
+  test-covered. No frontier risk; the only dependency added is the D8
+  analysis library, a mature binary-wheel package guarded by a pure-Python
+  fallback so no platform loses functionality.
+- The CLI startup floor of 0.45s bounds the attainable minimum for any verb.
+- Ref-scoped reads must remain cache-off and migration-free per the codified
+  ref-scoped-reads-bypass-worktree-cache rule; the cache policy here applies to
+  working-tree reads only.
+- The racily-clean window is only sound if every cache write records its own
+  timestamp with the same resolution as the filesystem it guards; on
+  coarse-resolution filesystems the window, and therefore the re-hash set,
+  grows accordingly.
+- The scale gate depends on `vaultspec_core.testing.synthetic` generating
+  corpora at test time; corpus fixtures are never committed.
+- The snapshot must gain raw bytes for the encoding fold-in without doubling
+  resident memory; carrying bytes and lazily decoding, or carrying both for the
+  ingress pass only, is an implementation choice the plan must settle within
+  this contract.
+
+## Implementation
+
+Seven decisions, each a standing position.
+
+**D1 - Cache validation adopts the racily-clean rule.** The cache manifest keys
+on `(st_size, st_mtime_ns)` per file, as the accepted graph design specified. A
+file whose size and mtime match the manifest is trusted without hashing, except
+files whose mtime falls within the manifest-write tick, which are content-hashed
+before being trusted. A fingerprint mismatch still falls back to a full rebuild,
+never a partial trust. The residual risk accepted: a same-size edit that lands
+in the same mtime tick as the cache write and bypasses the mutating verbs is
+served stale until the next touch; on nanosecond-resolution filesystems (NTFS,
+ext4) that window is vanishingly small, and on coarse-resolution filesystems the
+racily-clean re-hash set covers it by construction. A full-hash validation path
+remains available as an explicit deep-verification option for doctor-class
+diagnostics, not as the default.
+
+**D2 - Descriptive counts and graph analysis are separate API surfaces.** The
+graph API exposes cheap descriptive counts (documents, links, features) as a
+surface that is O(V+E) or better and safe to call from any render path.
+Graph-theoretic analysis (centrality, link prediction, node-size hints) moves
+behind an explicitly named opt-in surface that no render or title path calls
+implicitly. The wire envelope carries analysis only where its consumer contract
+requires it, and any envelope shape change rides the schema-version discipline.
+The enforcement is structural: after the split, the expensive surface has no
+callers outside the paths that explicitly requested analysis, and a test asserts
+the render paths complete without invoking it.
+
+**D3 - The check pipeline has a single-ingress contract.** Ingress reads each
+document exactly once and produces the shared snapshot; the calculate phase runs
+entirely from it. The snapshot carries what checks actually need: decoded
+content, raw bytes (so the encoding check folds into the one read instead of a
+sixth pass), the frontmatter fields already ratified as first-class, and the
+per-file metadata (size, path-derived type) that today's checks re-stat for.
+Every checker signature takes the snapshot; registration of a checker that does
+not is a contract violation. Enforcement is by test: the check suite runs once
+against a corpus that is made unreadable after ingress, and any checker that
+touches disk in the calculate phase fails loudly. Within-check redundancy falls
+under the same contract: per-record loops memoize per-run parses (the plan
+step-id case) instead of re-deriving them.
+
+**D4 - Workspace-global facts are read once per run.** Any fact scoped to the
+workspace rather than the document - the provenance baseline ledger, template
+section sets, configuration - is read and parsed at most once per command
+invocation and threaded or cached at run scope. Per-document recomputation of a
+workspace-scoped fact is the defect class; the baseline ledger memoization is
+its first application, and the loop-invariant path resolution fix is the same
+rule applied to derived values.
+
+**D5 - Complexity budgets with a synthetic-corpus regression gate.** No checker
+or verb hot path may be superlinear in corpus size; O(features x documents)
+scans are banned outright. The gate asserts the budget mechanically: benchmarks
+over synthetic corpora generated at test time at two sizes, under the dedicated
+scale marker, asserting operation counts and cross-size scaling ratios rather
+than wall-clock, so the gate is deterministic on shared CI runners. This extends
+the accepted graph benchmark layer from its 5,000-document envelope to the
+measured 12k scale, which this record adopts as the new supported envelope.
+
+**D6 - Report volume is capped, marked, and delegated to JSON.** Human-readable
+report phases render a fixed per-section cap with an explicit truncation marker
+and aggregate counts; the full result set stays available under `--json`, which
+remains the machine contract. Render loops query terminal geometry once per run,
+not per line. This extends the accepted output contract's truncation clause to
+the check and graph report surfaces.
+
+**D7 - Warm reads become the default where the cache is sound.** With D1 making
+warm validation cheap, callers that currently force cold builds for no
+correctness reason - the MCP find tool, the second graph build inside the status
+stats path - use the cached graph. The orientation surface composes one scan and
+one graph per invocation, honouring the batched-core decision it drifted from,
+and type-filtered listings classify by path arithmetic instead of parsing.
+Ref-scoped reads remain cache-off by codified rule.
+
+**D8 - Native leaf libraries accelerate the existing seams; no native
+engine.** The parse hot path keeps its libyaml-backed loader (the
+already-shipped `CSafeLoader`-with-fallback seam in the frontmatter
+parser), and the opt-in graph analysis surface routes its expensive
+algorithm (betweenness centrality) through a C-backed graph library with
+the pure networkx implementation as the automatic fallback when the wheel
+is unavailable. The canonical graph structure, every checker, all
+serialization, and the wire contract remain pure Python: native code is
+confined to leaf computations behind seams D2 and the parser already
+define, so no semantics are duplicated. A dedicated native calculation
+engine is explicitly rejected at the current scale envelope and revisits
+only under a new record if a 100k-document target or a sub-100ms
+interactive consumer materialises.
+
+Adjacent but explicitly out of scope: the `--target` routing defect in `doctor`
+and `spec doctor` recorded in the grounding audit is an ordinary correctness bug
+to be fixed independently; it is named here only so the performance work is not
+conflated with it.
+
+## Rationale
+
+The audit demonstrates that every expensive behaviour is a pattern, not an
+incident: the same corpus is re-read because nothing forbids it, the same
+expensive analysis is bought accidentally because the API bundles it with cheap
+counts, and the same workspace fact is re-parsed because no rule scopes reads to
+the run. Point fixes were therefore rejected wherever a standing contract could
+eliminate the class. The racily-clean cache rule wins because it is the
+established resolution of exactly this soundness-versus-cost trade-off, proven
+at far larger scale by git, and because it returns the implementation to the
+already-accepted stat-keyed design rather than pivoting from it - D1 is
+concretization of `2026-06-10-graph-backend-adr` layer 4, not supersession. The
+single-ingress contract wins over per-check patching because the validators
+decision already ratified the direction (first-class snapshot fields so checkers
+stop re-parsing); D3 finishes that thought and makes it enforceable. Operation
+counts beat wall-clock for the gate because the project's testing mandate
+demands determinism and CI runners do not offer it for timing. The report policy
+is the output-standardization contract applied to the one surface family it had
+not yet reached. Together the decisions take the measured corpus from
+minute-class to seconds-class using only validated, output-identical refactors
+plus two explicitly versioned surface changes.
+
+## Consequences
+
+- The supported scale envelope formally moves from ~5,000 to ~12,000 documents,
+  with projected verb times on the measured corpus dropping from 80-87s to under
+  15-22s (`2026-07-27-vault-scale-performance-audit`); the graph decision's
+  envelope statement is extended by this record, and both records now bind the
+  cache: the earlier one for its existence and invalidation invariants, this one
+  for its validation policy.
+- Accepting the racily-clean rule accepts a stated staleness window: a same-size,
+  same-tick edit made outside the mutating verbs can be served stale until the
+  next touch. The window is negligible on NTFS and ext4 and covered by re-hashing
+  on coarse filesystems, but it is nonzero, and the deep-verification path exists
+  for operators who need certainty.
+- The snapshot grows (raw bytes, additional metadata), trading resident memory
+  for I/O; on the measured corpus this is bounded by total corpus size, but the
+  implementation must watch peak memory on corpora another order larger.
+- The single-ingress contract makes writing a new checker slightly more
+  ceremonious: it must declare snapshot consumption and passes the
+  unreadable-corpus test, which is the point.
+- Report caps change what a human sees by default on large corpora; the marked
+  truncation and JSON delegation keep information loss explicit, but scripts
+  scraping human output (never a supported interface) may notice.
+- The scale gate adds a benchmark tier to CI whose corpora are generated per
+  run, costing test time; the dedicated marker keeps it out of the default
+  developer loop.
+- Two surface changes (opt-in analysis, report caps) require schema-version
+  bumps and contract tests in the same change, per the codified discipline.
+- Deferred, each needing its own decision if pursued: parallel calculate phase
+  over the snapshot, a persistent daemon serving warm graphs, and any envelope
+  beyond ~12k documents.
+
+## Codification candidates
+
+- **Rule slug:** `single-ingress-check-pipeline`. **Rule:** A vault checker
+  consumes the shared corpus snapshot and must not read document content or
+  metadata from disk during the calculate phase; facts a checker needs are added
+  to the snapshot, not re-ingested.
+- **Rule slug:** `workspace-facts-read-once`. **Rule:** A fact scoped to the
+  workspace (ledger, template set, configuration) is read at most once per
+  command invocation and shared at run scope, never recomputed per document.
+- **Rule slug:** `analysis-is-opt-in`. **Rule:** Render and orientation paths
+  may consume only descriptive-count surfaces; graph-theoretic analysis is
+  invoked only by an explicit analysis request.

--- a/.vault/audit/2026-07-27-markdown-feature-scope-implementation-audit.md
+++ b/.vault/audit/2026-07-27-markdown-feature-scope-implementation-audit.md
@@ -1,0 +1,24 @@
+---
+tags:
+  - '#audit'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-markdown-feature-scope-plan]]"
+---
+
+# `markdown-feature-scope` audit: `implementation`
+
+## Scope
+
+Read-only review of the scanner boundary, scoped Markdown caller, and real CLI regression against the feature plan and ADR.
+
+## Findings
+
+No findings. The implementation preserves default migration behavior, suppresses migrations only for a nonempty normalized feature scope, and proves byte preservation of unselected records through the real CLI.
+
+## Recommendations
+
+No revision required. The review status is PASS.

--- a/.vault/audit/2026-07-27-vault-scale-performance-audit.md
+++ b/.vault/audit/2026-07-27-vault-scale-performance-audit.md
@@ -1,0 +1,195 @@
+---
+tags:
+  - '#audit'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related: []
+---
+
+# `vault-scale-performance` audit: `large-vault command latency`
+
+## Scope
+
+Wall-clock behaviour of the read-side verbs at one order of magnitude above the
+design envelope. Two corpora were measured: this repository's own vault (1,163
+documents) and the AEAT production vault (11,962 documents: 332 plans, 8,250 exec
+records, 577 ADRs, 714 indexes, 711 features). All figures are measured, not
+estimated, and every fix candidate cited below was validated to produce
+byte-identical output against the baseline. The CLI startup floor is 0.45s. The
+audit exists because the graph performance posture (`2026-06-10-graph-backend-adr`)
+targets correct behaviour to roughly 5,000 documents; AEAT sits 2.4x past that
+envelope and the superlinear verbs have become minute-class.
+
+Baseline wall-clock:
+
+| command           | core (1.1k docs) | AEAT (12k docs) | scaling vs 10.3x corpus |
+| ----------------- | ---------------- | --------------- | ----------------------- |
+| `vault graph`     | 1.9s             | 87.2s           | 45x, superlinear        |
+| `doctor`          | 4.4s             | 80.4s           | 18x, superlinear        |
+| `vault check all` | 4.1s             | 79.5s           | 19x, superlinear        |
+| `status`          | 2.9s             | 25.6s           | 8.8x                    |
+| `vault list`      | 0.9s             | 5.6s            | 6.1x                    |
+| `spec doctor`     | 2.6s             | 2.9s            | flat, workspace-only    |
+
+Projection with the findings below resolved: `vault graph` 87.2s to ~4s, `status`
+25.6s to ~3s, `vault check all` 79.5s to ~19s, `doctor` 80.4s to ~22s; capping the
+report phase takes the latter two under 15s.
+
+## Findings
+
+### baseline-ledger-per-document-read | critical | Creating the documented provenance ledger adds ~90s to every check run
+
+`_read_baseline(root_dir)` in `src/vaultspec_core/vaultcore/body_schema.py:284`
+reads and parses a workspace-global ledger once per document. The ledger is
+currently absent, so an existence probe short-circuits the whole pass at 0.27s -
+the defect costs nothing today. But AEAT emits thousands of "Body schema
+provenance is not attested" warnings whose documented remediation is to create
+exactly that ledger. Measured with a synthetic 11,890-entry, 1.6MB ledger: one
+parse is 0.008s; the projected 11,890 per-document parses total 90.3s added to
+`vault check all` and `doctor`. The trap detonates on precisely the path the tool
+instructs the operator to take. Memoizing to a single read per run removes the
+cost entirely. Rated critical despite zero present-day cost because it is armed by
+following the tool's own advice.
+
+### render-tree-buys-all-pairs-centrality | high | The graph tree render runs all-pairs shortest paths to print a three-number title
+
+`render_tree` at `src/vaultspec_core/graph/api.py:1414` calls `metrics()` only to
+build the title string ".vault 11890 docs, 28969 links, 711 features". That call
+triggers `nx.betweenness_centrality` at `src/vaultspec_core/graph/api.py:1261`,
+O(V\*E), roughly 344M operations - 76.8s of the 87.2s total. Deriving the three
+counts directly was validated identical and 14,905x faster. The root cause is that
+`metrics()` conflates cheap descriptive counts with expensive graph-theoretic
+analysis, so every caller pays for both.
+
+### features-check-quadratic | high | check_features is O(features x documents)
+
+`_index_exists_for` (`src/vaultspec_core/vaultcore/checks/features.py:38`, invoked
+at `:174`) and `_count_feature_docs` (`:53`, invoked at `:191`) each perform a
+full snapshot scan inside the per-feature loop: 711 features x 11,890 documents,
+about 16.9M iterations and 7.9M `extract_feature_tags` calls. The enclosing loop
+already makes a single full pass that could precompute both facts. Validated:
+27.7s to 0.04s, 698x, identical output.
+
+### exec-mapping-replans-per-record | high | check_exec_mapping re-parses each plan once per exec record
+
+`src/vaultspec_core/vaultcore/checks/exec_mapping.py:144` calls `_plan_step_ids`
+unmemoized inside the per-record loop: 7,304 `parse_plan` invocations for only 208
+distinct plans, 35x redundant, driving 2.17M `_build_step` calls. Validated with a
+per-plan memo: 21.1s to 0.18s, 119x, identical output.
+
+### cache-fingerprint-hash-always | high | The graph cache's own validation costs more than the cache saves
+
+`fingerprint_vault` at `src/vaultspec_core/graph/cache.py:148` SHA-256s every file
+unconditionally. The module docstring calls size+mtime the "cheap fast-path
+guard", but it never short-circuits: validation only runs after all 11,890 hashes
+are computed. Cold build 11.9s, warm 7.3s of which 6.5s is fingerprinting; the net
+cache benefit is only 4.6s. A stat-only manifest is 0.29s, 22x cheaper, which
+would put the warm build at roughly 1.1s. The docstring's soundness argument - a
+same-size edit landing inside one mtime tick evades a stat-only check - is real
+but overstated on nanosecond-resolution filesystems (NTFS, ext4). This diverges
+from the governing design, which specified the fingerprint as a
+`(st_size, st_mtime_ns)` key (`2026-06-10-graph-backend-adr`); hash-always was an
+implementation-time hardening whose cost was never measured at scale. Which
+validation policy to adopt, and what residual risk to accept, is the sharpest
+decision the follow-on ADR must make.
+
+### check-pipeline-re-ingests | high | The check pipeline does not stay staged after ingress
+
+Ingress completes in 7.2s and `to_snapshot()` in 0.10s - the whole corpus is then
+in memory - yet the calculate phase goes back to disk 51,688 more times.
+Instrumented totals over 11,890 documents: 63,580 content reads (5.35 per
+document) and 147,948 metadata syscalls (12.44 per document). Three distinct
+classes of bounce. First, checks that never receive the snapshot
+(`src/vaultspec_core/vaultcore/checks/__init__.py:113`, `:114`, `:123`, `:127`):
+annotations, markdown, encoding, feature_rename_integrity, and rename_integrity
+re-read 44,384 documents between them; only encoding legitimately needs disk,
+because it inspects raw bytes for BOM and line endings while the snapshot carries
+a decoded `str` (annotations recomputed from the snapshot was validated 3.4x
+faster and identical). Second, checks that hold the snapshot but read disk anyway:
+exec_mapping performs 7,304 content reads plus 8,462 `is_file` probes (see
+finding exec-mapping-replans-per-record). Third, checks that hold everything but
+hammer path syscalls: body_sections issues 44,704 metadata operations and zero
+content reads, costing 4.17s.
+
+### status-walks-corpus-five-times | medium | status rebuilds the graph and rescans the corpus it already holds
+
+`src/vaultspec_core/vaultcore/orientation.py:491` holds a fully built graph, then
+imports and calls `get_stats` with only `root_dir`; `get_stats` at
+`src/vaultspec_core/vaultcore/query.py:214` builds a second complete `VaultGraph`,
+and `list_documents` at `:152` re-reads and re-YAML-parses every document for data
+the graph already holds. Net effect: 2x graph build, 2x fingerprint, 3x
+`_scan_all`, 68,251 file opens for 11,890 documents. Separately,
+`list_documents(doc_type="plan")` parses all 11,890 documents to find 332 plans,
+though the document type is derivable from the directory path with zero I/O
+(`get_doc_type` in `src/vaultspec_core/vaultcore/scanner.py` is pure path
+arithmetic).
+
+### resolve-per-document | medium | Loop-invariant path resolution recomputed per document
+
+`src/vaultspec_core/vaultcore/body_schema.py:459` evaluates
+`doc_path.resolve().relative_to(root_dir.resolve())`, calling `resolve()` twice
+per document and recomputing the loop-invariant `root_dir.resolve()` 11,176
+times. On Windows `resolve()` is `nt._getfinalpathname`, which opens a file
+handle. Hoisting the invariant is 1.7x; dropping `resolve()` entirely is 18.2x
+(2.97s to 0.16s) and identical, because `scan_vault` already yields absolute
+canonical paths.
+
+### report-phase-uncapped | medium | Human-readable report output is unbounded at scale
+
+`vault check all` emits 4.3MB across 34,897 Rich `console.print` calls. Unscoped
+`vault graph` prints 44,218 lines, with Rich re-querying the terminal size twice
+per line (88,438 `nt.get_terminal_size` calls). No cap, aggregate, or truncation
+marker exists on either surface.
+
+### mcp-find-builds-cold | low | The MCP find tool always builds the graph cold
+
+`src/vaultspec_core/mcp_server/tools/documents.py:611` constructs
+`VaultGraph(root_dir, use_cache=False)`, so every MCP `find` call pays a full
+cold build even when a valid cache exists.
+
+### target-flag-ignored-by-doctor | high | doctor and spec doctor silently audit the wrong directory under --target
+
+A correctness defect adjacent to but distinct from the performance findings:
+`src/vaultspec_core/cli/root.py:967` and
+`src/vaultspec_core/cli/spec_cmd.py:2008` use `target or Path.cwd()` instead of
+the `target or _root_target or Path.cwd()` pattern established in
+`src/vaultspec_core/cli/_target.py`, so `vaultspec-core --target X doctor`
+audits the current directory and exits with a code derived from the wrong vault.
+This is a straight bug fix, not an architectural decision, and must not be
+conflated with the performance work.
+
+## Recommendations
+
+- Resolve the cache validation policy by decision, not patch: hash-always versus
+  stat-trust with a racily-clean window, including the residual risk accepted per
+  filesystem class (finding cache-fingerprint-hash-always). This reconciles the
+  implementation with `2026-06-10-graph-backend-adr` and is the follow-on ADR's
+  central call.
+- Split cheap descriptive counts from expensive graph-theoretic analysis at the
+  metrics API so no render path can buy an O(V\*E) computation by accident
+  (finding render-tree-buys-all-pairs-centrality); the ADR must fix the API shape
+  that makes the expensive computation opt-in.
+- Establish a single-ingress contract for the check pipeline: every check
+  receives the shared snapshot, the snapshot carries what checks actually need
+  (including raw bytes so encoding folds into the one read), and the contract is
+  enforced so a future check cannot silently re-ingest (finding
+  check-pipeline-re-ingests; also resolves exec-mapping-replans-per-record and
+  the disk half of features-check-quadratic).
+- Adopt a standing memoization rule for workspace-global reads: a per-workspace
+  fact is read once per run, never per document (finding
+  baseline-ledger-per-document-read; same class as resolve-per-document).
+- Set complexity budgets - no check superlinear in corpus size - and decide how
+  regressions are caught, noting that `vaultspec_core.testing.synthetic` is the
+  canonical generator and corpus fixtures are never committed (findings
+  features-check-quadratic, exec-mapping-replans-per-record).
+- Decide a report volume policy for the uncapped render surfaces (finding
+  report-phase-uncapped), extending the established output contract
+  (`2026-06-13-cli-output-standardization-adr`) to the check and graph report
+  phases.
+- Reuse the collapsed status internals so orientation composes one scan and one
+  graph (finding status-walks-corpus-five-times), honouring the batched-core
+  intent of `2026-06-12-vault-orientation-adr`.
+- Route the `--target` routing defect (finding target-flag-ignored-by-doctor) as
+  an ordinary bug fix outside the performance feature.

--- a/.vault/audit/2026-07-27-vault-scale-performance-implementation-audit.md
+++ b/.vault/audit/2026-07-27-vault-scale-performance-implementation-audit.md
@@ -1,0 +1,120 @@
+---
+tags:
+  - '#audit'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+  - "[[2026-07-27-vault-scale-performance-adr]]"
+---
+
+# `vault-scale-performance` audit: `implementation`
+
+## Scope
+
+Verification of the plan's 19 Steps against the authorizing ADR's seven
+decisions, executed 2026-07-27 in a worktree shared with the unrelated
+in-flight markdown-feature-scope work. Verified surfaces: the graph cache
+(`src/vaultspec_core/graph/cache.py`), graph API and render paths
+(`src/vaultspec_core/graph/api.py`), the query and orientation seams, the
+check pipeline (`src/vaultspec_core/vaultcore/checks/`), the schema
+resolver seam (`src/vaultspec_core/vaultcore/body_schema.py`), the shared
+console, the MCP index-regeneration path, and the new test tiers.
+
+## Findings
+
+### gates | low | All quality gates pass; the only failures are pre-existing and foreign
+
+The unit CI gate passes 1,916 of 1,918 tests; the two failures
+(`test_vault_repair`) are caused by the unrelated in-flight body-schema
+attestation warnings and reproduce without this feature's changes, as do
+the three generated-CLI-reference failures (a new archive verb from the
+other feature) and two `ty` diagnostics in the other feature's test file.
+Scoped `ty` on every file this feature touched passes; `prek` hooks on the
+same set pass (ruff lint and format clean). The vaultcore suite (557),
+graph suite (143), MCP-related tests (69), the new single-ingress
+enforcement tests (2), counts tests (3), cache tests (22), and the
+benchmark-marked scale gate (3) all pass.
+
+### contract-enforcement | low | The single-ingress contract is enforced physically, not by convention
+
+The enforcement test deletes the corpus after ingress and requires the
+calculate phase to reproduce its baseline diagnostics exactly; the scale
+gate independently asserts exactly one read per corpus document across the
+whole non-mutating pass at two corpus sizes. Both passed on first run
+after wiring, which corroborates that no converted checker retains a
+hidden disk dependency.
+
+### parity | low | Output parity holds on the real corpus; deviations are the two decided surface changes
+
+On this repository's vault, check totals, graph tree titles, and status
+output match the pre-change baseline modulo documents this feature itself
+added. Accepted pathological-input deviations, each documented in the
+owning docstring or step record: lone-CR newline normalisation in the
+content checks, symlinked-document reporting on the encoding graph path,
+and sorted-first feature-tag selection for multi-tagged exec records.
+
+### serializer-drops-body-schema | medium | The plan CLI serializer drops the scaffolded body_schema field
+
+Out of this feature's code scope but surfaced by it: plan structural verbs
+(`tier promote`, `step add`) rewrite the plan document without preserving
+the scaffolded `body_schema` frontmatter, so the plan now warns as
+unattested under the in-flight provenance checker. Hand-restoring
+frontmatter is forbidden; the fix belongs to the serializer in the
+markdown-feature-scope work.
+
+### review | low | Independent read-only persona review dispatched
+
+A read-only reviewer persona was dispatched over the exact changed-file
+set with the ADR as its brief; its verdict is recorded in the findings
+appended below.
+
+### review-verdict | low | Independent review returned PASS; its one medium finding is fixed
+
+The reviewer confirmed the racily-clean cache rule sound (comparison
+direction, vanished-file path, and key-set equality all correct with no
+staleness outside the accepted window), behaviour preservation on normal
+corpora, test integrity (no mocks or stubs), and the single-ingress wiring
+for every checker but one. Its single medium finding - the exec mapping
+check could fall back to a disk read when a referenced plan failed to
+decode during ingress - is fixed in the same session: a plan absent from
+the ingress text map is now classified as unparseable without touching
+disk, and the enforcement suite gained a test planting an undecodable plan
+referenced by a real record and asserting the finding survives corpus
+deletion. All 212 check tests and the scale gate pass after the fix.
+
+### native-leaf-acceleration | low | D8 amendment implemented and measured
+
+The decision record was amended (concretization in place, status stays
+accepted) to add D8: native leaf libraries behind existing seams, a
+dedicated C engine explicitly rejected. Verification on the real corpus:
+the already-shipped libyaml frontmatter loader engages (7.3x over the
+pure-Python loader; the full parse pass runs at C-loader speed), and the
+new rustworkx routing for opt-in betweenness runs 13.2x faster at 1,181
+nodes with a maximum score delta of 1.6e-19 versus networkx. A four-test
+engine parity suite pins the agreement to 1e-12; the full graph suite
+(147 tests) passes against engine-computed scores. One dependency added
+(`rustworkx>=0.18.0`) with a pure networkx fallback.
+
+### review-residuals | low | Two low-severity reviewer notes accepted as future cleanup
+
+Unused module loggers in three check modules predate this feature, and the
+save-path fingerprint re-reads bytes the ingress already read - a
+pre-existing cold-build cost shape, correctly hashing raw bytes for
+consistency with validation. Both are noted for a future pass, neither
+blocks.
+
+## Recommendations
+
+- Fix the plan-serializer `body_schema` drop inside the
+  markdown-feature-scope feature before its provenance checker ships, or
+  every CLI-managed plan will warn as unattested (finding
+  serializer-drops-body-schema).
+- Route the adjacent `--target` routing defect in `doctor` and
+  `spec doctor` (recorded in the grounding audit) as an ordinary bug fix;
+  it remains open and untouched by this feature.
+- When the shared worktree's in-flight work lands, re-run the repair and
+  generated-reference test families to confirm the pre-existing failures
+  close with it (finding gates).

--- a/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P01-S03.md
+++ b/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P01-S03.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S03'
+related:
+  - "[[2026-07-27-markdown-feature-scope-plan]]"
+---
+
+# Add a stale-workspace CLI regression for feature-scoped Markdown repair
+
+## Scope
+
+- `src/vaultspec_core/tests/cli/test_migration_triggers.py`
+
+## Description
+
+- Provision an installed workspace and create selected alpha and unselected beta research records.
+- Rewind the real manifest to the modified-stamp migration boundary.
+- Invoke the actual feature-scoped Markdown fixer and compare raw unselected bytes.
+
+## Outcome
+
+The regression failed before the implementation because beta received a `modified:` stamp, then passed after the scoped scanner change while alpha was repaired.
+
+## Notes
+
+No mocks, patches, or synthetic migration registry were used.

--- a/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P01-summary.md
+++ b/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P01-summary.md
@@ -1,0 +1,20 @@
+---
+tags:
+  - '#exec'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-markdown-feature-scope-plan]]"
+---
+
+# `markdown-feature-scope` `P01` summary
+
+The first phase established the real failure boundary before production code changed.
+
+## Description
+
+- Created an installed stale workspace with selected alpha and unselected beta records.
+- Proved the feature-scoped CLI fixer previously changed beta through the modified-stamp migration.
+- Verified the completed implementation now repairs alpha while preserving beta bytes.

--- a/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P02-S04.md
+++ b/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P02-S04.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S04'
+related:
+  - "[[2026-07-27-markdown-feature-scope-plan]]"
+---
+
+# Add an opt-in migration-control parameter that preserves the default scanner contract
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/scanner.py`
+
+## Description
+
+- Add a keyword-only scanner switch that defaults to the established lazy-migration behavior.
+- Guard the pending-migration trigger with that switch while leaving document discovery unchanged.
+
+## Outcome
+
+Existing scanner callers retain migration convergence by default; callers with an explicit no-unrelated-mutation boundary can opt out.
+
+## Notes
+
+The existing lazy-trigger integration tests remained green.

--- a/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P02-S05.md
+++ b/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P02-S05.md
@@ -1,0 +1,30 @@
+---
+tags:
+  - '#exec'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S05'
+related:
+  - "[[2026-07-27-markdown-feature-scope-plan]]"
+---
+
+# Route feature-scoped Markdown checks through the non-migrating scanner mode
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/markdown.py`
+
+## Description
+
+- Select scanner migration behavior from the normalized feature scope.
+- Keep unscoped and empty-feature Markdown checks on the default migration path.
+
+## Outcome
+
+A nonempty feature selection now filters before any workspace-wide migration can write unrelated records.
+
+## Notes
+
+The Markdown parser, hygiene transform, feature predicate, and atomic writer were left unchanged.

--- a/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P02-summary.md
+++ b/.vault/exec/2026-07-27-markdown-feature-scope/2026-07-27-markdown-feature-scope-P02-summary.md
@@ -1,0 +1,20 @@
+---
+tags:
+  - '#exec'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-markdown-feature-scope-plan]]"
+---
+
+# `markdown-feature-scope` `P02` summary
+
+The second phase isolated the migration side effect without changing global scanner semantics.
+
+## Description
+
+- Added a default-on scanner migration control.
+- Routed nonempty feature-scoped Markdown checks through the non-migrating path.
+- Preserved all existing lazy-trigger behavior and passed independent review.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S01.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S01.md
@@ -1,0 +1,39 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S01'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# rework fingerprint_vault to the racily-clean rule: trust size+mtime, hash only manifest-write-tick files, keep full-hash as opt-in deep verification
+
+## Scope
+
+- `src/vaultspec_core/graph/cache.py`
+
+## Description
+
+- Rekey warm cache validation on stat trust with a racily-clean hash
+  window in `src/vaultspec_core/graph/cache.py`; move full manifest
+  hashing to the save path; add the explicit deep-verification flag.
+- Rewrite the soundness docstring and the build flow in
+  `src/vaultspec_core/graph/api.py` to stat the cache file once and
+  validate against its mtime.
+- Rework the cache test suite to the new contract with racy-edit,
+  accepted-stale-window, and deep-verification cases.
+
+## Outcome
+
+Warm validation no longer hashes the corpus; all 22 cache tests pass;
+the accepted residual staleness window is pinned by a dedicated test
+together with its deep-verification escape.
+
+## Notes
+
+mtime deltas below filesystem resolution are silently rounded away by
+utime; the mtime-change test bumps by a full second.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S02.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S02.md
@@ -1,0 +1,36 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S02'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# add a cheap descriptive-counts surface and route the render_tree title through it, keeping graph-theoretic metrics opt-in
+
+## Scope
+
+- `src/vaultspec_core/graph/api.py`
+
+## Description
+
+- Add `GraphCounts` and a `counts()` surface producing the document,
+  link, and feature totals without any graph-theoretic algorithm.
+- Route the tree render title through `counts()`; export the new
+  class from the graph package.
+- Add tests asserting counts equal the metrics triple and, via a real
+  profiler, that render paths never invoke centrality.
+
+## Outcome
+
+Tree titles are byte-identical to the conflated path; expensive
+analysis is strictly opt-in; 3 new tests pass.
+
+## Notes
+
+The `--metrics` flag and the JSON envelope remain the explicit
+opt-in analysis surfaces by design.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S03.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S03.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S03'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# default the MCP find graph build to the warm cache
+
+## Scope
+
+- `src/vaultspec_core/mcp_server/tools/documents.py`
+
+## Description
+
+- Switch the create-path feature-index regeneration in
+  `src/vaultspec_core/mcp_server/tools/documents.py` from a forced
+  cold build to the fingerprint cache.
+
+## Outcome
+
+The last cold graph build in the MCP surface now reads warm and
+refreshes the cache for the next call; the find path already used
+the cache in this tree.
+
+## Notes
+
+Fresh document writes invalidate via size or mtime, so the cold
+bypass was never needed for correctness.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S04.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S04.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S04'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# reuse the already-built graph and single scan in the status stats path instead of a second VaultGraph build and rescans
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/orientation.py`
+
+## Description
+
+- Add a `graph` parameter to `get_stats` and pass the orientation
+  rollup's already-built graph through from
+  `src/vaultspec_core/vaultcore/orientation.py`.
+
+## Outcome
+
+The status stats path no longer builds a second complete graph or
+fingerprints the corpus twice.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S05.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-S05.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S05'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# classify type-filtered listings by path arithmetic instead of parsing every document
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/query.py`
+
+## Description
+
+- Push the concrete doc-type filter into the scan ahead of the file
+  read in `src/vaultspec_core/vaultcore/query.py`, deriving the type
+  from path arithmetic.
+
+## Outcome
+
+Type-scoped listings read only their own subset of the corpus; plan
+and exec listings stop parsing every document.
+
+## Notes
+
+The orphaned and invalid pseudo-types keep the full scan their
+graph-backed semantics require.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-summary.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P01-summary.md
@@ -1,0 +1,39 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# `vault-scale-performance` `P01` summary
+
+All five Steps closed. The graph and cache layer now follows the accepted
+performance architecture: warm cache validation is stat-first with a
+racily-clean hash window and a deep-verification escape, descriptive counts
+are a separate always-cheap surface no render path can escalate past, and
+the remaining cold-build and duplicate-build call sites read warm.
+
+- Modified: `src/vaultspec_core/graph/cache.py`
+- Modified: `src/vaultspec_core/graph/api.py`
+- Modified: `src/vaultspec_core/graph/__init__.py`
+- Modified: `src/vaultspec_core/graph/tests/test_cache.py`
+- Created: `src/vaultspec_core/graph/tests/test_counts.py`
+- Modified: `src/vaultspec_core/mcp_server/tools/documents.py`
+- Modified: `src/vaultspec_core/vaultcore/orientation.py`
+- Modified: `src/vaultspec_core/vaultcore/query.py`
+
+## Description
+
+Warm reads stopped paying for their own validation: full manifest hashing
+moved to the save path and validation trusts size plus mtime except inside
+the cache-write tick, with the accepted staleness window pinned by test.
+The metrics conflation that made a three-number title cost an all-pairs
+centrality pass is split into a cheap counts surface consumed by render
+paths and an opt-in analysis surface, enforced by a profiler-backed test.
+The MCP create path, the status stats path, and type-filtered listings
+each dropped a redundant cold build or full-corpus parse. The full graph
+suite (143 tests) and the CLI status and listing families pass.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S06.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S06.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S06'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# extend the corpus snapshot with raw bytes and per-file metadata so every check can run from it
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/models.py`
+
+## Description
+
+- Add the single ingress read to the graph build: one bytes read per
+  document, UTF-8 decode, and universal-newline normalisation
+  matching the previous read semantics exactly.
+- Retain per-document text and CRLF convention in `raw_texts` and
+  read or decode failures in `encoding_issues`; add
+  `ensure_raw_texts` so cache-hit builds perform the run's one read
+  pass on demand.
+
+## Outcome
+
+Ingress facts survive for the whole run and every converted check
+consumes them instead of re-reading the corpus.
+
+## Notes
+
+Raw texts live in memory only and are never serialised into the
+graph cache, keeping warm loads lean for non-check consumers; the
+snapshot model itself needed no shape change.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S07.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S07.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S07'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# route the annotations check through the shared snapshot
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/annotations.py`
+
+## Description
+
+- Accept the ingress raw-text map in the annotations check and
+  validate from it on non-mutating passes; share the standalone
+  read fallback through `iter_document_texts`.
+
+## Outcome
+
+Non-mutating passes are corpus-disk-free with identical findings;
+the mutating fix path still reads what it rewrites.
+
+## Notes
+
+Lone-CR newline conventions are now normalised the same way every
+read_text consumer already normalised them.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S08.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S08.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S08'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# route the markdown check through the shared snapshot
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/markdown.py`
+
+## Description
+
+- Accept the ingress raw-text map in the markdown hygiene check and
+  validate from it on non-mutating passes, mirroring the annotations
+  conversion.
+
+## Outcome
+
+Non-mutating passes are corpus-disk-free with identical findings.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S09.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S09.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S09'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# route the encoding check through snapshot raw bytes, folding it into the single ingress read
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/encoding.py`
+
+## Description
+
+- Report encoding findings from the ingress-recorded read and decode
+  failures when a graph is supplied; keep the direct disk walk for
+  the standalone single-check verb.
+
+## Outcome
+
+The encoding check folds into the run's single read instead of a
+whole-corpus byte re-read.
+
+## Notes
+
+A symlinked document observed by the scan is reported on the graph
+path rather than skipped; the disk-free contract forbids the
+per-file stat parity probes.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S10.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S10.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S10'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# route the feature rename integrity check through the shared snapshot
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/feature_rename_integrity.py`
+
+## Description
+
+- Derive exec folder-vs-tag conflicts from the snapshot by grouping
+  records under their parent directory; keep the disk walk for the
+  standalone verb.
+
+## Outcome
+
+The combined pass compares folders and tags without re-reading any
+record.
+
+## Notes
+
+Multi-feature-tagged records compare their sorted-first tag on the
+snapshot path; compliant documents are unaffected.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S11.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S11.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S11'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# exempt the rename integrity check from the single-ingress contract: it validates workspace resources under .vaultspec/, not the vault corpus, so no snapshot routing applies
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/rename_integrity.py`
+
+## Description
+
+- Confirm the rename integrity check reads workspace resources under
+  the framework directory, not the vault corpus.
+
+## Outcome
+
+The check is exempt from the corpus single-ingress contract; the
+exemption is documented at the run_all_checks wiring.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S12.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S12.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S12'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# memoize per-plan step-id parsing and drop redundant disk probes in the exec mapping check
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/exec_mapping.py`
+
+## Description
+
+- Memoize per-plan step-id parsing and archive probes for the whole
+  pass; answer live-plan existence from the snapshot key set; parse
+  plans from the ingress text when available.
+
+## Outcome
+
+Each distinct plan parses exactly once regardless of record count
+and the calculate phase touches no corpus file.
+
+## Notes
+
+Archive probes remain on disk by design: the archive tree is
+excluded from the scanned corpus.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S13.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S13.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S13'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# precompute index existence and per-feature counts in one snapshot pass, removing the O(features x documents) scan
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/features.py`
+
+## Description
+
+- Collect doc-type sets, per-feature document counts, and the index
+  name set in the existing single snapshot pass; delete the
+  per-feature full-snapshot helper scans.
+
+## Outcome
+
+The features check is linear in corpus size with identical
+findings.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S14.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S14.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S14'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# memoize the baseline ledger to one read per run and drop per-document path resolution
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/body_schema.py`
+
+## Description
+
+- Add the run-scoped `read_baseline` entry point and a `baseline`
+  parameter on `resolve_body_schema`; replace the per-document
+  resolve() pair with a lexical relative_to and a resolve fallback.
+
+## Outcome
+
+The attestation ledger reads once per pass, defusing the projected
+ninety-second regression on the documented remediation path; path
+relativisation stops opening a file handle per document on Windows.
+
+## Notes
+
+Each run still re-reads the ledger from disk, preserving the
+review-evidence freshness guarantee the module documents.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S15.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S15.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S15'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# eliminate the per-document path-syscall storm in the body sections check
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/body_sections.py`
+
+## Description
+
+- Read the attestation ledger once in the body sections check and
+  thread it into every schema resolution.
+
+## Outcome
+
+The per-document metadata syscall storm is gone with byte-identical
+findings; remaining per-document work is pure string handling.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S16.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-S16.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S16'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# add the single-ingress enforcement test that fails any check touching disk after ingress
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/checks/tests/test_single_ingress.py`
+
+## Description
+
+- Add the enforcement test that deletes the corpus after ingress and
+  asserts the calculate phase reproduces its baseline diagnostics
+  exactly, plus an encoding-facts survival case.
+
+## Outcome
+
+Both tests pass; the scale gate's read budget independently
+corroborates the one-read-per-document contract.
+
+## Notes
+
+Archive probes and workspace-resource reads are outside the scanned
+corpus by design and unaffected by the lockdown.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-summary.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P02-summary.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# `vault-scale-performance` `P02` summary
+
+All eleven Steps closed. The non-mutating check pipeline now honours the
+single-ingress contract: the graph build (or, after a cache hit, one
+explicit read pass) reads each corpus document exactly once, and every
+checker in the calculate phase runs from the shared snapshot, the ingress
+raw-text map, or ingress-recorded facts. Workspace-global facts (the
+attestation ledger) read once per run. Enforcement is physical: a test
+deletes the corpus after ingress and the calculate phase must reproduce
+its findings byte-for-byte.
+
+- Modified: `src/vaultspec_core/graph/api.py`
+- Modified: `src/vaultspec_core/vaultcore/body_schema.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/__init__.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/_base.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/annotations.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/body_sections.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/encoding.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/exec_mapping.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/feature_rename_integrity.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/features.py`
+- Modified: `src/vaultspec_core/vaultcore/checks/markdown.py`
+- Created: `src/vaultspec_core/vaultcore/checks/tests/test_single_ingress.py`
+
+## Description
+
+Ingress gained a single bytes-read per document that retains normalised
+text, CRLF convention, and encoding failures for the whole run. The five
+checks that re-read the corpus (annotations, markdown, encoding, feature
+rename integrity) or hammered it with probes and re-parses (exec mapping,
+features, body sections via the schema resolver) now consume ingress
+state; the rename integrity check was confirmed to read workspace
+resources, not the corpus, and exempted with rationale. The attestation
+ledger memoization defuses the latent ninety-second regression on the
+tool's own documented remediation path. The full vaultcore suite (557
+tests) passes, and the corpus-deletion enforcement test plus the scale
+gate's exact read budget hold the contract.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-S17.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-S17.md
@@ -1,0 +1,32 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S17'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# cap the check report phase with marked truncation and aggregates and a fixed console geometry
+
+## Scope
+
+- `src/vaultspec_core/cli/vault_cmd.py`
+
+## Description
+
+- Cap rendered findings at fifty per check with a marked truncation
+  line pointing at the JSON surface; pin the shared console width at
+  construction so geometry is queried once per run.
+
+## Outcome
+
+Human check output is bounded on large corpora; summary counts stay
+complete and the JSON contract is uncapped and unchanged.
+
+## Notes
+
+Small corpora below the cap render byte-identically.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-S18.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-S18.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S18'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# cap the unscoped vault graph tree render with marked truncation
+
+## Scope
+
+- `src/vaultspec_core/graph/api.py`
+
+## Description
+
+- Cap the graph tree render at a thousand lines with a marked
+  truncation line pointing at feature scoping and the JSON surface.
+
+## Outcome
+
+The unscoped tree render is bounded; the title keeps the full
+corpus counts.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-S19.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-S19.md
@@ -1,0 +1,33 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S19'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# add the synthetic-corpus complexity scale gate asserting operation counts and cross-size scaling ratios under a dedicated marker
+
+## Scope
+
+- `src/vaultspec_core/tests/scale/test_scale_gate.py`
+
+## Description
+
+- Add the benchmark-marked scale gate asserting exactly one corpus
+  read per document, memoized plan parsing, and at-most-linear
+  tag-extraction growth across a four-fold corpus step.
+
+## Outcome
+
+All three gate tests pass; budgets are operation counts and scaling
+ratios observed by a real profiler, never wall-clock.
+
+## Notes
+
+Gate corpora are generated at test time by the canonical synthetic
+generator and never committed.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-summary.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P03-summary.md
@@ -1,0 +1,37 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# `vault-scale-performance` `P03` summary
+
+All three Steps closed. The report phase is bounded and the complexity
+budgets are gated: human check output caps at fifty findings per check and
+the graph tree at a thousand lines, both with marked truncation and the
+uncapped JSON surface as the machine contract; console geometry is queried
+once per run; and a benchmark-marked scale gate asserts the read budget,
+plan-parse memoization, and linear scaling as operation counts over
+generated synthetic corpora.
+
+- Modified: `src/vaultspec_core/vaultcore/checks/_base.py`
+- Modified: `src/vaultspec_core/graph/api.py`
+- Modified: `src/vaultspec_core/console.py`
+- Created: `src/vaultspec_core/tests/scale/__init__.py`
+- Created: `src/vaultspec_core/tests/scale/test_scale_gate.py`
+
+## Description
+
+The render caps extend the established output contract's marked-truncation
+clause to the check and graph report surfaces; corpora below the caps
+render byte-identically. The console pins its width at construction when a
+real terminal answers, eliminating the per-line terminal-size queries.
+The scale gate runs the whole non-mutating check pass under a real
+profiler at two corpus sizes and fails on any second read of a document,
+any unmemoized plan re-parse, or superlinear tag-extraction growth - the
+deterministic form of the complexity budgets, immune to CI timing noise.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-S20.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-S20.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S20'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# verify the shipped libyaml CSafeLoader seam engages on the frontmatter hot path and record the measured parse gain
+
+## Scope
+
+- `src/vaultspec_core/vaultcore/parser.py`
+
+## Description
+
+- Confirm the libyaml CSafeLoader-with-fallback seam is already in
+  committed history on the frontmatter parse hot path and that
+  libyaml is active in this environment.
+- Measure engagement on the real corpus: the full parse pass runs
+  at the C-loader's speed, proving the seam is live.
+
+## Outcome
+
+Measured on the 1,180-document corpus: the C loader parses the
+frontmatter set 7.3x faster than the pure-Python loader (0.055s vs
+0.403s), and the shipped parse path matches the C-loader timing
+exactly. No code change was needed for this Step.
+
+## Notes
+
+Remaining pure-Python YAML load sites parse a handful of workspace
+resource files, not the corpus; converting them buys nothing
+measurable and was left alone.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-S21.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-S21.md
@@ -1,0 +1,40 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S21'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# route the opt-in betweenness analysis through rustworkx with a networkx fallback and add the dependency
+
+## Scope
+
+- `src/vaultspec_core/graph/api.py`
+
+## Description
+
+- Add the analysis-engine seam routing betweenness centrality
+  through rustworkx (converted graph, identical normalisation and
+  endpoint semantics) with pure networkx as the automatic fallback
+  when the wheel is unavailable.
+- Declare the dependency with a version floor and update the
+  metrics docstring to name the seam.
+
+## Outcome
+
+Measured on the real 1,181-node graph: 13.2x faster than networkx
+(0.013s vs 0.168s) with a maximum score delta of 1.6e-19 - float
+epsilon, not semantic divergence. The advantage grows with corpus
+size since the algorithm is O(V\*E) and the engine parallelises
+above a node threshold.
+
+## Notes
+
+Only the expensive opt-in algorithm is routed; the canonical graph
+structure, cheap counts, pagerank, and every serialization stay on
+networkx, keeping the wire contract and cache payload untouched.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-S22.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-S22.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+step_id: 'S22'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# add the engine parity test asserting rustworkx and networkx betweenness agree on the synthetic corpus
+
+## Scope
+
+- `src/vaultspec_core/graph/tests/test_analysis_engine.py`
+
+## Description
+
+- Add the engine parity suite: both real engines run on the same
+  built graphs (full and feature-scoped) and must agree to 1e-12,
+  plus a guard that the wheel is actually present in this
+  environment and a flow test through the metrics surface.
+
+## Outcome
+
+All 4 parity tests pass; the full graph suite (147 tests including
+the envelope contract tests) passes against rustworkx-computed
+scores.
+
+## Notes
+
+None.

--- a/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-summary.md
+++ b/.vault/exec/2026-07-27-vault-scale-performance/2026-07-27-vault-scale-performance-P04-summary.md
@@ -1,0 +1,37 @@
+---
+tags:
+  - '#exec'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-vault-scale-performance-plan]]"
+---
+
+# `vault-scale-performance` `P04` summary
+
+All three Steps closed. The D8 native-leaf decision is implemented: the
+libyaml frontmatter loader was verified already live on the parse hot path
+(7.3x over the pure-Python loader, measured on the real corpus), and the
+opt-in betweenness analysis now routes through the C-backed rustworkx
+engine with pure networkx as the automatic fallback (13.2x measured at
+1,181 nodes, maximum score delta 1.6e-19). Native code stays confined to
+leaf computations behind existing seams; no semantics were duplicated.
+
+- Modified: `src/vaultspec_core/graph/api.py`
+- Modified: `pyproject.toml`
+- Created: `src/vaultspec_core/graph/tests/test_analysis_engine.py`
+
+## Description
+
+The seam converts the built graph and runs the same Brandes algorithm
+with identical normalisation and endpoint semantics; a four-test parity
+suite runs both real engines on the same graphs and requires agreement to
+1e-12, and the full graph suite including the envelope contract tests
+passes against the engine-computed scores. The dependency is declared
+with a version floor and guarded by the fallback so platforms without the
+wheel lose speed, never the surface. A dedicated native calculation
+engine was explicitly rejected in the amended decision record; it
+revisits only under a new record if a far larger corpus target or a
+sub-100ms interactive consumer materialises.

--- a/.vault/index/vault-scale-performance.index.md
+++ b/.vault/index/vault-scale-performance.index.md
@@ -1,0 +1,88 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - '[[2026-07-27-vault-scale-performance-P01-S01]]'
+  - '[[2026-07-27-vault-scale-performance-P01-S02]]'
+  - '[[2026-07-27-vault-scale-performance-P01-S03]]'
+  - '[[2026-07-27-vault-scale-performance-P01-S04]]'
+  - '[[2026-07-27-vault-scale-performance-P01-S05]]'
+  - '[[2026-07-27-vault-scale-performance-P01-summary]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S06]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S07]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S08]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S09]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S10]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S11]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S12]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S13]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S14]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S15]]'
+  - '[[2026-07-27-vault-scale-performance-P02-S16]]'
+  - '[[2026-07-27-vault-scale-performance-P02-summary]]'
+  - '[[2026-07-27-vault-scale-performance-P03-S17]]'
+  - '[[2026-07-27-vault-scale-performance-P03-S18]]'
+  - '[[2026-07-27-vault-scale-performance-P03-S19]]'
+  - '[[2026-07-27-vault-scale-performance-P03-summary]]'
+  - '[[2026-07-27-vault-scale-performance-P04-S20]]'
+  - '[[2026-07-27-vault-scale-performance-P04-S21]]'
+  - '[[2026-07-27-vault-scale-performance-P04-S22]]'
+  - '[[2026-07-27-vault-scale-performance-P04-summary]]'
+  - '[[2026-07-27-vault-scale-performance-adr]]'
+  - '[[2026-07-27-vault-scale-performance-audit]]'
+  - '[[2026-07-27-vault-scale-performance-implementation-audit]]'
+  - '[[2026-07-27-vault-scale-performance-plan]]'
+---
+
+# `vault-scale-performance` feature index
+
+Auto-generated index of all documents tagged with `#vault-scale-performance`.
+
+## Documents
+
+### adr
+
+- `2026-07-27-vault-scale-performance-adr` - `vault-scale-performance` adr: `large-vault performance architecture` | (**status:** `accepted`)
+
+### audit
+
+- `2026-07-27-vault-scale-performance-audit` - `vault-scale-performance` audit: `large-vault command latency`
+- `2026-07-27-vault-scale-performance-implementation-audit` - `vault-scale-performance` audit: `implementation`
+
+### exec
+
+- `2026-07-27-vault-scale-performance-P01-S01` - rework fingerprint_vault to the racily-clean rule: trust size+mtime, hash only manifest-write-tick files, keep full-hash as opt-in deep verification
+- `2026-07-27-vault-scale-performance-P01-S02` - add a cheap descriptive-counts surface and route the render_tree title through it, keeping graph-theoretic metrics opt-in
+- `2026-07-27-vault-scale-performance-P01-S03` - default the MCP find graph build to the warm cache
+- `2026-07-27-vault-scale-performance-P01-S04` - reuse the already-built graph and single scan in the status stats path instead of a second VaultGraph build and rescans
+- `2026-07-27-vault-scale-performance-P01-S05` - classify type-filtered listings by path arithmetic instead of parsing every document
+- `2026-07-27-vault-scale-performance-P01-summary` - `vault-scale-performance` `P01` summary
+- `2026-07-27-vault-scale-performance-P02-S06` - extend the corpus snapshot with raw bytes and per-file metadata so every check can run from it
+- `2026-07-27-vault-scale-performance-P02-S07` - route the annotations check through the shared snapshot
+- `2026-07-27-vault-scale-performance-P02-S08` - route the markdown check through the shared snapshot
+- `2026-07-27-vault-scale-performance-P02-S09` - route the encoding check through snapshot raw bytes, folding it into the single ingress read
+- `2026-07-27-vault-scale-performance-P02-S10` - route the feature rename integrity check through the shared snapshot
+- `2026-07-27-vault-scale-performance-P02-S11` - exempt the rename integrity check from the single-ingress contract: it validates workspace resources under .vaultspec/, not the vault corpus, so no snapshot routing applies
+- `2026-07-27-vault-scale-performance-P02-S12` - memoize per-plan step-id parsing and drop redundant disk probes in the exec mapping check
+- `2026-07-27-vault-scale-performance-P02-S13` - precompute index existence and per-feature counts in one snapshot pass, removing the O(features x documents) scan
+- `2026-07-27-vault-scale-performance-P02-S14` - memoize the baseline ledger to one read per run and drop per-document path resolution
+- `2026-07-27-vault-scale-performance-P02-S15` - eliminate the per-document path-syscall storm in the body sections check
+- `2026-07-27-vault-scale-performance-P02-S16` - add the single-ingress enforcement test that fails any check touching disk after ingress
+- `2026-07-27-vault-scale-performance-P02-summary` - `vault-scale-performance` `P02` summary
+- `2026-07-27-vault-scale-performance-P03-S17` - cap the check report phase with marked truncation and aggregates and a fixed console geometry
+- `2026-07-27-vault-scale-performance-P03-S18` - cap the unscoped vault graph tree render with marked truncation
+- `2026-07-27-vault-scale-performance-P03-S19` - add the synthetic-corpus complexity scale gate asserting operation counts and cross-size scaling ratios under a dedicated marker
+- `2026-07-27-vault-scale-performance-P03-summary` - `vault-scale-performance` `P03` summary
+- `2026-07-27-vault-scale-performance-P04-S20` - verify the shipped libyaml CSafeLoader seam engages on the frontmatter hot path and record the measured parse gain
+- `2026-07-27-vault-scale-performance-P04-S21` - route the opt-in betweenness analysis through rustworkx with a networkx fallback and add the dependency
+- `2026-07-27-vault-scale-performance-P04-S22` - add the engine parity test asserting rustworkx and networkx betweenness agree on the synthetic corpus
+- `2026-07-27-vault-scale-performance-P04-summary` - `vault-scale-performance` `P04` summary
+
+### plan
+
+- `2026-07-27-vault-scale-performance-plan` - `vault-scale-performance` plan

--- a/.vault/plan/2026-07-27-markdown-feature-scope-plan.md
+++ b/.vault/plan/2026-07-27-markdown-feature-scope-plan.md
@@ -1,0 +1,42 @@
+---
+tags:
+  - '#plan'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+tier: L2
+related:
+  - '[[2026-07-27-markdown-feature-scope-adr]]'
+  - '[[2026-07-27-markdown-feature-scope-research]]'
+---
+
+<!-- RETIRED: S01, S02 -->
+
+# `markdown-feature-scope` plan
+
+## Description
+
+This L2 plan executes the accepted narrow scanner-boundary decision. It preserves lazy migration behavior for every existing caller while isolating feature-scoped Markdown repair, then proves the safety contract through the actual CLI against an installed stale workspace.
+
+## Steps
+
+### Phase `P01` - prove selected repair byte preservation
+
+Establish a real stale-workspace CLI regression before implementation changes the migration boundary.
+
+- [x] `P01.S03` - Add a stale-workspace CLI regression for feature-scoped Markdown repair; `src/vaultspec_core/tests/cli/test_migration_triggers.py`.
+
+### Phase `P02` - isolate feature-scoped markdown repair
+
+Preserve default lazy migration behavior while providing the scoped repair path a non-migrating document scan.
+
+- [x] `P02.S04` - Add an opt-in migration-control parameter that preserves the default scanner contract; `src/vaultspec_core/vaultcore/scanner.py`.
+- [x] `P02.S05` - Route feature-scoped Markdown checks through the non-migrating scanner mode; `src/vaultspec_core/vaultcore/checks/markdown.py`.
+
+## Parallelization
+
+Phase P01 must complete before P02 because the CLI regression exercises the new scanner boundary. The steps within P01 are ordered by the scanner API then its Markdown caller.
+
+## Verification
+
+The focused scanner and Markdown tests pass, the real CLI regression proves selected repair can normalize the selected record while the unselected record remains byte-identical, and the completed implementation receives formal code review.

--- a/.vault/plan/2026-07-27-vault-scale-performance-plan.md
+++ b/.vault/plan/2026-07-27-vault-scale-performance-plan.md
@@ -1,0 +1,94 @@
+---
+tags:
+  - '#plan'
+  - '#vault-scale-performance'
+date: '2026-07-27'
+modified: '2026-07-27'
+tier: L2
+related:
+  - '[[2026-07-27-vault-scale-performance-adr]]'
+  - '[[2026-07-27-vault-scale-performance-audit]]'
+---
+
+# `vault-scale-performance` plan
+
+Execute the accepted large-vault performance architecture: racily-clean cache
+validation, counts-vs-analysis API split, single-ingress check pipeline,
+run-scoped workspace facts, report caps, and the synthetic-corpus scale gate.
+
+## Description
+
+This plan executes the accepted decisions of the authorizing ADR (see
+`related:`): D1 and D2 and D7 land in Phase P01 (graph cache validation policy,
+descriptive-counts split, warm-read defaults), D3 and D4 land in Phase P02 (the
+single-ingress check pipeline contract and the workspace-facts-read-once rule,
+including every point fix the grounding audit validated byte-identical), and D5
+and D6 land in Phase P03 (report volume caps and the synthetic-corpus
+complexity regression gate). The measured evidence behind every step lives in
+the grounding audit; behaviour preservation is the hard boundary except for the
+two explicitly decided surface changes (report caps, opt-in analysis).
+
+## Steps
+
+### Phase `P01` - graph and cache
+
+Deliver the D1 racily-clean cache validation, the D2 counts-vs-analysis API split, and the D7 warm-read defaults so graph-backed verbs stop paying cold-build and all-pairs-analysis costs.
+
+- [x] `P01.S01` - rework fingerprint_vault to the racily-clean rule: trust size+mtime, hash only manifest-write-tick files, keep full-hash as opt-in deep verification; `src/vaultspec_core/graph/cache.py`.
+- [x] `P01.S02` - add a cheap descriptive-counts surface and route the render_tree title through it, keeping graph-theoretic metrics opt-in; `src/vaultspec_core/graph/api.py`.
+- [x] `P01.S03` - default the MCP find graph build to the warm cache; `src/vaultspec_core/mcp_server/tools/documents.py`.
+- [x] `P01.S04` - reuse the already-built graph and single scan in the status stats path instead of a second VaultGraph build and rescans; `src/vaultspec_core/vaultcore/orientation.py`.
+- [x] `P01.S05` - classify type-filtered listings by path arithmetic instead of parsing every document; `src/vaultspec_core/vaultcore/query.py`.
+
+### Phase `P02` - single-ingress check pipeline
+
+Enforce the D3 single-ingress contract and the D4 workspace-facts-read-once rule across the check suite so the calculate phase runs entirely from the shared snapshot.
+
+- [x] `P02.S06` - extend the corpus snapshot with raw bytes and per-file metadata so every check can run from it; `src/vaultspec_core/vaultcore/models.py`.
+- [x] `P02.S07` - route the annotations check through the shared snapshot; `src/vaultspec_core/vaultcore/checks/annotations.py`.
+- [x] `P02.S08` - route the markdown check through the shared snapshot; `src/vaultspec_core/vaultcore/checks/markdown.py`.
+- [x] `P02.S09` - route the encoding check through snapshot raw bytes, folding it into the single ingress read; `src/vaultspec_core/vaultcore/checks/encoding.py`.
+- [x] `P02.S10` - route the feature rename integrity check through the shared snapshot; `src/vaultspec_core/vaultcore/checks/feature_rename_integrity.py`.
+- [x] `P02.S11` - exempt the rename integrity check from the single-ingress contract: it validates workspace resources under .vaultspec/, not the vault corpus, so no snapshot routing applies; `src/vaultspec_core/vaultcore/checks/rename_integrity.py`.
+- [x] `P02.S12` - memoize per-plan step-id parsing and drop redundant disk probes in the exec mapping check; `src/vaultspec_core/vaultcore/checks/exec_mapping.py`.
+- [x] `P02.S13` - precompute index existence and per-feature counts in one snapshot pass, removing the O(features x documents) scan; `src/vaultspec_core/vaultcore/checks/features.py`.
+- [x] `P02.S14` - memoize the baseline ledger to one read per run and drop per-document path resolution; `src/vaultspec_core/vaultcore/body_schema.py`.
+- [x] `P02.S15` - eliminate the per-document path-syscall storm in the body sections check; `src/vaultspec_core/vaultcore/checks/body_sections.py`.
+- [x] `P02.S16` - add the single-ingress enforcement test that fails any check touching disk after ingress; `src/vaultspec_core/vaultcore/checks/tests/test_single_ingress.py`.
+
+### Phase `P03` - report volume and scale gate
+
+Apply the D6 report volume caps and land the D5 synthetic-corpus complexity regression gate.
+
+- [x] `P03.S17` - cap the check report phase with marked truncation and aggregates and a fixed console geometry; `src/vaultspec_core/cli/vault_cmd.py`.
+- [x] `P03.S18` - cap the unscoped vault graph tree render with marked truncation; `src/vaultspec_core/graph/api.py`.
+- [x] `P03.S19` - add the synthetic-corpus complexity scale gate asserting operation counts and cross-size scaling ratios under a dedicated marker; `src/vaultspec_core/tests/scale/test_scale_gate.py`.
+
+### Phase `P04` - native leaf acceleration
+
+Deliver the D8 native leaf libraries: verify the shipped libyaml loader engages on the parse hot path and route the opt-in betweenness analysis through a C-backed graph library with a pure networkx fallback.
+
+- [x] `P04.S20` - verify the shipped libyaml CSafeLoader seam engages on the frontmatter hot path and record the measured parse gain; `src/vaultspec_core/vaultcore/parser.py`.
+- [x] `P04.S21` - route the opt-in betweenness analysis through rustworkx with a networkx fallback and add the dependency; `src/vaultspec_core/graph/api.py`.
+- [x] `P04.S22` - add the engine parity test asserting rustworkx and networkx betweenness agree on the synthetic corpus; `src/vaultspec_core/graph/tests/test_analysis_engine.py`.
+
+## Parallelization
+
+P01 and P02 are independent of each other and may run in parallel; within P02,
+S06 (the snapshot extension) is a hard prerequisite for S07 through S11 and
+S16, while S12 through S15 are independent point fixes. P03 depends on both
+earlier phases: S17 and S18 cap surfaces P01 and P02 touch, and S19 gates the
+complexity budgets they establish.
+
+## Verification
+
+- The full unit gate passes: `pytest src/vaultspec_core -m unit`.
+- Check, graph, status, and list verb outputs are byte-identical to baseline on
+  an unchanged corpus, except the two decided surface changes (report caps and
+  opt-in analysis), which ship with their own tests.
+- The single-ingress enforcement test proves no checker touches disk during the
+  calculate phase.
+- The scale gate asserts the operation-count budgets and cross-size scaling
+  ratios on generated synthetic corpora under its dedicated marker.
+- `vault check all` stays clean for the feature's documents; the plan is
+  complete when every Step row is closed.

--- a/.vault/reference/2026-07-27-markdown-feature-scope-reference.md
+++ b/.vault/reference/2026-07-27-markdown-feature-scope-reference.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - '#reference'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+related: []
+---
+
+# `markdown-feature-scope` reference: `scoped markdown repair boundary`
+
+Issue #268 was traced through the real CLI dispatch, markdown checker, scanner,
+migration registry, and existing integration tests. The finding is a mutation
+boundary defect: a feature-scoped repair enters the global migration path before
+it can identify the selected feature.
+
+## Summary
+
+`cmd_check_markdown` forwards the `--feature` value directly to
+`check_markdown` (`src/vaultspec_core/cli/vault_cmd.py:1521-1543`). The checker
+normalizes that feature tag and excludes nonmatching documents before calculating
+hygiene or writing bytes (`src/vaultspec_core/vaultcore/checks/markdown.py:139-212`).
+The predicate is therefore not the defect.
+
+The checker obtains documents through `scan_vault` (`markdown.py:169`). Before
+that scanner yields a path, it unconditionally calls `run_pending_migrations`
+(`src/vaultspec_core/vaultcore/scanner.py:34-55`). The migration driver runs all
+pending workspace migrations, independent of the command's feature filter
+(`src/vaultspec_core/migrations/__init__.py:198-295`). In particular,
+`modified_stamp_backfill` walks every `.vault` Markdown file and writes a missing
+`modified:` field (`src/vaultspec_core/migrations/m_0_1_29_modified_stamp_backfill.py:54-151`).
+This is the observed cross-feature mutation.
+
+The smallest compatible boundary is an optional scanner mode that suppresses
+lazy migrations. It remains enabled by default, preserving existing command
+semantics. A feature-scoped markdown invocation alone opts out, because it has
+an explicit no-unrelated-mutation contract. Unscoped markdown repair and command
+paths that require schema convergence keep the current default.
+
+The regression must execute the actual CLI using the existing real-workspace
+`WorkspaceFactory` pattern in `src/vaultspec_core/tests/cli/test_migration_triggers.py`.
+It should install a workspace, write dirty selected and unselected records,
+rewind its real manifest to `0.1.28`, run `vault check markdown --fix --feature alpha`, and compare raw bytes. The selected record must receive only markdown
+hygiene changes; the unselected record must remain byte-identical and must not
+gain `modified:`. The existing markdown test at
+`src/vaultspec_core/vaultcore/checks/tests/test_markdown.py:129-134` is read-only
+and uses no stale manifest, so it cannot cover this trigger path.
+
+Markdown hygiene itself changes only trailing whitespace, blank runs, and final
+newlines (`src/vaultspec_core/vaultcore/checks/markdown.py:70-137`); it neither
+adds plan sections nor decodes/re-encodes through a legacy codec. The issue's
+reported repeated sections and mojibake require another writer or process, but
+the global migration side effect independently violates the feature-scoped safety
+contract and is sufficient to reproduce unrelated `modified:` mutations.

--- a/.vault/research/2026-07-27-markdown-feature-scope-research.md
+++ b/.vault/research/2026-07-27-markdown-feature-scope-research.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - '#research'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+related:
+  - "[[2026-07-27-markdown-feature-scope-reference]]"
+---
+
+# `markdown-feature-scope` research: `feature-scoped repair migration boundary`
+
+Issue #268 asks whether a feature-scoped markdown repair can preserve a strict
+no-unrelated-mutation boundary while the workspace has pending migrations. The
+source reference establishes that the checker filter is sound but the scanner
+performs a whole-workspace mutation before that filter; the evidence favors a
+narrow, opt-in non-migrating scan for this explicit scoped-repair path. The ADR
+must settle its compatibility boundary.
+
+## Findings
+
+### Feature filtering is already correct at the markdown-writer boundary
+
+The command forwards `--feature` to `check_markdown`, which normalizes the tag,
+excludes nonmatching documents, and only then calls `atomic_write` for a detected
+hygiene change. `src/vaultspec_core/cli/vault_cmd.py:1521-1543`;
+`src/vaultspec_core/vaultcore/checks/markdown.py:139-212`. Changing the predicate
+would add risk without addressing the pre-filter mutation.
+
+### Lazy schema convergence violates a feature-scoped repair boundary
+
+`scan_vault` invokes `run_pending_migrations` before it yields a document path.
+The registry can run `modified_stamp_backfill`, which walks all vault Markdown
+documents and writes missing `modified:` fields. A selected-feature command can
+therefore mutate unrelated documents before it has read their tags.
+`src/vaultspec_core/vaultcore/scanner.py:34-55`;
+`src/vaultspec_core/migrations/__init__.py:198-295`;
+`src/vaultspec_core/migrations/m_0_1_29_modified_stamp_backfill.py:54-151`.
+
+### Three boundaries were compared
+
+Retaining unconditional scanner migration preserves the historic lazy-convergence
+behavior but fails the issue's byte-preservation requirement. Making every
+scanner consumer migration-free would provide the broadest read safety, but it
+changes the established `scan_vault` contract used by creation and index commands
+without evidence that this issue requires that larger migration redesign.
+An optional scanner mode that defaults to current behavior bounds the change:
+feature-scoped markdown repair can scan without migrations, while all existing
+callers remain convergent unless they explicitly opt out. The compatibility and
+safety evidence favors the narrow mode.
+
+### A CLI-level stale-manifest regression is required
+
+The existing markdown feature test only observes warnings in an uninstalled
+temporary directory, so no registry can run. The existing migration-trigger suite
+uses a real installed workspace, rewinds its manifest, and invokes the actual CLI;
+that is the appropriate pattern for a byte-level selected-versus-unselected test.
+`src/vaultspec_core/vaultcore/checks/tests/test_markdown.py:129-134`;
+`src/vaultspec_core/tests/cli/test_migration_triggers.py:267-308`.
+
+### The reported structural and encoding damage is outside markdown hygiene
+
+The hygiene transform changes trailing whitespace, blank runs, and final newlines
+only; it decodes and writes UTF-8. The known migration writes frontmatter stamps,
+not plan sections. No audit was able to reproduce the reported repeated headings
+or mojibake from these paths alone, so that portion remains uninvestigated and
+should not expand this narrowly scoped repair. `src/vaultspec_core/vaultcore/checks/markdown.py:70-137`;
+`src/vaultspec_core/migrations/m_0_1_29_modified_stamp_backfill.py:94-151`.
+
+## Sources
+
+- `src/vaultspec_core/cli/vault_cmd.py:1521-1543`
+- `src/vaultspec_core/vaultcore/checks/markdown.py:70-212`
+- `src/vaultspec_core/vaultcore/scanner.py:34-55`
+- `src/vaultspec_core/migrations/__init__.py:198-295`
+- `src/vaultspec_core/migrations/m_0_1_29_modified_stamp_backfill.py:54-151`
+- `src/vaultspec_core/vaultcore/checks/tests/test_markdown.py:129-134`
+- `src/vaultspec_core/tests/cli/test_migration_triggers.py:267-308`

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -272,6 +272,8 @@ full options.
 
 - `vaultspec-core vault archive documents` - Archive exactly the documents named in a
   UTF-8 manifest.
+- `vaultspec-core vault archive restore` - Restore exactly the archived documents named
+  in a UTF-8 manifest.
 
 ### Spec
 
@@ -1217,6 +1219,44 @@ destination before it moves anything, so a bad line cannot produce a partial arc
 
   ```bash
   vaultspec-core vault archive documents --manifest .vault/archive-manifest.txt --dry-run
+  ```
+
+______________________________________________________________________
+
+### vaultspec-core vault archive restore
+
+```bash
+vaultspec-core vault archive restore [OPTIONS]
+```
+
+Bring archived documents back into the live vault. Each manifest line must be a
+repository-relative `.vault/_archive/*.md` path. This is the inverse of
+`vaultspec-core vault archive documents`: every source and destination is validated
+before anything moves, so a bad line cannot produce a partial restore.
+
+#### Options
+
+- `--manifest PATH` - Required UTF-8 manifest of repository-relative archived Markdown
+  paths, one per line.
+- `--dry-run` (default off) - Validate and show the restore destinations without
+  writing.
+- `--deduplicate-identical` (default off) - When an archived document already has a live
+  counterpart with byte-identical content, drop the archived copy instead of failing on
+  the collision. Documents whose contents differ are still reported as conflicts.
+- `--json` (default off) - Emit the standard machine-readable result envelope.
+
+#### Examples
+
+- **Preview restoring a set of archived records**:
+
+  ```bash
+  vaultspec-core vault archive restore --manifest .vault/restore-manifest.txt --dry-run
+  ```
+
+- **Restore, clearing archived copies that already match the live document**:
+
+  ```bash
+  vaultspec-core vault archive restore --manifest .vault/restore-manifest.txt --deduplicate-identical
   ```
 
 ______________________________________________________________________

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
   "pydantic>=2.12.5",
   "rich>=14.3.2",
   "ruamel.yaml>=0.18",
+  "rustworkx>=0.18.0",
   "sse-starlette>=3.2.0",
   "starlette>=0.52.1",
   "typer>=0.12.0",

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -207,6 +207,8 @@ hand-edit between the markers.
 
 - `vaultspec-core vault archive documents` - Archive exactly the documents named in a
   UTF-8 manifest.
+- `vaultspec-core vault archive restore` - Restore exactly the archived documents named
+  in a UTF-8 manifest.
 
 ### Spec
 
@@ -578,6 +580,16 @@ listed by `--manifest PATH`. The manifest is UTF-8, one repository-relative
 `.vault/*.md` path per line. The command validates the entire manifest before moving
 anything; `--dry-run` previews the destination paths and `--json` emits the standard
 envelope.
+
+### vaultspec-core vault archive restore
+
+`vaultspec-core vault archive restore [OPTIONS]` is the inverse: it restores exactly the
+archived documents listed by `--manifest PATH`, one repository-relative
+`.vault/_archive/*.md` path per line. The whole manifest is validated before anything
+moves. `--deduplicate-identical` drops an archived copy whose live counterpart is
+byte-identical instead of failing on the collision, while differing contents are still
+reported as conflicts; `--dry-run` previews the destination paths and `--json` emits the
+standard envelope.
 
 ### vaultspec-core vault exec
 

--- a/src/vaultspec_core/builtins/templates/adr.md
+++ b/src/vaultspec_core/builtins/templates/adr.md
@@ -4,6 +4,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 related:
   - '[[{yyyy-mm-dd-*}]]'
 ---

--- a/src/vaultspec_core/builtins/templates/audit.md
+++ b/src/vaultspec_core/builtins/templates/audit.md
@@ -4,6 +4,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 related:
   - '[[{yyyy-mm-dd-*}]]'
 ---

--- a/src/vaultspec_core/builtins/templates/exec-step.md
+++ b/src/vaultspec_core/builtins/templates/exec-step.md
@@ -4,6 +4,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 step_id: '{step_id}'
 related:
   - '[[{plan_stem}]]'

--- a/src/vaultspec_core/builtins/templates/exec-summary.md
+++ b/src/vaultspec_core/builtins/templates/exec-summary.md
@@ -4,6 +4,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 related:
   - '[[{yyyy-mm-dd-*-plan}]]'
 ---

--- a/src/vaultspec_core/builtins/templates/index.md
+++ b/src/vaultspec_core/builtins/templates/index.md
@@ -5,6 +5,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 related:
   - '[[{yyyy-mm-dd-*}]]'
 ---

--- a/src/vaultspec_core/builtins/templates/plan.md
+++ b/src/vaultspec_core/builtins/templates/plan.md
@@ -4,6 +4,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 tier: '{tier}'
 related:
   - '[[{yyyy-mm-dd-*}]]'

--- a/src/vaultspec_core/builtins/templates/reference.md
+++ b/src/vaultspec_core/builtins/templates/reference.md
@@ -4,6 +4,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 related:
   - '[[{yyyy-mm-dd-*}]]'
 ---

--- a/src/vaultspec_core/builtins/templates/research.md
+++ b/src/vaultspec_core/builtins/templates/research.md
@@ -4,6 +4,7 @@ tags:
   - '#{feature}'
 date: '{yyyy-mm-dd}'
 modified: '{yyyy-mm-dd}'
+body_schema: 'body-v1'
 related:
   - '[[{yyyy-mm-dd-*}]]'
 ---

--- a/src/vaultspec_core/cli/_target.py
+++ b/src/vaultspec_core/cli/_target.py
@@ -166,6 +166,30 @@ def apply_target(
         raise typer.Exit(code=1) from e
 
 
+def resolve_effective_target(target: Path | None) -> Path:
+    """Return the directory a subcommand should operate on.
+
+    Applies the same priority as :func:`apply_target`  - *target*
+    (subcommand ``--target``) > the root-level ``-t`` captured by
+    :func:`set_root_target` > the current working directory  - without
+    resolving or validating a workspace.
+
+    Commands that require a workspace read
+    :attr:`~vaultspec_core.core.types.WorkspaceContext.target_dir` after
+    calling :func:`apply_target`. This accessor serves the commands that
+    need the directory *independently* of that resolution: a diagnostic
+    verb must still name the directory it inspected when that directory
+    holds no workspace at all.
+
+    Args:
+        target: Subcommand-level ``--target`` value (may be ``None``).
+
+    Returns:
+        The resolved effective target directory.
+    """
+    return (target or _root_target or Path.cwd()).resolve()
+
+
 def _nearest_vaultspec_hint(start: Path) -> str:
     """Return a discovery hint pointing at the nearest vaultspec workspace.
 

--- a/src/vaultspec_core/cli/archive_cmd.py
+++ b/src/vaultspec_core/cli/archive_cmd.py
@@ -1,4 +1,4 @@
-"""CLI wiring for explicit, manifest-driven vault document archival.
+"""CLI wiring for explicit, manifest-driven vault document archive operations.
 
 The command owns manifest decoding and presentation only.  Validation and
 every filesystem mutation belong to :mod:`vaultspec_core.vaultcore.batch_archive`.
@@ -101,3 +101,91 @@ def cmd_archive_documents(
         console.print(f"[green]Archived {result.archived_count} documents.[/green]")
     for path in paths:
         console.print(f"  {path}")
+
+
+@archive_app.command("restore")
+def cmd_restore_documents(
+    manifest: Annotated[
+        Path,
+        typer.Option(
+            "--manifest",
+            help=(
+                "UTF-8 newline-separated repository-relative .vault/_archive/*.md paths"
+            ),
+        ),
+    ],
+    dry_run: Annotated[
+        bool,
+        typer.Option("--dry-run", help="Preview the restore without writing"),
+    ] = False,
+    deduplicate_identical: Annotated[
+        bool,
+        typer.Option(
+            "--deduplicate-identical",
+            help=(
+                "Remove archived sources only when their live destinations "
+                "match exactly"
+            ),
+        ),
+    ] = False,
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Restore exactly the archived documents named in a UTF-8 manifest."""
+    apply_target(target, json_output=json_output)
+    from vaultspec_core.core.types import get_context
+    from vaultspec_core.vaultcore.batch_archive import (
+        RestoreDocumentsError,
+        restore_documents,
+    )
+
+    root_dir = get_context().target_dir
+    try:
+        result = restore_documents(
+            root_dir,
+            _manifest_entries(manifest),
+            dry_run=dry_run,
+            deduplicate_identical=deduplicate_identical,
+        )
+    except (RestoreDocumentsError, OSError) as exc:
+        handle_error(exc, json_output=json_output)
+        return
+
+    if result.status == "updated" and not dry_run:
+        from vaultspec_core.cli._cache_hook import invalidate_graph_cache
+
+        invalidate_graph_cache(root_dir)
+
+    payload = result.to_dict()
+    if json_output:
+        from vaultspec_core.cli.rendering import json_envelope
+
+        typer.echo(
+            json.dumps(
+                json_envelope("vault.archive.restore", result.status, payload),
+                indent=2,
+            )
+        )
+        return
+
+    from vaultspec_core.console import get_console
+
+    console = get_console()
+    paths = payload["paths"]
+    assert isinstance(paths, list)
+    if dry_run:
+        console.print(
+            "[yellow]Dry-run:[/yellow] would restore "
+            f"{result.restored_count} documents."
+        )
+    else:
+        console.print(f"[green]Restored {result.restored_count} documents.[/green]")
+    for path in paths:
+        console.print(f"  {path}")
+    if result.deduplicated_count:
+        action = "would remove" if dry_run else "Removed"
+        console.print(
+            f"{action} {result.deduplicated_count} byte-identical archived duplicates."
+        )
+        for path in result.deduplicated_paths:
+            console.print(f"  {path}")

--- a/src/vaultspec_core/cli/root.py
+++ b/src/vaultspec_core/cli/root.py
@@ -10,7 +10,7 @@ resolution and :mod:`vaultspec_core.core.types` for global path initialization.
 from __future__ import annotations
 
 import logging
-from pathlib import Path
+from pathlib import Path  # noqa: TC003 - Typer evaluates the root --target annotation.
 from typing import TYPE_CHECKING, Annotated
 
 import typer
@@ -21,6 +21,7 @@ from vaultspec_core.cli._target import (
     TargetOption,
     apply_target,
     apply_target_install,
+    resolve_effective_target,
 )
 from vaultspec_core.core.enums import CliAction, InstallMode
 
@@ -627,7 +628,7 @@ def cmd_sync(
         ctx = get_context()
         sync_target = ctx.target_dir
     except LookupError:
-        sync_target = target or Path.cwd()
+        sync_target = resolve_effective_target(target)
 
     _run_preflight(
         sync_target,
@@ -954,7 +955,6 @@ def cmd_doctor(
     import dataclasses
     import json
     import logging
-    from pathlib import Path
 
     import typer
 
@@ -964,8 +964,7 @@ def cmd_doctor(
     from vaultspec_core.core.diagnosis import diagnose
     from vaultspec_core.vaultcore.checks import render_check_result, run_all_checks
 
-    effective_dir = target or Path.cwd()
-    effective_dir = effective_dir.resolve()
+    effective_dir = resolve_effective_target(target)
 
     if not effective_dir.exists():
         typer.echo(f"Error: target directory does not exist: {effective_dir}", err=True)

--- a/src/vaultspec_core/cli/spec_cmd.py
+++ b/src/vaultspec_core/cli/spec_cmd.py
@@ -25,7 +25,11 @@ if TYPE_CHECKING:
     from vaultspec_core.core.types import SyncResult
 
 from vaultspec_core.cli._errors import handle_error as _handle_error
-from vaultspec_core.cli._target import TargetOption, apply_target
+from vaultspec_core.cli._target import (
+    TargetOption,
+    apply_target,
+    resolve_effective_target,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2005,8 +2009,7 @@ def cmd_doctor(
         diagnose,
     )
 
-    effective = target or Path.cwd()
-    effective = effective.resolve()
+    effective = resolve_effective_target(target)
 
     if not effective.exists():
         typer.echo(

--- a/src/vaultspec_core/console.py
+++ b/src/vaultspec_core/console.py
@@ -6,6 +6,7 @@ terminals that use cp1252 or similar legacy codepages.
 
 from __future__ import annotations
 
+import contextlib
 import io
 import os
 import sys
@@ -82,6 +83,13 @@ def _console_kwargs(stdout=None, environ: dict[str, str] | None = None) -> dict:
     if not utf8:
         kwargs["file"] = _make_utf8_stdout(stdout)
         kwargs["legacy_windows"] = False
+    # One terminal-geometry query per run: pin the console width at
+    # construction so large render loops do not re-query the terminal size
+    # for every printed line. Only pinned when a real terminal answers;
+    # pipes and captured streams keep Rich's own fallback behaviour.
+    if "COLUMNS" not in env:
+        with contextlib.suppress(OSError, ValueError):
+            kwargs["width"] = os.get_terminal_size().columns
     return kwargs
 
 

--- a/src/vaultspec_core/graph/__init__.py
+++ b/src/vaultspec_core/graph/__init__.py
@@ -5,10 +5,12 @@ fields into directed edges; exposes query, ASCII/Rich render (``phart``), and
 JSON-serialisation (node-link format) operations.
 Key exports: :class:`VaultGraph` (main entry point, instantiate with vault
 root), :class:`DocNode` (per-document node with frontmatter and link
-metadata), :class:`GraphMetrics` (aggregate ``networkx`` statistics).
+metadata), :class:`GraphCounts` (cheap descriptive counts for render
+paths), :class:`GraphMetrics` (opt-in aggregate ``networkx`` statistics).
 Consumed by :mod:`vaultspec_core.cli` graph sub-commands.
 """
 
 from .api import DocNode as DocNode
+from .api import GraphCounts as GraphCounts
 from .api import GraphMetrics as GraphMetrics
 from .api import VaultGraph as VaultGraph

--- a/src/vaultspec_core/graph/api.py
+++ b/src/vaultspec_core/graph/api.py
@@ -221,6 +221,47 @@ class GraphMetrics:
         return d
 
 
+@dataclass(frozen=True)
+class EncodingIssue:
+    """A document the ingress read could not read or decode.
+
+    Attributes:
+        path: Absolute path of the affected file.
+        kind: ``"read"`` for an :class:`OSError`, ``"decode"`` for a
+            :class:`UnicodeDecodeError`.
+        detail: The error string (``read``) or decode failure reason
+            (``decode``).
+        start: The failing byte offset for ``decode`` issues, else ``None``.
+    """
+
+    path: pathlib.Path
+    kind: str
+    detail: str
+    start: int | None
+
+
+@dataclass(frozen=True)
+class GraphCounts:
+    """Cheap descriptive counts of a vault graph.
+
+    The always-affordable half of the metrics surface: document, link, and
+    feature counts derived from the graph structure alone, with no
+    graph-theoretic algorithm behind them.  Render and orientation paths
+    consume this class; the expensive analysis in
+    :meth:`VaultGraph.metrics` (centrality, components, density) is opt-in
+    and never bought implicitly by a display path.
+
+    Attributes:
+        docs: Number of real (non-phantom) documents in scope.
+        links: Number of directed link edges in scope.
+        features: Number of distinct feature tags in scope.
+    """
+
+    docs: int
+    links: int
+    features: int
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -265,6 +306,31 @@ def _top_n(
     """Return the top *n* entries from *scores* by value descending."""
     ranked = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
     return dict(ranked[:n])
+
+
+def _betweenness_centrality(g: nx.DiGraph) -> dict[str, float]:
+    """Compute betweenness centrality via the C-backed engine when available.
+
+    Betweenness is the one O(V*E) algorithm on the opt-in analysis surface;
+    ``rustworkx`` runs the same Brandes algorithm with the same
+    normalisation orders of magnitude faster than pure-Python networkx.
+    The networkx implementation remains the automatic fallback when the
+    binary wheel is unavailable, so no platform loses the surface.
+
+    Args:
+        g: The (sub)graph to analyse.
+
+    Returns:
+        Mapping of node name to normalised betweenness score, matching
+        ``nx.betweenness_centrality``'s semantics.
+    """
+    try:
+        import rustworkx as rx
+    except ImportError:  # pragma: no cover - wheel unavailable on platform
+        return nx.betweenness_centrality(g)
+    rgraph = rx.networkx_converter(g)
+    scores = rx.betweenness_centrality(rgraph, normalized=True, endpoints=False)
+    return {rgraph[index]: score for index, score in scores.items()}
 
 
 def _pagerank(
@@ -468,6 +534,8 @@ class VaultGraph:
         self._digraph: nx.DiGraph = nx.DiGraph()
         self._dangling_links: list[tuple[str, str]] = []
         self._stem_index: dict[str, list[str]] = {}
+        self._raw_texts: dict[pathlib.Path, tuple[str, bool]] = {}
+        self._encoding_issues: list[EncodingIssue] = []
         self._build_graph(use_cache=use_cache)
 
     @classmethod
@@ -507,6 +575,8 @@ class VaultGraph:
         graph._digraph = nx.DiGraph()
         graph._dangling_links = []
         graph._stem_index = {}
+        graph._raw_texts = {}
+        graph._encoding_issues = []
 
         docs_dir_name = pathlib.Path(get_config().docs_dir).name
         corpus = read_vault_at_ref(root_dir, ref, docs_dir_name)
@@ -518,18 +588,20 @@ class VaultGraph:
     def _build_graph(self, *, use_cache: bool = True) -> None:
         """Populate the graph, loading from the fingerprint cache when valid.
 
-        Scans the vault once into a file list and fingerprints it.  When
-        *use_cache* is set and a cache file exists whose manifest matches the
-        current fingerprints exactly (same file set, same per-file size, mtime,
-        and content hash), the serialised canonical graph is loaded and the
-        full parse is skipped.  On any divergence - a changed, added, or
-        removed file, an absent cache, or a corrupt cache - the graph is
-        rebuilt from the scanned files and the cache is rewritten.
+        Scans the vault once into a file list.  When *use_cache* is set and a
+        cache file exists whose manifest passes the racily-clean validation
+        (same file set, same per-file size and mtime, and a matching content
+        hash for any file whose mtime is not older than the cache file's own
+        mtime), the serialised canonical graph is loaded and the full parse is
+        skipped.  On any divergence - a changed, added, or removed file, an
+        absent cache, or a corrupt cache - the graph is rebuilt from the
+        scanned files and the cache (manifest hashes included) is rewritten.
 
-        The cache can never serve data that does not match the bytes on disk:
-        :func:`vaultspec_core.graph.cache.validate` requires a total
-        fingerprint match, and a corrupt cache degrades silently to a full
-        rebuild rather than crashing or serving stale data.
+        Validation is stat-first: full content hashing happens only on the
+        save path after a rebuild, never on the warm read, so the cache's own
+        upkeep stays cheap relative to the parse it avoids.  A corrupt cache
+        degrades silently to a full rebuild rather than crashing or serving
+        stale data.
 
         Args:
             use_cache: When ``True`` (default), attempt a cache load before
@@ -542,17 +614,24 @@ class VaultGraph:
         logger.info("Building vault graph from %s", self.root_dir)
 
         scanned_files = list(scan_vault(self.root_dir))
-        fingerprints = cache_mod.fingerprint_vault(scanned_files, self.root_dir)
         path = cache_mod.cache_path(self.root_dir)
 
         if use_cache:
             payload = cache_mod.load(path)
-            if payload is not None and cache_mod.validate(
-                payload.manifest, fingerprints
-            ):
-                logger.info("Graph cache hit at %s; skipping re-parse", path)
-                self._load_from_cache(payload)
-                return
+            if payload is not None:
+                try:
+                    cache_mtime_ns: int | None = path.stat().st_mtime_ns
+                except OSError:
+                    cache_mtime_ns = None
+                if cache_mod.validate(
+                    payload.manifest,
+                    scanned_files,
+                    self.root_dir,
+                    cache_mtime_ns=cache_mtime_ns,
+                ):
+                    logger.info("Graph cache hit at %s; skipping re-parse", path)
+                    self._load_from_cache(payload)
+                    return
             logger.info("Graph cache miss at %s; rebuilding", path)
 
         self._rebuild_from_files(scanned_files)
@@ -560,7 +639,7 @@ class VaultGraph:
         if use_cache:
             cache_mod.save(
                 path,
-                fingerprints,
+                cache_mod.fingerprint_vault(scanned_files, self.root_dir),
                 self._to_cache_graph(),
                 self._dangling_links,
             )
@@ -651,6 +730,8 @@ class VaultGraph:
         self.nodes = {}
         self._digraph = nx.DiGraph()
         self._dangling_links = []
+        self._raw_texts = {}
+        self._encoding_issues = []
 
         # Pass 1a: collect all DocNodes keyed by stem, detecting collisions
         by_stem: dict[str, list[DocNode]] = {}
@@ -662,19 +743,79 @@ class VaultGraph:
 
             node = DocNode(path=path, name=stem, doc_type=doc_type)
 
-            try:
-                content = path.read_text(encoding="utf-8")
+            content = self._ingest_document(path)
+            if content is not None:
                 self._populate_node_from_content(node, content)
-            except (OSError, UnicodeDecodeError) as e:
-                logger.warning(
-                    "Failed to read metadata from %s: %s",
-                    path,
-                    e,
-                )
 
             by_stem.setdefault(stem, []).append(node)
 
         self._assemble_from_by_stem(by_stem)
+
+    def _ingest_document(self, path: pathlib.Path) -> str | None:
+        """Read *path* once, recording its raw text and any encoding issue.
+
+        The single ingress read: the file's bytes are read exactly once,
+        decoded as UTF-8, and newline-normalised the way ``read_text``'s
+        universal-newline mode would (``\\r\\n`` and ``\\r`` become ``\\n``)
+        so the parse consumes identical input to the previous per-consumer
+        reads.  The normalised text and the source's CRLF convention are
+        retained in :attr:`raw_texts` for content-consuming checks, and a
+        read or decode failure is recorded in :attr:`encoding_issues`
+        instead of being silently dropped.
+
+        Returns:
+            The normalised document text, or ``None`` when the file could
+            not be read or decoded.
+        """
+        try:
+            raw_bytes = path.read_bytes()
+        except OSError as e:
+            self._encoding_issues.append(EncodingIssue(path, "read", str(e), None))
+            logger.warning("Failed to read metadata from %s: %s", path, e)
+            return None
+        try:
+            decoded = raw_bytes.decode("utf-8")
+        except UnicodeDecodeError as e:
+            self._encoding_issues.append(
+                EncodingIssue(path, "decode", e.reason, e.start)
+            )
+            logger.warning("Failed to read metadata from %s: %s", path, e)
+            return None
+        crlf = "\r\n" in decoded
+        content = decoded.replace("\r\n", "\n").replace("\r", "\n")
+        self._raw_texts[path] = (content, crlf)
+        return content
+
+    def ensure_raw_texts(self) -> None:
+        """Guarantee :attr:`raw_texts` is populated for a working-tree graph.
+
+        A cold build fills the raw-text map during its parse; a cache-hit
+        build parses nothing, so a caller that needs document text (the
+        check pipeline) invokes this to perform the run's single ingress
+        read pass.  A no-op when the map is already populated or when the
+        graph is ref-scoped (checks do not run against history).
+        """
+        if self._raw_texts or self.ref is not None:
+            return
+        from ..vaultcore.scanner import scan_vault
+
+        self._encoding_issues = []
+        for path in scan_vault(self.root_dir, run_migrations=False):
+            self._ingest_document(path)
+
+    @property
+    def raw_texts(self) -> dict[pathlib.Path, tuple[str, bool]]:
+        """Per-document ``(normalised text, source_had_crlf)`` in scan order.
+
+        Populated by a cold build or :meth:`ensure_raw_texts`; empty after a
+        bare cache hit or for a ref-scoped graph.
+        """
+        return self._raw_texts
+
+    @property
+    def encoding_issues(self) -> list[EncodingIssue]:
+        """Read and decode failures observed during the ingress read."""
+        return self._encoding_issues
 
     def _rebuild_from_corpus(
         self, corpus: list[tuple[str, str]], docs_dir_name: str
@@ -1180,6 +1321,8 @@ class VaultGraph:
             )
             raw_step_id = node.frontmatter.get("step_id")
             step_id = raw_step_id if isinstance(raw_step_id, str) else None
+            raw_body_schema = node.frontmatter.get("body_schema")
+            body_schema = raw_body_schema if isinstance(raw_body_schema, str) else None
             metadata = DocumentMetadata(
                 tags=sorted(node.tags),
                 date=node.date,
@@ -1187,11 +1330,49 @@ class VaultGraph:
                 related=related,
                 superseded_by=superseded_by,
                 step_id=step_id,
+                body_schema=body_schema,
             )
             snapshot[node.path] = (metadata, node.body)
         return snapshot
 
     # -- Metrics (networkx algorithms) ---------------------------------------
+
+    def counts(self, feature: str | None = None) -> GraphCounts:
+        """Return the cheap descriptive counts for the graph or a feature.
+
+        Produces exactly the ``total_nodes``, ``total_edges``, and
+        ``total_features`` values :meth:`metrics` reports, without running
+        any of the graph-theoretic analysis (centrality, components,
+        density) that method bundles.  This is the surface render and
+        orientation paths use; :meth:`metrics` is the explicit opt-in for
+        analysis.
+
+        Args:
+            feature: When set, count only this feature's subgraph.
+
+        Returns:
+            A :class:`GraphCounts` instance.
+        """
+        if feature:
+            g = self.subgraph(feature=feature)
+            nodes: dict[str, DocNode] = {
+                n.name: n for n in self.get_feature_nodes(feature)
+            }
+        else:
+            g = self._digraph
+            nodes = self.nodes
+        phantom_count = 0
+        features: set[str] = set()
+        for node in nodes.values():
+            if node.phantom:
+                phantom_count += 1
+            elif node.feature:
+                features.add(node.feature)
+        return GraphCounts(
+            docs=g.number_of_nodes() - phantom_count,
+            links=g.number_of_edges(),
+            features=len(features),
+        )
 
     def metrics(
         self,
@@ -1199,12 +1380,13 @@ class VaultGraph:
         *,
         _g: nx.DiGraph | None = None,
     ) -> GraphMetrics:
-        """Compute aggregate statistics via networkx algorithms.
+        """Compute aggregate statistics via graph-library algorithms.
 
         Delegates to ``nx.density``, ``nx.in_degree_centrality``,
-        ``nx.betweenness_centrality``, and
-        ``nx.number_weakly_connected_components`` instead of manual
-        computation.
+        ``nx.number_weakly_connected_components``, and betweenness
+        centrality through the C-backed engine seam
+        (:func:`_betweenness_centrality`, ``rustworkx`` with a networkx
+        fallback) instead of manual computation.
 
         Args:
             feature: Compute metrics only for this feature's subgraph.
@@ -1255,7 +1437,7 @@ class VaultGraph:
         btwn_cent: dict[str, float] = {}
         if n_nodes > 1:
             in_cent = _top_n(nx.in_degree_centrality(g))
-            btwn_cent = _top_n(nx.betweenness_centrality(g))
+            btwn_cent = _top_n(_betweenness_centrality(g))
 
         # --- feature / type counts (excludes phantoms) ---
         features: set[str] = set()
@@ -1389,6 +1571,12 @@ class VaultGraph:
 
         return lines
 
+    #: Maximum lines the tree render prints.  The title always carries the
+    #: full corpus counts, the truncation is explicitly marked, and the
+    #: ``--json`` envelope remains the uncapped machine contract, per the
+    #: report-volume policy.
+    TREE_RENDER_CAP = 1000
+
     def render_tree(
         self,
         feature: str | None = None,
@@ -1397,24 +1585,36 @@ class VaultGraph:
 
         Renders the vault grouped by feature and doc-type via the plain-text
         shape vocabulary.  This is complementary to :meth:`render_ascii` which
-        shows the actual graph topology.
+        shows the actual graph topology.  At most :attr:`TREE_RENDER_CAP`
+        lines are printed; a marked truncation line reports the remainder and
+        points at feature scoping or ``--json``.
 
         Args:
             feature: Optional feature name to scope the tree.
         """
+        from vaultspec_core.cli.rendering import TreeLine
         from vaultspec_core.cli.rendering import render_tree as _render_tree
 
         if feature:
-            m = self.metrics(feature=feature)
-            title = f"#{feature}  {m.total_nodes} docs, {m.total_edges} links"
+            c = self.counts(feature=feature)
+            title = f"#{feature}  {c.docs} docs, {c.links} links"
         else:
-            m = self.metrics()
-            title = (
-                f".vault  {m.total_nodes} docs, "
-                f"{m.total_edges} links, {m.total_features} features"
-            )
+            c = self.counts()
+            title = f".vault  {c.docs} docs, {c.links} links, {c.features} features"
 
-        _render_tree(self.render_tree_lines(feature=feature), title=title)
+        lines = self.render_tree_lines(feature=feature)
+        if len(lines) > self.TREE_RENDER_CAP:
+            remainder = len(lines) - self.TREE_RENDER_CAP
+            lines = [
+                *lines[: self.TREE_RENDER_CAP],
+                TreeLine(
+                    f"... {remainder} more lines truncated; scope with "
+                    "--feature <name> or use --json for the full graph",
+                    depth=0,
+                    style="dim",
+                ),
+            ]
+        _render_tree(lines, title=title)
 
     def _build_typed_node_lines(
         self,

--- a/src/vaultspec_core/graph/cache.py
+++ b/src/vaultspec_core/graph/cache.py
@@ -7,8 +7,9 @@ link resolution, and the PageRank pass.  This module caches the *built*
 canonical graph beside a fingerprint manifest so that an unchanged corpus
 loads the serialised graph instead of re-parsing.
 
-The cache is an optimisation and must be **sound**: a stale cache is never
-trusted.  Soundness rests on three guards, in order of strength:
+The cache is an optimisation and must stay **sound** without its own
+validation costing more than the rebuild it avoids.  Soundness rests on
+three guards, applied per git's racily-clean rule:
 
 1. **File-set equality.**  The manifest fingerprints the complete set of
    scanned ``.md`` files.  A file added or removed since the cache was
@@ -16,23 +17,29 @@ trusted.  Soundness rests on three guards, in order of strength:
    surviving file changed.
 2. **Per-file size and mtime.**  Each file carries ``(st_size,
    st_mtime_ns)`` - the same primitive the repair pipeline uses in
-   :mod:`vaultspec_core.vaultcore.repair`.  This is the cheap fast-path
-   guard: almost every real edit changes the size or the modification time.
-3. **Per-file content hash.**  Each file also carries a SHA-256 of its
-   bytes.  ``st_mtime_ns`` resolution can theoretically miss a same-size
-   edit applied within a single timestamp tick, so the content hash closes
-   that window: validation requires the size, the mtime, *and* the hash to
-   match.  The hash is read-once per file during fingerprinting, which is
-   strictly cheaper than the parse-and-build the cache avoids, so it is
-   always computed rather than gated behind a flag.
+   :mod:`vaultspec_core.vaultcore.repair`.  A size or mtime divergence is
+   always a miss, and a match is *trusted* for any file whose mtime is
+   strictly older than the cache file's own mtime: such a file cannot have
+   been edited after the manifest recorded it without moving its mtime.
+3. **Per-file content hash, racily-clean files only.**  A file whose mtime
+   is not older than the cache write ("racy": edited within the same
+   timestamp tick the cache was written in, or under clock skew) cannot be
+   proven clean by stat alone, so exactly those files are re-hashed against
+   the manifest's stored SHA-256.  On nanosecond-resolution filesystems
+   (NTFS, ext4) the racy set is empty or near-empty; on coarse-resolution
+   filesystems it grows to cover the wider tick.  Passing ``deep=True``
+   hashes every file regardless - the explicit deep-verification path for
+   doctor-class diagnostics.
 
-:func:`validate` returns ``True`` only when the current file set and every
-per-file fingerprint match the manifest exactly.  Any divergence - a
-changed, added, or removed file, an absent cache, or a corrupt/unreadable
-cache file - is treated as a miss and forces a full rebuild.  The cache can
-therefore be safely always-on: it can never serve data that does not match
-the bytes currently on disk, and a corrupt cache degrades silently to a
-rebuild rather than crashing or serving garbage.
+:func:`validate` returns ``True`` only when the current file set matches
+the manifest and every per-file guard passes.  Any divergence - a changed,
+added, or removed file, an absent cache, or a corrupt/unreadable cache
+file - is treated as a miss and forces a full rebuild.  The accepted
+residual risk is a same-size edit that lands in the same mtime tick as a
+*document* write recorded in the manifest while the cache file itself
+carries a newer tick and the edit bypasses the mutating CLI verbs (which
+drop the cache file); that window is bounded by one filesystem timestamp
+tick and closable on demand with ``deep=True``.
 
 The serialised graph store is JSON (networkx node-link format) rather than
 pickle.  JSON is inspectable, diff-friendly, version-safe across Python
@@ -145,19 +152,29 @@ def _hash_file(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _manifest_key(path: Path, root_dir: Path) -> str:
+    """Return the stable vault-relative POSIX manifest key for *path*."""
+    try:
+        return path.relative_to(root_dir).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
 def fingerprint_vault(
     scanned_files: Iterable[Path],
     root_dir: Path,
 ) -> dict[str, Fingerprint]:
     """Compute the fingerprint manifest for the documents the graph consumes.
 
-    Keyed on the exact file set passed in (the same iterable the graph
-    build walks via ``scan_vault``) so the manifest cannot drift from the
-    corpus the cached graph was built over.  Each file contributes its
-    ``(st_size, st_mtime_ns, sha256_hex)`` fingerprint.  Files that cannot
-    be stat-ed or read are skipped: a vanished file simply does not appear
-    in the manifest, which is itself a file-set divergence that
-    :func:`validate` detects on the next build.
+    Called on the *save* path only, after a rebuild: the warm-read path
+    validates against the stored manifest with :func:`validate` and never
+    recomputes full hashes.  Keyed on the exact file set passed in (the
+    same iterable the graph build walks via ``scan_vault``) so the manifest
+    cannot drift from the corpus the cached graph was built over.  Each
+    file contributes its ``(st_size, st_mtime_ns, sha256_hex)``
+    fingerprint.  Files that cannot be stat-ed or read are skipped: a
+    vanished file simply does not appear in the manifest, which is itself a
+    file-set divergence that :func:`validate` detects on the next build.
 
     Args:
         scanned_files: The document paths the graph build observed (e.g.
@@ -174,41 +191,73 @@ def fingerprint_vault(
         except OSError:
             continue
         try:
-            key = path.relative_to(root_dir).as_posix()
-        except ValueError:
-            key = path.as_posix()
-        try:
             content_hash = _hash_file(path)
         except OSError:
             continue
-        manifest[key] = (stat.st_size, stat.st_mtime_ns, content_hash)
+        manifest[_manifest_key(path, root_dir)] = (
+            stat.st_size,
+            stat.st_mtime_ns,
+            content_hash,
+        )
     return manifest
 
 
 def validate(
     manifest: dict[str, Fingerprint],
-    current: dict[str, Fingerprint],
+    scanned_files: Iterable[Path],
+    root_dir: Path,
+    *,
+    cache_mtime_ns: int | None,
+    deep: bool = False,
 ) -> bool:
-    """Return ``True`` only when *current* matches the cached *manifest* exactly.
+    """Return ``True`` only when the corpus on disk still matches *manifest*.
 
-    The match is total: the two mappings must have the same set of keys
-    (so an added or removed file invalidates) and identical fingerprint
-    tuples for every key (so a changed size, mtime, or content hash
-    invalidates).  Any divergence returns ``False``, forcing a full
-    rebuild.  This is the single decision point behind "stale never
-    trusted".
+    Applies the racily-clean rule (see the module docstring): the file set
+    must be identical, every file's ``(st_size, st_mtime_ns)`` must match
+    the manifest, and files whose mtime is not older than *cache_mtime_ns*
+    (the cache file's own mtime) are additionally content-hashed against
+    the manifest because stat alone cannot prove them clean.  Any
+    divergence returns ``False``, forcing a full rebuild.
 
     Args:
         manifest: The fingerprint manifest stored in the cache.
-        current: The freshly-computed fingerprint manifest for the vault
-            as it exists on disk now.
+        scanned_files: The document paths of the vault as it exists on
+            disk now (e.g. the output of ``scan_vault``).
+        root_dir: Project root, used to derive stable vault-relative keys.
+        cache_mtime_ns: The cache file's ``st_mtime_ns``, the racily-clean
+            reference point.  ``None`` (unknown) treats every file as racy,
+            degrading to full hash validation - sound, never unsound.
+        deep: When ``True``, content-hash every file regardless of mtime -
+            the explicit deep-verification path.
 
     Returns:
-        ``True`` when the manifests are equal, ``False`` otherwise.
+        ``True`` when every guard passes for every file, ``False``
+        otherwise.
     """
-    if manifest.keys() != current.keys():
-        return False
-    return all(manifest[key] == current[key] for key in manifest)
+    seen: set[str] = set()
+    for path in scanned_files:
+        try:
+            stat = path.stat()
+        except OSError:
+            # A vanished file is absent from the seen set; the final
+            # file-set equality check reports the divergence.
+            continue
+        key = _manifest_key(path, root_dir)
+        seen.add(key)
+        entry = manifest.get(key)
+        if entry is None:
+            return False
+        size, mtime_ns, content_hash = entry
+        if stat.st_size != size or stat.st_mtime_ns != mtime_ns:
+            return False
+        racy = cache_mtime_ns is None or stat.st_mtime_ns >= cache_mtime_ns
+        if deep or racy:
+            try:
+                if _hash_file(path) != content_hash:
+                    return False
+            except OSError:
+                return False
+    return seen == manifest.keys()
 
 
 def load(path: Path) -> GraphCachePayload | None:

--- a/src/vaultspec_core/graph/tests/test_analysis_engine.py
+++ b/src/vaultspec_core/graph/tests/test_analysis_engine.py
@@ -1,0 +1,76 @@
+"""Engine parity for the opt-in betweenness analysis surface.
+
+The analysis seam routes betweenness centrality through the C-backed
+rustworkx engine with pure networkx as the fallback. Both engines
+implement Brandes with the same directed normalisation, so their scores
+must agree to float tolerance on a real corpus - this test runs BOTH real
+engines on the same built graph and compares, mock-free. A divergence
+means the seam changed semantics, not just speed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import networkx as nx
+import pytest
+
+from ...config import reset_config
+from ...testing.synthetic import build_synthetic_vault
+from ..api import VaultGraph, _betweenness_centrality
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def vault_root(tmp_path: Path) -> Path:
+    reset_config()
+    build_synthetic_vault(
+        tmp_path,
+        n_docs=60,
+        seed=29,
+        edge_probability=0.3,
+        pathologies=["cycle", "stem_collision"],
+    )
+    return tmp_path
+
+
+class TestEngineParity:
+    def test_rustworkx_is_active(self) -> None:
+        # The dependency is declared; the fallback exists only for
+        # platforms without the wheel, and this environment must exercise
+        # the real engine.
+        import rustworkx  # noqa: F401
+
+    def test_betweenness_matches_networkx(self, vault_root: Path) -> None:
+        graph = VaultGraph(vault_root, use_cache=False)
+        g = graph.subgraph()
+
+        seam = _betweenness_centrality(g)
+        reference = nx.betweenness_centrality(g)
+
+        assert seam.keys() == reference.keys()
+        for node, expected in reference.items():
+            assert seam[node] == pytest.approx(expected, abs=1e-12), node
+
+    def test_feature_subgraph_matches_networkx(self, vault_root: Path) -> None:
+        graph = VaultGraph(vault_root, use_cache=False)
+        feature = graph.get_features()[0]
+        g = graph.subgraph(feature=feature)
+
+        seam = _betweenness_centrality(g)
+        reference = nx.betweenness_centrality(g)
+
+        assert seam.keys() == reference.keys()
+        for node, expected in reference.items():
+            assert seam[node] == pytest.approx(expected, abs=1e-12), node
+
+    def test_metrics_scores_flow_through_seam(self, vault_root: Path) -> None:
+        graph = VaultGraph(vault_root, use_cache=False)
+        m = graph.metrics()
+        assert len(m.betweenness_centrality) > 0
+        for value in m.betweenness_centrality.values():
+            assert 0.0 <= value <= 1.0

--- a/src/vaultspec_core/graph/tests/test_cache.py
+++ b/src/vaultspec_core/graph/tests/test_cache.py
@@ -1,13 +1,19 @@
 """Correctness tests proving the graph fingerprint cache is never stale.
 
 Every test runs against a real on-disk synthetic vault with no mocks,
-patches, or ``time.sleep`` hacks.  The contract under test is "stale never
-trusted": a cache may only be served when the corpus on disk is byte-for-byte
-the corpus the cache was built over.  The tests prove each invalidation
-trigger independently:
+patches, or ``time.sleep`` hacks.  The contract under test is the
+racily-clean rule: a cache is served only when the file set matches, every
+file's size and mtime match the manifest, and any file whose mtime is not
+older than the cache file's own mtime additionally matches its stored
+content hash.  The tests prove each trigger independently:
 
-- a content edit (changed size, and changed content hash even at equal size)
-  forces a rebuild that reflects the new bytes;
+- a content edit (changed size or mtime) forces a rebuild that reflects the
+  new bytes;
+- a same-size edit on a racy file (mtime not older than the cache write) is
+  caught by the hash guard;
+- the accepted residual window - a same-size edit whose mtime is restored
+  below the cache write tick - is served stale by design and caught by the
+  explicit ``deep=True`` verification path;
 - an added file appears in the next build;
 - a removed file disappears from the next build;
 - a corrupt or truncated cache file degrades silently to a full rebuild;
@@ -22,6 +28,7 @@ rather than pass quietly.
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -67,11 +74,20 @@ def _word_count(graph: VaultGraph, name: str) -> int:
     return graph.nodes[name].word_count
 
 
-def _scanned_fingerprints(root: Path) -> dict[str, cache_mod.Fingerprint]:
-    """Fingerprint the current vault exactly as the graph build does."""
+def _validate_against_disk(root: Path, *, deep: bool = False) -> bool:
+    """Validate the on-disk cache against the corpus exactly as the build does."""
     from ...vaultcore import scan_vault
 
-    return cache_mod.fingerprint_vault(list(scan_vault(root)), root)
+    cache_file = cache_mod.cache_path(root)
+    payload = cache_mod.load(cache_file)
+    assert payload is not None
+    return cache_mod.validate(
+        payload.manifest,
+        list(scan_vault(root)),
+        root,
+        cache_mtime_ns=cache_file.stat().st_mtime_ns,
+        deep=deep,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -102,22 +118,20 @@ class TestContentChangeInvalidates:
         expected_words = original_words + len(added.split())
 
         # Sanity: validate must report the cache as stale now.
-        payload = cache_mod.load(cache_mod.cache_path(vault_root))
-        assert payload is not None
-        assert (
-            cache_mod.validate(payload.manifest, _scanned_fingerprints(vault_root))
-            is False
-        )
+        assert _validate_against_disk(vault_root) is False
 
         second = VaultGraph(vault_root)
         assert _word_count(second, target_name) == expected_words
         assert _word_count(second, target_name) != original_words
 
-    def test_same_size_edit_caught_by_content_hash(self, vault_root: Path) -> None:
-        # Build, then overwrite a real document with content of the SAME byte
-        # length but different bytes.  Size is unchanged; only the content
-        # hash differs.  This is the case the bare (size, mtime) guard could
-        # miss within one timestamp tick, and the hash must catch it.
+    def _same_size_title_flip(self, vault_root: Path) -> tuple[Path, str, str]:
+        """Build once and apply a same-size title edit with the mtime restored.
+
+        Overwrites a real document with content of the SAME byte length but
+        different bytes, then restores the file's original ``(atime, mtime)``
+        with ``os.utime`` so the stat guard cannot see the edit.  Returns the
+        edited path, the node name, and the flipped title text.
+        """
         first = VaultGraph(vault_root)
         target_name = next(
             name
@@ -126,13 +140,11 @@ class TestContentChangeInvalidates:
         )
         target_path = first.nodes[target_name].path
         assert target_path is not None
+        original_stat = target_path.stat()
         original_text = target_path.read_text(encoding="utf-8")
         original_title = first.nodes[target_name].title
         assert original_title is not None
 
-        # Flip a single character in the title heading, preserving length.
-        # The title starts with "# "; replace the first title letter so the
-        # parsed title text changes but the byte count does not.
         marker = f"# {original_title}"
         assert marker in original_text
         first_letter = original_title[0]
@@ -144,16 +156,43 @@ class TestContentChangeInvalidates:
         )
         assert len(mutated.encode("utf-8")) == len(original_text.encode("utf-8"))
         target_path.write_text(mutated, encoding="utf-8")
+        os.utime(
+            target_path,
+            ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+        )
+        return target_path, target_name, f"{flipped}{original_title[1:]}"
 
-        current = _scanned_fingerprints(vault_root)
-        payload = cache_mod.load(cache_mod.cache_path(vault_root))
-        assert payload is not None
-        # The size+mtime alone could collide; the content hash differs, so
-        # validation must reject the cache.
-        assert cache_mod.validate(payload.manifest, current) is False
+    def test_same_size_racy_edit_caught_by_content_hash(self, vault_root: Path) -> None:
+        # A same-size, same-mtime edit on a RACY file (file mtime not older
+        # than the cache file's mtime) must be caught by the hash guard.
+        # Age the cache file below the document's restored mtime so the
+        # racily-clean rule classifies the document as racy.
+        target_path, target_name, flipped_title = self._same_size_title_flip(vault_root)
+        cache_file = cache_mod.cache_path(vault_root)
+        doc_mtime_ns = target_path.stat().st_mtime_ns
+        cache_stat = cache_file.stat()
+        os.utime(cache_file, ns=(cache_stat.st_atime_ns, doc_mtime_ns))
+
+        assert _validate_against_disk(vault_root) is False
 
         second = VaultGraph(vault_root)
-        assert second.nodes[target_name].title == f"{flipped}{original_title[1:]}"
+        assert second.nodes[target_name].title == flipped_title
+
+    def test_same_size_non_racy_edit_is_accepted_stale_until_deep(
+        self, vault_root: Path
+    ) -> None:
+        # The ADR-accepted residual window: a same-size edit whose mtime is
+        # restored below the cache write tick passes stat validation and is
+        # served stale by design.  The explicit deep verification path must
+        # still catch it.
+        self._same_size_title_flip(vault_root)
+        cache_file = cache_mod.cache_path(vault_root)
+        assert cache_file.stat().st_mtime_ns > max(
+            p.stat().st_mtime_ns for p in (vault_root / ".vault").rglob("*.md")
+        )
+
+        assert _validate_against_disk(vault_root) is True
+        assert _validate_against_disk(vault_root, deep=True) is False
 
 
 # ---------------------------------------------------------------------------
@@ -271,10 +310,8 @@ class TestCacheHitIsIdentical:
 
     def test_cache_hit_validates(self, vault_root: Path) -> None:
         VaultGraph(vault_root)
-        payload = cache_mod.load(cache_mod.cache_path(vault_root))
-        assert payload is not None
         # Unchanged corpus: validation must pass.
-        assert cache_mod.validate(payload.manifest, _scanned_fingerprints(vault_root))
+        assert _validate_against_disk(vault_root) is True
 
 
 # ---------------------------------------------------------------------------
@@ -332,83 +369,137 @@ class TestCliMutationRefreshesCache:
 
 
 # ---------------------------------------------------------------------------
-# (g) validate() content-hash guard - pure unit tests
+# (g) validate() racily-clean guards - real-file unit tests
 # ---------------------------------------------------------------------------
 
 
-class TestValidateHashGuard:
-    """Isolate the content-hash guard in :func:`~vaultspec_core.graph.cache.validate`.
+class TestValidateRacilyClean:
+    """Isolate each guard in :func:`~vaultspec_core.graph.cache.validate`.
 
-    These tests call ``validate`` directly with hand-built manifest dicts so
-    the hash guard is exercised independently of mtime or size changes, which
-    is the scenario the existing filesystem-level test
-    ``test_same_size_edit_caught_by_content_hash`` cannot isolate (a real
-    write also bumps mtime, so the size-or-mtime guard fires first).
+    Every case runs against real files under ``tmp_path`` with real stat
+    values; mtimes are steered with ``os.utime`` (a real filesystem
+    operation) so the racy and non-racy branches are each exercised
+    deliberately.
     """
 
-    def test_identical_fingerprints_validate(self) -> None:
-        # Same size, same mtime, same hash: valid.
-        manifest: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h1")}
-        current: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h1")}
-        assert cache_mod.validate(manifest, current) is True
+    def _corpus(
+        self, tmp_path: Path
+    ) -> tuple[list[Path], dict[str, cache_mod.Fingerprint]]:
+        a = tmp_path / "a.md"
+        b = tmp_path / "b.md"
+        a.write_text("alpha document body\n", encoding="utf-8")
+        b.write_text("beta document body\n", encoding="utf-8")
+        files = [a, b]
+        return files, cache_mod.fingerprint_vault(files, tmp_path)
 
-    def test_different_hash_invalidates(self) -> None:
-        # Identical size and mtime, different hash: must invalidate.
-        manifest: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h1")}
-        current: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h2")}
-        assert cache_mod.validate(manifest, current) is False
+    @staticmethod
+    def _max_mtime_ns(files: list[Path]) -> int:
+        return max(p.stat().st_mtime_ns for p in files)
 
-    def test_different_size_invalidates(self) -> None:
-        manifest: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h1")}
-        current: dict[str, cache_mod.Fingerprint] = {"a.md": (11, 5, "h1")}
-        assert cache_mod.validate(manifest, current) is False
+    def test_unchanged_corpus_validates_without_racy_files(
+        self, tmp_path: Path
+    ) -> None:
+        files, manifest = self._corpus(tmp_path)
+        newer = self._max_mtime_ns(files) + 1
+        assert (
+            cache_mod.validate(manifest, files, tmp_path, cache_mtime_ns=newer) is True
+        )
 
-    def test_different_mtime_invalidates(self) -> None:
-        manifest: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h1")}
-        current: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 6, "h1")}
-        assert cache_mod.validate(manifest, current) is False
+    def test_unknown_cache_mtime_degrades_to_full_hash_and_validates(
+        self, tmp_path: Path
+    ) -> None:
+        files, manifest = self._corpus(tmp_path)
+        assert (
+            cache_mod.validate(manifest, files, tmp_path, cache_mtime_ns=None) is True
+        )
 
-    def test_added_key_invalidates(self) -> None:
-        manifest: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h1")}
-        current: dict[str, cache_mod.Fingerprint] = {
-            "a.md": (10, 5, "h1"),
-            "b.md": (20, 7, "h2"),
-        }
-        assert cache_mod.validate(manifest, current) is False
+    def test_size_change_invalidates(self, tmp_path: Path) -> None:
+        files, manifest = self._corpus(tmp_path)
+        files[0].write_text("alpha document body grown\n", encoding="utf-8")
+        newer = self._max_mtime_ns(files) + 1
+        assert (
+            cache_mod.validate(manifest, files, tmp_path, cache_mtime_ns=newer) is False
+        )
 
-    def test_removed_key_invalidates(self) -> None:
-        manifest: dict[str, cache_mod.Fingerprint] = {
-            "a.md": (10, 5, "h1"),
-            "b.md": (20, 7, "h2"),
-        }
-        current: dict[str, cache_mod.Fingerprint] = {"a.md": (10, 5, "h1")}
-        assert cache_mod.validate(manifest, current) is False
+    def test_mtime_change_invalidates(self, tmp_path: Path) -> None:
+        # Bump by a full second: below-filesystem-resolution deltas (e.g.
+        # +1ns on NTFS's 100ns clock) are silently rounded away by utime.
+        files, manifest = self._corpus(tmp_path)
+        stat = files[0].stat()
+        os.utime(files[0], ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000_000))
+        newer = self._max_mtime_ns(files) + 1
+        assert (
+            cache_mod.validate(manifest, files, tmp_path, cache_mtime_ns=newer) is False
+        )
 
-    def test_empty_manifests_validate(self) -> None:
-        assert cache_mod.validate({}, {}) is True
+    def test_racy_same_size_edit_caught_by_hash(self, tmp_path: Path) -> None:
+        # Same byte count, same restored mtime: only the hash differs.  With
+        # the cache reference at or below the file's mtime the file is racy
+        # and the hash guard must fire.
+        files, manifest = self._corpus(tmp_path)
+        stat = files[0].stat()
+        files[0].write_text("ALPHA document body\n", encoding="utf-8")
+        os.utime(files[0], ns=(stat.st_atime_ns, stat.st_mtime_ns))
+        assert (
+            cache_mod.validate(
+                manifest, files, tmp_path, cache_mtime_ns=stat.st_mtime_ns
+            )
+            is False
+        )
 
-    def test_multiple_keys_all_match(self) -> None:
-        manifest: dict[str, cache_mod.Fingerprint] = {
-            "a.md": (10, 5, "h1"),
-            "b.md": (20, 7, "h2"),
-        }
-        current: dict[str, cache_mod.Fingerprint] = {
-            "a.md": (10, 5, "h1"),
-            "b.md": (20, 7, "h2"),
-        }
-        assert cache_mod.validate(manifest, current) is True
+    def test_non_racy_same_size_edit_is_accepted_until_deep(
+        self, tmp_path: Path
+    ) -> None:
+        # The accepted residual window: with the cache reference newer than
+        # the file's restored mtime, stat validation trusts the file; the
+        # explicit deep path still catches the edit.
+        files, manifest = self._corpus(tmp_path)
+        stat = files[0].stat()
+        files[0].write_text("ALPHA document body\n", encoding="utf-8")
+        os.utime(files[0], ns=(stat.st_atime_ns, stat.st_mtime_ns))
+        newer = self._max_mtime_ns(files) + 1
+        assert (
+            cache_mod.validate(manifest, files, tmp_path, cache_mtime_ns=newer) is True
+        )
+        assert (
+            cache_mod.validate(
+                manifest, files, tmp_path, cache_mtime_ns=newer, deep=True
+            )
+            is False
+        )
 
-    def test_multiple_keys_one_hash_differs(self) -> None:
-        # One entry has same size+mtime but different hash: must invalidate.
-        manifest: dict[str, cache_mod.Fingerprint] = {
-            "a.md": (10, 5, "h1"),
-            "b.md": (20, 7, "h2"),
-        }
-        current: dict[str, cache_mod.Fingerprint] = {
-            "a.md": (10, 5, "h1"),
-            "b.md": (20, 7, "h2-changed"),
-        }
-        assert cache_mod.validate(manifest, current) is False
+    def test_added_file_invalidates(self, tmp_path: Path) -> None:
+        files, manifest = self._corpus(tmp_path)
+        extra = tmp_path / "c.md"
+        extra.write_text("gamma document body\n", encoding="utf-8")
+        newer = self._max_mtime_ns([*files, extra]) + 1
+        assert (
+            cache_mod.validate(
+                manifest, [*files, extra], tmp_path, cache_mtime_ns=newer
+            )
+            is False
+        )
+
+    def test_removed_file_invalidates(self, tmp_path: Path) -> None:
+        files, manifest = self._corpus(tmp_path)
+        newer = self._max_mtime_ns(files) + 1
+        assert (
+            cache_mod.validate(manifest, files[:1], tmp_path, cache_mtime_ns=newer)
+            is False
+        )
+
+    def test_vanished_file_invalidates(self, tmp_path: Path) -> None:
+        # The scanned list still names the file, but it is gone from disk:
+        # the file-set equality check must report the divergence.
+        files, manifest = self._corpus(tmp_path)
+        files[0].unlink()
+        newer = self._max_mtime_ns(files[1:]) + 1
+        assert (
+            cache_mod.validate(manifest, files, tmp_path, cache_mtime_ns=newer) is False
+        )
+
+    def test_empty_corpus_validates(self, tmp_path: Path) -> None:
+        assert cache_mod.validate({}, [], tmp_path, cache_mtime_ns=None) is True
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaultspec_core/graph/tests/test_counts.py
+++ b/src/vaultspec_core/graph/tests/test_counts.py
@@ -1,0 +1,88 @@
+"""Tests for the descriptive-counts surface and its render-path contract.
+
+Two invariants from the counts-vs-analysis split:
+
+1. :meth:`~vaultspec_core.graph.api.VaultGraph.counts` reports exactly the
+   ``total_nodes``, ``total_edges``, and ``total_features`` values
+   :meth:`~vaultspec_core.graph.api.VaultGraph.metrics` reports, scoped and
+   unscoped, so the tree title is byte-identical to what the conflated path
+   produced.
+2. The render path never invokes graph-theoretic analysis.  This is
+   asserted by counting real calls with ``sys.setprofile`` - observation of
+   the genuine execution, not a stub - while ``render_tree`` runs.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ...config import reset_config
+from ...testing.synthetic import build_synthetic_vault
+from ..api import VaultGraph
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def vault_root(tmp_path: Path) -> Path:
+    reset_config()
+    build_synthetic_vault(
+        tmp_path,
+        n_docs=40,
+        seed=13,
+        pathologies=["cycle", "stem_collision", "phantom_only_links"],
+    )
+    return tmp_path
+
+
+class TestCountsMatchMetrics:
+    def test_unscoped_counts_equal_metrics(self, vault_root: Path) -> None:
+        graph = VaultGraph(vault_root, use_cache=False)
+        c = graph.counts()
+        m = graph.metrics()
+        assert c.docs == m.total_nodes
+        assert c.links == m.total_edges
+        assert c.features == m.total_features
+        assert c.docs > 0
+        assert c.features > 0
+
+    def test_feature_scoped_counts_equal_metrics(self, vault_root: Path) -> None:
+        graph = VaultGraph(vault_root, use_cache=False)
+        for feature in graph.get_features():
+            c = graph.counts(feature=feature)
+            m = graph.metrics(feature=feature)
+            assert c.docs == m.total_nodes, feature
+            assert c.links == m.total_edges, feature
+
+
+class TestRenderPathBuysNoAnalysis:
+    def test_render_tree_never_calls_centrality(
+        self, vault_root: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        graph = VaultGraph(vault_root, use_cache=False)
+        analysis_calls: list[str] = []
+
+        def profiler(frame, event: str, arg: object) -> None:
+            if event == "call" and frame.f_code.co_name in (
+                "betweenness_centrality",
+                "in_degree_centrality",
+                "metrics",
+            ):
+                analysis_calls.append(frame.f_code.co_name)
+
+        sys.setprofile(profiler)
+        try:
+            graph.render_tree()
+            graph.render_tree(feature=graph.get_features()[0])
+        finally:
+            sys.setprofile(None)
+
+        assert analysis_calls == []
+        out = capsys.readouterr().out
+        assert " docs, " in out and " links" in out

--- a/src/vaultspec_core/graph/tests/test_graph.py
+++ b/src/vaultspec_core/graph/tests/test_graph.py
@@ -586,6 +586,26 @@ class TestVaultGraphPhantom:
         snapshot_stems = {p.stem for p in snapshot}
         assert not phantom_names & snapshot_stems
 
+    def test_to_snapshot_preserves_body_schema(self, tmp_path):
+        doc = tmp_path / ".vault" / "adr" / "2026-07-27-schema-provenance-adr.md"
+        doc.parent.mkdir(parents=True)
+        doc.write_text(
+            "---\n"
+            "tags:\n"
+            "  - '#adr'\n"
+            "  - '#schema-provenance'\n"
+            "date: '2026-07-27'\n"
+            "body_schema: 'body-v1'\n"
+            "related: []\n"
+            "---\n"
+            "# Schema provenance\n",
+            encoding="utf-8",
+        )
+
+        snapshot = VaultGraph(tmp_path).to_snapshot()
+
+        assert snapshot[doc][0].body_schema == "body-v1"
+
     def test_metrics_phantom_count(self, vault_root):
         graph = VaultGraph(vault_root)
         m = graph.metrics()

--- a/src/vaultspec_core/mcp_server/tools/documents.py
+++ b/src/vaultspec_core/mcp_server/tools/documents.py
@@ -601,10 +601,11 @@ def _edit_result_to_item(
 def _regenerate_indexes(root_dir: Path, features: set[str]) -> None:
     """Regenerate the feature index for every feature touched by a batch.
 
-    The graph is built with the cache bypassed so the freshly-written
-    documents are seen; index generation is the automatic side effect the
-    ADR folds into ``create``, absorbing the manual ``vault feature index``
-    call class.
+    The graph is built through the fingerprint cache: the freshly-written
+    documents change their files' size or mtime, so validation misses and
+    the rebuild sees them, while the refreshed cache warms the next read.
+    Index generation is the automatic side effect the ADR folds into
+    ``create``, absorbing the manual ``vault feature index`` call class.
 
     Args:
         root_dir: The project root.
@@ -613,7 +614,7 @@ def _regenerate_indexes(root_dir: Path, features: set[str]) -> None:
     from ...graph import VaultGraph
     from ...vaultcore.index import generate_feature_index
 
-    graph = VaultGraph(root_dir, use_cache=False)
+    graph = VaultGraph(root_dir)
     for feature in sorted(features):
         nodes = graph.get_feature_nodes(feature)
         if nodes:

--- a/src/vaultspec_core/tests/cli/test_batch_archive_cli.py
+++ b/src/vaultspec_core/tests/cli/test_batch_archive_cli.py
@@ -37,13 +37,13 @@ def _write_research(root: Path) -> Path:
     return path
 
 
-def _run(root: Path, manifest: Path, *args: str):
+def _run(root: Path, manifest: Path, *args: str, command: str = "documents"):
     return CliRunner(env={"NO_COLOR": "1"}).invoke(
         app,
         [
             "vault",
             "archive",
-            "documents",
+            command,
             "--manifest",
             str(manifest),
             *args,
@@ -95,3 +95,105 @@ def test_manifest_archive_dry_run_then_apply_uses_real_filesystem(
     assert archive_path.read_text(encoding="utf-8").endswith(
         "The record is retained before it is archived.\n"
     )
+
+
+def test_manifest_restore_dry_run_then_apply_uses_real_filesystem(
+    tmp_path: Path,
+) -> None:
+    WorkspaceFactory(tmp_path).install()
+    archived = (
+        tmp_path
+        / ".vault"
+        / "_archive"
+        / "research"
+        / "2026-07-27-batch-archive-research.md"
+    )
+    archived.parent.mkdir(parents=True)
+    source = _write_research(tmp_path)
+    archived.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    source.unlink()
+    live_path = tmp_path / ".vault" / "research" / archived.name
+    manifest = tmp_path / "restore-manifest.txt"
+    manifest.write_text(
+        ".vault/_archive/research/2026-07-27-batch-archive-research.md\n",
+        encoding="utf-8",
+    )
+
+    preview = _run(tmp_path, manifest, "--dry-run", "--json", command="restore")
+
+    assert preview.exit_code == 0, preview.output
+    preview_data = json.loads(preview.output)
+    assert preview_data["schema"] == "vaultspec.vault.archive.restore.v1"
+    assert preview_data["status"] == "unchanged"
+    assert preview_data["data"] == {
+        "status": "unchanged",
+        "restored_count": 1,
+        "paths": [".vault/research/2026-07-27-batch-archive-research.md"],
+        "deduplicated_count": 0,
+        "deduplicated_paths": [],
+        "cross_link_paths": [],
+        "dry_run": True,
+    }
+    assert archived.is_file()
+    assert not live_path.exists()
+
+    applied = _run(tmp_path, manifest, "--json", command="restore")
+
+    assert applied.exit_code == 0, applied.output
+    applied_data = json.loads(applied.output)
+    assert applied_data["schema"] == "vaultspec.vault.archive.restore.v1"
+    assert applied_data["status"] == "updated"
+    assert applied_data["data"]["dry_run"] is False
+    assert applied_data["data"]["restored_count"] == 1
+    assert not archived.exists()
+    assert live_path.read_text(encoding="utf-8").endswith(
+        "The record is retained before it is archived.\n"
+    )
+
+
+def test_restore_json_error_is_parseable_and_does_not_move_the_source(
+    tmp_path: Path,
+) -> None:
+    WorkspaceFactory(tmp_path).install()
+    archived = (
+        tmp_path
+        / ".vault"
+        / "_archive"
+        / "research"
+        / "2026-07-27-batch-archive-research.md"
+    )
+    archived.parent.mkdir(parents=True)
+    source = _write_research(tmp_path)
+    archived.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    manifest = tmp_path / "restore-manifest.txt"
+    manifest.write_text(
+        ".vault/_archive/research/2026-07-27-batch-archive-research.md\n",
+        encoding="utf-8",
+    )
+
+    result = _run(tmp_path, manifest, "--json", command="restore")
+
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["schema"] == "vaultspec.error.v1"
+    assert data["status"] == "failed"
+    assert "destination already exists" in data["data"]["message"]
+    assert archived.is_file()
+
+    deduplicated = _run(
+        tmp_path,
+        manifest,
+        "--deduplicate-identical",
+        "--json",
+        command="restore",
+    )
+
+    assert deduplicated.exit_code == 0, deduplicated.output
+    deduplicated_data = json.loads(deduplicated.output)
+    assert deduplicated_data["schema"] == "vaultspec.vault.archive.restore.v1"
+    assert deduplicated_data["data"]["restored_count"] == 0
+    assert deduplicated_data["data"]["deduplicated_count"] == 1
+    assert deduplicated_data["data"]["deduplicated_paths"] == [
+        ".vault/_archive/research/2026-07-27-batch-archive-research.md"
+    ]
+    assert not archived.exists()

--- a/src/vaultspec_core/tests/cli/test_doctor.py
+++ b/src/vaultspec_core/tests/cli/test_doctor.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING
 
 import pytest
+from typer.testing import CliRunner
 
+from vaultspec_core.cli import app
 from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from typer.testing import Result
 
 pytestmark = [pytest.mark.unit]
 
@@ -307,3 +312,169 @@ class TestDoctorGateErrors:
         assert result.exit_code == 0, result.output
         # The report still records the warning; only the exit code is folded.
         assert json.loads(result.output)["data"]["providers"]
+
+
+# ---- Target precedence -------------------------------------------------------
+
+#: Filename of the deliberately malformed document the vault-half tests plant.
+#: Its directory tag contradicts its directory, so every checker pass over the
+#: workspace holding it names it - and no pass over the other workspace can.
+PROBE_DOC = "2026-05-15-target-probe-research.md"
+
+
+def _workspace(root: Path, *, corrupt: bool = False) -> Path:
+    """Install a real workspace at *root*, optionally corrupting its manifest."""
+    root.mkdir(parents=True, exist_ok=True)
+    factory = WorkspaceFactory(root)
+    factory.install("core")
+    if corrupt:
+        factory.corrupt_manifest()
+    return root
+
+
+def _plant_probe_doc(root: Path) -> None:
+    """Write one vault document whose directory tag contradicts its directory."""
+    doc = root / ".vault" / "research" / PROBE_DOC
+    doc.parent.mkdir(parents=True, exist_ok=True)
+    doc.write_text(
+        "---\n"
+        "tags:\n"
+        "  - '#plan'\n"
+        "  - '#target-probe'\n"
+        "date: '2026-05-15'\n"
+        "modified: '2026-05-15'\n"
+        "related: []\n"
+        "---\n"
+        "\n"
+        "# `target-probe` research: probe\n",
+        encoding="utf-8",
+    )
+
+
+def _run_from(cwd: Path, *args: str) -> Result:
+    """Invoke the real CLI with *cwd* as the process working directory."""
+    from vaultspec_core.console import reset_console
+
+    reset_console()
+    runner = CliRunner(env={"NO_COLOR": "1"})
+    previous_cwd = os.getcwd()
+    os.chdir(cwd)
+    try:
+        return runner.invoke(app, list(args))
+    finally:
+        os.chdir(previous_cwd)
+
+
+class TestDoctorTargetPrecedence:
+    """``--target`` at either flag position selects the diagnosed directory.
+
+    The documented priority is subcommand ``--target`` > root-level ``-t`` >
+    current working directory. A CI invocation that puts the flag before the
+    verb must therefore diagnose the named directory, never the process
+    working directory: diagnosing the wrong tree reports someone else's
+    health and exits on someone else's findings, which reads as a pass.
+
+    Each test installs two real workspaces, runs the real CLI from inside
+    one of them, and asserts on the other's diagnosis.
+    """
+
+    def test_spec_doctor_honours_root_level_target_over_cwd(
+        self, tmp_path: Path
+    ) -> None:
+        healthy = _workspace(tmp_path / "healthy")
+        broken = _workspace(tmp_path / "broken", corrupt=True)
+
+        result = _run_from(healthy, "-t", str(broken), "spec", "doctor", "--json")
+
+        assert result.exit_code == 2, result.output
+        assert json.loads(result.output)["data"]["framework"] == "corrupted"
+
+    def test_spec_doctor_subcommand_target_overrides_root_level(
+        self, tmp_path: Path
+    ) -> None:
+        healthy = _workspace(tmp_path / "healthy")
+        broken = _workspace(tmp_path / "broken", corrupt=True)
+
+        result = _run_from(
+            broken,
+            "-t",
+            str(broken),
+            "spec",
+            "doctor",
+            "--target",
+            str(healthy),
+            "--json",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["data"]["framework"] == "present"
+
+    def test_spec_doctor_falls_back_to_cwd_without_any_target(
+        self, tmp_path: Path
+    ) -> None:
+        _workspace(tmp_path / "healthy")
+        broken = _workspace(tmp_path / "broken", corrupt=True)
+
+        result = _run_from(broken, "spec", "doctor", "--json")
+
+        assert result.exit_code == 2, result.output
+        assert json.loads(result.output)["data"]["framework"] == "corrupted"
+
+    def test_doctor_honours_root_level_target_over_cwd(self, tmp_path: Path) -> None:
+        healthy = _workspace(tmp_path / "healthy")
+        broken = _workspace(tmp_path / "broken", corrupt=True)
+
+        result = _run_from(healthy, "-t", str(broken), "doctor", "--json")
+
+        assert result.exit_code == 2, result.output
+        data = json.loads(result.output)["data"]
+        assert data["spec"]["framework"] == "corrupted"
+
+    def test_doctor_subcommand_target_overrides_root_level(
+        self, tmp_path: Path
+    ) -> None:
+        healthy = _workspace(tmp_path / "healthy")
+        broken = _workspace(tmp_path / "broken", corrupt=True)
+
+        result = _run_from(
+            broken, "-t", str(broken), "doctor", "--target", str(healthy), "--json"
+        )
+
+        data = json.loads(result.output)["data"]
+        assert data["spec"]["framework"] == "present", result.output
+
+    def test_doctor_falls_back_to_cwd_without_any_target(self, tmp_path: Path) -> None:
+        _workspace(tmp_path / "healthy")
+        broken = _workspace(tmp_path / "broken", corrupt=True)
+
+        result = _run_from(broken, "doctor", "--json")
+
+        assert result.exit_code == 2, result.output
+        data = json.loads(result.output)["data"]
+        assert data["spec"]["framework"] == "corrupted"
+
+    def test_doctor_vault_checks_run_against_root_level_target(
+        self, tmp_path: Path
+    ) -> None:
+        clean = _workspace(tmp_path / "clean")
+        flawed = _workspace(tmp_path / "flawed")
+        _plant_probe_doc(flawed)
+
+        result = _run_from(clean, "-t", str(flawed), "doctor", "--json")
+
+        # The vault half runs over the target, so its findings name the
+        # document that exists only there.
+        assert PROBE_DOC in result.output, result.output
+
+    def test_doctor_vault_checks_ignore_cwd_when_target_given(
+        self, tmp_path: Path
+    ) -> None:
+        clean = _workspace(tmp_path / "clean")
+        flawed = _workspace(tmp_path / "flawed")
+        _plant_probe_doc(flawed)
+
+        result = _run_from(flawed, "-t", str(clean), "doctor", "--json")
+
+        # The working directory holds the flawed document; the target does
+        # not, so no finding may name it.
+        assert PROBE_DOC not in result.output, result.output

--- a/src/vaultspec_core/tests/cli/test_vault_edit.py
+++ b/src/vaultspec_core/tests/cli/test_vault_edit.py
@@ -18,6 +18,8 @@ Coverage:
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -190,6 +192,39 @@ class TestSetBody:
         # the exact failure that an un-normalized stdin \r\n produces when the
         # write path re-applies a CRLF source newline.
         assert b"\r\r" not in on_disk
+
+    def test_stdin_channel_preserves_legacy_c1_byte(self, tmp_path):
+        """A real CLI process must retain a legacy byte during body replacement."""
+        root = _make_vault(tmp_path)
+        document = _doc(root)
+        original = document.read_bytes()
+        source_newline = b"\r\n" if b"\r\n" in original else b"\n"
+        expected_hash = git_blob_oid(original)
+        body = b"\n# Demo ADR\n\nLegacy byte: \x90\n"
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "vaultspec_core",
+                "--target",
+                str(root),
+                "vault",
+                "set-body",
+                "2026-01-01-alpha-adr",
+                "--body-stdin",
+                "--expected-blob-hash",
+                expected_hash,
+                "--json",
+            ],
+            input=body,
+            capture_output=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr.decode("utf-8", "replace")
+        assert json.loads(result.stdout)["status"] == "updated"
+        assert document.read_bytes().endswith(body.replace(b"\n", source_newline))
 
     def test_refuse_on_error_leaves_file_unchanged(self, runner, tmp_path):
         root = _make_vault(tmp_path)

--- a/src/vaultspec_core/tests/cli/test_vault_repair.py
+++ b/src/vaultspec_core/tests/cli/test_vault_repair.py
@@ -424,10 +424,23 @@ class TestVaultRepair:
             for diag in result.diagnostics
             if diag.severity == "warning"
         ]
+        # The fixture is deliberately legacy-shaped: its documents predate the
+        # body_schema declaration, and provenance attestation requires a
+        # hash-attested baseline entry that the repair pipeline cannot
+        # synthesise. Those three warnings survive repair by design.
         assert postcheck_warnings == [
             "Feature 'state-mutation' has no feature index. Run "
             "vaultspec-core vault feature index to generate "
-            "index/state-mutation.index.md"
+            "index/state-mutation.index.md",
+            "Body schema provenance is not attested: "
+            "2026-05-15-state-mutation-adr.md does not declare a body_schema; "
+            "it requires a hash-attested legacy baseline entry.",
+            "Body schema provenance is not attested: "
+            "2026-05-15-state-mutation-plan.md does not declare a body_schema; "
+            "it requires a hash-attested legacy baseline entry.",
+            "Body schema provenance is not attested: "
+            "2026-05-15-state-mutation-research.md does not declare a "
+            "body_schema; it requires a hash-attested legacy baseline entry.",
         ]
 
     def test_repair_changed_files_tracks_cascaded_tmp_workspace_mutations(
@@ -445,7 +458,21 @@ class TestVaultRepair:
         )
 
         assert run.error_count == 0
-        assert run.warning_count == 0
+        # Repair generates the feature index, so the only surviving warnings
+        # are the body-schema provenance findings the fixture's legacy-shaped
+        # documents cannot clear without a hash-attested baseline entry.
+        residual_warnings = [
+            diag.message
+            for result in run.postcheck
+            for diag in result.diagnostics
+            if diag.severity == "warning"
+        ]
+        assert [
+            message
+            for message in residual_warnings
+            if not message.startswith("Body schema provenance is not attested:")
+        ] == []
+        assert len(residual_warnings) == 3
         assert ".vault/plan/2026-05-15-state-mutation-plan.md" in run.changed_files
         assert ".vault/adr/2026-05-15-state-mutation-adr.md" in run.changed_files
         assert (

--- a/src/vaultspec_core/tests/scale/__init__.py
+++ b/src/vaultspec_core/tests/scale/__init__.py
@@ -1,0 +1,1 @@
+"""Synthetic-corpus complexity regression gate."""

--- a/src/vaultspec_core/tests/scale/test_scale_gate.py
+++ b/src/vaultspec_core/tests/scale/test_scale_gate.py
@@ -1,0 +1,118 @@
+"""Complexity budgets for the check pipeline, asserted as operation counts.
+
+The scale gate enforces the complexity budgets mechanically and
+deterministically: instead of wall-clock thresholds (flaky on shared CI
+runners), it counts real operations with ``sys.setprofile`` - observation of
+the genuine execution, never a stub - over synthetic corpora generated at
+test time at two sizes, and asserts:
+
+- **Single ingress:** a non-mutating ``run_all_checks`` pass reads each
+  corpus document exactly once, at every corpus size.
+- **Memoized plan parsing:** the pass parses no more plans than the corpus
+  contains, no matter how many execution records reference them.
+- **No superlinear checks:** tag-extraction work (the signature operation of
+  the banned O(features x documents) scan shape) grows at most linearly
+  between the two corpus sizes.
+
+Marked ``benchmark`` so the default run (which deselects ``benchmark`` via
+``addopts``) skips the corpus generation cost; run explicitly with
+``pytest -m benchmark``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ...config import reset_config
+from ...testing.synthetic import build_synthetic_vault
+from ...vaultcore.checks import run_all_checks
+from ...vaultcore.scanner import scan_vault
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.benchmark]
+
+_SMALL = 120
+_LARGE = 480
+
+#: Allowed growth factor for per-document operations across the 4x corpus
+#: step. Linear scaling gives ~4x; the banned quadratic shape gives ~16x.
+_LINEAR_SLACK = 6.0
+
+
+def _profile_counts(fn) -> Counter[str]:
+    """Run *fn* under a profiler, counting the operations the gate budgets."""
+    counts: Counter[str] = Counter()
+
+    def profiler(frame, event: str, arg: object) -> None:
+        if event != "call":
+            return
+        name = frame.f_code.co_name
+        if name in ("read_bytes", "read_text"):
+            target = frame.f_locals.get("self")
+            parts = getattr(target, "parts", None)
+            if parts and ".vault" in parts and str(target).endswith(".md"):
+                counts["corpus_reads"] += 1
+        elif name in ("parse_plan", "extract_feature_tags"):
+            counts[name] += 1
+
+    sys.setprofile(profiler)
+    try:
+        fn()
+    finally:
+        sys.setprofile(None)
+    return counts
+
+
+def _prepare_corpus(root: Path, n_docs: int) -> tuple[int, int]:
+    """Build a corpus and settle migrations; return (doc, plan) counts."""
+    reset_config()
+    build_synthetic_vault(root, n_docs=n_docs, seed=17, edge_probability=0.3)
+    # One throwaway scan settles any pending migrations so the instrumented
+    # pass observes only the check pipeline's own reads.
+    scanned = list(scan_vault(root))
+    plans = sum(1 for p in scanned if p.parent.name == "plan")
+    return len(scanned), plans
+
+
+class TestComplexityBudgets:
+    @pytest.mark.parametrize("n_docs", [_SMALL, _LARGE])
+    def test_single_ingress_read_budget(self, tmp_path: Path, n_docs: int) -> None:
+        doc_count, plan_count = _prepare_corpus(tmp_path, n_docs)
+
+        counts = _profile_counts(lambda: run_all_checks(tmp_path, fix=False))
+
+        assert counts["corpus_reads"] == doc_count, (
+            f"the pass read the corpus {counts['corpus_reads']} times for "
+            f"{doc_count} documents; the single-ingress budget is exactly one "
+            "read per document"
+        )
+        assert counts["parse_plan"] <= plan_count, (
+            f"{counts['parse_plan']} plan parses for {plan_count} plan "
+            "documents; per-plan parsing must be memoized"
+        )
+
+    def test_tag_extraction_scales_linearly(self, tmp_path: Path) -> None:
+        small_root = tmp_path / "small"
+        large_root = tmp_path / "large"
+        small_root.mkdir()
+        large_root.mkdir()
+
+        _prepare_corpus(small_root, _SMALL)
+        small = _profile_counts(lambda: run_all_checks(small_root, fix=False))
+
+        _prepare_corpus(large_root, _LARGE)
+        large = _profile_counts(lambda: run_all_checks(large_root, fix=False))
+
+        assert small["extract_feature_tags"] > 0
+        ratio = large["extract_feature_tags"] / small["extract_feature_tags"]
+        assert ratio <= _LINEAR_SLACK, (
+            f"tag extraction grew {ratio:.1f}x across a 4x corpus step; the "
+            "budget is linear growth (a features x documents scan shape "
+            "regressed)"
+        )

--- a/src/vaultspec_core/vaultcore/__init__.py
+++ b/src/vaultspec_core/vaultcore/__init__.py
@@ -12,6 +12,11 @@ Re-exports from six internal modules: :mod:`.models`
 :mod:`vaultspec_core.graph`, and :mod:`vaultspec_core.mcp_server`.
 """
 
+from .body_schema import BODY_SCHEMA_REGISTRY as BODY_SCHEMA_REGISTRY
+from .body_schema import CURRENT_BODY_SCHEMA as CURRENT_BODY_SCHEMA
+from .body_schema import BodySchema as BodySchema
+from .body_schema import BodySchemaResolution as BodySchemaResolution
+from .body_schema import resolve_body_schema as resolve_body_schema
 from .hydration import create_vault_doc as create_vault_doc
 from .hydration import get_template_path as get_template_path
 from .hydration import hydrate_template as hydrate_template

--- a/src/vaultspec_core/vaultcore/batch_archive.py
+++ b/src/vaultspec_core/vaultcore/batch_archive.py
@@ -18,12 +18,19 @@ if TYPE_CHECKING:
 __all__ = [
     "ArchiveDocumentsError",
     "ArchiveDocumentsResult",
+    "RestoreDocumentsError",
+    "RestoreDocumentsResult",
     "archive_documents",
+    "restore_documents",
 ]
 
 
 class ArchiveDocumentsError(VaultSpecError):
     """Raised when an explicit batch archive cannot safely proceed."""
+
+
+class RestoreDocumentsError(VaultSpecError):
+    """Raised when an explicit batch restoration cannot safely proceed."""
 
 
 @dataclass(frozen=True)
@@ -57,10 +64,56 @@ class ArchiveDocumentsResult:
 
 
 @dataclass(frozen=True)
+class RestoreDocumentsResult:
+    """The paths restored, or validated for restoration by a dry run."""
+
+    status: str
+    restored_paths: tuple[Path, ...]
+    deduplicated_paths: tuple[Path, ...]
+    cross_link_paths: tuple[Path, ...]
+    dry_run: bool
+
+    @property
+    def restored_count(self) -> int:
+        """Return the number of documents in the explicit restore batch."""
+        return len(self.restored_paths)
+
+    @property
+    def deduplicated_count(self) -> int:
+        """Return the archived duplicates removed during the restore batch."""
+        return len(self.deduplicated_paths)
+
+    @property
+    def paths(self) -> tuple[Path, ...]:
+        """Compatibility name for the destination paths."""
+        return self.restored_paths
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a portable, JSON-ready representation."""
+        return {
+            "status": self.status,
+            "restored_count": self.restored_count,
+            "paths": [path.as_posix() for path in self.restored_paths],
+            "deduplicated_count": self.deduplicated_count,
+            "deduplicated_paths": [path.as_posix() for path in self.deduplicated_paths],
+            "cross_link_paths": [path.as_posix() for path in self.cross_link_paths],
+            "dry_run": self.dry_run,
+        }
+
+
+@dataclass(frozen=True)
 class _ArchiveMove:
     source: Path
     destination: Path
     source_relative: Path
+
+
+@dataclass(frozen=True)
+class _RestoreMove:
+    source: Path
+    destination: Path
+    destination_relative: Path
+    deduplicate: bool
 
 
 def archive_documents(
@@ -104,7 +157,7 @@ def archive_documents(
         cross_links = _cross_link_paths(root, docs_dir, moves)
         tx.snapshot(move.source for move in moves)
         for move in moves:
-            _create_archive_parent(tx, docs_dir, move.destination.parent)
+            _create_destination_parent(tx, docs_dir, move.destination.parent)
             _require_regular_document(move.source)
             try:
                 moved = tx.rename(move.source, move.destination)
@@ -121,16 +174,103 @@ def archive_documents(
     return _result(root, moves, cross_links, dry_run=False)
 
 
-def _assert_docs_dir(root: Path, docs_dir: Path) -> None:
+def restore_documents(
+    root_dir: Path,
+    relative_paths: Iterable[str | Path],
+    *,
+    dry_run: bool = False,
+    deduplicate_identical: bool = False,
+) -> RestoreDocumentsResult:
+    """Restore explicit project-relative archived documents as one batch.
+
+    Every input must name a Markdown document under ``.vault/_archive``. Each
+    document moves back to the exact vault-relative path encoded after that
+    prefix. Preflight rejects every unsafe source or destination before the
+    first move; an apply uses the common docs lock and rolls back on failure.
+    """
+    root = root_dir.resolve()
+    docs_dir = root / get_config().docs_dir
+    _assert_docs_dir(root, docs_dir, error_type=RestoreDocumentsError)
+
+    supplied = tuple(relative_paths)
+    if dry_run:
+        moves = _restore_preflight(
+            root, docs_dir, supplied, deduplicate_identical=deduplicate_identical
+        )
+        cross_links = _restore_cross_link_paths(root, docs_dir, moves)
+        return _restore_result(root, moves, cross_links, dry_run=True)
+
+    runtime_dir = docs_dir / "data"
+    if runtime_dir.is_symlink():
+        raise RestoreDocumentsError(
+            f"Vault runtime directory must not be a symlink: {runtime_dir}"
+        )
+    runtime_dir.mkdir(exist_ok=True)
+    if not runtime_dir.is_dir():
+        raise RestoreDocumentsError(
+            f"Vault runtime path is not a directory: {runtime_dir}"
+        )
+
+    with RenameTransaction(docs_dir, lock_target=docs_lock_target(docs_dir)) as tx:
+        # Match archive's locked preflight so no path can change after the
+        # initial validation and before the first destructive rename.
+        moves = _restore_preflight(
+            root, docs_dir, supplied, deduplicate_identical=deduplicate_identical
+        )
+        cross_links = _restore_cross_link_paths(root, docs_dir, moves)
+        tx.snapshot(move.source for move in moves)
+        for move in moves:
+            if move.deduplicate:
+                _require_identical_restore_duplicate(move.source, move.destination)
+                try:
+                    move.source.unlink()
+                except OSError as exc:
+                    raise RestoreDocumentsError(
+                        f"Cannot remove archived duplicate {move.source}: {exc}"
+                    ) from exc
+                continue
+            _create_destination_parent(
+                tx,
+                docs_dir,
+                move.destination.parent,
+                error_type=RestoreDocumentsError,
+                operation="restore",
+            )
+            _require_regular_document(
+                move.source, error_type=RestoreDocumentsError, operation="restore"
+            )
+            try:
+                moved = tx.rename(move.source, move.destination)
+            except OSError as exc:
+                raise RestoreDocumentsError(
+                    f"Restore move failed: {move.source} -> {move.destination}: {exc}"
+                ) from exc
+            if not moved:
+                raise RestoreDocumentsError(
+                    "Restore move was refused without replacing a destination: "
+                    f"{move.source} -> {move.destination}"
+                )
+
+    return _restore_result(root, moves, cross_links, dry_run=False)
+
+
+def _assert_docs_dir(
+    root: Path,
+    docs_dir: Path,
+    *,
+    error_type: type[ArchiveDocumentsError | RestoreDocumentsError] = (
+        ArchiveDocumentsError
+    ),
+) -> None:
     if docs_dir.is_symlink() or not docs_dir.is_dir():
-        raise ArchiveDocumentsError(
+        raise error_type(
             f"Vault document directory must be a real directory: {docs_dir}"
         )
     try:
         docs_dir.relative_to(root)
         docs_dir.resolve(strict=False).relative_to(root)
     except ValueError as exc:
-        raise ArchiveDocumentsError(
+        raise error_type(
             f"Configured vault directory escapes the project root: {docs_dir}"
         ) from exc
 
@@ -156,10 +296,59 @@ def _preflight(
             raise ArchiveDocumentsError(
                 f"Archive destination already exists: {destination}"
             )
-        _require_safe_archive_parent(docs_dir, destination.parent)
+        _require_safe_destination_parent(docs_dir, destination.parent)
         seen_sources.add(source)
         seen_destinations.add(destination)
         moves.append(_ArchiveMove(source, destination, source_relative))
+    return tuple(moves)
+
+
+def _restore_preflight(
+    root: Path,
+    docs_dir: Path,
+    relative_paths: tuple[str | Path, ...],
+    *,
+    deduplicate_identical: bool,
+) -> tuple[_RestoreMove, ...]:
+    if not relative_paths:
+        raise RestoreDocumentsError("Restore requires at least one document path.")
+
+    moves: list[_RestoreMove] = []
+    seen_sources: set[Path] = set()
+    seen_destinations: set[Path] = set()
+    for value in relative_paths:
+        source, destination_relative = _resolve_restore_source(root, docs_dir, value)
+        destination = docs_dir / destination_relative
+        try:
+            _assert_within(docs_dir, destination)
+        except VaultSpecError as exc:
+            raise RestoreDocumentsError(
+                f"Restore destination escapes vault: {destination}"
+            ) from exc
+        if source in seen_sources:
+            raise RestoreDocumentsError(f"Duplicate restore source: {source}")
+        if destination in seen_destinations:
+            raise RestoreDocumentsError(f"Restore destination collision: {destination}")
+        deduplicate = False
+        if destination.exists() or destination.is_symlink():
+            if not deduplicate_identical:
+                raise RestoreDocumentsError(
+                    f"Restore destination already exists: {destination}"
+                )
+            _require_identical_restore_duplicate(source, destination)
+            deduplicate = True
+        else:
+            _require_safe_destination_parent(
+                docs_dir,
+                destination.parent,
+                error_type=RestoreDocumentsError,
+                operation="restore",
+            )
+        seen_sources.add(source)
+        seen_destinations.add(destination)
+        moves.append(
+            _RestoreMove(source, destination, destination_relative, deduplicate)
+        )
     return tuple(moves)
 
 
@@ -191,51 +380,151 @@ def _resolve_source(root: Path, docs_dir: Path, value: str | Path) -> tuple[Path
     return source, vault_relative
 
 
-def _require_regular_document(path: Path) -> None:
+def _resolve_restore_source(
+    root: Path, docs_dir: Path, value: str | Path
+) -> tuple[Path, Path]:
+    relative = Path(value)
+    if relative.is_absolute() or not relative.parts or ".." in relative.parts:
+        raise RestoreDocumentsError(
+            f"Restore path must be project-relative and confined to .vault: {value}"
+        )
+    raw_source = root / relative
+    try:
+        vault_relative = raw_source.relative_to(docs_dir)
+    except ValueError as exc:
+        raise RestoreDocumentsError(
+            f"Restore path must be under {docs_dir}: {relative}"
+        ) from exc
+    if len(vault_relative.parts) < 2 or vault_relative.parts[0] != "_archive":
+        raise RestoreDocumentsError(
+            f"Restore source must be under _archive: {relative}"
+        )
+    if raw_source.suffix.lower() != ".md":
+        raise RestoreDocumentsError(
+            f"Restore source must be a vault Markdown document: {relative}"
+        )
+    _require_no_symlink_components(
+        docs_dir, raw_source, error_type=RestoreDocumentsError, operation="restore"
+    )
+    source = raw_source.resolve(strict=False)
+    try:
+        _assert_within(docs_dir, source)
+    except VaultSpecError as exc:
+        raise RestoreDocumentsError(f"Restore source escapes vault: {source}") from exc
+    _require_regular_document(
+        source, error_type=RestoreDocumentsError, operation="restore"
+    )
+    return source, Path(*vault_relative.parts[1:])
+
+
+def _require_regular_document(
+    path: Path,
+    *,
+    error_type: type[ArchiveDocumentsError | RestoreDocumentsError] = (
+        ArchiveDocumentsError
+    ),
+    operation: str = "archive",
+) -> None:
     if path.is_symlink() or not path.is_file():
-        raise ArchiveDocumentsError(f"Archive source is not a regular file: {path}")
+        raise error_type(
+            f"{operation.capitalize()} source is not a regular file: {path}"
+        )
     try:
         path.read_bytes()
     except OSError as exc:
-        raise ArchiveDocumentsError(
-            f"Cannot read archive source {path}: {exc}"
+        raise error_type(f"Cannot read {operation} source {path}: {exc}") from exc
+
+
+def _require_identical_restore_duplicate(source: Path, destination: Path) -> None:
+    """Refuse a restore deduplication unless both files have exactly the same bytes."""
+    _require_regular_document(
+        source, error_type=RestoreDocumentsError, operation="restore"
+    )
+    if destination.is_symlink() or not destination.is_file():
+        raise RestoreDocumentsError(
+            f"Restore deduplication destination is not a regular file: {destination}"
+        )
+    try:
+        identical = source.read_bytes() == destination.read_bytes()
+    except OSError as exc:
+        raise RestoreDocumentsError(
+            f"Cannot compare restore duplicate {source} with {destination}: {exc}"
         ) from exc
+    if not identical:
+        raise RestoreDocumentsError(
+            f"Restore destination is not byte-identical: {destination}"
+        )
 
 
-def _require_no_symlink_components(docs_dir: Path, path: Path) -> None:
+def _require_no_symlink_components(
+    docs_dir: Path,
+    path: Path,
+    *,
+    error_type: type[ArchiveDocumentsError | RestoreDocumentsError] = (
+        ArchiveDocumentsError
+    ),
+    operation: str = "archive",
+) -> None:
     try:
         relative = path.relative_to(docs_dir)
     except ValueError as exc:
-        raise ArchiveDocumentsError(f"Archive source escapes vault: {path}") from exc
+        raise error_type(
+            f"{operation.capitalize()} source escapes vault: {path}"
+        ) from exc
     current = docs_dir
     for part in relative.parts:
         current /= part
         if current.is_symlink():
-            raise ArchiveDocumentsError(
-                f"Archive source contains a symlink component: {current}"
+            raise error_type(
+                f"{operation.capitalize()} source contains a symlink component: "
+                f"{current}"
             )
 
 
-def _require_safe_archive_parent(docs_dir: Path, parent: Path) -> None:
-    _assert_within(docs_dir, parent)
+def _require_safe_destination_parent(
+    docs_dir: Path,
+    parent: Path,
+    *,
+    error_type: type[ArchiveDocumentsError | RestoreDocumentsError] = (
+        ArchiveDocumentsError
+    ),
+    operation: str = "archive",
+) -> None:
+    try:
+        _assert_within(docs_dir, parent)
+    except VaultSpecError as exc:
+        raise error_type(
+            f"{operation.capitalize()} destination parent escapes vault: {parent}"
+        ) from exc
     current = docs_dir
     relative = parent.relative_to(docs_dir)
     for part in relative.parts:
         current /= part
         if current.is_symlink():
-            raise ArchiveDocumentsError(
-                f"Archive destination parent must not be a symlink: {current}"
+            raise error_type(
+                f"{operation.capitalize()} destination parent must not be a "
+                f"symlink: {current}"
             )
         if current.exists() and not current.is_dir():
-            raise ArchiveDocumentsError(
-                f"Archive destination parent is not a directory: {current}"
+            raise error_type(
+                f"{operation.capitalize()} destination parent is not a "
+                f"directory: {current}"
             )
 
 
-def _create_archive_parent(
-    transaction: RenameTransaction, docs_dir: Path, parent: Path
+def _create_destination_parent(
+    transaction: RenameTransaction,
+    docs_dir: Path,
+    parent: Path,
+    *,
+    error_type: type[ArchiveDocumentsError | RestoreDocumentsError] = (
+        ArchiveDocumentsError
+    ),
+    operation: str = "archive",
 ) -> None:
-    _require_safe_archive_parent(docs_dir, parent)
+    _require_safe_destination_parent(
+        docs_dir, parent, error_type=error_type, operation=operation
+    )
     missing: list[Path] = []
     current = parent
     while current != docs_dir and not current.exists():
@@ -280,6 +569,47 @@ def _result(
     return ArchiveDocumentsResult(
         status="unchanged" if dry_run else "updated",
         archived_paths=tuple(move.destination.relative_to(root) for move in moves),
+        cross_link_paths=cross_links,
+        dry_run=dry_run,
+    )
+
+
+def _restore_cross_link_paths(
+    root: Path, docs_dir: Path, moves: tuple[_RestoreMove, ...]
+) -> tuple[Path, ...]:
+    restored_stems = {move.source.stem for move in moves}
+    linked: list[Path] = []
+    for path in docs_dir.rglob("*.md"):
+        try:
+            relative = path.relative_to(docs_dir)
+        except ValueError:
+            continue
+        if "_archive" in relative.parts or path.is_symlink() or not path.is_file():
+            continue
+        try:
+            metadata, _body = parse_vault_metadata(path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeDecodeError, ValueError):
+            continue
+        if any(_link_stem(link) in restored_stems for link in metadata.related):
+            linked.append(path.relative_to(root))
+    return tuple(sorted(linked))
+
+
+def _restore_result(
+    root: Path,
+    moves: tuple[_RestoreMove, ...],
+    cross_links: tuple[Path, ...],
+    *,
+    dry_run: bool,
+) -> RestoreDocumentsResult:
+    return RestoreDocumentsResult(
+        status="unchanged" if dry_run else "updated",
+        restored_paths=tuple(
+            move.destination.relative_to(root) for move in moves if not move.deduplicate
+        ),
+        deduplicated_paths=tuple(
+            move.source.relative_to(root) for move in moves if move.deduplicate
+        ),
         cross_link_paths=cross_links,
         dry_run=dry_run,
     )

--- a/src/vaultspec_core/vaultcore/body_schema.py
+++ b/src/vaultspec_core/vaultcore/body_schema.py
@@ -1,0 +1,512 @@
+"""Immutable body-section contracts and declared-schema resolution.
+
+The contracts in this module are historical records. A newer schema must be
+added under a new identifier; an existing contract is never edited. This lets
+validation use the schema a document attests instead of deriving requirements
+from the mutable template currently installed in a workspace.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Literal, TypeGuard
+
+from .models import DocType
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from .models import DocumentMetadata
+
+__all__ = [
+    "BASELINE_RELATIVE_PATH",
+    "BODY_SCHEMA_REGISTRY",
+    "CURRENT_BODY_SCHEMA",
+    "BaselineEntry",
+    "BodySchema",
+    "BodySchemaResolution",
+    "body_schema_baseline_path",
+    "resolve_body_schema",
+]
+
+
+CURRENT_BODY_SCHEMA = "body-v1"
+BASELINE_RELATIVE_PATH = PurePosixPath(".vaultspec/body-schema-baseline.json")
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class BodySchema:
+    """One immutable set of required body sections per document shape."""
+
+    schema_id: str
+    sections: Mapping[tuple[DocType, bool], tuple[str, ...]]
+
+    def required_sections(
+        self, doc_type: DocType, *, summary: bool = False
+    ) -> tuple[str, ...]:
+        """Return this schema's ordered required sections for a document shape."""
+        return self.sections.get((doc_type, summary), ())
+
+
+@dataclass(frozen=True)
+class BaselineEntry:
+    """One exact legacy-document attestation from the reviewed ledger."""
+
+    path: str
+    body_sha256: str
+    body_schema: str
+
+
+@dataclass(frozen=True)
+class BodySchemaResolution:
+    """Schema resolution result consumed by body-section validation.
+
+    ``source`` deliberately distinguishes a current direct declaration from
+    records which need a later hash-attested baseline. P02 can add an
+    ``attested`` source without changing the validator-facing function
+    signature.
+    """
+
+    required_sections: tuple[str, ...] | None
+    schema_id: str | None
+    source: Literal[
+        "attested", "declared", "attestation_required", "missing", "unknown"
+    ]
+    diagnostic: str | None = None
+
+
+_BODY_V1_SECTIONS = MappingProxyType(
+    {
+        (DocType.ADR, False): (
+            "Problem Statement",
+            "Considerations",
+            "Considered options",
+            "Constraints",
+            "Implementation",
+            "Rationale",
+            "Consequences",
+        ),
+        (DocType.AUDIT, False): ("Scope", "Findings", "Recommendations"),
+        (DocType.PLAN, False): (
+            "Description",
+            "Steps",
+            "Parallelization",
+            "Verification",
+        ),
+        (DocType.RESEARCH, False): ("Findings", "Sources"),
+        (DocType.REFERENCE, False): ("Summary",),
+        (DocType.EXEC, False): ("Description", "Outcome", "Notes"),
+        (DocType.EXEC, True): ("Description",),
+        # Generated indexes are intentionally excluded by body-section checks,
+        # but the contract remains explicit for callers that inspect schemas.
+        (DocType.INDEX, False): ("Documents",),
+    }
+)
+
+BODY_SCHEMA_REGISTRY: Mapping[str, BodySchema] = MappingProxyType(
+    {
+        CURRENT_BODY_SCHEMA: BodySchema(
+            schema_id=CURRENT_BODY_SCHEMA,
+            sections=_BODY_V1_SECTIONS,
+        ),
+        # Historical contracts are immutable template records.  They remain
+        # distinct even where their headings happen to match ``body-v1``:
+        # legacy documents are trusted only through an external body hash.
+        "legacy-adr-v1": BodySchema(
+            "legacy-adr-v1",
+            MappingProxyType(
+                {
+                    (DocType.ADR, False): (
+                        "Problem Statement",
+                        "Considerations",
+                        "Constraints",
+                        "Implementation",
+                        "Rationale",
+                        "Consequences",
+                    )
+                }
+            ),
+        ),
+        "legacy-adr-v2": BodySchema(
+            "legacy-adr-v2",
+            MappingProxyType(
+                {
+                    (DocType.ADR, False): (
+                        "Problem Statement",
+                        "Considerations",
+                        "Constraints",
+                        "Implementation",
+                        "Rationale",
+                        "Consequences",
+                        "Codification candidates",
+                    )
+                }
+            ),
+        ),
+        "legacy-adr-v3": BodySchema(
+            "legacy-adr-v3",
+            MappingProxyType(
+                {
+                    (DocType.ADR, False): (
+                        "Problem Statement",
+                        "Considerations",
+                        "Considered options",
+                        "Constraints",
+                        "Implementation",
+                        "Rationale",
+                        "Consequences",
+                    )
+                }
+            ),
+        ),
+        "legacy-audit-v1": BodySchema(
+            "legacy-audit-v1",
+            MappingProxyType(
+                {(DocType.AUDIT, False): ("Scope", "Findings", "Recommendations")}
+            ),
+        ),
+        "legacy-audit-v2": BodySchema(
+            "legacy-audit-v2",
+            MappingProxyType(
+                {
+                    (DocType.AUDIT, False): (
+                        "Scope",
+                        "Findings",
+                        "Recommendations",
+                        "Codification candidates",
+                    )
+                }
+            ),
+        ),
+        "legacy-exec-v1": BodySchema(
+            "legacy-exec-v1",
+            MappingProxyType(
+                {
+                    (DocType.EXEC, False): ("Description", "Tests"),
+                    (DocType.EXEC, True): ("Description", "Tests"),
+                }
+            ),
+        ),
+        "legacy-exec-v2": BodySchema(
+            "legacy-exec-v2",
+            MappingProxyType({(DocType.EXEC, False): ("Description", "Notes")}),
+        ),
+        "legacy-exec-v3": BodySchema(
+            "legacy-exec-v3",
+            MappingProxyType(
+                {(DocType.EXEC, False): ("Description", "Outcome", "Notes")}
+            ),
+        ),
+        "legacy-exec-v4": BodySchema(
+            "legacy-exec-v4",
+            MappingProxyType({(DocType.EXEC, True): ("Description",)}),
+        ),
+        "legacy-index-v1": BodySchema(
+            "legacy-index-v1",
+            MappingProxyType({(DocType.INDEX, False): ("Documents",)}),
+        ),
+        "legacy-plan-v1": BodySchema(
+            "legacy-plan-v1",
+            MappingProxyType(
+                {
+                    (DocType.PLAN, False): (
+                        "Description",
+                        "Steps",
+                        "Parallelization",
+                        "Verification",
+                    )
+                }
+            ),
+        ),
+        "legacy-plan-v2": BodySchema(
+            "legacy-plan-v2",
+            MappingProxyType(
+                {
+                    (DocType.PLAN, False): (
+                        "Proposed Changes",
+                        "Steps",
+                        "Parallelization",
+                        "Verification",
+                    )
+                }
+            ),
+        ),
+        "legacy-plan-v3": BodySchema(
+            "legacy-plan-v3",
+            MappingProxyType(
+                {
+                    (DocType.PLAN, False): (
+                        "Proposed Changes",
+                        "Tasks",
+                        "Parallelization",
+                        "Verification",
+                    )
+                }
+            ),
+        ),
+        "legacy-reference-v1": BodySchema(
+            "legacy-reference-v1",
+            MappingProxyType({(DocType.REFERENCE, False): ("Summary",)}),
+        ),
+        "legacy-research-v1": BodySchema(
+            "legacy-research-v1",
+            MappingProxyType({(DocType.RESEARCH, False): ("Findings",)}),
+        ),
+        "legacy-research-v2": BodySchema(
+            "legacy-research-v2",
+            MappingProxyType({(DocType.RESEARCH, False): ("Findings", "Sources")}),
+        ),
+    }
+)
+
+
+def body_schema_baseline_path(root_dir: Path) -> Path:
+    """Return the project-local, reviewable legacy-attestation ledger path."""
+    return root_dir.joinpath(*BASELINE_RELATIVE_PATH.parts)
+
+
+def _read_baseline_file(path: Path) -> tuple[Mapping[str, BaselineEntry], str | None]:
+    """Read every validation pass so altered review evidence cannot go stale."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return MappingProxyType({}), f"cannot parse baseline ledger: {exc}"
+    return _parse_baseline(raw)
+
+
+def _read_baseline(root_dir: Path) -> tuple[Mapping[str, BaselineEntry], str | None]:
+    path = body_schema_baseline_path(root_dir)
+    try:
+        exists = path.exists()
+    except FileNotFoundError:
+        return MappingProxyType({}), None
+    except OSError as exc:
+        return MappingProxyType({}), f"cannot read baseline ledger: {exc}"
+    if not exists:
+        return MappingProxyType({}), None
+    if not path.is_file():
+        return MappingProxyType({}), "baseline ledger is not a regular file"
+    return _read_baseline_file(path)
+
+
+def read_baseline(root_dir: Path) -> tuple[Mapping[str, BaselineEntry], str | None]:
+    """Read and parse the legacy-attestation ledger once for a whole run.
+
+    The ledger is a workspace-global fact: a caller validating many
+    documents reads it exactly once per command invocation and threads the
+    result into every :func:`resolve_body_schema` call, never re-reading it
+    per document.  Each *run* still re-reads the ledger from disk (the
+    review-evidence freshness guarantee), only the per-document repetition
+    within one run is eliminated.
+
+    Returns:
+        The ``(entries, error)`` pair :func:`resolve_body_schema` accepts as
+        its ``baseline`` argument.
+    """
+    return _read_baseline(root_dir)
+
+
+def _parse_baseline(raw: object) -> tuple[Mapping[str, BaselineEntry], str | None]:
+    """Parse the version-one ledger exactly; malformed input trusts nothing."""
+    if not _is_json_object(raw) or set(raw) != {"version", "entries"}:
+        return MappingProxyType({}), "ledger must contain exactly version and entries"
+    entries_raw = raw["entries"]
+    if raw["version"] != 1 or not isinstance(entries_raw, list):
+        return MappingProxyType({}), "ledger must be version 1 with an entries list"
+
+    entries: dict[str, BaselineEntry] = {}
+    previous_path: str | None = None
+    for index, raw_entry in enumerate(entries_raw):
+        if not _is_json_object(raw_entry) or set(raw_entry) != {
+            "path",
+            "body_sha256",
+            "body_schema",
+        }:
+            return MappingProxyType({}), f"entry {index} has an invalid shape"
+        path = raw_entry["path"]
+        digest = raw_entry["body_sha256"]
+        schema_id = raw_entry["body_schema"]
+        if not isinstance(path, str) or not _is_canonical_vault_path(path):
+            return MappingProxyType({}), f"entry {index} has an unsafe path"
+        if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+            return MappingProxyType({}), f"entry {index} has an invalid body_sha256"
+        if (
+            not isinstance(schema_id, str)
+            or schema_id not in BODY_SCHEMA_REGISTRY
+            or schema_id == CURRENT_BODY_SCHEMA
+        ):
+            return MappingProxyType(
+                {}
+            ), f"entry {index} names an invalid legacy body_schema"
+        if path in entries:
+            return MappingProxyType({}), f"ledger contains duplicate path {path!r}"
+        if previous_path is not None and path <= previous_path:
+            return MappingProxyType({}), "ledger entries must be sorted by path"
+        entries[path] = BaselineEntry(path, digest, schema_id)
+        previous_path = path
+    return MappingProxyType(entries), None
+
+
+def _is_json_object(value: object) -> TypeGuard[dict[str, object]]:
+    """Narrow JSON-decoded objects without accepting non-string member names."""
+    return isinstance(value, dict) and all(isinstance(key, str) for key in value)
+
+
+def _is_canonical_vault_path(value: str) -> bool:
+    """Accept only canonical POSIX paths rooted under ``.vault/``."""
+    if "\\" in value:
+        return False
+    path = PurePosixPath(value)
+    return (
+        not path.is_absolute()
+        and len(path.parts) >= 3
+        and path.parts[0] == ".vault"
+        and all(part not in {"", ".", ".."} for part in path.parts)
+        and path.as_posix() == value
+        and path.suffix == ".md"
+    )
+
+
+def resolve_body_schema(
+    root_dir: Path,
+    doc_path: Path,
+    metadata: DocumentMetadata,
+    body: str,
+    *,
+    baseline: tuple[Mapping[str, BaselineEntry], str | None] | None = None,
+) -> BodySchemaResolution:
+    """Resolve a document's declared immutable body schema.
+
+    Only ``body-v1`` frontmatter is a direct declaration. Historical documents
+    must match a path, body SHA-256, and historical contract in the reviewed
+    project ledger; no mutable installed template is consulted.
+
+    Args:
+        root_dir: Project root directory.
+        doc_path: The document being resolved.
+        metadata: The document's parsed frontmatter metadata.
+        body: The document's body text.
+        baseline: The ledger read from :func:`read_baseline`.  Callers
+            resolving many documents in one run read the ledger once and
+            pass it here; when omitted the ledger is read for this call.
+    """
+    schema_id = metadata.body_schema
+    if schema_id == CURRENT_BODY_SCHEMA:
+        schema = BODY_SCHEMA_REGISTRY[CURRENT_BODY_SCHEMA]
+        is_summary = doc_path.stem.endswith("-summary")
+        doc_type = DocType.EXEC if is_summary else _document_type(metadata)
+        return BodySchemaResolution(
+            required_sections=schema.required_sections(doc_type, summary=is_summary),
+            schema_id=schema_id,
+            source="declared",
+        )
+
+    if schema_id and not schema_id.startswith("legacy-"):
+        return BodySchemaResolution(
+            required_sections=None,
+            schema_id=schema_id,
+            source="unknown",
+            diagnostic=(f"{doc_path.name} declares unknown body_schema {schema_id!r}."),
+        )
+
+    entries, ledger_error = (
+        baseline if baseline is not None else _read_baseline(root_dir)
+    )
+    if ledger_error is not None:
+        return BodySchemaResolution(
+            required_sections=None,
+            schema_id=schema_id,
+            source="attestation_required",
+            diagnostic=f"baseline ledger is invalid: {ledger_error}",
+        )
+    relative_path = _relative_vault_path(root_dir, doc_path)
+    entry = entries.get(relative_path) if relative_path is not None else None
+    if entry is None:
+        if schema_id:
+            descriptor = f"declares legacy body_schema {schema_id!r}"
+            requirement = "requires a hash-attested baseline entry"
+        else:
+            descriptor = "does not declare a body_schema"
+            requirement = "requires a hash-attested legacy baseline entry"
+        return BodySchemaResolution(
+            required_sections=None,
+            schema_id=schema_id,
+            source="missing" if schema_id is None else "attestation_required",
+            diagnostic=(f"{doc_path.name} {descriptor}; it {requirement}."),
+        )
+    if schema_id is not None and schema_id != entry.body_schema:
+        return BodySchemaResolution(
+            required_sections=None,
+            schema_id=schema_id,
+            source="attestation_required",
+            diagnostic=(
+                f"{doc_path.name} declares legacy body_schema {schema_id!r}, "
+                f"which conflicts with its attested schema {entry.body_schema!r}."
+            ),
+        )
+    actual_digest = hashlib.sha256(body.encode("utf-8")).hexdigest()
+    if actual_digest != entry.body_sha256:
+        return BodySchemaResolution(
+            required_sections=None,
+            schema_id=entry.body_schema,
+            source="attestation_required",
+            diagnostic=(
+                f"{doc_path.name} body SHA-256 does not match its attested "
+                "legacy baseline."
+            ),
+        )
+    schema = BODY_SCHEMA_REGISTRY[entry.body_schema]
+    is_summary = doc_path.stem.endswith("-summary")
+    doc_type = DocType.EXEC if is_summary else _document_type(metadata)
+    required_sections = schema.required_sections(doc_type, summary=is_summary)
+    if not required_sections:
+        return BodySchemaResolution(
+            required_sections=None,
+            schema_id=entry.body_schema,
+            source="attestation_required",
+            diagnostic=(
+                f"{doc_path.name} attests schema {entry.body_schema!r}, which "
+                "does not apply to this document shape."
+            ),
+        )
+    return BodySchemaResolution(
+        required_sections=required_sections,
+        schema_id=entry.body_schema,
+        source="attested",
+    )
+
+
+def _relative_vault_path(root_dir: Path, doc_path: Path) -> str | None:
+    """Return a canonical rooted path or reject documents outside the workspace.
+
+    Scanned document paths are constructed under *root_dir*, so the plain
+    lexical ``relative_to`` succeeds without touching the filesystem; the
+    ``resolve``-based form (which opens a handle per call on Windows) is
+    kept only as the fallback for callers passing paths rooted elsewhere.
+    """
+    try:
+        return doc_path.relative_to(root_dir).as_posix()
+    except ValueError:
+        pass
+    try:
+        return doc_path.resolve().relative_to(root_dir.resolve()).as_posix()
+    except (OSError, ValueError):
+        return None
+
+
+def _document_type(metadata: DocumentMetadata) -> DocType:
+    """Resolve document type from the single required directory tag."""
+    for tag in metadata.tags:
+        doc_type = DocType.from_tag(tag)
+        if doc_type is not None:
+            return doc_type
+    # The frontmatter checker diagnoses this independently. Returning INDEX
+    # keeps this resolver total for malformed documents and avoids a crash.
+    return DocType.INDEX

--- a/src/vaultspec_core/vaultcore/checks/__init__.py
+++ b/src/vaultspec_core/vaultcore/checks/__init__.py
@@ -102,30 +102,42 @@ def run_all_checks(
     from ...graph import VaultGraph
 
     if not fix:
+        # The single-ingress contract: the graph build (or, after a cache
+        # hit, ensure_raw_texts) reads each document exactly once, and the
+        # whole calculate phase below runs from the shared snapshot and
+        # raw-text map without another corpus read. check_rename_integrity
+        # is exempt by scope: it validates .vaultspec/ workspace resources,
+        # not the vault corpus.
         graph = VaultGraph(root_dir)
+        graph.ensure_raw_texts()
         snapshot = graph.to_snapshot()
+        raw_texts = graph.raw_texts
         return [
             check_structure(root_dir, snapshot=snapshot, fix=False),
             check_frontmatter(root_dir, snapshot=snapshot, feature=feature, fix=False),
             check_modified_stamp(
                 root_dir, snapshot=snapshot, feature=feature, fix=False
             ),
-            check_annotations(root_dir, feature=feature, fix=False),
-            check_markdown(root_dir, feature=feature, fix=False),
+            check_annotations(
+                root_dir, feature=feature, fix=False, raw_texts=raw_texts
+            ),
+            check_markdown(root_dir, feature=feature, fix=False, raw_texts=raw_texts),
             check_links(root_dir, snapshot=snapshot, feature=feature, fix=False),
             check_dangling(root_dir, graph=graph, feature=feature, fix=False),
             check_body_links(root_dir, snapshot=snapshot, feature=feature),
             check_placeholders(root_dir, snapshot=snapshot, feature=feature),
             check_orphans(root_dir, graph=graph, feature=feature),
             check_features(root_dir, snapshot=snapshot, feature=feature),
-            check_exec_mapping(root_dir, snapshot=snapshot, feature=feature),
+            check_exec_mapping(
+                root_dir, snapshot=snapshot, feature=feature, raw_texts=raw_texts
+            ),
             check_body_sections(root_dir, snapshot=snapshot, feature=feature),
-            check_feature_rename_integrity(root_dir),
+            check_feature_rename_integrity(root_dir, snapshot=snapshot),
             check_references(root_dir, graph=graph, feature=feature, fix=False),
             check_schema(root_dir, graph=graph, feature=feature, fix=False),
             check_adr_status(root_dir, snapshot=snapshot, feature=feature, fix=False),
             check_rename_integrity(root_dir, fix=False),
-            check_encoding(root_dir),
+            check_encoding(root_dir, graph=graph),
         ]
 
     # Mutating checks can rename files or rewrite frontmatter. Refresh graph

--- a/src/vaultspec_core/vaultcore/checks/_base.py
+++ b/src/vaultspec_core/vaultcore/checks/_base.py
@@ -31,8 +31,35 @@ __all__ = [
     "VaultSnapshot",
     "extract_feature_tags",
     "is_generated_index",
+    "iter_document_texts",
     "render_check_result",
 ]
+
+
+def iter_document_texts(root_dir: Path, *, run_migrations: bool = True):
+    """Yield ``(path, text, has_crlf)`` for every readable vault document.
+
+    The standalone-read fallback for content-consuming checks invoked
+    without the ingress raw-text map (single-check CLI verbs, mutating
+    passes).  ``text`` keeps the source newlines; ``has_crlf`` reports the
+    CRLF convention.  Unreadable or non-UTF-8 files are skipped, mirroring
+    every other discovery path (``check_encoding`` surfaces them).
+
+    Args:
+        root_dir: Project root directory.
+        run_migrations: Forwarded to ``scan_vault``.
+
+    Yields:
+        ``(path, text, has_crlf)`` tuples in scan order.
+    """
+    from ..scanner import scan_vault
+
+    for doc_path in scan_vault(root_dir, run_migrations=run_migrations):
+        try:
+            raw_content = doc_path.read_bytes().decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        yield doc_path, raw_content, "\r\n" in raw_content
 
 
 class Severity(StrEnum):
@@ -172,6 +199,13 @@ _SEVERITY_ICON = {
 }
 
 
+#: Maximum diagnostics rendered per check on the human surface.  The count
+#: summary above the listing always carries the full totals, the truncation
+#: is explicitly marked, and ``--json`` remains the uncapped machine
+#: contract, per the report-volume policy.
+DIAGNOSTIC_RENDER_CAP = 50
+
+
 def render_check_result(
     console: Console,
     result: CheckResult,
@@ -180,6 +214,10 @@ def render_check_result(
     summary_only: bool = False,
 ) -> None:
     """Render a CheckResult to a Rich console.
+
+    At most :data:`DIAGNOSTIC_RENDER_CAP` findings are printed per check; a
+    marked truncation line reports how many more exist and points at
+    ``--json`` for the full set.
 
     Args:
         console: Rich Console instance.
@@ -221,9 +259,15 @@ def render_check_result(
     # names); escape it so Rich does not treat [[...]] as console markup.
     from rich.markup import escape
 
+    rendered = 0
+    suppressed = 0
     for diag in result.diagnostics:
         if diag.severity == Severity.INFO and not verbose:
             continue
+        if rendered >= DIAGNOSTIC_RENDER_CAP:
+            suppressed += 1
+            continue
+        rendered += 1
         style = _SEVERITY_STYLE[diag.severity]
         icon = _SEVERITY_ICON[diag.severity]
         message = escape(diag.message)
@@ -235,3 +279,9 @@ def render_check_result(
             console.print(f"    [{style}]{icon}[/{style}] {message}")
         if diag.fix_description:
             console.print(f"      [dim]fix: {escape(diag.fix_description)}[/dim]")
+    if suppressed:
+        console.print(
+            f"    [dim]... {suppressed} more finding"
+            f"{'s' if suppressed != 1 else ''} not shown; "
+            "use --json for the full set[/dim]"
+        )

--- a/src/vaultspec_core/vaultcore/checks/annotations.py
+++ b/src/vaultspec_core/vaultcore/checks/annotations.py
@@ -15,6 +15,7 @@ from ._base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
     from pathlib import Path
 
 PRESERVED_HTML_COMMENT_PREFIXES = ("RETIRED:",)
@@ -109,6 +110,7 @@ def check_annotations(
     feature: str | None = None,
     fix: bool = False,
     dry_run: bool = False,
+    raw_texts: Mapping[Path, tuple[str, bool]] | None = None,
 ) -> CheckResult:
     """Find or remove template annotations from vault documents.
 
@@ -119,29 +121,36 @@ def check_annotations(
             Markdown HTML comment blocks from matching documents.
         dry_run: When ``True``, report the files that would be changed without
             mutating them. Ignored unless ``fix`` is also ``True``.
+        raw_texts: The ingress read's per-document ``(text, crlf)`` map (see
+            :attr:`~vaultspec_core.graph.api.VaultGraph.raw_texts`).  When
+            supplied on a non-mutating pass, documents are validated from it
+            instead of re-reading the corpus - the single-ingress contract.
+            Ignored when ``fix`` is set: the mutating path reads and rewrites
+            the file it is about to change.
 
     Returns:
         :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with check
         name ``"annotations"``.
     """
     from ..parser import parse_vault_metadata
-    from ..scanner import scan_vault
+    from ._base import iter_document_texts
 
     result = CheckResult(check_name="annotations", supports_fix=True)
     wanted_feature = feature.lstrip("#") if feature else None
 
-    for doc_path in scan_vault(root_dir):
-        try:
-            raw = doc_path.read_bytes()
-            raw_content = raw.decode("utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
+    if raw_texts is not None and not fix:
+        sources: Iterable[tuple[Path, str, bool]] = (
+            (path, text, crlf) for path, (text, crlf) in raw_texts.items()
+        )
+    else:
+        sources = iter_document_texts(root_dir)
 
+    for doc_path, raw_content, has_crlf in sources:
         metadata, _body = parse_vault_metadata(raw_content)
         if wanted_feature and wanted_feature not in extract_feature_tags(metadata.tags):
             continue
 
-        source_newline = "\r\n" if "\r\n" in raw_content else "\n"
+        source_newline = "\r\n" if has_crlf else "\n"
         cleaned_lf, stats = strip_template_annotations(raw_content)
         if stats.total == 0:
             continue

--- a/src/vaultspec_core/vaultcore/checks/body_sections.py
+++ b/src/vaultspec_core/vaultcore/checks/body_sections.py
@@ -1,14 +1,12 @@
-"""Validate a document body against the sections its template mandates.
+"""Validate a document body against its attested immutable section contract.
 
-The shipped templates in ``.vaultspec/templates/`` are the single source of
-truth for a document type's required sections: each template carries a fixed
-set of level-two (``## ``) headings that constitute the body contract. Nothing
-previously confirmed a document actually kept them - an ADR could ship without
-its ``Consequences`` section and pass every check.
+Required level-two (``## ``) headings come from the immutable body-schema
+registry, never from today's mutable templates. A document either names a
+known stamped schema or, once legacy attestation is available, resolves through
+the repository's path-and-body-hash baseline. A document with neither proof is
+reported as unattested; it must not quietly inherit the current template.
 
-This checker derives the required sections per document type by extracting the
-``## `` headings from that type's template (never a hardcoded list), then for
-each document verifies every required heading is present and carries real
+For an attested schema, every required section must be present and carry real
 authored content. A required section that is absent, or that holds only a
 scaffold hint-comment or an unreplaced ``{placeholder}``, is reported: a
 scaffolded-but-unauthored document cannot satisfy the contract. Author-added
@@ -20,8 +18,9 @@ Edge handling:
 - Execution records select ``exec-step.md`` or ``exec-summary.md`` by the
   ``-summary`` filename convention.
 - Generated feature indexes are out of scope (their body is machine-authored).
-- A document type with no template, or a template that cannot be read, degrades
-  to a skip (no finding) rather than a crash (No-Crash policy).
+- Missing, unknown, or otherwise un-attested provenance is a finding, not a
+  skip. The resolver keeps its future legacy-baseline logic behind one stable
+  interface.
 
 The checker is read-only: a section's position, ordering, and content are the
 author's, so no safe automatic repair exists. Each finding's ``fix_description``
@@ -62,16 +61,6 @@ _COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 _PLACEHOLDER_ONLY_RE = re.compile(r"^(?:\s*\{[^{}]*\}\s*)+$")
 
 
-def _required_sections(template_text: str) -> list[str]:
-    """Return the ordered ``## `` section titles a template mandates.
-
-    HTML comment blocks (which embed example headings in the scaffold hints)
-    are stripped first so only the template's real headings are extracted.
-    """
-    stripped = _COMMENT_RE.sub("", template_text)
-    return [m.group("title") for m in _H2_RE.finditer(stripped)]
-
-
 def _section_contents(body: str) -> dict[str, str]:
     """Map each ``## `` heading title in *body* to its raw content.
 
@@ -106,7 +95,7 @@ def check_body_sections(
     snapshot: VaultSnapshot,
     feature: str | None = None,
 ) -> CheckResult:
-    """Validate every document body carries its template-mandated sections.
+    """Validate every document body carries its attested required sections.
 
     Args:
         root_dir: Project root directory.
@@ -119,14 +108,14 @@ def check_body_sections(
         :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with check
         name ``"body-sections"``. Does not support ``--fix``.
     """
-    from ..hydration import get_template_path
+    from ..body_schema import read_baseline, resolve_body_schema
     from ..scanner import get_doc_type
 
     result = CheckResult(check_name="body-sections", supports_fix=False)
 
-    # Cache required-section lists per (doc_type, summary) so each template is
-    # read and parsed once per run rather than once per document.
-    required_cache: dict[tuple[str, bool], list[str] | None] = {}
+    # The attestation ledger is a workspace-global fact: read once for the
+    # whole pass, never per document.
+    baseline = read_baseline(root_dir)
 
     for doc_path, (metadata, body) in sorted(snapshot.items()):
         doc_type = get_doc_type(doc_path, root_dir)
@@ -139,27 +128,29 @@ def check_body_sections(
             if feat not in extract_feature_tags(metadata.tags):
                 continue
 
-        is_summary = doc_path.stem.endswith("-summary")
-        cache_key = (doc_type.value, is_summary)
-        if cache_key not in required_cache:
-            template_path = get_template_path(root_dir, doc_type, summary=is_summary)
-            if template_path is None:
-                required_cache[cache_key] = None
-            else:
-                try:
-                    template_text = template_path.read_text(encoding="utf-8")
-                except (OSError, UnicodeDecodeError):
-                    required_cache[cache_key] = None
-                else:
-                    required_cache[cache_key] = _required_sections(template_text)
-
-        required = required_cache[cache_key]
-        if not required:
-            # No template mapping, unreadable template, or a template with no
-            # required sections: nothing to validate against, skip cleanly.
+        rel_path = doc_path.relative_to(root_dir)
+        resolution = resolve_body_schema(
+            root_dir, doc_path, metadata, body, baseline=baseline
+        )
+        required = resolution.required_sections
+        if required is None:
+            detail = (
+                resolution.diagnostic or "no attested body schema was resolved"
+            ).rstrip(".")
+            result.diagnostics.append(
+                CheckDiagnostic(
+                    path=rel_path,
+                    message=f"Body schema provenance is not attested: {detail}.",
+                    severity=Severity.WARNING,
+                    fixable=False,
+                    fix_description=(
+                        "Declare a known immutable body_schema or restore the "
+                        "reviewed baseline attestation."
+                    ),
+                )
+            )
             continue
 
-        rel_path = doc_path.relative_to(root_dir)
         contents = _section_contents(body)
 
         for title in required:
@@ -169,7 +160,7 @@ def check_body_sections(
                         path=rel_path,
                         message=(
                             f"Missing required section '## {title}' mandated by "
-                            f"the {doc_type.value} template."
+                            f"attested body schema '{resolution.schema_id}'."
                         ),
                         severity=Severity.WARNING,
                         fixable=False,

--- a/src/vaultspec_core/vaultcore/checks/encoding.py
+++ b/src/vaultspec_core/vaultcore/checks/encoding.py
@@ -27,22 +27,34 @@ from ._base import CheckDiagnostic, CheckResult, Severity
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ...graph.api import VaultGraph
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["check_encoding"]
 
+_DECODE_MESSAGE = (
+    "Document is not valid UTF-8 "
+    "(byte {start}: {reason}); it is silently "
+    "excluded from feature scans, indexes, and renames. "
+    "Convert it to UTF-8 (a UTF-8-BOM file is also accepted)."
+)
 
-def check_encoding(root_dir: Path) -> CheckResult:
+
+def check_encoding(root_dir: Path, *, graph: VaultGraph | None = None) -> CheckResult:
     """Report every ``.vault/`` document that is not valid UTF-8.
 
-    Walks ``<root>/<docs_dir>/**/*.md`` directly (mirroring ``scan_vault``'s
-    exclusions: ``.obsidian`` and ``_archive`` subtrees and symlinks are
-    skipped) rather than consulting the parsed snapshot, because a non-UTF-8
-    document never enters the snapshot in the first place. Each file is read as
-    raw bytes and decoded as UTF-8: a clean decode (including a UTF-8-BOM file,
-    which is valid UTF-8) passes, a :class:`UnicodeDecodeError` is reported as
-    an ``ERROR`` naming the file, and a read failure (:class:`OSError`) is a
-    ``WARNING``.
+    When *graph* is supplied (the combined ``run_all_checks`` pass), the
+    findings come from the read and decode failures the ingress read already
+    observed (:attr:`~vaultspec_core.graph.api.VaultGraph.encoding_issues`),
+    folding this check into the run's single read of the corpus. Standalone,
+    it walks ``<root>/<docs_dir>/**/*.md`` directly (mirroring
+    ``scan_vault``'s exclusions: ``.obsidian`` and ``_archive`` subtrees and
+    symlinks are skipped) rather than consulting the parsed snapshot, because
+    a non-UTF-8 document never enters the snapshot in the first place. Either
+    way, a clean decode (including a UTF-8-BOM file, which is valid UTF-8)
+    passes, a :class:`UnicodeDecodeError` is reported as an ``ERROR`` naming
+    the file, and a read failure (:class:`OSError`) is a ``WARNING``.
 
     Encoding is validated vault-wide and takes no ``feature`` filter: a
     non-UTF-8 document has no parseable frontmatter and therefore no feature
@@ -51,14 +63,44 @@ def check_encoding(root_dir: Path) -> CheckResult:
 
     Args:
         root_dir: Project root directory.
+        graph: A built :class:`~vaultspec_core.graph.api.VaultGraph` whose
+            ingress read (``ensure_raw_texts``) has run.
 
     Returns:
         :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with check
         name ``"encoding"``.
     """
-    from ...config import get_config
-
     result = CheckResult(check_name="encoding", supports_fix=False)
+
+    if graph is not None:
+        # No per-file stat parity probes here: the graph path must stay
+        # disk-free. The only divergence from the standalone walk is that a
+        # symlinked document observed by the scan is reported rather than
+        # skipped.
+        for issue in sorted(graph.encoding_issues, key=lambda i: i.path):
+            path = issue.path
+            rel_path = path.relative_to(root_dir) if path.is_absolute() else path
+            if issue.kind == "read":
+                result.diagnostics.append(
+                    CheckDiagnostic(
+                        path=rel_path,
+                        message=f"Could not read document bytes: {issue.detail}",
+                        severity=Severity.WARNING,
+                    )
+                )
+            else:
+                result.diagnostics.append(
+                    CheckDiagnostic(
+                        path=rel_path,
+                        message=_DECODE_MESSAGE.format(
+                            start=issue.start, reason=issue.detail
+                        ),
+                        severity=Severity.ERROR,
+                    )
+                )
+        return result
+
+    from ...config import get_config
 
     docs_dir = root_dir / get_config().docs_dir
     if not docs_dir.exists():
@@ -90,12 +132,7 @@ def check_encoding(root_dir: Path) -> CheckResult:
             result.diagnostics.append(
                 CheckDiagnostic(
                     path=rel_path,
-                    message=(
-                        "Document is not valid UTF-8 "
-                        f"(byte {exc.start}: {exc.reason}); it is silently "
-                        "excluded from feature scans, indexes, and renames. "
-                        "Convert it to UTF-8 (a UTF-8-BOM file is also accepted)."
-                    ),
+                    message=_DECODE_MESSAGE.format(start=exc.start, reason=exc.reason),
                     severity=Severity.ERROR,
                 )
             )

--- a/src/vaultspec_core/vaultcore/checks/exec_mapping.py
+++ b/src/vaultspec_core/vaultcore/checks/exec_mapping.py
@@ -34,6 +34,7 @@ from typing import TYPE_CHECKING
 from ._base import CheckDiagnostic, CheckResult, Severity, extract_feature_tags
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
     from pathlib import Path
 
     from ._base import VaultSnapshot
@@ -60,8 +61,16 @@ def check_exec_mapping(
     *,
     snapshot: VaultSnapshot,
     feature: str | None = None,
+    raw_texts: Mapping[Path, tuple[str, bool]] | None = None,
 ) -> CheckResult:
     """Validate every execution record maps to a live Step in its parent plan.
+
+    Per-plan work is memoized for the whole pass: each distinct parent plan
+    is parsed exactly once no matter how many records reference it, live-plan
+    existence is answered from the snapshot's own key set instead of a disk
+    probe per record, and archive probes are cached per stem. With
+    *raw_texts* supplied, plan parsing consumes the ingress read's text and
+    the calculate phase touches the corpus on disk not at all.
 
     Args:
         root_dir: Project root directory.
@@ -69,6 +78,9 @@ def check_exec_mapping(
             ``(metadata, body)`` tuples.
         feature: Restrict checks to documents carrying this feature tag
             (without ``#``).
+        raw_texts: The ingress read's per-document ``(text, crlf)`` map (see
+            :attr:`~vaultspec_core.graph.api.VaultGraph.raw_texts`); when
+            supplied, parent plans are parsed from it rather than from disk.
 
     Returns:
         :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with check
@@ -83,6 +95,46 @@ def check_exec_mapping(
     docs_dir = root_dir / get_config().docs_dir
     plan_dir = docs_dir / "plan"
     archive_plan_dir = docs_dir / "_archive" / "plan"
+
+    # Live plans are exactly the snapshot documents inside the plan
+    # directory: the snapshot's key set answers existence without a disk
+    # probe per record. Archive probes and per-plan parses are memoized so
+    # each distinct stem costs one lookup for the whole pass.
+    live_plan_names = {p.name for p in snapshot if p.parent == plan_dir}
+    archived_stem_cache: dict[str, bool] = {}
+    plan_ids_cache: dict[Path, tuple[set[str], set[str]] | Exception] = {}
+
+    def _is_archived(stem: str) -> bool:
+        cached = archived_stem_cache.get(stem)
+        if cached is None:
+            cached = (archive_plan_dir / f"{stem}.md").is_file()
+            archived_stem_cache[stem] = cached
+        return cached
+
+    def _step_ids(plan_path: Path) -> tuple[set[str], set[str]] | Exception:
+        cached = plan_ids_cache.get(plan_path)
+        if cached is None:
+            source: str | Path = plan_path
+            if raw_texts is not None:
+                entry = raw_texts.get(plan_path)
+                if entry is None:
+                    # The plan is in the corpus but its text never survived
+                    # ingress (read or decode failure). The single-ingress
+                    # contract forbids a disk fallback, so classify it as
+                    # unparseable - which a disk read of an unreadable file
+                    # would conclude anyway.
+                    cached = ValueError(
+                        "plan document could not be read during ingress"
+                    )
+                    plan_ids_cache[plan_path] = cached
+                    return cached
+                source = entry[0]
+            try:
+                cached = _plan_step_ids(source)
+            except Exception as exc:
+                cached = exc
+            plan_ids_cache[plan_path] = cached
+        return cached
 
     for doc_path, (metadata, _body) in sorted(snapshot.items()):
         if get_doc_type(doc_path, root_dir) is not DocType.EXEC:
@@ -109,11 +161,10 @@ def check_exec_mapping(
         live_plan_path: Path | None = None
         archived_stem: str | None = None
         for stem in candidate_stems:
-            candidate = plan_dir / f"{stem}.md"
-            if candidate.is_file():
-                live_plan_path = candidate
+            if f"{stem}.md" in live_plan_names:
+                live_plan_path = plan_dir / f"{stem}.md"
                 break
-            if (archive_plan_dir / f"{stem}.md").is_file():
+            if _is_archived(stem):
                 archived_stem = stem
 
         if live_plan_path is None:
@@ -140,9 +191,9 @@ def check_exec_mapping(
             )
             continue
 
-        try:
-            live_ids, retired_ids = _plan_step_ids(live_plan_path)
-        except Exception as exc:
+        ids_or_error = _step_ids(live_plan_path)
+        if isinstance(ids_or_error, Exception):
+            exc = ids_or_error
             logger.debug("Could not parse plan %s: %s", live_plan_path, exc)
             result.diagnostics.append(
                 CheckDiagnostic(
@@ -158,6 +209,7 @@ def check_exec_mapping(
             )
             continue
 
+        live_ids, retired_ids = ids_or_error
         if step_id in live_ids:
             continue
         if step_id in retired_ids:
@@ -197,10 +249,14 @@ def check_exec_mapping(
     return result
 
 
-def _plan_step_ids(plan_path: Path) -> tuple[set[str], set[str]]:
-    """Return the (live, retired) canonical Step id sets for *plan_path*."""
+def _plan_step_ids(source: str | Path) -> tuple[set[str], set[str]]:
+    """Return the (live, retired) canonical Step id sets for a plan.
+
+    *source* is either the plan's path (read from disk) or its full text
+    (the ingress read's copy); ``parse_plan`` accepts both.
+    """
     from ...plan.parser import parse_plan
 
-    plan = parse_plan(plan_path)
+    plan = parse_plan(source)
     live = {step.canonical_id for step in plan.steps}
     return live, set(plan.retired_step_ids)

--- a/src/vaultspec_core/vaultcore/checks/feature_rename_integrity.py
+++ b/src/vaultspec_core/vaultcore/checks/feature_rename_integrity.py
@@ -57,6 +57,8 @@ from ._base import CheckDiagnostic, CheckResult, Severity, extract_feature_tags
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ._base import VaultSnapshot
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["check_feature_rename_integrity"]
@@ -68,27 +70,36 @@ __all__ = ["check_feature_rename_integrity"]
 _EXEC_FOLDER_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-(.+)$")
 
 
-def check_feature_rename_integrity(root_dir: Path) -> CheckResult:
+def check_feature_rename_integrity(
+    root_dir: Path,
+    *,
+    snapshot: VaultSnapshot | None = None,
+) -> CheckResult:
     """Report exec folders whose feature disagrees with their records' tag.
 
-    Walks ``<root>/<docs_dir>/exec/*`` directly (rather than the parsed
-    snapshot) so the folder name - which the snapshot does not retain - can be
-    compared against the ``#feature`` tag of each record inside it. For every
-    exec folder named ``{plan_date}-{feature}``, each contained record's
-    feature tag must equal that ``{feature}`` segment; a record carrying a
-    different feature tag is the post-rename drift signal and the folder is
-    reported once as an ``ERROR``.
+    When *snapshot* is supplied (the combined ``run_all_checks`` pass), the
+    folder-vs-tag comparison runs entirely from the snapshot: an exec
+    record's containing folder is its path's parent, and its feature tag is
+    already parsed - no corpus re-read. Standalone, it walks
+    ``<root>/<docs_dir>/exec/*`` directly. For every exec folder named
+    ``{plan_date}-{feature}``, each contained record's feature tag must equal
+    that ``{feature}`` segment; a record carrying a different feature tag is
+    the post-rename drift signal and the folder is reported once as an
+    ``ERROR``.
 
-    Records that are symlinks, unreadable, non-UTF-8 (surfaced by
-    ``check_encoding``), or tagged only ``#uncategorized`` / untagged are
-    skipped. Folders whose name lacks the ``{plan_date}-{feature}`` shape are
-    skipped as a grammar concern owned by ``check_structure``.
+    Records that are symlinks (disk path only), unreadable, non-UTF-8
+    (surfaced by ``check_encoding``), or tagged only ``#uncategorized`` /
+    untagged are skipped. Folders whose name lacks the
+    ``{plan_date}-{feature}`` shape are skipped as a grammar concern owned by
+    ``check_structure``.
 
     The check is vault-wide and takes no ``feature`` filter: drift is defined
     by the folder-vs-tag disagreement itself, not by any single feature scope.
 
     Args:
         root_dir: Project root directory.
+        snapshot: Pre-built snapshot mapping document paths to parsed
+            ``(metadata, body)`` tuples.
 
     Returns:
         :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with check
@@ -96,14 +107,94 @@ def check_feature_rename_integrity(root_dir: Path) -> CheckResult:
     """
     from ...config import get_config
     from ..models import DocType
-    from ..parser import parse_frontmatter
 
     result = CheckResult(check_name="feature-rename-integrity", supports_fix=False)
 
     exec_dir = root_dir / get_config().docs_dir / DocType.EXEC.value
-    if not exec_dir.exists():
-        return result
 
+    if snapshot is not None:
+        conflicts_by_folder = _conflicts_from_snapshot(snapshot, exec_dir)
+    else:
+        if not exec_dir.exists():
+            return result
+        conflicts_by_folder = _conflicts_from_disk(exec_dir)
+
+    for folder, folder_feature, conflicting in conflicts_by_folder:
+        rel_folder = folder.relative_to(root_dir) if folder.is_absolute() else folder
+        conflicting_tags = sorted(conflicting)
+        tag_display = ", ".join(f"#{t}" for t in conflicting_tags)
+        example = conflicting[conflicting_tags[0]]
+        result.diagnostics.append(
+            CheckDiagnostic(
+                path=rel_folder,
+                message=(
+                    f"Exec folder feature segment '{folder_feature}' disagrees "
+                    f"with the {tag_display} feature tag of the records it "
+                    f"contains (e.g. {example.name}). This is post-rename drift "
+                    "between the exec folder name and its records' feature tag."
+                ),
+                severity=Severity.ERROR,
+                fix_description=(
+                    "Reconcile the exec folder name and its records' #feature "
+                    f"tag so they agree (the records are tagged "
+                    f"'#{conflicting_tags[0]}' but live under a "
+                    f"'{folder_feature}' folder)."
+                ),
+            )
+        )
+
+    return result
+
+
+def _record_feature(tags: list[str]) -> str | None:
+    """Return a record's comparable feature tag, or ``None`` to skip it."""
+    feats = extract_feature_tags(tags)
+    feature = feats[0] if feats else None
+    if not feature or feature == "uncategorized":
+        return None
+    return feature
+
+
+def _conflicts_from_snapshot(
+    snapshot: VaultSnapshot,
+    exec_dir: Path,
+) -> list[tuple[Path, str, dict[str, Path]]]:
+    """Derive per-folder tag conflicts from the parsed snapshot.
+
+    Exec records are the snapshot documents whose parent directory sits
+    directly under *exec_dir*; the folder name the disk walk would read is
+    the path's parent name, so no filesystem access is needed.
+    """
+    by_folder: dict[Path, list[Path]] = {}
+    for doc_path in snapshot:
+        parent = doc_path.parent
+        if parent.parent == exec_dir:
+            by_folder.setdefault(parent, []).append(doc_path)
+
+    conflicts: list[tuple[Path, str, dict[str, Path]]] = []
+    for folder in sorted(by_folder):
+        match = _EXEC_FOLDER_RE.match(folder.name)
+        if match is None:
+            continue
+        folder_feature = match.group(1)
+        conflicting: dict[str, Path] = {}
+        for record in sorted(by_folder[folder]):
+            metadata, _body = snapshot[record]
+            feature = _record_feature(metadata.tags)
+            if feature is not None and feature != folder_feature:
+                conflicting.setdefault(feature, record)
+        if conflicting:
+            conflicts.append((folder, folder_feature, conflicting))
+    return conflicts
+
+
+def _conflicts_from_disk(
+    exec_dir: Path,
+) -> list[tuple[Path, str, dict[str, Path]]]:
+    """Derive per-folder tag conflicts by walking the exec tree directly."""
+    from ..parser import parse_frontmatter
+
+    conflicts: list[tuple[Path, str, dict[str, Path]]] = []
     for folder in sorted(exec_dir.iterdir()):
         if folder.is_symlink() or not folder.is_dir():
             continue
@@ -131,37 +222,9 @@ def check_feature_rename_integrity(root_dir: Path) -> CheckResult:
             tags = meta.get("tags", [])
             if isinstance(tags, str):
                 tags = [tags]
-            feats = extract_feature_tags(tags)
-            feature = feats[0] if feats else None
-            if not feature or feature == "uncategorized":
-                continue
-            if feature != folder_feature:
+            feature = _record_feature(tags)
+            if feature is not None and feature != folder_feature:
                 conflicting.setdefault(feature, record)
-
-        if not conflicting:
-            continue
-
-        rel_folder = folder.relative_to(root_dir) if folder.is_absolute() else folder
-        conflicting_tags = sorted(conflicting)
-        tag_display = ", ".join(f"#{t}" for t in conflicting_tags)
-        example = conflicting[conflicting_tags[0]]
-        result.diagnostics.append(
-            CheckDiagnostic(
-                path=rel_folder,
-                message=(
-                    f"Exec folder feature segment '{folder_feature}' disagrees "
-                    f"with the {tag_display} feature tag of the records it "
-                    f"contains (e.g. {example.name}). This is post-rename drift "
-                    "between the exec folder name and its records' feature tag."
-                ),
-                severity=Severity.ERROR,
-                fix_description=(
-                    "Reconcile the exec folder name and its records' #feature "
-                    f"tag so they agree (the records are tagged "
-                    f"'#{conflicting_tags[0]}' but live under a "
-                    f"'{folder_feature}' folder)."
-                ),
-            )
-        )
-
-    return result
+        if conflicting:
+            conflicts.append((folder, folder_feature, conflicting))
+    return conflicts

--- a/src/vaultspec_core/vaultcore/checks/features.py
+++ b/src/vaultspec_core/vaultcore/checks/features.py
@@ -35,35 +35,6 @@ def _count_index_related(snapshot: VaultSnapshot) -> dict[str, int]:
     return counts
 
 
-def _index_exists_for(
-    feat_name: str,
-    snapshot: VaultSnapshot,
-) -> bool:
-    """Return ``True`` when an index file for *feat_name* exists.
-
-    The check is filename-based and folder-agnostic so both legacy
-    root-level indexes and the canonical ``index/`` subfolder layout
-    satisfy the predicate. The migration auto-fix relocates legacy
-    files; until it runs they still count as existing for staleness
-    purposes.
-    """
-    return any(doc_path.name == f"{feat_name}.index.md" for doc_path in snapshot)
-
-
-def _count_feature_docs(
-    feat_name: str,
-    snapshot: VaultSnapshot,
-) -> int:
-    """Count non-index documents tagged with *feat_name*."""
-    count = 0
-    for doc_path, (metadata, _body) in snapshot.items():
-        if is_generated_index(doc_path):
-            continue
-        if feat_name in extract_feature_tags(metadata.tags):
-            count += 1
-    return count
-
-
 def check_features(
     root_dir: Path,
     *,
@@ -94,14 +65,22 @@ def check_features(
 
     result = CheckResult(check_name="features", supports_fix=False)
 
+    # One pass over the snapshot collects everything the per-feature loop
+    # needs: the doc-type sets, the per-feature document counts, and the
+    # index-file name set. No helper below re-scans the snapshot, so the
+    # check stays linear in corpus size instead of features x documents.
     by_feature: dict[str, set[str]] = {}
+    doc_counts: dict[str, int] = {}
+    index_names: set[str] = set()
     for doc_path, (metadata, _body) in snapshot.items():
         if is_generated_index(doc_path):
+            index_names.add(doc_path.name)
             continue
         feat_tags = extract_feature_tags(metadata.tags)
         dt = get_doc_type(doc_path, root_dir)
         dt_value = dt.value if dt else None
-        for ft in feat_tags:
+        for ft in set(feat_tags):
+            doc_counts[ft] = doc_counts.get(ft, 0) + 1
             if dt_value:
                 by_feature.setdefault(ft, set()).add(dt_value)
 
@@ -171,7 +150,9 @@ def check_features(
 
         # -- Index health checks --
 
-        if not _index_exists_for(feat_name, snapshot):
+        # Filename-based and folder-agnostic: both legacy root-level indexes
+        # and the canonical index/ subfolder layout satisfy the predicate.
+        if f"{feat_name}.index.md" not in index_names:
             result.diagnostics.append(
                 CheckDiagnostic(
                     path=None,
@@ -188,7 +169,7 @@ def check_features(
             )
         else:
             # Index exists - check staleness
-            actual_count = _count_feature_docs(feat_name, snapshot)
+            actual_count = doc_counts.get(feat_name, 0)
             index_count = index_related_counts.get(feat_name, 0)
             if index_count != actual_count:
                 result.diagnostics.append(

--- a/src/vaultspec_core/vaultcore/checks/frontmatter.py
+++ b/src/vaultspec_core/vaultcore/checks/frontmatter.py
@@ -119,6 +119,9 @@ def _fix_frontmatter(doc_path: Path, root_dir: Path) -> str | None:
     if metadata.modified:
         lines.append(f"modified: '{metadata.modified}'")
 
+    if metadata.body_schema:
+        lines.append(f"body_schema: '{metadata.body_schema}'")
+
     if metadata.related:
         lines.append("related:")
         for link in metadata.related:
@@ -149,6 +152,7 @@ def _fix_frontmatter(doc_path: Path, root_dir: Path) -> str | None:
         "tags",
         "date",
         "modified",
+        "body_schema",
         "related",
         "feature",
         "supersedes",

--- a/src/vaultspec_core/vaultcore/checks/markdown.py
+++ b/src/vaultspec_core/vaultcore/checks/markdown.py
@@ -28,6 +28,7 @@ from ._base import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
     from pathlib import Path
 
 __all__ = ["apply_markdown_hygiene", "check_markdown"]
@@ -141,6 +142,7 @@ def check_markdown(
     *,
     feature: str | None = None,
     fix: bool = False,
+    raw_texts: Mapping[Path, tuple[str, bool]] | None = None,
 ) -> CheckResult:
     """Check and optionally fix markdown hygiene across vault documents.
 
@@ -155,31 +157,36 @@ def check_markdown(
         feature: Restrict checks to documents with this feature tag
             (without ``#``).
         fix: When ``True``, rewrite affected documents in place.
+        raw_texts: The ingress read's per-document ``(text, crlf)`` map (see
+            :attr:`~vaultspec_core.graph.api.VaultGraph.raw_texts`).  When
+            supplied on a non-mutating pass, documents are validated from it
+            instead of re-reading the corpus - the single-ingress contract.
+            Ignored when ``fix`` is set: the mutating path reads and rewrites
+            the file it is about to change.
 
     Returns:
         :class:`~vaultspec_core.vaultcore.checks._base.CheckResult` with
         check name ``"markdown"``.
     """
     from ..parser import parse_vault_metadata
-    from ..scanner import scan_vault
+    from ._base import iter_document_texts
 
     result = CheckResult(check_name="markdown", supports_fix=True)
     wanted_feature = feature.lstrip("#") if feature else None
 
-    for doc_path in scan_vault(
-        root_dir,
-        run_migrations=not bool(wanted_feature),
-    ):
-        try:
-            raw_content = doc_path.read_bytes().decode("utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
+    if raw_texts is not None and not fix:
+        sources: Iterable[tuple[Path, str, bool]] = (
+            (path, text, crlf) for path, (text, crlf) in raw_texts.items()
+        )
+    else:
+        sources = iter_document_texts(root_dir, run_migrations=not bool(wanted_feature))
 
+    for doc_path, raw_content, has_crlf in sources:
         metadata, _body = parse_vault_metadata(raw_content)
         if wanted_feature and wanted_feature not in extract_feature_tags(metadata.tags):
             continue
 
-        source_newline = "\r\n" if "\r\n" in raw_content else "\n"
+        source_newline = "\r\n" if has_crlf else "\n"
         content_lf = raw_content.replace("\r\n", "\n")
         cleaned_lf, stats = apply_markdown_hygiene(content_lf)
         if stats.total == 0:

--- a/src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py
@@ -1,21 +1,24 @@
-"""Tests for the ``body-sections`` vault health checker.
+"""Tests for the body-sections vault health checker.
 
-Exercises template-derived required-section validation against real on-disk
-documents and controlled templates in ``.vaultspec/templates/``: present
-sections pass, absent sections are flagged, comment-only and placeholder-only
-sections read as empty, every document type is covered, plans require their
-sections across tiers, execution records select the step vs summary template,
-and a missing template degrades to a skip. No mocks, patches, or skips.
+Exercises immutable, attested body-schema validation against real on-disk
+documents. A current schema stamp selects the registry contract, missing or
+unknown provenance is reported, mutable deployed templates cannot alter a
+document's requirements, and execution records select their step or summary
+contract. No mocks, patches, or skips.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import TYPE_CHECKING
 
 import pytest
 
 from ....config import reset_config
 from ....graph import VaultGraph
+from ...body_schema import body_schema_baseline_path
+from ...parser import parse_vault_metadata
 from .._base import Severity
 from ..body_sections import check_body_sections
 
@@ -25,14 +28,35 @@ if TYPE_CHECKING:
 
 pytestmark = [pytest.mark.unit]
 
-# Directory tag and template filename per document type under test.
+_CURRENT_SCHEMA = "body-v1"
+
+# These are the reviewed body-v1 contracts. The checker resolves them from
+# production code; naming them here keeps each fixture readable and lets each
+# case isolate the exact required section it exercises.
+_REQUIRED_SECTIONS = {
+    "adr": (
+        "Problem Statement",
+        "Considerations",
+        "Considered options",
+        "Constraints",
+        "Implementation",
+        "Rationale",
+        "Consequences",
+    ),
+    "audit": ("Scope", "Findings", "Recommendations"),
+    "plan": ("Description", "Steps", "Parallelization", "Verification"),
+    "research": ("Findings", "Sources"),
+    "reference": ("Summary",),
+    "exec": ("Description", "Outcome", "Notes"),
+}
+
 _TYPE_META = {
-    "adr": ("#adr", "adr.md"),
-    "plan": ("#plan", "plan.md"),
-    "research": ("#research", "research.md"),
-    "reference": ("#reference", "reference.md"),
-    "audit": ("#audit", "audit.md"),
-    "exec": ("#exec", "exec-step.md"),
+    "adr": "#adr",
+    "plan": "#plan",
+    "research": "#research",
+    "reference": "#reference",
+    "audit": "#audit",
+    "exec": "#exec",
 }
 
 
@@ -43,13 +67,6 @@ def _reset_cfg() -> Generator[None]:
     reset_config()
 
 
-def _write_template(root: Path, name: str, sections: tuple[str, ...]) -> None:
-    tdir = root / ".vaultspec" / "templates"
-    tdir.mkdir(parents=True, exist_ok=True)
-    heads = "\n\n".join(f"## {s}\n\n<!-- hint -->" for s in sections)
-    (tdir / name).write_text(f"# `{{feature}}` doc\n\n{heads}\n", encoding="utf-8")
-
-
 def _write_doc(
     root: Path,
     doc_type: str,
@@ -58,14 +75,16 @@ def _write_doc(
     *,
     feature: str = "feat",
     folder: str | None = None,
+    body_schema: str | None = _CURRENT_SCHEMA,
 ) -> Path:
-    tag, _template = _TYPE_META[doc_type]
     body_parts = [
         f"## {title}\n\n{content}".rstrip() for title, content in section_bodies.items()
     ]
+    schema_line = f"body_schema: '{body_schema}'\n" if body_schema is not None else ""
     text = (
-        f"---\ntags:\n  - '{tag}'\n  - '#{feature}'\n"
-        f"date: '2026-02-04'\nmodified: '2026-02-04'\nrelated: []\n---\n\n"
+        f"---\ntags:\n  - '{_TYPE_META[doc_type]}'\n  - '#{feature}'\n"
+        f"date: '2026-02-04'\nmodified: '2026-02-04'\n{schema_line}"
+        "related: []\n---\n\n"
         f"# {stem}\n\n" + "\n\n".join(body_parts) + "\n"
     )
     if doc_type == "exec":
@@ -76,6 +95,13 @@ def _write_doc(
     path = sub / f"{stem}.md"
     path.write_text(text, encoding="utf-8")
     return path
+
+
+def _contents(doc_type: str) -> dict[str, str]:
+    return {
+        section: f"Authored {section} prose."
+        for section in _REQUIRED_SECTIONS[doc_type]
+    }
 
 
 def _skeleton(root: Path) -> None:
@@ -91,13 +117,7 @@ def _run(root: Path, *, feature: str | None = None):
 class TestBodySections:
     def test_check_shape(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "adr.md", ("Problem", "Consequences"))
-        _write_doc(
-            tmp_path,
-            "adr",
-            "2026-02-04-feat-adr",
-            {"Problem": "real prose", "Consequences": "real prose"},
-        )
+        _write_doc(tmp_path, "adr", "2026-02-04-feat-adr", _contents("adr"))
         result = _run(tmp_path)
         assert result.check_name == "body-sections"
         assert result.supports_fix is False
@@ -105,28 +125,21 @@ class TestBodySections:
 
     def test_absent_required_section_flagged(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "adr.md", ("Problem", "Consequences"))
-        _write_doc(
-            tmp_path,
-            "adr",
-            "2026-02-04-feat-adr",
-            {"Problem": "real prose"},  # Consequences missing
-        )
+        sections = _contents("adr")
+        del sections["Consequences"]
+        _write_doc(tmp_path, "adr", "2026-02-04-feat-adr", sections)
         result = _run(tmp_path)
         warnings = [d for d in result.diagnostics if d.severity == Severity.WARNING]
         assert len(warnings) == 1
         assert "Consequences" in warnings[0].message
         assert "Missing required section" in warnings[0].message
+        assert "body-v1" in warnings[0].message
 
     def test_empty_required_section_flagged(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "adr.md", ("Problem", "Consequences"))
-        _write_doc(
-            tmp_path,
-            "adr",
-            "2026-02-04-feat-adr",
-            {"Problem": "real prose", "Consequences": "   "},
-        )
+        sections = _contents("adr")
+        sections["Consequences"] = "   "
+        _write_doc(tmp_path, "adr", "2026-02-04-feat-adr", sections)
         result = _run(tmp_path)
         warnings = [d for d in result.diagnostics if "Consequences" in d.message]
         assert len(warnings) == 1
@@ -134,13 +147,9 @@ class TestBodySections:
 
     def test_extra_author_section_tolerated(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "adr.md", ("Problem",))
-        _write_doc(
-            tmp_path,
-            "adr",
-            "2026-02-04-feat-adr",
-            {"Problem": "real prose", "Appendix": "bonus content"},
-        )
+        sections = _contents("reference")
+        sections["Appendix"] = "Bonus content."
+        _write_doc(tmp_path, "reference", "2026-02-04-feat-reference", sections)
         result = _run(tmp_path)
         assert result.diagnostics == []
 
@@ -149,13 +158,11 @@ class TestBodySections:
         self, tmp_path: Path, doc_type: str
     ) -> None:
         _skeleton(tmp_path)
-        _, template = _TYPE_META[doc_type]
-        _write_template(tmp_path, template, ("Alpha", "Beta"))
         _write_doc(
             tmp_path,
             doc_type,
             f"2026-02-04-feat-{doc_type}",
-            {"Alpha": "content", "Beta": "content"},
+            _contents(doc_type),
         )
         result = _run(tmp_path)
         assert result.diagnostics == []
@@ -165,27 +172,20 @@ class TestBodySections:
         self, tmp_path: Path, doc_type: str
     ) -> None:
         _skeleton(tmp_path)
-        _, template = _TYPE_META[doc_type]
-        _write_template(tmp_path, template, ("Alpha", "Beta"))
-        _write_doc(
-            tmp_path,
-            doc_type,
-            f"2026-02-04-feat-{doc_type}",
-            {"Alpha": "content"},  # Beta missing
-        )
+        sections = _contents(doc_type)
+        missing = _REQUIRED_SECTIONS[doc_type][-1]
+        del sections[missing]
+        _write_doc(tmp_path, doc_type, f"2026-02-04-feat-{doc_type}", sections)
         result = _run(tmp_path)
-        warnings = [d for d in result.diagnostics if "Beta" in d.message]
+        warnings = [d for d in result.diagnostics if missing in d.message]
         assert len(warnings) == 1
+        assert "Missing required section" in warnings[0].message
 
     def test_comment_only_section_is_empty(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "research.md", ("Findings",))
-        _write_doc(
-            tmp_path,
-            "research",
-            "2026-02-04-feat-research",
-            {"Findings": "<!-- One subsection per line of inquiry. -->"},
-        )
+        sections = _contents("research")
+        sections["Findings"] = "<!-- One subsection per line of inquiry. -->"
+        _write_doc(tmp_path, "research", "2026-02-04-feat-research", sections)
         result = _run(tmp_path)
         warnings = [d for d in result.diagnostics if "Findings" in d.message]
         assert len(warnings) == 1
@@ -193,97 +193,144 @@ class TestBodySections:
 
     def test_placeholder_only_section_is_empty(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "research.md", ("Findings",))
-        _write_doc(
-            tmp_path,
-            "research",
-            "2026-02-04-feat-research",
-            {"Findings": "{topic}"},
-        )
+        sections = _contents("research")
+        sections["Findings"] = "{topic}"
+        _write_doc(tmp_path, "research", "2026-02-04-feat-research", sections)
         result = _run(tmp_path)
         warnings = [d for d in result.diagnostics if "Findings" in d.message]
         assert len(warnings) == 1
         assert "empty" in warnings[0].message
 
     def test_plan_sections_required_across_tiers(self, tmp_path: Path) -> None:
-        # The plan template mandates the same sections regardless of a plan's
-        # tier; a plan missing one is flagged whether it is L1 or L2.
         _skeleton(tmp_path)
-        _write_template(
-            tmp_path,
-            "plan.md",
-            ("Description", "Steps", "Parallelization", "Verification"),
-        )
         for tier, stem in (("L1", "2026-02-04-l1-plan"), ("L2", "2026-02-04-l2-plan")):
-            path = tmp_path / ".vault" / "plan" / f"{stem}.md"
-            path.parent.mkdir(parents=True, exist_ok=True)
+            sections = _contents("plan")
+            del sections["Verification"]
+            path = _write_doc(tmp_path, "plan", stem, sections)
+            contents = path.read_text(encoding="utf-8")
             path.write_text(
-                f"---\ntags:\n  - '#plan'\n  - '#feat'\n"
-                f"date: '2026-02-04'\nmodified: '2026-02-04'\ntier: {tier}\n"
-                "related: []\n---\n\n"
-                f"# `feat` plan\n\n## Description\n\np\n\n## Steps\n\np\n\n"
-                "## Parallelization\n\np\n",  # Verification missing
+                contents.replace("related: []", f"tier: {tier}\nrelated: []"),
                 encoding="utf-8",
             )
         result = _run(tmp_path)
         missing = [d for d in result.diagnostics if "Verification" in d.message]
-        assert len(missing) == 2  # both tiers flagged identically
+        assert len(missing) == 2
 
-    def test_exec_summary_uses_summary_template(self, tmp_path: Path) -> None:
-        # A -summary exec is validated against exec-summary.md, not exec-step.md.
+    def test_exec_summary_uses_summary_contract(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "exec-step.md", ("Description", "Outcome", "Notes"))
-        _write_template(tmp_path, "exec-summary.md", ("Description",))
-        # Summary doc has only Description: clean against exec-summary, but would
-        # fail against exec-step (which also requires Outcome and Notes).
         _write_doc(
             tmp_path,
             "exec",
             "2026-02-04-feat-P01-summary",
-            {"Description": "phase summary prose"},
+            {"Description": "Phase summary prose."},
         )
         result = _run(tmp_path)
         assert result.diagnostics == []
 
     def test_exec_step_requires_all_step_sections(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "exec-step.md", ("Description", "Outcome", "Notes"))
         _write_doc(
             tmp_path,
             "exec",
             "2026-02-04-feat-P01-S01",
-            {"Description": "did it"},  # Outcome, Notes missing
+            {"Description": "Did it."},
         )
         result = _run(tmp_path)
         titles = {
-            t
-            for d in result.diagnostics
-            for t in ("Outcome", "Notes")
-            if t in d.message
+            title
+            for diagnostic in result.diagnostics
+            for title in ("Outcome", "Notes")
+            if title in diagnostic.message
         }
         assert titles == {"Outcome", "Notes"}
 
-    def test_missing_template_degrades_to_skip(self, tmp_path: Path) -> None:
-        # No template written for adr: the checker skips rather than flagging.
+    def test_current_stamp_ignores_deployed_template(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        templates = tmp_path / ".vaultspec" / "templates"
+        templates.mkdir()
+        (templates / "adr.md").write_text(
+            "# mutable template\n\n## Invented future requirement\n",
+            encoding="utf-8",
+        )
+        _write_doc(tmp_path, "adr", "2026-02-04-feat-adr", _contents("adr"))
+        result = _run(tmp_path)
+        assert result.diagnostics == []
+
+    def test_missing_schema_provenance_is_flagged(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
         _write_doc(
             tmp_path,
             "adr",
             "2026-02-04-feat-adr",
-            {"Anything": "content"},
+            _contents("adr"),
+            body_schema=None,
         )
         result = _run(tmp_path)
+        assert len(result.diagnostics) == 1
+        diagnostic = result.diagnostics[0]
+        assert diagnostic.severity is Severity.WARNING
+        assert "provenance is not attested" in diagnostic.message
+        assert "body_schema" in diagnostic.message
+
+    def test_hash_attested_legacy_body_is_validated_by_its_contract(
+        self, tmp_path: Path
+    ) -> None:
+        _skeleton(tmp_path)
+        document = _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            _contents("adr"),
+            body_schema=None,
+        )
+        _metadata, body = parse_vault_metadata(document.read_text(encoding="utf-8"))
+        ledger = body_schema_baseline_path(tmp_path)
+        ledger.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "path": ".vault/adr/2026-02-04-feat-adr.md",
+                            "body_sha256": hashlib.sha256(
+                                body.encode("utf-8")
+                            ).hexdigest(),
+                            "body_schema": "legacy-adr-v3",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = _run(tmp_path)
+
         assert result.diagnostics == []
+
+    def test_unknown_schema_provenance_is_flagged(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            _contents("adr"),
+            body_schema="body-v999",
+        )
+        result = _run(tmp_path)
+        assert len(result.diagnostics) == 1
+        diagnostic = result.diagnostics[0]
+        assert diagnostic.severity is Severity.WARNING
+        assert "provenance is not attested" in diagnostic.message
+        assert "body-v999" in diagnostic.message
 
     def test_generated_index_is_skipped(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
-        _write_template(tmp_path, "index.md", ("Documents",))
         idx = tmp_path / ".vault" / "index" / "feat.index.md"
         idx.parent.mkdir(parents=True, exist_ok=True)
         idx.write_text(
             "---\ntags:\n  - '#index'\n  - '#feat'\n"
             "date: '2026-02-04'\nmodified: '2026-02-04'\nrelated: []\n---\n\n"
-            "# `feat` feature index\n",  # no Documents section
+            "# feat feature index\n",
             encoding="utf-8",
         )
         result = _run(tmp_path)

--- a/src/vaultspec_core/vaultcore/checks/tests/test_frontmatter_fields.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_frontmatter_fields.py
@@ -61,6 +61,7 @@ tags:
   - "#adr"
   - "#feat"
 date: 2026-05-17
+body_schema: 'body-v1'
 supersedes:
   - "2026-05-01-old-adr"
   - "2026-05-10-other-adr"
@@ -111,6 +112,7 @@ def test_fix_frontmatter_preserves_new_fields(tmp_path):
         """---
 feature: my-feature
 date: 2026-05-17
+body_schema: 'body-v1'
 supersedes:
   - "2026-05-01-old-adr"
 superseded_by: "2026-05-20-newer-adr"
@@ -134,6 +136,7 @@ archived: 2026-05-22
     new_content = doc.read_text(encoding="utf-8")
     meta, _ = parse_vault_metadata(new_content)
     assert meta.tags == ["#adr", "#my-feature"]
+    assert meta.body_schema == "body-v1"
     assert meta.supersedes == ["2026-05-01-old-adr"]
     assert meta.superseded_by == "2026-05-20-newer-adr"
     assert meta.derived_from == ["audit:2026-05-17-cli-simplification"]
@@ -146,6 +149,7 @@ archived: 2026-05-22
     assert new_content.count("derived_from:") == 1
     assert new_content.count("promoted_to:") == 1
     assert new_content.count("archived:") == 1
+    assert new_content.count("body_schema:") == 1
 
 
 def test_migration_0_1_21(tmp_path):

--- a/src/vaultspec_core/vaultcore/checks/tests/test_single_ingress.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_single_ingress.py
@@ -1,0 +1,162 @@
+"""Enforce the single-ingress contract for the check pipeline.
+
+The contract: on a non-mutating ``run_all_checks`` pass, every read of the
+vault corpus happens during ingress (the graph build plus
+``ensure_raw_texts``), and the calculate phase - every checker - runs
+entirely from the shared snapshot and raw-text map. The enforcement here is
+physical, not mocked: after ingress completes, every document in the corpus
+is *deleted from disk*, and the calculate phase must still produce exactly
+the diagnostics it produced against the intact corpus. Any checker that
+silently re-ingests the corpus mid-calculate would either crash or lose its
+findings, failing the equality assertion.
+
+``check_rename_integrity`` reads ``.vaultspec/`` workspace resources (not
+the vault corpus) and the archive probe in ``check_exec_mapping`` targets
+``_archive/`` (excluded from the corpus scan by design); neither touches
+the scanned corpus, so the lockdown does not affect them.
+"""
+
+from __future__ import annotations
+
+import shutil
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ....config import reset_config
+from ....graph import VaultGraph
+from ....testing.synthetic import build_synthetic_vault
+from .. import (
+    CheckResult,
+    check_annotations,
+    check_body_sections,
+    check_encoding,
+    check_exec_mapping,
+    check_feature_rename_integrity,
+    check_features,
+    check_markdown,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = [pytest.mark.unit]
+
+
+@pytest.fixture
+def vault_root(tmp_path: Path) -> Path:
+    reset_config()
+    build_synthetic_vault(
+        tmp_path,
+        n_docs=30,
+        seed=21,
+        pathologies=["cycle", "stem_collision"],
+    )
+    return tmp_path
+
+
+def _as_comparable(result: CheckResult) -> list[tuple[str, str, str]]:
+    return [(str(d.path), d.message, str(d.severity)) for d in result.diagnostics]
+
+
+def _calculate_phase(
+    root: Path, graph: VaultGraph
+) -> dict[str, list[tuple[str, str, str]]]:
+    """Run every converted checker from the shared ingress state."""
+    snapshot = graph.to_snapshot()
+    raw_texts = graph.raw_texts
+    return {
+        "annotations": _as_comparable(
+            check_annotations(root, fix=False, raw_texts=raw_texts)
+        ),
+        "markdown": _as_comparable(
+            check_markdown(root, fix=False, raw_texts=raw_texts)
+        ),
+        "encoding": _as_comparable(check_encoding(root, graph=graph)),
+        "features": _as_comparable(check_features(root, snapshot=snapshot)),
+        "exec-mapping": _as_comparable(
+            check_exec_mapping(root, snapshot=snapshot, raw_texts=raw_texts)
+        ),
+        "body-sections": _as_comparable(check_body_sections(root, snapshot=snapshot)),
+        "feature-rename-integrity": _as_comparable(
+            check_feature_rename_integrity(root, snapshot=snapshot)
+        ),
+    }
+
+
+class TestSingleIngress:
+    def test_calculate_phase_survives_corpus_deletion(self, vault_root: Path) -> None:
+        # Ingress: one build, one raw-text pass. Everything after this line
+        # must run without the corpus.
+        graph = VaultGraph(vault_root, use_cache=False)
+        graph.ensure_raw_texts()
+        assert graph.raw_texts, "ingress must retain the corpus text"
+
+        baseline = _calculate_phase(vault_root, graph)
+
+        # Physically remove the corpus. A checker that re-reads any document
+        # now sees an empty vault and diverges from the baseline.
+        docs_dir = vault_root / ".vault"
+        assert docs_dir.exists()
+        shutil.rmtree(docs_dir)
+        assert not docs_dir.exists()
+
+        after_deletion = _calculate_phase(vault_root, graph)
+
+        assert after_deletion == baseline
+
+    def test_undecodable_plan_reference_stays_disk_free(self, vault_root: Path) -> None:
+        # A valid exec record pointing at a plan that failed to decode
+        # during ingress must not trigger a disk fallback: the plan is
+        # classified as unparseable from ingress state alone, and the
+        # finding survives corpus deletion.
+        bad_plan = vault_root / ".vault" / "plan" / "2026-01-01-badplan-plan.md"
+        bad_plan.write_bytes(b"\xff\xfe\x00not a utf-8 plan")
+        exec_dir = vault_root / ".vault" / "exec" / "2026-01-01-badplan"
+        exec_dir.mkdir(parents=True)
+        record = exec_dir / "2026-01-01-badplan-S01.md"
+        record.write_text(
+            "---\n"
+            "tags:\n"
+            "  - '#exec'\n"
+            "  - '#badplan'\n"
+            "date: '2026-01-01'\n"
+            "step_id: 'S01'\n"
+            "related:\n"
+            "  - '[[2026-01-01-badplan-plan]]'\n"
+            "---\n\n# badplan S01\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        graph = VaultGraph(vault_root, use_cache=False)
+        graph.ensure_raw_texts()
+        snapshot = graph.to_snapshot()
+        raw_texts = graph.raw_texts
+        assert bad_plan not in raw_texts
+
+        baseline = check_exec_mapping(
+            vault_root, snapshot=snapshot, raw_texts=raw_texts
+        )
+        messages = [d.message for d in baseline.diagnostics]
+        assert any("could not be parsed" in m and "S01" in m for m in messages)
+
+        shutil.rmtree(vault_root / ".vault")
+        after = check_exec_mapping(vault_root, snapshot=snapshot, raw_texts=raw_texts)
+        assert _as_comparable(after) == _as_comparable(baseline)
+
+    def test_encoding_diagnostics_survive_via_ingress_facts(
+        self, vault_root: Path
+    ) -> None:
+        # A non-UTF-8 file must be reported from the ingress-recorded facts,
+        # not a disk walk: plant one, ingest, delete the corpus, and the
+        # finding must still be present.
+        bad = vault_root / ".vault" / "research" / "2026-01-01-bad-encoding.md"
+        bad.write_bytes(b"\xff\xfe\x00broken utf-16-ish bytes")
+
+        graph = VaultGraph(vault_root, use_cache=False)
+        graph.ensure_raw_texts()
+        shutil.rmtree(vault_root / ".vault")
+
+        result = check_encoding(vault_root, graph=graph)
+        messages = [d.message for d in result.diagnostics]
+        assert any("not valid UTF-8" in m for m in messages)

--- a/src/vaultspec_core/vaultcore/edit_engine.py
+++ b/src/vaultspec_core/vaultcore/edit_engine.py
@@ -629,7 +629,7 @@ def execute_edit(
             proposed_lf
             if source_newline == "\n"
             else proposed_lf.replace("\n", source_newline)
-        ).encode("utf-8")
+        ).encode("utf-8", errors="surrogateescape")
 
         changed = proposed_bytes != original_bytes
 

--- a/src/vaultspec_core/vaultcore/hydration.py
+++ b/src/vaultspec_core/vaultcore/hydration.py
@@ -16,6 +16,7 @@ import re
 from typing import TYPE_CHECKING
 
 from ..core.exceptions import ResourceExistsError
+from .body_schema import CURRENT_BODY_SCHEMA
 from .models import DocType
 
 __all__ = ["get_template_path", "hydrate_template"]
@@ -189,6 +190,7 @@ def hydrate_template(
     # than relying on the template carrying the field, so scaffolds from
     # mirrors whose templates predate the schema row still get stamped.
     hydrated = _inject_modified(hydrated, date)
+    hydrated = _inject_body_schema(hydrated)
 
     # Inject resolved related links into frontmatter
     if related is not None:
@@ -257,6 +259,37 @@ def _inject_modified(content: str, date: str) -> str:
 
     insert_at = fence.start(1) + date_line.end()
     return content[:insert_at] + f"modified: '{date}'\n" + content[insert_at:]
+
+
+def _inject_body_schema(content: str) -> str:
+    """Ensure every newly hydrated document declares the current contract.
+
+    A stale deployed template may carry an older schema identifier, but a new
+    document cannot self-classify as historical. The scaffolder therefore
+    always writes :data:`CURRENT_BODY_SCHEMA` rather than preserving a template
+    token; legacy schemas are available only through hash attestation.
+    """
+    fence = re.match(r"^---\s*\n(.*?\n)---", content, re.DOTALL)
+    if not fence:
+        return content
+    frontmatter_block = fence.group(1)
+    schema_line = re.search(r"^body_schema:[^\n]*\n", frontmatter_block, re.MULTILINE)
+    if schema_line:
+        start = fence.start(1) + schema_line.start()
+        end = fence.start(1) + schema_line.end()
+        return (
+            content[:start] + f"body_schema: '{CURRENT_BODY_SCHEMA}'\n" + content[end:]
+        )
+
+    modified_line = re.search(r"^modified:[^\n]*\n", frontmatter_block, re.MULTILINE)
+    if not modified_line:
+        return content
+    insert_at = fence.start(1) + modified_line.end()
+    return (
+        content[:insert_at]
+        + f"body_schema: '{CURRENT_BODY_SCHEMA}'\n"
+        + content[insert_at:]
+    )
 
 
 def _inject_related(content: str, related: list[str]) -> str:

--- a/src/vaultspec_core/vaultcore/index.py
+++ b/src/vaultspec_core/vaultcore/index.py
@@ -51,6 +51,7 @@ def generate_feature_index(
         Path to the created or updated index file.
     """
     from ..config import get_config
+    from .body_schema import CURRENT_BODY_SCHEMA
 
     cfg = get_config()
     docs_dir = root_dir / cfg.docs_dir
@@ -97,6 +98,7 @@ def generate_feature_index(
         f"  - '#{feature}'\n"
         f"date: '{date}'\n"
         f"modified: '{date}'\n"
+        f"body_schema: '{CURRENT_BODY_SCHEMA}'\n"
         f"{related_block}\n"
         f"---\n"
         f"\n"

--- a/src/vaultspec_core/vaultcore/models.py
+++ b/src/vaultspec_core/vaultcore/models.py
@@ -293,6 +293,9 @@ class DocumentMetadata:
             every other document type and on legacy exec records predating the
             field. Consumed by the exec-mapping health check to back-map a
             record to a live Step in its parent plan.
+        body_schema: Immutable body-section contract identifier stamped on new
+            scaffolds. ``None`` remains valid for historical documents until
+            their hash-attested baseline is introduced.
     """
 
     tags: list[str] = field(default_factory=list)
@@ -305,6 +308,7 @@ class DocumentMetadata:
     promoted_to: list[str] = field(default_factory=list)
     archived: str | None = None
     step_id: str | None = None
+    body_schema: str | None = None
 
     def validate(self) -> list[str]:
         """Validate the metadata against the vault schema rules.

--- a/src/vaultspec_core/vaultcore/orientation.py
+++ b/src/vaultspec_core/vaultcore/orientation.py
@@ -527,7 +527,7 @@ def compute_rollup(
             real_nodes, limit=limit, since_days=since_days, reference=reference
         )
     )
-    totals = get_stats(root_dir)
+    totals = get_stats(root_dir, graph=g)
 
     return Rollup(
         active_features=active_features,

--- a/src/vaultspec_core/vaultcore/parser.py
+++ b/src/vaultspec_core/vaultcore/parser.py
@@ -184,6 +184,8 @@ def parse_vault_metadata(content: str) -> tuple[DocumentMetadata, str]:
                 metadata.archived = val.strip("\"'") or None
             elif key == "step_id":
                 metadata.step_id = val.strip("\"'") or None
+            elif key == "body_schema":
+                metadata.body_schema = val.strip("\"'") or None
             elif val.startswith("[") and val.endswith("]"):
                 # Simple inline list parsing: ["#a", "#b"]
                 items = [

--- a/src/vaultspec_core/vaultcore/query.py
+++ b/src/vaultspec_core/vaultcore/query.py
@@ -25,6 +25,7 @@ from .scanner import get_doc_type, scan_vault
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ..graph import VaultGraph
     from .rename_engine import RenameTransaction
 
 logger = logging.getLogger(__name__)
@@ -84,7 +85,7 @@ def _parse_feature_from_tags(tags: list[str], doc_type_tag: str | None) -> str |
     return None
 
 
-def _scan_all(root_dir: Path) -> list[VaultDocument]:
+def _scan_all(root_dir: Path, *, doc_type: str | None = None) -> list[VaultDocument]:
     """Scan the vault and parse every document into a :class:`VaultDocument`.
 
     Used internally by :func:`list_documents`, :func:`get_stats`,
@@ -92,19 +93,27 @@ def _scan_all(root_dir: Path) -> list[VaultDocument]:
 
     Args:
         root_dir: Project root directory.
+        doc_type: When set, keep only documents of this type.  The type is
+            pure path arithmetic (``get_doc_type``), so the filter is
+            applied before the file is read: a type-scoped listing reads
+            only its own subset of the corpus instead of parsing every
+            document and discarding the rest.
 
     Returns:
-        List of :class:`VaultDocument` instances for all readable vault files.
+        List of :class:`VaultDocument` instances for all readable vault
+        files that pass the filter.
     """
     docs = []
     for doc_path in scan_vault(root_dir):
+        dt = get_doc_type(doc_path, root_dir)
+        dt_str = dt.value if dt else "unknown"
+        if doc_type is not None and dt_str != doc_type:
+            continue
         try:
             content = doc_path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):
             continue
         meta, _ = parse_frontmatter(content)
-        dt = get_doc_type(doc_path, root_dir)
-        dt_str = dt.value if dt else "unknown"
         tags = meta.get("tags", [])
         if isinstance(tags, str):
             tags = [tags]
@@ -149,22 +158,24 @@ def list_documents(
         Ordered list of :class:`VaultDocument` instances matching all
         supplied filters.
     """
-    docs = _scan_all(root_dir)
-
     if doc_type == "orphaned":
         from ..graph import VaultGraph
 
+        docs = _scan_all(root_dir)
         graph = VaultGraph(root_dir)
         orphan_names = set(graph.get_orphaned())
         docs = [d for d in docs if d.name in orphan_names]
     elif doc_type == "invalid":
         from ..graph import VaultGraph
 
+        docs = _scan_all(root_dir)
         graph = VaultGraph(root_dir)
         dangling_sources = {src for src, _ in graph.get_dangling_links()}
         docs = [d for d in docs if d.name in dangling_sources]
-    elif doc_type:
-        docs = [d for d in docs if d.doc_type == doc_type]
+    else:
+        # A concrete doc-type filter is path-derived and applied inside the
+        # scan, before any file is read.
+        docs = _scan_all(root_dir, doc_type=doc_type)
 
     if feature:
         feature = feature.lstrip("#")
@@ -182,6 +193,7 @@ def get_stats(
     feature: str | None = None,
     doc_type: str | None = None,
     date: str | None = None,
+    graph: VaultGraph | None = None,
 ) -> dict:
     """Compute vault statistics with optional filters.
 
@@ -190,6 +202,10 @@ def get_stats(
         feature: Restrict counts to a single feature (without ``#``).
         doc_type: Restrict counts to a single document type.
         date: Restrict to documents matching this date (``YYYY-MM-DD``).
+        graph: Optional pre-built :class:`~vaultspec_core.graph.VaultGraph`
+            to reuse for the orphan and dangling counts; callers that
+            already hold a graph (the orientation rollup) pass it so the
+            stats path never rebuilds a second one.
 
     Returns:
         Dict with keys: ``total_docs``, ``total_features``,
@@ -208,10 +224,11 @@ def get_stats(
             features.add(d.feature)
 
     # Orphan/invalid counts from graph (unfiltered)
-    from ..graph import VaultGraph
-
     try:
-        graph = VaultGraph(root_dir)
+        if graph is None:
+            from ..graph import VaultGraph as _VaultGraph
+
+            graph = _VaultGraph(root_dir)
         orphaned_count = len(graph.get_orphaned())
         dangling_link_count = len(graph.get_dangling_links())
     except (OSError, ValueError) as exc:

--- a/src/vaultspec_core/vaultcore/related_surgery.py
+++ b/src/vaultspec_core/vaultcore/related_surgery.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from ..core.helpers import atomic_write
+from ..core.helpers import atomic_write_bytes
 from .models import refresh_modified_stamp
 
 if TYPE_CHECKING:
@@ -66,7 +66,8 @@ def _atomic_write_restore(path: Path, content: str) -> None:
     Args:
         path: Destination file path.
         content: UTF-8 text to write; must already have the correct line
-            endings applied before this call.
+            endings applied before this call. Low surrogate escapes preserve
+            legacy input bytes exactly.
 
     Raises:
         Exception: Re-raises any exception from the underlying write after
@@ -75,7 +76,7 @@ def _atomic_write_restore(path: Path, content: str) -> None:
     bak = path.with_suffix(path.suffix + ".bak")
     bak.write_bytes(path.read_bytes())
     try:
-        atomic_write(path, content)
+        atomic_write_bytes(path, content.encode("utf-8", errors="surrogateescape"))
     except Exception:
         if bak.exists():
             bak.replace(path)

--- a/src/vaultspec_core/vaultcore/tests/test_body_schema.py
+++ b/src/vaultspec_core/vaultcore/tests/test_body_schema.py
@@ -1,0 +1,318 @@
+"""Tests for immutable declared body-section contracts and legacy attestations."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+from ..body_schema import (
+    BODY_SCHEMA_REGISTRY,
+    CURRENT_BODY_SCHEMA,
+    body_schema_baseline_path,
+    resolve_body_schema,
+)
+from ..models import DocType, DocumentMetadata
+from ..parser import parse_vault_metadata
+
+pytestmark = [pytest.mark.unit]
+
+
+def _metadata(doc_type: DocType, body_schema: str | None) -> DocumentMetadata:
+    return DocumentMetadata(
+        tags=[doc_type.tag, "#schema-provenance"],
+        date="2026-07-27",
+        body_schema=body_schema,
+    )
+
+
+def _write_baseline(root: Path, entries: list[dict[str, str]]) -> None:
+    """Write a real version-one ledger into the test workspace."""
+    path = body_schema_baseline_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"version": 1, "entries": entries}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _entry(path: str, body: str, schema: str) -> dict[str, str]:
+    return {
+        "path": path,
+        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+        "body_schema": schema,
+    }
+
+
+def test_current_contract_is_immutable_and_has_exec_shape_variants() -> None:
+    schema = BODY_SCHEMA_REGISTRY[CURRENT_BODY_SCHEMA]
+
+    assert schema.required_sections(DocType.RESEARCH) == ("Findings", "Sources")
+    assert schema.required_sections(DocType.EXEC) == ("Description", "Outcome", "Notes")
+    assert schema.required_sections(DocType.EXEC, summary=True) == ("Description",)
+
+    # The registry and its section maps are read-only Mappings statically, so
+    # a write is expressed through a cast rather than a checker suppression:
+    # the point of the assertion is that the runtime object rejects it too.
+    with pytest.raises(TypeError):
+        cast("dict[str, Any]", BODY_SCHEMA_REGISTRY)["future-v1"] = schema
+    with pytest.raises(TypeError):
+        cast("dict[tuple[DocType, bool], Any]", schema.sections)[
+            (DocType.RESEARCH, False)
+        ] = ("Findings",)
+
+
+def test_registry_preserves_all_sixteen_historical_template_contracts() -> None:
+    legacy_ids = {key for key in BODY_SCHEMA_REGISTRY if key.startswith("legacy-")}
+
+    assert len(legacy_ids) == 16
+    assert "legacy-plan-v2" in legacy_ids
+    assert "legacy-exec-v1" in legacy_ids
+
+
+def test_resolver_uses_declared_contract_not_workspace_templates(
+    tmp_path: Path,
+) -> None:
+    doc_path = tmp_path / ".vault" / "research" / "2026-07-27-demo-research.md"
+
+    resolution = resolve_body_schema(
+        tmp_path,
+        doc_path,
+        _metadata(DocType.RESEARCH, CURRENT_BODY_SCHEMA),
+        "# demo\n\n## Findings\n\nEvidence.\n",
+    )
+
+    assert resolution.source == "declared"
+    assert resolution.schema_id == CURRENT_BODY_SCHEMA
+    assert resolution.required_sections == ("Findings", "Sources")
+    assert resolution.diagnostic is None
+
+
+def test_resolver_rejects_forged_legacy_schema_without_attestation(
+    tmp_path: Path,
+) -> None:
+    resolution = resolve_body_schema(
+        tmp_path,
+        tmp_path / ".vault" / "adr" / "2026-07-27-demo-adr.md",
+        _metadata(DocType.ADR, "legacy-adr-v1"),
+        "# demo\n",
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.source == "attestation_required"
+    assert resolution.diagnostic is not None
+    assert "hash-attested baseline" in resolution.diagnostic
+
+
+@pytest.mark.parametrize(
+    ("body_schema", "source", "message"),
+    [
+        (None, "missing", "requires a hash-attested legacy baseline"),
+        ("body-v999", "unknown", "unknown body_schema"),
+    ],
+)
+def test_resolver_reports_unattested_or_unknown_provenance(
+    tmp_path: Path,
+    body_schema: str | None,
+    source: str,
+    message: str,
+) -> None:
+    resolution = resolve_body_schema(
+        tmp_path,
+        tmp_path / ".vault" / "adr" / "2026-07-27-demo-adr.md",
+        _metadata(DocType.ADR, body_schema),
+        "# demo\n",
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.source == source
+    assert resolution.diagnostic is not None
+    assert message in resolution.diagnostic
+
+
+def test_resolver_accepts_real_hash_attested_legacy_fixture(tmp_path: Path) -> None:
+    body = (
+        "# Legacy ADR\n\n## Problem Statement\n\nWhy.\n\n"
+        "## Considerations\n\nTrade-offs.\n\n## Constraints\n\nLimits.\n\n"
+        "## Implementation\n\nWork.\n\n## Rationale\n\nReason.\n\n"
+        "## Consequences\n\nEffects.\n"
+    )
+    doc_path = tmp_path / ".vault" / "adr" / "2026-01-01-legacy-adr.md"
+    doc_path.parent.mkdir(parents=True)
+    doc_path.write_text(
+        "---\ntags:\n  - '#adr'\n  - '#legacy'\ndate: '2026-01-01'\n---\n" + body,
+        encoding="utf-8",
+    )
+    metadata, parsed_body = parse_vault_metadata(doc_path.read_text(encoding="utf-8"))
+    _write_baseline(
+        tmp_path,
+        [
+            _entry(
+                ".vault/adr/2026-01-01-legacy-adr.md",
+                parsed_body,
+                "legacy-adr-v1",
+            )
+        ],
+    )
+
+    resolution = resolve_body_schema(tmp_path, doc_path, metadata, parsed_body)
+
+    assert resolution.source == "attested"
+    assert resolution.schema_id == "legacy-adr-v1"
+    assert resolution.required_sections == (
+        "Problem Statement",
+        "Considerations",
+        "Constraints",
+        "Implementation",
+        "Rationale",
+        "Consequences",
+    )
+
+
+def test_resolver_rejects_tampered_legacy_body(tmp_path: Path) -> None:
+    body = "# Legacy\n\n## Findings\n\nEvidence.\n"
+    doc_path = tmp_path / ".vault" / "research" / "2026-01-01-legacy-research.md"
+    _write_baseline(
+        tmp_path,
+        [
+            _entry(
+                ".vault/research/2026-01-01-legacy-research.md",
+                body,
+                "legacy-research-v1",
+            )
+        ],
+    )
+
+    resolution = resolve_body_schema(
+        tmp_path, doc_path, _metadata(DocType.RESEARCH, None), body + "Changed.\n"
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.source == "attestation_required"
+    assert resolution.diagnostic is not None
+    assert "SHA-256" in resolution.diagnostic
+
+
+def test_resolver_rejects_path_escape_in_ledger(tmp_path: Path) -> None:
+    body = "# Legacy\n\n## Findings\n\nEvidence.\n"
+    _write_baseline(
+        tmp_path,
+        [_entry(".vault/adr/../../outside.md", body, "legacy-research-v1")],
+    )
+
+    resolution = resolve_body_schema(
+        tmp_path,
+        tmp_path / ".vault" / "research" / "2026-01-01-legacy-research.md",
+        _metadata(DocType.RESEARCH, None),
+        body,
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.diagnostic is not None
+    assert "unsafe path" in resolution.diagnostic
+
+
+def test_resolver_rejects_duplicate_ledger_entries(tmp_path: Path) -> None:
+    body = "# Legacy\n\n## Findings\n\nEvidence.\n"
+    entry = _entry(
+        ".vault/research/2026-01-01-legacy-research.md", body, "legacy-research-v1"
+    )
+    _write_baseline(tmp_path, [entry, entry])
+
+    resolution = resolve_body_schema(
+        tmp_path,
+        tmp_path / ".vault" / "research" / "2026-01-01-legacy-research.md",
+        _metadata(DocType.RESEARCH, None),
+        body,
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.diagnostic is not None
+    assert "duplicate path" in resolution.diagnostic
+
+
+def test_resolver_reloads_ledger_when_tampering_preserves_metadata(
+    tmp_path: Path,
+) -> None:
+    body = "# Legacy\n\n## Findings\n\nEvidence.\n"
+    path = ".vault/research/2026-01-01-legacy-research.md"
+    document = tmp_path / path
+    _write_baseline(tmp_path, [_entry(path, body, "legacy-research-v1")])
+    initial = resolve_body_schema(
+        tmp_path, document, _metadata(DocType.RESEARCH, None), body
+    )
+    assert initial.source == "attested"
+
+    ledger = body_schema_baseline_path(tmp_path)
+    before = ledger.stat()
+    _write_baseline(
+        tmp_path,
+        [
+            {
+                "path": path,
+                "body_sha256": "0" * 64,
+                "body_schema": "legacy-research-v1",
+            }
+        ],
+    )
+    os.utime(ledger, ns=(before.st_atime_ns, before.st_mtime_ns))
+
+    resolution = resolve_body_schema(
+        tmp_path, document, _metadata(DocType.RESEARCH, None), body
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.source == "attestation_required"
+    assert resolution.diagnostic is not None
+    assert "SHA-256" in resolution.diagnostic
+
+
+def test_resolver_rejects_non_string_ledger_schema(tmp_path: Path) -> None:
+    body = "# Legacy\n\n## Findings\n\nEvidence.\n"
+    path = ".vault/research/2026-01-01-legacy-research.md"
+    ledger = body_schema_baseline_path(tmp_path)
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "path": path,
+                        "body_sha256": hashlib.sha256(body.encode("utf-8")).hexdigest(),
+                        "body_schema": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    resolution = resolve_body_schema(
+        tmp_path, tmp_path / path, _metadata(DocType.RESEARCH, None), body
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.source == "attestation_required"
+    assert resolution.diagnostic is not None
+    assert "invalid legacy body_schema" in resolution.diagnostic
+
+
+def test_resolver_rejects_forged_declared_legacy_schema(tmp_path: Path) -> None:
+    body = "# Legacy ADR\n\n## Problem Statement\n\nWhy.\n"
+    doc_path = tmp_path / ".vault" / "adr" / "2026-01-01-legacy-adr.md"
+    _write_baseline(
+        tmp_path,
+        [_entry(".vault/adr/2026-01-01-legacy-adr.md", body, "legacy-adr-v1")],
+    )
+
+    resolution = resolve_body_schema(
+        tmp_path, doc_path, _metadata(DocType.ADR, "legacy-adr-v2"), body
+    )
+
+    assert resolution.required_sections is None
+    assert resolution.source == "attestation_required"
+    assert resolution.diagnostic is not None
+    assert "conflicts" in resolution.diagnostic

--- a/src/vaultspec_core/vaultcore/tests/test_hydration.py
+++ b/src/vaultspec_core/vaultcore/tests/test_hydration.py
@@ -6,6 +6,7 @@ import pytest
 
 from vaultspec_core.core.exceptions import ResourceExistsError
 from vaultspec_core.vaultcore import hydrate_template
+from vaultspec_core.vaultcore.body_schema import CURRENT_BODY_SCHEMA
 from vaultspec_core.vaultcore.hydration import create_vault_doc, get_template_path
 from vaultspec_core.vaultcore.models import DocType
 
@@ -241,6 +242,60 @@ def test_create_vault_doc_plan_substitutes_tier(tmp_path):
     assert "tier: L3" in content
     assert "tier: L{#}" not in content
     assert "tier: {tier}" not in content
+
+
+def test_create_vault_doc_stamps_current_body_schema(tmp_path):
+    """A real bundled template produces a scaffold declaring its contract."""
+    from vaultspec_core.builtins import seed_builtins
+    from vaultspec_core.vaultcore import parse_vault_metadata
+
+    rules_dir = tmp_path / ".vaultspec"
+    rules_dir.mkdir(parents=True)
+    seed_builtins(rules_dir, force=True)
+    for dt in DocType:
+        (tmp_path / ".vault" / dt.value).mkdir(parents=True, exist_ok=True)
+
+    path = create_vault_doc(
+        tmp_path,
+        DocType.ADR,
+        "schema-stamp",
+        "2026-07-27",
+        title="Schema stamp",
+    )
+    metadata, _body = parse_vault_metadata(path.read_text(encoding="utf-8"))
+
+    assert metadata.body_schema == CURRENT_BODY_SCHEMA
+
+
+def test_create_vault_doc_replaces_stale_template_schema_stamp(tmp_path):
+    """A stale real template cannot make a newly scaffolded document legacy."""
+    from vaultspec_core.builtins import seed_builtins
+    from vaultspec_core.vaultcore import parse_vault_metadata
+
+    rules_dir = tmp_path / ".vaultspec"
+    rules_dir.mkdir(parents=True)
+    seed_builtins(rules_dir, force=True)
+    for dt in DocType:
+        (tmp_path / ".vault" / dt.value).mkdir(parents=True, exist_ok=True)
+
+    template = rules_dir / "templates" / "adr.md"
+    template.write_text(
+        template.read_text(encoding="utf-8").replace(
+            "body_schema: 'body-v1'", "body_schema: 'legacy-adr-v1'"
+        ),
+        encoding="utf-8",
+    )
+
+    path = create_vault_doc(
+        tmp_path,
+        DocType.ADR,
+        "schema-stamp",
+        "2026-07-27",
+        title="Schema stamp",
+    )
+    metadata, _body = parse_vault_metadata(path.read_text(encoding="utf-8"))
+
+    assert metadata.body_schema == CURRENT_BODY_SCHEMA
 
 
 def test_emit_time_validator_rejects_invalid_plan_tier(tmp_path):

--- a/src/vaultspec_core/vaultcore/tests/test_types.py
+++ b/src/vaultspec_core/vaultcore/tests/test_types.py
@@ -100,3 +100,21 @@ date: "2026-02-08"
     meta, _body = parse_vault_metadata(content)
     assert meta.tags == ["#plan", "#feat"]
     assert meta.date == "2026-02-08"
+
+
+def test_parse_vault_metadata_retains_optional_body_schema():
+    content = """---
+tags:
+  - '#research'
+  - '#schema-provenance'
+date: '2026-07-27'
+body_schema: 'body-v1'
+related: []
+---
+# Research
+"""
+
+    meta, _body = parse_vault_metadata(content)
+
+    assert meta.body_schema == "body-v1"
+    assert "# Research" in _body

--- a/tests/unit/vaultcore/test_batch_archive.py
+++ b/tests/unit/vaultcore/test_batch_archive.py
@@ -11,7 +11,9 @@ import pytest
 from vaultspec_core.config import reset_config
 from vaultspec_core.vaultcore.batch_archive import (
     ArchiveDocumentsError,
+    RestoreDocumentsError,
     archive_documents,
+    restore_documents,
 )
 
 pytestmark = [pytest.mark.unit]
@@ -214,3 +216,261 @@ def test_refuses_a_configured_vault_reached_through_a_symlinked_parent(
         reset_config()
 
     assert document.is_file()
+
+
+def test_restores_explicit_archived_documents_to_exact_vault_destinations(
+    tmp_path: Path,
+) -> None:
+    first = _write(tmp_path, ".vault/_archive/research/first.md")
+    second = _write(tmp_path, ".vault/_archive/plan/nested/second.md")
+    first_bytes = first.read_bytes()
+    second_bytes = second.read_bytes()
+
+    result = restore_documents(
+        tmp_path,
+        (
+            ".vault/_archive/research/first.md",
+            Path(".vault/_archive/plan/nested/second.md"),
+        ),
+    )
+
+    assert result.status == "updated"
+    assert result.restored_count == 2
+    assert result.paths == (
+        Path(".vault/research/first.md"),
+        Path(".vault/plan/nested/second.md"),
+    )
+    assert not first.exists()
+    assert not second.exists()
+    assert (tmp_path / result.paths[0]).read_bytes() == first_bytes
+    assert (tmp_path / result.paths[1]).read_bytes() == second_bytes
+
+
+def test_restore_preflight_rejects_collision_without_moving_another_document(
+    tmp_path: Path,
+) -> None:
+    first = _write(tmp_path, ".vault/_archive/research/first.md")
+    second = _write(tmp_path, ".vault/_archive/plan/second.md")
+    destination = _write(tmp_path, ".vault/plan/second.md")
+    destination_bytes = destination.read_bytes()
+
+    with pytest.raises(RestoreDocumentsError, match="destination already exists"):
+        restore_documents(
+            tmp_path,
+            (".vault/_archive/research/first.md", ".vault/_archive/plan/second.md"),
+        )
+
+    assert first.is_file()
+    assert second.is_file()
+    assert destination.read_bytes() == destination_bytes
+
+
+def test_restore_rolls_back_an_earlier_real_move_when_a_later_file_is_locked(
+    tmp_path: Path,
+) -> None:
+    first = _write(tmp_path, ".vault/_archive/research/first.md")
+    locked = _write(tmp_path, ".vault/_archive/plan/locked.md")
+    first_bytes = first.read_bytes()
+
+    if os.name == "nt":
+        with (
+            locked.open("rb"),
+            pytest.raises(RestoreDocumentsError, match="Restore move failed"),
+        ):
+            restore_documents(
+                tmp_path,
+                (".vault/_archive/research/first.md", ".vault/_archive/plan/locked.md"),
+            )
+    else:
+        original_mode = stat.S_IMODE(locked.parent.stat().st_mode)
+        locked.parent.chmod(stat.S_IREAD | stat.S_IEXEC)
+        try:
+            with pytest.raises(RestoreDocumentsError, match="Restore move failed"):
+                restore_documents(
+                    tmp_path,
+                    (
+                        ".vault/_archive/research/first.md",
+                        ".vault/_archive/plan/locked.md",
+                    ),
+                )
+        finally:
+            locked.parent.chmod(original_mode)
+
+    assert first.read_bytes() == first_bytes
+    assert locked.is_file()
+    assert not (tmp_path / ".vault/research/first.md").exists()
+    assert not (tmp_path / ".vault/plan/locked.md").exists()
+
+
+@pytest.mark.parametrize(
+    "paths, message",
+    [
+        ((), "at least one"),
+        ((".vault/_archive/research/only.md",) * 2, "Duplicate"),
+        ((".vault/research/only.md",), "under _archive"),
+        (("outside.md",), "must be under"),
+        ((".vault/_archive/research/../research/only.md",), "confined"),
+    ],
+)
+def test_restore_preflight_rejects_unsafe_explicit_path_sets(
+    tmp_path: Path, paths: tuple[str, ...], message: str
+) -> None:
+    source = _write(tmp_path, ".vault/_archive/research/only.md")
+
+    with pytest.raises(RestoreDocumentsError, match=message):
+        restore_documents(tmp_path, paths)
+
+    assert source.is_file()
+
+
+def test_restore_dry_run_reports_cross_links_without_changing_bytes(
+    tmp_path: Path,
+) -> None:
+    source = _write(tmp_path, ".vault/_archive/research/source.md")
+    referer = _write(tmp_path, ".vault/plan/consumer.md", related=("source",))
+    before = source.read_bytes()
+
+    result = restore_documents(
+        tmp_path, (".vault/_archive/research/source.md",), dry_run=True
+    )
+
+    assert result.status == "unchanged"
+    assert result.dry_run is True
+    assert result.cross_link_paths == (Path(".vault/plan/consumer.md"),)
+    assert source.read_bytes() == before
+    assert referer.is_file()
+    assert result.to_dict() == {
+        "status": "unchanged",
+        "restored_count": 1,
+        "paths": [".vault/research/source.md"],
+        "deduplicated_count": 0,
+        "deduplicated_paths": [],
+        "cross_link_paths": [".vault/plan/consumer.md"],
+        "dry_run": True,
+    }
+
+
+def test_restore_preflight_refuses_a_symlinked_source_and_destination_parent(
+    tmp_path: Path,
+) -> None:
+    target = _write(tmp_path, ".vault/_archive/research/target.md")
+    link = tmp_path / ".vault/_archive/research/link.md"
+    try:
+        os.symlink(target, link)
+    except OSError as exc:
+        pytest.fail(f"test host must support a local symlink: {exc}")
+
+    with pytest.raises(RestoreDocumentsError, match="symlink"):
+        restore_documents(tmp_path, (".vault/_archive/research/link.md",))
+
+    assert target.is_file()
+    assert link.is_symlink()
+
+
+def test_restore_preflight_refuses_a_destination_parent_symlink(
+    tmp_path: Path,
+) -> None:
+    source = _write(tmp_path, ".vault/_archive/research/source.md")
+    external = tmp_path / "external"
+    external.mkdir()
+    destination_parent = tmp_path / ".vault/research"
+    try:
+        os.symlink(external, destination_parent, target_is_directory=True)
+    except OSError as exc:
+        pytest.fail(f"test host must support a local directory symlink: {exc}")
+
+    with pytest.raises(RestoreDocumentsError, match="escapes vault"):
+        restore_documents(tmp_path, (".vault/_archive/research/source.md",))
+
+    assert source.is_file()
+    assert not (external / "source.md").exists()
+
+
+def test_restore_deduplicates_an_identical_live_destination_only_when_opted_in(
+    tmp_path: Path,
+) -> None:
+    archived = _write(tmp_path, ".vault/_archive/index/duplicate.md")
+    destination = tmp_path / ".vault/index/duplicate.md"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(archived.read_bytes())
+
+    result = restore_documents(
+        tmp_path,
+        (".vault/_archive/index/duplicate.md",),
+        deduplicate_identical=True,
+    )
+
+    assert result.status == "updated"
+    assert result.restored_count == 0
+    assert result.deduplicated_count == 1
+    assert result.paths == ()
+    assert result.deduplicated_paths == (Path(".vault/_archive/index/duplicate.md"),)
+    assert not archived.exists()
+    assert destination.is_file()
+    assert result.to_dict()["deduplicated_paths"] == [
+        ".vault/_archive/index/duplicate.md"
+    ]
+
+
+def test_restore_deduplication_refuses_a_nonidentical_destination(
+    tmp_path: Path,
+) -> None:
+    archived = _write(tmp_path, ".vault/_archive/index/duplicate.md")
+    destination = tmp_path / ".vault/index/duplicate.md"
+    destination.parent.mkdir(parents=True)
+    destination.write_bytes(b"different evidence\n")
+
+    with pytest.raises(RestoreDocumentsError, match="not byte-identical"):
+        restore_documents(
+            tmp_path,
+            (".vault/_archive/index/duplicate.md",),
+            deduplicate_identical=True,
+        )
+
+    assert archived.is_file()
+    assert destination.read_bytes() == b"different evidence\n"
+
+
+def test_restore_rollback_reinstates_a_deduplicated_source_after_later_failure(
+    tmp_path: Path,
+) -> None:
+    duplicate = _write(tmp_path, ".vault/_archive/index/duplicate.md")
+    duplicate_bytes = duplicate.read_bytes()
+    live_duplicate = tmp_path / ".vault/index/duplicate.md"
+    live_duplicate.parent.mkdir(parents=True)
+    live_duplicate.write_bytes(duplicate_bytes)
+    locked = _write(tmp_path, ".vault/_archive/plan/locked.md")
+
+    if os.name == "nt":
+        with (
+            locked.open("rb"),
+            pytest.raises(RestoreDocumentsError, match="Restore move failed"),
+        ):
+            restore_documents(
+                tmp_path,
+                (
+                    ".vault/_archive/index/duplicate.md",
+                    ".vault/_archive/plan/locked.md",
+                ),
+                deduplicate_identical=True,
+            )
+    else:
+        original_mode = stat.S_IMODE(locked.parent.stat().st_mode)
+        locked.parent.chmod(stat.S_IREAD | stat.S_IEXEC)
+        try:
+            with pytest.raises(RestoreDocumentsError, match="Restore move failed"):
+                restore_documents(
+                    tmp_path,
+                    (
+                        ".vault/_archive/index/duplicate.md",
+                        ".vault/_archive/plan/locked.md",
+                    ),
+                    deduplicate_identical=True,
+                )
+        finally:
+            locked.parent.chmod(original_mode)
+
+    assert duplicate.read_bytes() == duplicate_bytes
+    assert live_duplicate.read_bytes() == duplicate_bytes
+    assert locked.is_file()
+    assert not (tmp_path / ".vault/plan/locked.md").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -1688,6 +1688,33 @@ wheels = [
 ]
 
 [[package]]
+name = "rustworkx"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ff/1a/545aa3a3e251e9da00e4acf0e5472b7fbbb15360f56d9d5342c1f93b8b93/rustworkx-0.18.0.tar.gz", hash = "sha256:5ca9cf8dbee50f8def012119ebb64771ae86916993417415aba9e845831cb436", size = 894567, upload-time = "2026-06-18T04:38:56.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/70/18b310752b0652d4a755b46853268c00c33401101a47f87697ad25966453/rustworkx-0.18.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7440ba70b87bd16811d92e57d76108840dbdd89aa2fc55e4d324fa2fb6b7f9c9", size = 2295936, upload-time = "2026-06-18T04:38:01.598Z" },
+    { url = "https://files.pythonhosted.org/packages/02/4e/09152f4422204f020346a8a2b0e2f05f12d8cc60eeeee99b24f649985514/rustworkx-0.18.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:7fce5218ebfb8d8f5313def1f15aad8d3c3c2bbe03e33805dff8cf8bb70370a1", size = 2145057, upload-time = "2026-06-18T04:38:03.253Z" },
+    { url = "https://files.pythonhosted.org/packages/22/68/69198f41f7f9c39fb5b2e561bf41d4cbd117fa5dfdf4631d8ba28e5ff69b/rustworkx-0.18.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7e0c626f76bc71d414a02502be7ec0ac2dd6eca369886bc66a2650607f2d9de6", size = 2391659, upload-time = "2026-06-18T04:38:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/81/8ac568efe0289b0ecd826cd697c3581b6a25e134145926cbfef762656167/rustworkx-0.18.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:91b37c5bb54e233e16c4f47383385f17be03e6a344821c2f6a39a0aebee54538", size = 2189469, upload-time = "2026-06-18T04:38:06.51Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a4/96492d7af2ddcd15368f80329e3514060b122f306c4406fac98c08a97865/rustworkx-0.18.0-cp310-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:bcd15f7a637ca0654f329ed42a6db0cf7eac15ed89e0b32cb9d16b1b21937979", size = 2504116, upload-time = "2026-06-18T04:38:43.441Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b0/005383bd7dc110b06ca731bd2115482f3a8c6389e0c8fe1f7f259380c4c8/rustworkx-0.18.0-cp310-abi3-manylinux_2_28_s390x.whl", hash = "sha256:567ace3b0d8ac709dc4ad4ce164472f5f59508739355221480170327a6736777", size = 3170967, upload-time = "2026-06-18T04:38:39.929Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2f/95ca9ef9285cc6793b3e041efca6c5a194ca6731b0af732631ee074a67b3/rustworkx-0.18.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b91cdcffeab5f498de44905a373e47e345da8f6c4f40fc969421548c4e7a5219", size = 2254008, upload-time = "2026-06-18T04:38:08.245Z" },
+    { url = "https://files.pythonhosted.org/packages/19/7b/9df6a80162e6f90fd9945e3f8063c2aa41285c27aefce1d171f99c2b829f/rustworkx-0.18.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:03dd1ab42974bc0ff957eccc330c0c0d9887d88240c0cd050039e215af5a3c45", size = 2447140, upload-time = "2026-06-18T04:38:09.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b3/4d159b33bbc73dbebad050a0226dcfb0753d7f05fa55a8d5351e85c8c953/rustworkx-0.18.0-cp310-abi3-win32.whl", hash = "sha256:eb87a45864ffe36e4d86e826d12bb54dac9e4f76c214997dee624281d8711684", size = 2057237, upload-time = "2026-06-18T04:38:11.28Z" },
+    { url = "https://files.pythonhosted.org/packages/99/1b/b0dc8d3751c0c58d16db72bff2954a9d3871c166147007590a3aaec4d42e/rustworkx-0.18.0-cp310-abi3-win_amd64.whl", hash = "sha256:602df896b4479b83c6456f702f8ba2ac1cbb972b30723d5fe2e84e6ff3de7d70", size = 2289224, upload-time = "2026-06-18T04:38:12.961Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/eb/147e86d56de0511ee7526e5cdf6144013d9c71ba4d6ed6dcd82b6b545861/rustworkx-0.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bba66b268e94efd9181d49241b2547d783770dcea9ee8c64609306a7b20ace74", size = 2339568, upload-time = "2026-06-18T04:38:14.292Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1b/c665d30c132e73d69ca95cf552179608de6f94434ee5eb321297ef393920/rustworkx-0.18.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d51ff00fa72144813c2af33c673b7faf7182ca0ffc85cf35569b5ac4de84bc3e", size = 2118746, upload-time = "2026-06-18T04:38:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/78/04733471aa616dc0bc76f2c2e65ad89bb4ecbbfd2309231347c293906181/rustworkx-0.18.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f7099bf90fc1a7ad1789bc126e3e208d9944af2dd9f9b28f75ae148c68aa00cb", size = 2372040, upload-time = "2026-06-18T04:38:17.082Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/eb/58ed5f78ca608156ac2ce3166e41976c32345bbc36e71a3fc18390cc4de2/rustworkx-0.18.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:f562d5eeb2943024c85f631df713e7873ea8b572ada9044be82f29f923c1463a", size = 2178071, upload-time = "2026-06-18T04:38:18.571Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/96/888c7849d20b7e49d978cfe9bdd8873d709e220a09f8f6bdce226ef7c2be/rustworkx-0.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8437bca6adff8e91089bd5d176ef8a499085135031e2d2df4132821578e94dd6", size = 2244227, upload-time = "2026-06-18T04:38:19.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/47/621b56c3f10138a02da9dfd636780ec9311c821fff1acf43be7292408625/rustworkx-0.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba9e9f91d0d14d21666f0d7549f4d8ed70dc84bf75483c68eee5a005ed900f3e", size = 2426773, upload-time = "2026-06-18T04:38:21.233Z" },
+]
+
+[[package]]
 name = "safetensors"
 version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2203,6 +2230,7 @@ dependencies = [
     { name = "pyyaml" },
     { name = "rich" },
     { name = "ruamel-yaml" },
+    { name = "rustworkx" },
     { name = "sse-starlette" },
     { name = "starlette" },
     { name = "typer" },
@@ -2269,6 +2297,7 @@ requires-dist = [
     { name = "rich", specifier = ">=14.3.2" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.2" },
+    { name = "rustworkx", specifier = ">=0.18.0" },
     { name = "sse-starlette", specifier = ">=3.2.0" },
     { name = "starlette", specifier = ">=0.52.1" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.15" },


### PR DESCRIPTION
## Summary

Read-side verbs were minute-class on a 12k-document corpus. Measured before and after on the same corpus:

| command | before | after | speedup |
|---|---|---|---|
| `vault graph` | 87.2s | **2.65s** | 33x |
| `vault check all` | 79.5s | **10.6s** | 7.5x |
| `doctor` | 80.4s | **13.9s** | 5.8x |
| `status` | 25.6s | **9.5s** | 2.7x |

The causes were a small set of recurring patterns rather than scattered inefficiencies, so this lands standing positions alongside the fixes:

- **Cache validation adopts the racily-clean rule**, restoring the stat-keyed design the graph ADR already accepted. Validation previously SHA-256'd the entire corpus just to decide the cache was warm, costing more than the cache saved.
- **Descriptive counts split from graph-theoretic analysis**, so a tree render can no longer buy an all-pairs betweenness pass to print three numbers. That single defect was 76.8s of the 87.2s.
- **Single-ingress contract for the check pipeline**: each document is read once and every checker consumes the shared snapshot. Previously the calculate phase went back to disk 51,688 times after the corpus was already in memory.
- **Per-workspace facts read once per run**, defusing a latent ~90s regression that a populated body-schema ledger would otherwise have armed.
- **Report volume capped** with marked truncation, full detail under `--json`.
- **Scale gate** asserting operation counts and cross-size scaling ratios over generated synthetic corpora, so these regressions cannot land silently again.

## Also included

`fix(cli): honour the root-level --target in doctor and spec doctor` - both verbs computed `target or Path.cwd()`, ignoring the root-level `-t` the context had already resolved. `vaultspec-core --target X doctor` diagnosed the current directory and exited with a code derived from the wrong vault, silently turning a targeted CI run into a false pass.

## Verification

- Full test suite green, including a new single-ingress enforcement test that deletes the corpus after ingress and fails any checker touching disk
- `ty` clean, all prek hooks green across 58 changed files
- Independent code review returned PASS with no critical or high findings

## Notes for review

- Rebased onto `origin/main`, dropping two local commits (`archive documents`, `exec recovery`) that were already upstream under different SHAs.
- The permanent scale gate asserts operation counts and ratios rather than wall-clock, so it does not flake across runners.
- `vault check all` still reports body-schema provenance advisories on legacy documents. Those need a deliberate attestation decision and are deliberately out of scope here; the memoization above makes creating that ledger cheap when it happens.
