### PR TITLE
fix(vault): body-schema attestation decision and single-ingress document listings

### DIFF
--- a/.vault/adr/2026-07-27-body-schema-attestation-adr.md
+++ b/.vault/adr/2026-07-27-body-schema-attestation-adr.md
@@ -1,0 +1,178 @@
+---
+tags:
+  - '#adr'
+  - '#body-schema-attestation'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-vault-scale-performance-adr]]"
+  - "[[2026-07-27-markdown-feature-scope-adr]]"
+  - '[[2026-07-27-body-schema-attestation-reference]]'
+---
+
+# `body-schema-attestation` adr: `body-schema provenance warning default` | (**status:** `proposed`)
+
+## Problem Statement
+
+`vault check all` reports 1,049 body-sections provenance warnings across the
+corpus (`adr` 99/100, `audit` 59/62, `exec` 668/699, `plan` 88/88, `reference`
+20/20, `research` 115/115; `index` 0/116). Every one of these traces to
+`resolve_body_schema`'s `missing` source: the document declares no
+`body_schema` and no entry for it exists in the legacy-attestation ledger at
+`.vaultspec/body-schema-baseline.json`. That ledger has never been populated -
+no CLI verb, MCP tool, or migration writes it; the only code that has ever
+produced its JSON shape is test setup that hand-constructs it directly. A
+warning whose only remedy today is a hand-authored `.vault/` mutation
+contradicts the owning-verb mandate this project enforces everywhere else, and
+`check_body_sections` currently collapses `missing` into the same diagnostic as
+`attestation_required` and `unknown`, even though only the latter two represent
+a document or ledger entry making a claim the evidence contradicts. A decision
+is needed on the default behavior for the `missing` source before this warning
+volume is treated as a backlog to clear or a design gap to close.
+
+## Considerations
+
+- `resolve_body_schema` and `BodySchemaResolution` already distinguish three
+  non-attested outcomes by `source`: `missing` (no declaration, no ledger
+  entry), `attestation_required` (a declared or ledger-recorded legacy id that
+  the evidence contradicts - path absent, hash mismatch, or shape mismatch),
+  and `unknown` (a `body_schema` value that is neither `body-v1` nor a
+  recognized `legacy-*` id). `check_body_sections` does not currently read
+  `source`; it emits the same warning whenever `required_sections` is `None`.
+- The ledger file does not exist in this workspace and has no writer anywhere
+  in `src/`; `BaselineEntry`'s docstring calls it a "reviewed ledger," meaning
+  population is designed as a human-attested act, not an inferred one.
+- Several `legacy-*` schemas are byte-identical in `required_sections` to the
+  current `body-v1` schema for the same `(DocType, is_summary)` shape (e.g.
+  `legacy-adr-v3`, `legacy-audit-v1`, `legacy-exec-v3`, `legacy-exec-v4`,
+  `legacy-index-v1`, `legacy-plan-v1`, `legacy-reference-v1`,
+  `legacy-research-v2`). Heading text alone cannot disambiguate these from
+  `body-v1` or from each other; only the ledger's `(path, sha256)` pair can.
+- `2026-07-27-vault-scale-performance-adr` decision D4 states a general rule -
+  workspace-scoped facts are read once per run - and names the "baseline
+  ledger memoization" as its first application, not as a decision that the
+  ledger is populated or that its provenance model changes. That record's
+  scope is read-cost, not the attestation contract.
+- `2026-07-27-markdown-feature-scope-adr` governs a narrow, unrelated
+  boundary (bounding `scan_vault`'s lazy-migration side effect behind an
+  opt-in parameter for `check_markdown --feature`); it contains no content on
+  body-schema provenance and does not bear on this decision beyond sharing the
+  `vault check` surface.
+- `check_modified_stamp` already ships a `--fix` path (`atomic_write` plus
+  `.bak` safety, exact-match reconciliation) for a structurally similar
+  CLI-maintained frontmatter provenance stamp, establishing the safety
+  template this project expects of any future mutating checker.
+- The CLAUDE.md owning-verb mandate forbids hand-writing `.vault/`
+  frontmatter; today the only way to silence a `missing` warning is exactly
+  that forbidden act, since no verb exists to populate the ledger or declare
+  `body_schema` at scale.
+
+## Considered options
+
+- **Build a populator verb now** (heading-tuple exact-match against
+  `BODY_SCHEMA_REGISTRY`, split into an auto-declare tier for `body-v1`
+  matches and a ledger-write tier for unambiguous `legacy-*` matches, plus a
+  human-review report for the remainder). Rejected: heading-tuple equality is
+  not the hash-based body attestation the ledger's own contract requires: the
+  registry itself proves at least eight `legacy-*` ids are heading-identical to
+  `body-v1` or to each other for the same shape, so a heading-only matcher
+  cannot honestly choose among them and would auto-write a ledger entry - or a
+  `body_schema` declaration - that is a guess wearing the shape of a
+  attestation. It also introduces a new mutating writer subsystem and a
+  corpus-wide `.vault/` mutation into a change this project wants tightly
+  scoped, and requires its own ADR before landing.
+- **Widen self-declaration to trust any registry-known `body_schema` id
+  directly, retiring the ledger.** Rejected: this reverses the deliberate
+  trust asymmetry `resolve_body_schema` encodes on purpose - `body-v1` is
+  trusted by direct declaration precisely because it is the live template a
+  document was authored against, while `legacy-*` ids require external,
+  path-and-hash-scoped evidence because no such live-authorship guarantee
+  exists for them. Collapsing that boundary the same day
+  `2026-07-27-vault-scale-performance-adr` treats the ledger as existing,
+  load-bearing infrastructure is a premise reversal, not a refinement, and its
+  own bulk-declaration step still requires the same unproven heading-match
+  judgment the first option makes explicit.
+- **Silence the `missing` source by default; keep `attestation_required` and
+  `unknown` as warnings (chosen).** `check_body_sections` inspects
+  `resolution.source` and skips the diagnostic only when `source == "missing"`.
+  A document that declares nothing and has no ledger entry is not making a
+  claim the evidence can contradict, so there is nothing to warn about; a
+  document or ledger entry that does make a claim - a declared legacy id
+  absent from the ledger, a path/hash/shape mismatch, or an unrecognized
+  schema id - keeps warning exactly as today. This changes zero validation
+  behavior: `required_sections` is `None` for `missing` today and stays
+  `None` after, so no section-completeness check is gained or lost for these
+  documents; only the redundant, unactionable notice is removed.
+
+## Constraints
+
+- No change to `BODY_SCHEMA_REGISTRY`, `BaselineEntry`, or the ledger file
+  format is authorized or required by this decision; the registry stays
+  append-only exactly as tested today.
+- The fix is confined to `check_body_sections`'s diagnostic-emission branch and
+  its module docstring; `resolve_body_schema`'s resolution logic, its `source`
+  values, and the `declared`/`attested` trust boundary are unchanged.
+- This decision does not authorize populating the ledger, building a `--fix`
+  path for provenance, or widening self-declaration; any of those remains a
+  separately-decided, separately-ADR'd expansion per the owning-verb mandate.
+- `2026-07-27-vault-scale-performance-adr` D4's premise - that the ledger is
+  read-once, workspace-scoped, load-bearing state - is unaffected: this record
+  changes only what a checker does when the ledger and the document agree
+  there is nothing to attest, not whether the ledger exists or how it is read.
+
+## Implementation
+
+`check_body_sections` reads `resolution.source` in addition to
+`resolution.required_sections`. When `required_sections` is `None` and
+`source == "missing"`, the function continues without appending a
+`CheckDiagnostic` for that document. When `source` is `attestation_required`
+or `unknown`, the existing warning path is unchanged. The module docstrings
+for `check_body_sections` and `BodySchemaResolution` are revised to state the
+new default explicitly: absence of a `body_schema` declaration and a ledger
+entry is silence, not a finding; only a contradicted or unrecognized claim is
+reported. A real-filesystem regression test asserts a document with no
+`body_schema` field and no ledger entry produces zero body-sections
+diagnostics, while a document declaring a legacy id absent from the ledger, or
+one with a hash or shape mismatch against an existing entry, still warns.
+
+## Rationale
+
+The `missing` source is not a case among several equally-live findings; by
+construction, because the ledger has never been populated and no pre-existing
+document declares `body_schema` outside of scaffold-time injection, it accounts
+for the overwhelming majority of the 1,049 warnings and will continue to fire
+on every document scaffolded before this feature existed, forever, with no
+tool-mediated remedy. A warning that fires true by construction on 93%+ of the
+non-index corpus and cannot be honestly cleared without either the forbidden
+hand-edit or a not-yet-built, not-yet-decided populator trains operators to
+skim past `vault check all` output, eroding trust in the warnings that are
+actionable today (`attestation_required`, `unknown`, and the unrelated
+checkers in the same report). Silencing `missing` costs nothing this project
+currently relies on: no section-completeness validation runs for these
+documents before or after the change, so the fix removes noise around an
+acknowledged gap rather than disabling an active protection. It is also the
+only option of the three that introduces no new mutating capability and no
+corpus-wide `.vault/` write, keeping this change reversible with a single-file
+diff and leaving the harder, still-open question - whether and how to build a
+ledger populator - for a dedicated future ADR informed by real operator
+demand rather than warning-volume pressure.
+
+## Consequences
+
+- The 1,049 `missing`-source warnings drop to zero on this workspace without
+  any `.vault/` document being touched; `attestation_required` and `unknown`
+  continue to surface exactly as today, so any document making a provenance
+  claim the evidence contradicts still fails `vault check all`.
+- Operators lose default visibility into how much of the corpus remains
+  unattested; if that visibility is wanted later, it belongs as an opt-in
+  info-level count (e.g. under `--json` or a dedicated report flag), not as a
+  per-document warning, and is left unscoped here.
+- If a populator or a widened self-declaration mechanism is authorized by a
+  future ADR, `missing` should be revisited: once population is tooled, an
+  unattested document represents a declined attestation rather than an
+  unbuilt remedy, and restoring a lighter-weight nudge at that point would be
+  reasonable friction rather than the current unconditional warning.
+- This record does not reopen or contradict `2026-07-27-vault-scale-performance-adr`
+  D4 or `2026-07-27-markdown-feature-scope-adr`; it narrows one checker's
+  default behavior within the boundaries both already leave untouched.

--- a/.vault/index/body-schema-attestation.index.md
+++ b/.vault/index/body-schema-attestation.index.md
@@ -1,0 +1,26 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#body-schema-attestation'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - '[[2026-07-27-body-schema-attestation-adr]]'
+  - '[[2026-07-27-body-schema-attestation-reference]]'
+---
+
+# `body-schema-attestation` feature index
+
+Auto-generated index of all documents tagged with `#body-schema-attestation`.
+
+## Documents
+
+### adr
+
+- `2026-07-27-body-schema-attestation-adr` - `body-schema-attestation` adr: `body-schema provenance warning default` | (**status:** `proposed`)
+
+### reference
+
+- `2026-07-27-body-schema-attestation-reference` - `body-schema-attestation` reference: `body-schema provenance ledger and warning surface`

--- a/.vault/reference/2026-07-27-body-schema-attestation-reference.md
+++ b/.vault/reference/2026-07-27-body-schema-attestation-reference.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - '#reference'
+  - '#body-schema-attestation'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - "[[2026-07-27-body-schema-attestation-adr]]"
+---
+
+# `body-schema-attestation` reference: `body-schema provenance ledger and warning surface`
+
+A `vault check all` sweep of this workspace was traced through
+`resolve_body_schema`, `check_body_sections`, and the body-schema baseline
+ledger to ground the 1,049 provenance warnings reported across `.vault/`.
+
+## Summary
+
+`resolve_body_schema` (`src/vaultspec_core/vaultcore/body_schema.py:377-483`)
+resolves a document's required body sections through one of five sources:
+`declared` (frontmatter `body_schema` equals the current `body-v1` schema,
+`body_schema.py:401-409`), `unknown` (a non-empty `body_schema` value that is
+neither `body-v1` nor a `legacy-*` id, `body_schema.py:411-417`),
+`attestation_required` (a `legacy-*` declaration or ledger entry the evidence
+contradicts - absent path, hash mismatch, or shape mismatch,
+`body_schema.py:422-464`), `attested` (path, hash, and shape all match a
+ledger entry, `body_schema.py:479-483`), and `missing` (no `body_schema`
+declared and no ledger entry for the document's path,
+`body_schema.py:431-443`). `required_sections` is `None` for every source
+except `declared` and `attested`.
+
+`check_body_sections` (`src/vaultspec_core/vaultcore/checks/body_sections.py:92-184`)
+does not currently branch on `resolution.source`; it appends the same
+`CheckDiagnostic` whenever `required_sections` is `None`, so `missing`,
+`attestation_required`, and `unknown` all render identically today.
+
+The ledger (`BASELINE_RELATIVE_PATH = '.vaultspec/body-schema-baseline.json'`,
+`body_schema.py:39`) does not exist in this workspace. No production code
+writes it: `_read_baseline`, `_read_baseline_file`, and `_parse_baseline`
+(`body_schema.py:270-354`) are readers only; the sole writers anywhere in the
+repository are test-setup helpers that hand-construct the JSON directly
+(`src/vaultspec_core/vaultcore/tests/test_body_schema.py:31-38`,
+`src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py:20,287`). No
+CLI verb, MCP tool, or migration populates it; `vault --help` and a grep of
+`src/vaultspec_core/migrations/` for `baseline`/`body_schema`/`legacy-` show
+no such surface.
+
+`BODY_SCHEMA_REGISTRY` (`body_schema.py:122-266`) defines 16 `legacy-*`
+schemas plus `body-v1`. At least eight `legacy-*` ids -
+`legacy-adr-v3`, `legacy-audit-v1`, `legacy-exec-v3`, `legacy-exec-v4`,
+`legacy-index-v1`, `legacy-plan-v1`, `legacy-reference-v1`, and
+`legacy-research-v2` - have a `required_sections` tuple byte-identical to
+`body-v1` for their `(DocType, is_summary)` shape, so heading-text matching
+alone cannot distinguish those legacy ids from `body-v1` or from each other;
+only the ledger's `(path, sha256)` pair disambiguates
+(`body_schema.py:429-464`).
+
+A corpus-wide `vault check all --json` run measured the warning distribution:
+`adr` 99/100, `audit` 59/62, `exec` 668/699, `plan` 88/88, `reference` 20/20,
+`research` 115/115, `index` 0/116 (index documents are exempt from this
+check). All warnings observed carry the `missing` source: no document in this
+corpus declares a legacy `body_schema` id, and the ledger is empty because it
+does not exist.
+
+`check_modified_stamp` (`src/vaultspec_core/vaultcore/checks/modified_stamp.py`)
+is the closest existing precedent for a CLI-maintained frontmatter provenance
+field with a real `--fix` path (`supports_fix=True`, `atomic_write`-based
+`_write_stamp`, `.bak` safety, exact-match reconciliation) - the shape a
+future body-schema populator would need to follow if one is ever authorized.
+
+`2026-07-27-vault-scale-performance-adr` decision D4
+(`.vault/adr/2026-07-27-vault-scale-performance-adr.md`, lines 184-190) scopes
+only read-once memoization of the ledger read path ("the baseline ledger
+memoization is its first application" of the workspace-facts-read-once rule);
+it does not scope populating the ledger or changing the checker's default.
+`2026-07-27-markdown-feature-scope-adr` governs an unrelated `scan_vault`
+migration-bypass boundary and contains no body-schema or provenance content.

--- a/src/vaultspec_core/graph/api.py
+++ b/src/vaultspec_core/graph/api.py
@@ -642,6 +642,10 @@ class VaultGraph:
                 cache_mod.fingerprint_vault(scanned_files, self.root_dir),
                 self._to_cache_graph(),
                 self._dangling_links,
+                [
+                    (str(issue.path), issue.kind, issue.detail, issue.start)
+                    for issue in self._encoding_issues
+                ],
             )
 
     def _to_cache_graph(self) -> dict[str, Any]:
@@ -703,6 +707,15 @@ class VaultGraph:
         for bare_stem, keys in by_stem.items():
             self._stem_index[bare_stem] = sorted(keys)
         self._dangling_links = [(pair[0], pair[1]) for pair in payload.dangling_links]
+        # A document that failed to read or decode never becomes a usable node,
+        # so the cache carries these separately; restoring them keeps a warm
+        # run's encoding findings identical to a cold one's.
+        from pathlib import Path as _Path
+
+        self._encoding_issues = [
+            EncodingIssue(_Path(raw_path), kind, detail, start)
+            for raw_path, kind, detail, start in payload.encoding_issues
+        ]
         logger.info(
             "Graph loaded from cache: %d nodes, %d edges",
             self._digraph.number_of_nodes(),

--- a/src/vaultspec_core/graph/cache.py
+++ b/src/vaultspec_core/graph/cache.py
@@ -85,7 +85,7 @@ __all__ = [
 #: Schema string stamped into every cache file.  Bump when the on-disk
 #: payload shape changes so an older cache is treated as a miss rather than
 #: misread.  Tied to the graph wire schema generation (``v3``).
-CACHE_SCHEMA = "vaultspec.vault.graph.cache.v3"
+CACHE_SCHEMA = "vaultspec.vault.graph.cache.v4"
 
 #: Manifest value type: ``(st_size, st_mtime_ns, sha256_hex)`` per file.
 Fingerprint = tuple[int, int, str]
@@ -105,12 +105,18 @@ class GraphCachePayload:
             ``edges="edges"``.
         dangling_links: The ``(source, target)`` dangling-link pairs
             recorded during the cached build, as two-element lists.
+        encoding_issues: The read and decode failures the cached build's
+            ingress read observed, as ``(path, kind, detail, start)`` rows.
+            Persisted because a document that fails to decode never enters
+            the serialised graph, so a cache hit would otherwise restore a
+            corpus that silently claims every file read cleanly.
     """
 
     schema: str
     manifest: dict[str, Fingerprint]
     graph: dict[str, Any]
     dangling_links: list[list[str]]
+    encoding_issues: list[tuple[str, str, str, int | None]]
 
 
 def cache_path(root_dir: Path) -> Path:
@@ -298,9 +304,10 @@ def load(path: Path) -> GraphCachePayload | None:
     raw_manifest = data.get("manifest")
     raw_graph = data.get("graph")
     raw_dangling = data.get("dangling_links")
+    raw_encoding = data.get("encoding_issues")
     if not isinstance(raw_manifest, dict) or not isinstance(raw_graph, dict):
         return None
-    if not isinstance(raw_dangling, list):
+    if not isinstance(raw_dangling, list) or not isinstance(raw_encoding, list):
         return None
 
     manifest: dict[str, Fingerprint] = {}
@@ -327,11 +334,28 @@ def load(path: Path) -> GraphCachePayload | None:
             return None
         dangling.append([pair[0], pair[1]])
 
+    encoding: list[tuple[str, str, str, int | None]] = []
+    for row in raw_encoding:
+        if (
+            not isinstance(row, list)
+            or len(row) != 4
+            or not isinstance(row[0], str)
+            or not isinstance(row[1], str)
+            or not isinstance(row[2], str)
+            or not (row[3] is None or isinstance(row[3], int))
+        ):
+            logger.debug(
+                "Graph cache encoding-issue row %r is malformed; ignoring", row
+            )
+            return None
+        encoding.append((row[0], row[1], row[2], row[3]))
+
     return GraphCachePayload(
         schema=CACHE_SCHEMA,
         manifest=manifest,
         graph=raw_graph,
         dangling_links=dangling,
+        encoding_issues=encoding,
     )
 
 
@@ -340,6 +364,7 @@ def save(
     manifest: dict[str, Fingerprint],
     graph: dict[str, Any],
     dangling_links: list[tuple[str, str]],
+    encoding_issues: list[tuple[str, str, str, int | None]] | None = None,
 ) -> None:
     """Atomically write a cache file for a freshly-built graph.
 
@@ -355,6 +380,10 @@ def save(
         graph: The networkx node-link ``dict`` of the canonical graph.
         dangling_links: The ``(source, target)`` dangling pairs recorded
             during the build.
+        encoding_issues: The ``(path, kind, detail, start)`` read and decode
+            failures the build's ingress read observed. A file that fails to
+            decode never becomes a usable node, so without this the cache
+            would restore a corpus that appears to have read cleanly.
     """
     from ..core.helpers import atomic_write
 
@@ -363,6 +392,7 @@ def save(
         "manifest": {key: list(value) for key, value in manifest.items()},
         "graph": graph,
         "dangling_links": [list(pair) for pair in dangling_links],
+        "encoding_issues": [list(row) for row in (encoding_issues or [])],
     }
     try:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/vaultspec_core/graph/tests/test_cache.py
+++ b/src/vaultspec_core/graph/tests/test_cache.py
@@ -558,3 +558,115 @@ class TestStemIndexParity:
             f"Keys only in fresh: {set(fresh_stem_index) - set(cached_stem_index)}\n"
             f"Keys only in cached: {set(cached_stem_index) - set(fresh_stem_index)}"
         )
+
+
+class TestEncodingIssuesSurviveCache:
+    """A cache hit must not lose the ingress read's decode failures.
+
+    A document that fails to decode never becomes a usable node, so it is
+    invisible in the serialised graph. Before these were persisted, a warm
+    build restored a corpus that appeared to have read cleanly, which made
+    the encoding check silently report nothing on every run after the first.
+    """
+
+    def _vault_with_undecodable_document(self, root: Path) -> Path:
+        research = root / ".vault" / "research"
+        research.mkdir(parents=True, exist_ok=True)
+        (research / "2026-05-15-ok-research.md").write_text(
+            "---\ntags:\n  - '#research'\n  - '#demo'\n"
+            "date: '2026-05-15'\nrelated: []\n---\n\n# ok\n",
+            encoding="utf-8",
+        )
+        broken = research / "2026-05-15-broken-research.md"
+        broken.write_bytes(b"---\ntags:\n\xff\xfe not utf-8\n---\n\n# broken\n")
+        return broken
+
+    def test_cached_build_reports_same_encoding_issues_as_cold(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "repo"
+        root.mkdir()
+        broken = self._vault_with_undecodable_document(root)
+
+        cold = VaultGraph(root, use_cache=False)
+        VaultGraph(root)  # prime the cache
+        warm = VaultGraph(root)
+
+        assert [i.path for i in cold.encoding_issues] == [broken]
+        assert [i.path for i in warm.encoding_issues] == [broken], (
+            "the warm build lost the ingress read's decode failure"
+        )
+        assert [i.kind for i in warm.encoding_issues] == ["decode"]
+
+    def test_encoding_check_agrees_across_cold_warm_and_standalone(
+        self, tmp_path: Path
+    ) -> None:
+        from ...vaultcore.checks.encoding import check_encoding
+
+        root = tmp_path / "repo"
+        root.mkdir()
+        self._vault_with_undecodable_document(root)
+
+        cold_graph = VaultGraph(root, use_cache=False)
+        cold = len(check_encoding(root, graph=cold_graph).diagnostics)
+        VaultGraph(root)
+        warm = len(check_encoding(root, graph=VaultGraph(root)).diagnostics)
+        standalone = len(check_encoding(root).diagnostics)
+
+        assert cold == standalone == 1
+        assert warm == 1, "check_encoding went blind on a warm cache"
+
+
+class TestUnreadableDocumentsExcludedFromGraphDerivedQueries:
+    """The graph-backed query path must drop what the disk path drops.
+
+    ``_scan_all`` skips a document it cannot decode. The graph still creates
+    a node for such a file, with empty frontmatter and body, which is
+    indistinguishable from a genuinely empty document by its fields alone.
+    """
+
+    def _vault(self, root: Path) -> None:
+        for sub in ("research", "plan"):
+            (root / ".vault" / sub).mkdir(parents=True, exist_ok=True)
+        (root / ".vault" / "research" / "2026-05-15-ok-research.md").write_text(
+            "---\ntags:\n  - '#research'\n  - '#demo'\n"
+            "date: '2026-05-15'\nrelated: []\n---\n\n# ok\n",
+            encoding="utf-8",
+        )
+        (root / ".vault" / "research" / "2026-05-15-bad-research.md").write_bytes(
+            b"---\ntags:\n\xff\xfe bad\n---\n\n# broken\n"
+        )
+        (root / ".vault" / "plan" / "2026-05-15-ok-plan.md").write_text(
+            "---\ntags:\n  - '#plan'\n  - '#demo'\n"
+            "date: '2026-05-15'\nrelated: []\n---\n\n# p\n",
+            encoding="utf-8",
+        )
+        (root / ".vault" / "plan" / "2026-05-15-bad-plan.md").write_bytes(
+            b"---\ntags:\n\xff\xfe bad\n---\n\n# broken\n"
+        )
+
+    def test_get_stats_totals_match_list_documents(self, tmp_path: Path) -> None:
+        from ...vaultcore.query import get_stats, list_documents
+
+        root = tmp_path / "repo"
+        root.mkdir()
+        self._vault(root)
+
+        assert get_stats(root)["total_docs"] == len(list_documents(root))
+
+    def test_collect_all_statuses_agrees_with_and_without_graph(
+        self, tmp_path: Path
+    ) -> None:
+        from ...plan.status import collect_all_statuses
+
+        root = tmp_path / "repo"
+        root.mkdir()
+        self._vault(root)
+
+        without = collect_all_statuses(root)
+        with_graph = collect_all_statuses(root, graph=VaultGraph(root))
+
+        assert len(with_graph) == len(without)
+        assert [e.document.name for e in with_graph] == [
+            e.document.name for e in without
+        ]

--- a/src/vaultspec_core/plan/status.py
+++ b/src/vaultspec_core/plan/status.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from vaultspec_core.graph import VaultGraph
     from vaultspec_core.plan.frontmatter import Tier
     from vaultspec_core.plan.parser import Plan
     from vaultspec_core.vaultcore.query import VaultDocument
@@ -105,24 +106,66 @@ class ExecRecordIndex:
     unlinked_by_feature: dict[str, list[str]] = field(default_factory=dict)
 
     @classmethod
-    def build(cls, root_dir: Path) -> ExecRecordIndex:
+    def build(
+        cls, root_dir: Path, *, graph: VaultGraph | None = None
+    ) -> ExecRecordIndex:
         """Scan every execution record once into the shared index.
 
         Args:
             root_dir: Project root directory.
+            graph: Optional pre-built
+                :class:`~vaultspec_core.graph.VaultGraph`. When supplied
+                (the orientation rollup's already-built graph), the exec
+                records are read from the graph's already-parsed
+                frontmatter instead of a fresh ``list_documents`` scan
+                plus a per-record ``read_text``/``parse_frontmatter`` pass.
 
         Returns:
             A populated :class:`ExecRecordIndex`. Records whose feature
             tag or ``step_id:`` cannot be read are bucketed as unlinked
             under their best-known feature rather than aborting the scan.
         """
+        index = cls()
+
+        if graph is not None:
+            from vaultspec_core.vaultcore.models import DocType
+            from vaultspec_core.vaultcore.query import _feature_from_tags_or_meta
+
+            # Match the disk path, which skips records it cannot read or
+            # decode; the graph still nodes such a file with empty frontmatter.
+            unreadable = {issue.path for issue in graph.encoding_issues}
+
+            for node in graph.nodes.values():
+                if (
+                    node.phantom
+                    or node.path is None
+                    or node.path in unreadable
+                    or node.doc_type is not DocType.EXEC
+                ):
+                    continue
+                meta = node.frontmatter
+                tags = meta.get("tags", [])
+                if isinstance(tags, str):
+                    tags = [tags]
+                feature = _feature_from_tags_or_meta(tags, meta, DocType.EXEC.value)
+                step_id: str | None = None
+                raw_step_id = meta.get("step_id")
+                if raw_step_id:
+                    step_id = str(raw_step_id).strip()
+                name = node.path.stem
+
+                if feature and step_id:
+                    index.by_step[(feature, step_id)] = name
+                elif feature:
+                    index.unlinked_by_feature.setdefault(feature, []).append(name)
+            return index
+
         from vaultspec_core.vaultcore.parser import parse_frontmatter
         from vaultspec_core.vaultcore.query import list_documents
 
-        index = cls()
         for doc in list_documents(root_dir, doc_type="exec"):
             feature = doc.feature
-            step_id: str | None = None
+            step_id = None
             try:
                 content = doc.path.read_text(encoding="utf-8")
                 meta, _ = parse_frontmatter(content)
@@ -291,7 +334,9 @@ class PlanStatusEntry:
     error: str | None = None
 
 
-def collect_all_statuses(root_dir: Path) -> list[PlanStatusEntry]:
+def collect_all_statuses(
+    root_dir: Path, *, graph: VaultGraph | None = None
+) -> list[PlanStatusEntry]:
     """Collect status for every plan in the vault in one batched pass.
 
     Implements the batched status core (decision D6): the execution
@@ -303,6 +348,12 @@ def collect_all_statuses(root_dir: Path) -> list[PlanStatusEntry]:
 
     Args:
         root_dir: Project root directory.
+        graph: Optional pre-built
+            :class:`~vaultspec_core.graph.VaultGraph`. When supplied (the
+            orientation rollup's already-built graph), both the exec-record
+            index and the plan-document listing are derived from the
+            graph's already-parsed frontmatter instead of independently
+            rescanning the corpus.
 
     Returns:
         A list of :class:`PlanStatusEntry`, one per plan document, in the
@@ -310,11 +361,16 @@ def collect_all_statuses(root_dir: Path) -> list[PlanStatusEntry]:
         returns them.
     """
     from vaultspec_core.plan.parser import parse_plan
-    from vaultspec_core.vaultcore.query import list_documents
+    from vaultspec_core.vaultcore.query import _docs_from_graph, list_documents
 
-    exec_index = ExecRecordIndex.build(root_dir)
+    exec_index = ExecRecordIndex.build(root_dir, graph=graph)
     entries: list[PlanStatusEntry] = []
-    for doc in list_documents(root_dir, doc_type="plan"):
+    docs = (
+        _docs_from_graph(graph, doc_type="plan")
+        if graph is not None
+        else list_documents(root_dir, doc_type="plan")
+    )
+    for doc in docs:
         try:
             content = doc.path.read_text(encoding="utf-8")
             plan = parse_plan(content)

--- a/src/vaultspec_core/tests/cli/test_vault_repair.py
+++ b/src/vaultspec_core/tests/cli/test_vault_repair.py
@@ -425,22 +425,13 @@ class TestVaultRepair:
             if diag.severity == "warning"
         ]
         # The fixture is deliberately legacy-shaped: its documents predate the
-        # body_schema declaration, and provenance attestation requires a
-        # hash-attested baseline entry that the repair pipeline cannot
-        # synthesise. Those three warnings survive repair by design.
+        # body_schema declaration and declare none. Undeclared provenance with
+        # no ledger entry makes no claim, so it is silent rather than a
+        # warning; only the missing feature index survives repair.
         assert postcheck_warnings == [
             "Feature 'state-mutation' has no feature index. Run "
             "vaultspec-core vault feature index to generate "
             "index/state-mutation.index.md",
-            "Body schema provenance is not attested: "
-            "2026-05-15-state-mutation-adr.md does not declare a body_schema; "
-            "it requires a hash-attested legacy baseline entry.",
-            "Body schema provenance is not attested: "
-            "2026-05-15-state-mutation-plan.md does not declare a body_schema; "
-            "it requires a hash-attested legacy baseline entry.",
-            "Body schema provenance is not attested: "
-            "2026-05-15-state-mutation-research.md does not declare a "
-            "body_schema; it requires a hash-attested legacy baseline entry.",
         ]
 
     def test_repair_changed_files_tracks_cascaded_tmp_workspace_mutations(
@@ -458,21 +449,16 @@ class TestVaultRepair:
         )
 
         assert run.error_count == 0
-        # Repair generates the feature index, so the only surviving warnings
-        # are the body-schema provenance findings the fixture's legacy-shaped
-        # documents cannot clear without a hash-attested baseline entry.
+        # Repair generates the feature index, and the fixture's legacy-shaped
+        # documents declare no body_schema and have no ledger entry - an
+        # undeclared claim, so no warning remains once the index exists.
         residual_warnings = [
             diag.message
             for result in run.postcheck
             for diag in result.diagnostics
             if diag.severity == "warning"
         ]
-        assert [
-            message
-            for message in residual_warnings
-            if not message.startswith("Body schema provenance is not attested:")
-        ] == []
-        assert len(residual_warnings) == 3
+        assert residual_warnings == []
         assert ".vault/plan/2026-05-15-state-mutation-plan.md" in run.changed_files
         assert ".vault/adr/2026-05-15-state-mutation-adr.md" in run.changed_files
         assert (

--- a/src/vaultspec_core/tests/plan/test_status.py
+++ b/src/vaultspec_core/tests/plan/test_status.py
@@ -232,3 +232,99 @@ def test_status_collect_missing_exec_records(tmp_path: Path) -> None:
     # Also assert JSON serialization of exec_missing_ids
     payload = status_to_json_dict(status)
     assert payload["exec_missing_ids"] == ["S01"]
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class TestExecRecordIndexGraphParity:
+    """``ExecRecordIndex.build(graph=...)`` matches the no-graph scan path."""
+
+    def test_build_with_graph_matches_without(self, tmp_path: Path) -> None:
+        from vaultspec_core.config import reset_config
+        from vaultspec_core.graph import VaultGraph
+        from vaultspec_core.plan.status import ExecRecordIndex
+
+        reset_config()
+        try:
+            exec_dir = tmp_path / ".vault" / "exec" / "2026-05-17-test-feature"
+            _write(
+                exec_dir / "2026-05-17-test-feature-P01-S01.md",
+                "---\ntags:\n  - '#exec'\n  - '#test-feature'\n"
+                "step_id: 'S01'\n---\n\nBody.\n",
+            )
+            _write(
+                exec_dir / "2026-05-17-test-feature-P01-S02.md",
+                "---\ntags:\n  - '#exec'\n  - '#test-feature'\n"
+                "step_id: 'S02'\n---\n\nBody.\n",
+            )
+            # An exec record with no resolvable step_id lands in the
+            # unlinked bucket under both paths.
+            _write(
+                exec_dir / "2026-05-17-test-feature-orphan.md",
+                "---\ntags:\n  - '#exec'\n  - '#test-feature'\n---\n\nBody.\n",
+            )
+
+            without_graph = ExecRecordIndex.build(tmp_path)
+            graph = VaultGraph(tmp_path)
+            with_graph = ExecRecordIndex.build(tmp_path, graph=graph)
+
+            assert with_graph.by_step == without_graph.by_step
+            assert with_graph.unlinked_by_feature == without_graph.unlinked_by_feature
+            assert with_graph.by_step == {
+                ("test-feature", "S01"): "2026-05-17-test-feature-P01-S01",
+                ("test-feature", "S02"): "2026-05-17-test-feature-P01-S02",
+            }
+            assert with_graph.unlinked_by_feature == {
+                "test-feature": ["2026-05-17-test-feature-orphan"]
+            }
+        finally:
+            reset_config()
+
+
+class TestCollectAllStatusesGraphParity:
+    """``collect_all_statuses(graph=...)`` matches the no-graph scan path."""
+
+    def test_collect_all_statuses_with_graph_matches_without(
+        self, tmp_path: Path
+    ) -> None:
+        from vaultspec_core.config import reset_config
+        from vaultspec_core.graph import VaultGraph
+        from vaultspec_core.plan.status import collect_all_statuses
+
+        reset_config()
+        try:
+            _write(
+                tmp_path / ".vault" / "plan" / "2026-05-17-alpha-plan.md",
+                "---\ntags:\n  - '#plan'\n  - '#alpha'\ndate: '2026-05-17'\n"
+                "tier: L1\n---\n\n# `alpha` plan\n\n"
+                "- [x] `S01` - do the work; `src/a.py`.\n"
+                "- [ ] `S02` - do more; `src/b.py`.\n",
+            )
+            _write(
+                tmp_path
+                / ".vault"
+                / "exec"
+                / "2026-05-17-alpha"
+                / "2026-05-17-alpha-S01.md",
+                "---\ntags:\n  - '#exec'\n  - '#alpha'\nstep_id: 'S01'\n---\n\nBody.\n",
+            )
+
+            without_graph = collect_all_statuses(tmp_path)
+            graph = VaultGraph(tmp_path)
+            with_graph = collect_all_statuses(tmp_path, graph=graph)
+
+            assert len(with_graph) == len(without_graph) == 1
+            a, b = with_graph[0], without_graph[0]
+            assert a.document.name == b.document.name
+            assert a.document.feature == b.document.feature
+            assert a.document.date == b.document.date
+            assert a.error == b.error is None
+            assert a.status is not None and b.status is not None
+            assert a.status.step_count == b.status.step_count == 2
+            assert a.status.steps_completed == b.status.steps_completed == 1
+            assert a.status.exec_missing_ids == b.status.exec_missing_ids == []
+        finally:
+            reset_config()

--- a/src/vaultspec_core/vaultcore/body_schema.py
+++ b/src/vaultspec_core/vaultcore/body_schema.py
@@ -69,9 +69,12 @@ class BodySchemaResolution:
     """Schema resolution result consumed by body-section validation.
 
     ``source`` deliberately distinguishes a current direct declaration from
-    records which need a later hash-attested baseline. P02 can add an
-    ``attested`` source without changing the validator-facing function
-    signature.
+    records which need a later hash-attested baseline. ``"missing"`` means no
+    schema was declared and no ledger entry exists: the document makes no
+    provenance claim, so a consumer should treat it as silence rather than a
+    finding. ``"attestation_required"`` and ``"unknown"`` mean a document or
+    the ledger made a claim the evidence contradicts, which a consumer should
+    still report.
     """
 
     required_sections: tuple[str, ...] | None

--- a/src/vaultspec_core/vaultcore/checks/body_sections.py
+++ b/src/vaultspec_core/vaultcore/checks/body_sections.py
@@ -2,9 +2,10 @@
 
 Required level-two (``## ``) headings come from the immutable body-schema
 registry, never from today's mutable templates. A document either names a
-known stamped schema or, once legacy attestation is available, resolves through
-the repository's path-and-body-hash baseline. A document with neither proof is
-reported as unattested; it must not quietly inherit the current template.
+known stamped schema or resolves through the repository's path-and-body-hash
+baseline. A document declaring neither is silent: absence of a claim is not a
+finding. A document (or the ledger) making a claim the evidence contradicts
+is reported; it must not quietly inherit the current template.
 
 For an attested schema, every required section must be present and carry real
 authored content. A required section that is absent, or that holds only a
@@ -18,9 +19,9 @@ Edge handling:
 - Execution records select ``exec-step.md`` or ``exec-summary.md`` by the
   ``-summary`` filename convention.
 - Generated feature indexes are out of scope (their body is machine-authored).
-- Missing, unknown, or otherwise un-attested provenance is a finding, not a
-  skip. The resolver keeps its future legacy-baseline logic behind one stable
-  interface.
+- No ``body_schema`` declared and no ledger entry makes no provenance claim,
+  so nothing is reported. A declared-but-unattested or ledger-contradicted
+  claim (``attestation_required``, ``unknown``) is a finding, not a skip.
 
 The checker is read-only: a section's position, ordering, and content are the
 author's, so no safe automatic repair exists. Each finding's ``fix_description``
@@ -134,6 +135,11 @@ def check_body_sections(
         )
         required = resolution.required_sections
         if required is None:
+            if resolution.source == "missing":
+                # No body_schema declared and no ledger entry: the document
+                # makes no provenance claim, so there is nothing to
+                # contradict. Silence, not a finding.
+                continue
             detail = (
                 resolution.diagnostic or "no attested body schema was resolved"
             ).rstrip(".")

--- a/src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_body_sections.py
@@ -1,10 +1,11 @@
 """Tests for the body-sections vault health checker.
 
 Exercises immutable, attested body-schema validation against real on-disk
-documents. A current schema stamp selects the registry contract, missing or
-unknown provenance is reported, mutable deployed templates cannot alter a
-document's requirements, and execution records select their step or summary
-contract. No mocks, patches, or skips.
+documents. A current schema stamp selects the registry contract, a declared
+or ledger-contradicted claim is reported while an undeclared document with no
+ledger entry is silent, mutable deployed templates cannot alter a document's
+requirements, and execution records select their step or summary contract.
+No mocks, patches, or skips.
 """
 
 from __future__ import annotations
@@ -256,7 +257,7 @@ class TestBodySections:
         result = _run(tmp_path)
         assert result.diagnostics == []
 
-    def test_missing_schema_provenance_is_flagged(self, tmp_path: Path) -> None:
+    def test_missing_schema_provenance_is_silent(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)
         _write_doc(
             tmp_path,
@@ -266,11 +267,25 @@ class TestBodySections:
             body_schema=None,
         )
         result = _run(tmp_path)
+        assert result.diagnostics == []
+
+    def test_declared_legacy_schema_absent_from_ledger_is_flagged(
+        self, tmp_path: Path
+    ) -> None:
+        _skeleton(tmp_path)
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            _contents("adr"),
+            body_schema="legacy-adr-v1",
+        )
+        result = _run(tmp_path)
         assert len(result.diagnostics) == 1
         diagnostic = result.diagnostics[0]
         assert diagnostic.severity is Severity.WARNING
         assert "provenance is not attested" in diagnostic.message
-        assert "body_schema" in diagnostic.message
+        assert "legacy-adr-v1" in diagnostic.message
 
     def test_hash_attested_legacy_body_is_validated_by_its_contract(
         self, tmp_path: Path
@@ -306,6 +321,40 @@ class TestBodySections:
         result = _run(tmp_path)
 
         assert result.diagnostics == []
+
+    def test_ledger_hash_mismatch_is_flagged(self, tmp_path: Path) -> None:
+        _skeleton(tmp_path)
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-02-04-feat-adr",
+            _contents("adr"),
+            body_schema=None,
+        )
+        ledger = body_schema_baseline_path(tmp_path)
+        ledger.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "entries": [
+                        {
+                            "path": ".vault/adr/2026-02-04-feat-adr.md",
+                            "body_sha256": "0" * 64,
+                            "body_schema": "legacy-adr-v3",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        result = _run(tmp_path)
+
+        assert len(result.diagnostics) == 1
+        diagnostic = result.diagnostics[0]
+        assert diagnostic.severity is Severity.WARNING
+        assert "provenance is not attested" in diagnostic.message
+        assert "SHA-256" in diagnostic.message
 
     def test_unknown_schema_provenance_is_flagged(self, tmp_path: Path) -> None:
         _skeleton(tmp_path)

--- a/src/vaultspec_core/vaultcore/orientation.py
+++ b/src/vaultspec_core/vaultcore/orientation.py
@@ -504,7 +504,7 @@ def compute_rollup(
     # Parse every plan once (predecessor D6) and share the result across
     # the in-flight bucket, the recently-completed bucket, and the
     # per-feature plan tail, rather than scanning plans three times.
-    entries = collect_all_statuses(root_dir)
+    entries = collect_all_statuses(root_dir, graph=g)
     status_by_feature: dict[str, PlanStatus] = {}
     for entry in entries:
         feature = entry.document.feature
@@ -798,7 +798,7 @@ def compute_trace(
     from ..plan.status import ExecRecordIndex
 
     g = graph if graph is not None else VaultGraph(root_dir)
-    exec_index = ExecRecordIndex.build(root_dir)
+    exec_index = ExecRecordIndex.build(root_dir, graph=g)
 
     plan_stems = {
         name

--- a/src/vaultspec_core/vaultcore/query.py
+++ b/src/vaultspec_core/vaultcore/query.py
@@ -85,6 +85,32 @@ def _parse_feature_from_tags(tags: list[str], doc_type_tag: str | None) -> str |
     return None
 
 
+def _feature_from_tags_or_meta(
+    tags: list[str], meta: dict, doc_type_tag: str | None
+) -> str | None:
+    """Derive a document's feature tag, with the bare ``feature:`` fallback.
+
+    Primarily reads *tags* via :func:`_parse_feature_from_tags`, falling
+    back to a bare top-level ``feature:`` frontmatter key when no
+    tag-derived feature is found. Shared by :func:`_scan_all` and
+    :func:`_docs_from_graph` so both callers apply the identical fallback
+    chain against the same parsed frontmatter shape.
+
+    Args:
+        tags: Normalised tag list (already coerced from a scalar).
+        meta: Parsed frontmatter dict for the document.
+        doc_type_tag: Bare doc-type value to skip (e.g. ``"adr"``), or
+            ``None``.
+
+    Returns:
+        Feature name string without the leading ``#``, or ``None``.
+    """
+    feature = _parse_feature_from_tags(tags, doc_type_tag)
+    if not feature and "feature" in meta:
+        feature = str(meta["feature"]).lstrip("#").strip().lower() or None
+    return feature
+
+
 def _scan_all(root_dir: Path, *, doc_type: str | None = None) -> list[VaultDocument]:
     """Scan the vault and parse every document into a :class:`VaultDocument`.
 
@@ -117,10 +143,7 @@ def _scan_all(root_dir: Path, *, doc_type: str | None = None) -> list[VaultDocum
         tags = meta.get("tags", [])
         if isinstance(tags, str):
             tags = [tags]
-        feature = _parse_feature_from_tags(tags, dt_str)
-        # Fallback: if no feature from tags, check bare 'feature:' field
-        if not feature and "feature" in meta:
-            feature = str(meta["feature"]).lstrip("#").strip().lower() or None
+        feature = _feature_from_tags_or_meta(tags, meta, dt_str)
         date = meta.get("date") or _parse_date_from_filename(doc_path.name)
 
         docs.append(
@@ -136,12 +159,89 @@ def _scan_all(root_dir: Path, *, doc_type: str | None = None) -> list[VaultDocum
     return docs
 
 
+def _docs_from_graph(
+    graph: VaultGraph,
+    *,
+    doc_type: str | None = None,
+    feature: str | None = None,
+    date: str | None = None,
+) -> list[VaultDocument]:
+    """Derive :class:`VaultDocument` records from an already-built graph.
+
+    Reuses the frontmatter each node already parsed during the graph build
+    instead of re-reading and re-parsing every file from disk, while
+    reproducing :func:`_scan_all`'s exact field derivation (including the
+    bare ``feature:`` fallback and the filename-date fallback) so the
+    result is byte-for-byte identical to the uncached path. Phantom nodes
+    and ref-scoped nodes (``path is None``) are never part of ``_scan_all``'s
+    domain and are skipped; a stem-collision node's qualified ``name`` is
+    sidestepped by deriving the document name from ``node.path.stem``
+    instead.
+
+    Args:
+        graph: An already-built :class:`~vaultspec_core.graph.VaultGraph`
+            over the same ``root_dir`` the caller would otherwise rescan.
+        doc_type: Filter by type, matching :func:`list_documents`'
+            concrete-type semantics. The ``"orphaned"``/``"invalid"``
+            pseudo-types are not supported here; callers needing them must
+            use :func:`list_documents`.
+        feature: Filter by feature tag (without ``#`` prefix).
+        date: Filter by exact date string (``YYYY-MM-DD``).
+
+    Returns:
+        Ordered list of :class:`VaultDocument` instances matching all
+        supplied filters.
+    """
+    # ``_scan_all`` drops a document it cannot read or decode, so the graph
+    # path must drop it too. The graph still creates a node for such a file
+    # (with empty frontmatter and body), which is indistinguishable from a
+    # genuinely empty document by its fields alone; the ingress read records
+    # the failure separately, and that record is the only sound signal.
+    unreadable = {issue.path for issue in graph.encoding_issues}
+
+    docs: list[VaultDocument] = []
+    for node in graph.nodes.values():
+        if node.phantom or node.path is None or node.path in unreadable:
+            continue
+        dt_str = node.doc_type.value if node.doc_type else "unknown"
+        if doc_type is not None and dt_str != doc_type:
+            continue
+
+        meta = node.frontmatter
+        tags = meta.get("tags", [])
+        if isinstance(tags, str):
+            tags = [tags]
+        doc_feature = _feature_from_tags_or_meta(tags, meta, dt_str)
+        doc_date = meta.get("date") or _parse_date_from_filename(node.path.name)
+
+        docs.append(
+            VaultDocument(
+                path=node.path,
+                name=node.path.stem,
+                doc_type=dt_str,
+                feature=doc_feature,
+                date=str(doc_date) if doc_date else None,
+                tags=tags,
+            )
+        )
+
+    if feature:
+        feature = feature.lstrip("#")
+        docs = [d for d in docs if d.feature == feature]
+
+    if date:
+        docs = [d for d in docs if d.date == date]
+
+    return docs
+
+
 def list_documents(
     root_dir: Path,
     *,
     doc_type: str | None = None,
     feature: str | None = None,
     date: str | None = None,
+    graph: VaultGraph | None = None,
 ) -> list[VaultDocument]:
     """List vault documents with optional filters.
 
@@ -153,25 +253,42 @@ def list_documents(
             (contains dangling outgoing links).
         feature: Filter by feature tag (without ``#`` prefix).
         date: Filter by exact date string (``YYYY-MM-DD``).
+        graph: Optional pre-built :class:`~vaultspec_core.graph.VaultGraph`
+            to reuse. One is built when omitted, and the already-parsed
+            frontmatter it carries backs the listing instead of a second
+            read-and-parse of every document. A graph that cannot be built
+            degrades to the direct disk scan rather than failing.
 
     Returns:
         Ordered list of :class:`VaultDocument` instances matching all
         supplied filters.
     """
-    if doc_type == "orphaned":
-        from ..graph import VaultGraph
+    if graph is None:
+        try:
+            from ..graph import VaultGraph as _VaultGraph
 
-        docs = _scan_all(root_dir)
-        graph = VaultGraph(root_dir)
-        orphan_names = set(graph.get_orphaned())
-        docs = [d for d in docs if d.name in orphan_names]
-    elif doc_type == "invalid":
-        from ..graph import VaultGraph
+            graph = _VaultGraph(root_dir)
+        except (OSError, ValueError) as exc:
+            logger.warning("Failed to build vault graph for listing: %s", exc)
+            graph = None
 
-        docs = _scan_all(root_dir)
-        graph = VaultGraph(root_dir)
-        dangling_sources = {src for src, _ in graph.get_dangling_links()}
-        docs = [d for d in docs if d.name in dangling_sources]
+    if graph is not None:
+        # The pseudo-types are graph predicates over the same derived set, so
+        # they filter the graph-backed listing rather than triggering a second
+        # full scan alongside the graph they already needed.
+        docs = _docs_from_graph(
+            graph, doc_type=None if doc_type in ("orphaned", "invalid") else doc_type
+        )
+        if doc_type == "orphaned":
+            orphan_names = set(graph.get_orphaned())
+            docs = [d for d in docs if d.name in orphan_names]
+        elif doc_type == "invalid":
+            dangling_sources = {src for src, _ in graph.get_dangling_links()}
+            docs = [d for d in docs if d.name in dangling_sources]
+    elif doc_type in ("orphaned", "invalid"):
+        # Both pseudo-types are defined by graph edges; without a graph there
+        # is no sound answer, so report nothing rather than something wrong.
+        docs = []
     else:
         # A concrete doc-type filter is path-derived and applied inside the
         # scan, before any file is read.
@@ -203,9 +320,12 @@ def get_stats(
         doc_type: Restrict counts to a single document type.
         date: Restrict to documents matching this date (``YYYY-MM-DD``).
         graph: Optional pre-built :class:`~vaultspec_core.graph.VaultGraph`
-            to reuse for the orphan and dangling counts; callers that
-            already hold a graph (the orientation rollup) pass it so the
-            stats path never rebuilds a second one.
+            to reuse. When *doc_type* is not the ``"orphaned"``/``"invalid"``
+            pseudo-type, the graph's already-parsed frontmatter also backs
+            the document listing (via :func:`_docs_from_graph`) instead of
+            a fresh disk scan; callers that already hold a graph (the
+            orientation rollup) pass it so the stats path never rebuilds
+            or rescans the corpus a second time.
 
     Returns:
         Dict with keys: ``total_docs``, ``total_features``,
@@ -214,7 +334,22 @@ def get_stats(
         computed against the full unfiltered vault via
         :class:`~vaultspec_core.graph.VaultGraph`.
     """
-    docs = list_documents(root_dir, feature=feature, doc_type=doc_type, date=date)
+    if graph is None:
+        try:
+            from ..graph import VaultGraph as _VaultGraph
+
+            graph = _VaultGraph(root_dir)
+        except (OSError, ValueError) as exc:
+            logger.warning("Failed to build vault graph for stats: %s", exc)
+            graph = None
+
+    # The "orphaned"/"invalid" pseudo-types need list_documents' own
+    # graph-backed semantics; every concrete type (and the unfiltered case)
+    # reads from the already-built graph instead of rescanning the corpus.
+    if graph is not None and doc_type not in ("orphaned", "invalid"):
+        docs = _docs_from_graph(graph, feature=feature, doc_type=doc_type, date=date)
+    else:
+        docs = list_documents(root_dir, feature=feature, doc_type=doc_type, date=date)
 
     counts_by_type: dict[str, int] = {}
     features: set[str] = set()
@@ -223,18 +358,14 @@ def get_stats(
         if d.feature:
             features.add(d.feature)
 
-    # Orphan/invalid counts from graph (unfiltered)
-    try:
-        if graph is None:
-            from ..graph import VaultGraph as _VaultGraph
-
-            graph = _VaultGraph(root_dir)
-        orphaned_count = len(graph.get_orphaned())
-        dangling_link_count = len(graph.get_dangling_links())
-    except (OSError, ValueError) as exc:
-        logger.warning("Failed to build vault graph for stats: %s", exc)
-        orphaned_count = 0
-        dangling_link_count = 0
+    orphaned_count = 0
+    dangling_link_count = 0
+    if graph is not None:
+        try:
+            orphaned_count = len(graph.get_orphaned())
+            dangling_link_count = len(graph.get_dangling_links())
+        except (OSError, ValueError) as exc:
+            logger.warning("Failed to compute orphan/dangling counts: %s", exc)
 
     return {
         "total_docs": len(docs),
@@ -454,9 +585,7 @@ def unarchive_feature(root_dir: Path, feature: str, dry_run: bool = False) -> di
         if isinstance(tags, str):
             tags = [tags]
 
-        feature_val = _parse_feature_from_tags(tags, dt_str)
-        if not feature_val and "feature" in meta:
-            feature_val = str(meta["feature"]).lstrip("#").strip().lower() or None
+        feature_val = _feature_from_tags_or_meta(tags, meta, dt_str)
 
         if feature_val == feature.lower():
             archived_docs.append((doc_path, rel_path))

--- a/src/vaultspec_core/vaultcore/tests/test_orientation.py
+++ b/src/vaultspec_core/vaultcore/tests/test_orientation.py
@@ -18,6 +18,7 @@ skips: every assertion reads structures computed from real files.
 from __future__ import annotations
 
 import datetime
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -28,6 +29,7 @@ from ..orientation import (
     compute_rollup,
     compute_trace,
 )
+from ..scanner import scan_vault
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -579,3 +581,101 @@ class TestTraceTargetResolution:
         assert summary_stem in plan.summaries
         assert summary_stem not in plan.unlinked_records
         assert stems["exec_orphan"] in plan.unlinked_records
+
+
+# ---------------------------------------------------------------------------
+# Scan budget: the rollup shares one corpus ingestion, not a rescan per
+# consumer (predecessor D7; the get_stats/collect_all_statuses gap closed
+# here threads the rollup's already-built graph through both).
+# ---------------------------------------------------------------------------
+
+
+def _count_corpus_reads(fn) -> int:
+    """Run *fn* under a real profiler, counting genuine ``.vault/*.md`` reads.
+
+    Mirrors the scale gate's ``sys.setprofile`` technique
+    (``tests/scale/test_scale_gate.py``): observes the real execution
+    rather than stubbing it, counting every ``read_text``/``read_bytes``
+    call whose ``self`` is a path ending in ``.md`` under a ``.vault``
+    directory. ``pathlib.Path.read_text`` delegates to a same-named
+    ``PathBase.read_text`` internally (CPython 3.13), so a delegating
+    inner frame whose immediate caller carries the same name is not
+    double-counted; only the outermost entry per logical read counts.
+    """
+    count = 0
+
+    def profiler(frame, event: str, arg: object) -> None:
+        nonlocal count
+        if event != "call":
+            return
+        name = frame.f_code.co_name
+        if name not in ("read_text", "read_bytes"):
+            return
+        caller = frame.f_back
+        if caller is not None and caller.f_code.co_name == name:
+            return
+        target = frame.f_locals.get("self")
+        parts = getattr(target, "parts", None)
+        if parts and ".vault" in parts and str(target).endswith(".md"):
+            count += 1
+
+    sys.setprofile(profiler)
+    try:
+        fn()
+    finally:
+        sys.setprofile(None)
+    return count
+
+
+class TestRollupScanBudget:
+    """A single ``compute_rollup`` call reads the corpus at most once, plus
+    one additional read per plan document for its full Step body (the one
+    read ``collect_all_statuses`` cannot avoid: ``parse_plan`` needs body
+    markup the graph does not retain in reparseable form)."""
+
+    def test_single_ingress_per_rollup_call(self, tmp_path: Path) -> None:
+        from ...testing.synthetic import build_synthetic_vault
+
+        build_synthetic_vault(tmp_path, n_docs=24, seed=11, edge_probability=0.3)
+        # Settle any pending migration before profiling so only the
+        # rollup's own reads are counted.
+        list(scan_vault(tmp_path))
+        scanned = list(scan_vault(tmp_path))
+        doc_count = len(scanned)
+        plan_count = sum(1 for p in scanned if p.parent.name == "plan")
+        assert doc_count > 0
+        assert plan_count > 0, "corpus must contain at least one plan document"
+
+        reads = _count_corpus_reads(lambda: compute_rollup(tmp_path))
+
+        # Before the fix this scan (get_stats + collect_all_statuses/
+        # ExecRecordIndex.build) re-read every document 2-3 separate times
+        # on top of the graph's own ingestion; now every document is read
+        # exactly once for the graph, and a plan document is read exactly
+        # one further time for its full body.
+        assert reads <= doc_count + plan_count, (
+            f"compute_rollup performed {reads} corpus reads for {doc_count} "
+            f"documents ({plan_count} plans); expected at most "
+            f"{doc_count + plan_count} (one graph-ingestion read per "
+            "document, plus one full-body read per plan)."
+        )
+
+    def test_repeated_rollup_calls_scale_linearly_not_multiplicatively(
+        self, tmp_path: Path
+    ) -> None:
+        """Two independent rollup calls must not each cost more than one
+        ingestion pass; guards against a future change reintroducing a
+        per-consumer rescan inside a single call."""
+        from ...testing.synthetic import build_synthetic_vault
+
+        build_synthetic_vault(tmp_path, n_docs=12, seed=13, edge_probability=0.3)
+        list(scan_vault(tmp_path))
+        scanned = list(scan_vault(tmp_path))
+        doc_count = len(scanned)
+        plan_count = sum(1 for p in scanned if p.parent.name == "plan")
+
+        reads = _count_corpus_reads(
+            lambda: (compute_rollup(tmp_path), compute_rollup(tmp_path))
+        )
+
+        assert reads <= 2 * (doc_count + plan_count)

--- a/src/vaultspec_core/vaultcore/tests/test_query.py
+++ b/src/vaultspec_core/vaultcore/tests/test_query.py
@@ -6,6 +6,7 @@ from ...config import reset_config
 from ...testing.synthetic import CorpusManifest, build_synthetic_vault
 from ..query import (
     VaultDocument,
+    _docs_from_graph,
     get_stats,
     list_documents,
     list_feature_details,
@@ -181,3 +182,264 @@ class TestArchiveFeature:
         archive = tmp_path / ".vault" / "_archive"
         assert (archive / "adr" / "2026-03-16-my-feat-adr.md").exists()
         assert (archive / "plan" / "2026-03-16-my-feat-plan.md").exists()
+
+
+class TestDocsFromGraph:
+    """``_docs_from_graph`` must be byte-for-byte equivalent to the
+    ``list_documents``/``_scan_all`` disk-scanning path it replaces inside
+    ``get_stats``/``collect_all_statuses``."""
+
+    def _graph(self, root):
+        from ...graph import VaultGraph
+
+        return VaultGraph(root)
+
+    def test_matches_list_documents_unfiltered(self, vault_project: CorpusManifest):
+        via_scan = list_documents(vault_project.root)
+        via_graph = _docs_from_graph(self._graph(vault_project.root))
+
+        def key(d: VaultDocument) -> str:
+            return str(d.path)
+
+        via_scan_sorted = sorted(via_scan, key=key)
+        via_graph_sorted = sorted(via_graph, key=key)
+        assert len(via_scan_sorted) == len(via_graph_sorted)
+        for a, b in zip(via_scan_sorted, via_graph_sorted, strict=True):
+            assert a.path == b.path
+            assert a.name == b.name
+            assert a.doc_type == b.doc_type
+            assert a.feature == b.feature
+            assert a.date == b.date
+            assert a.tags == b.tags
+
+    def test_matches_list_documents_with_doc_type_filter(
+        self, vault_project: CorpusManifest
+    ):
+        via_scan = list_documents(vault_project.root, doc_type="adr")
+        via_graph = _docs_from_graph(self._graph(vault_project.root), doc_type="adr")
+
+        assert {str(d.path) for d in via_scan} == {str(d.path) for d in via_graph}
+        assert via_graph
+        assert all(d.doc_type == "adr" for d in via_graph)
+
+    def test_matches_list_documents_with_feature_filter(
+        self, vault_project: CorpusManifest
+    ):
+        docs = list_documents(vault_project.root)
+        feature = next(d.feature for d in docs if d.feature)
+
+        via_scan = list_documents(vault_project.root, feature=feature)
+        via_graph = _docs_from_graph(self._graph(vault_project.root), feature=feature)
+
+        assert {str(d.path) for d in via_scan} == {str(d.path) for d in via_graph}
+        assert via_graph
+        assert all(d.feature == feature for d in via_graph)
+
+    def test_matches_list_documents_with_date_filter(
+        self, vault_project: CorpusManifest
+    ):
+        docs = list_documents(vault_project.root)
+        date = next(d.date for d in docs if d.date)
+
+        via_scan = list_documents(vault_project.root, date=date)
+        via_graph = _docs_from_graph(self._graph(vault_project.root), date=date)
+
+        assert {str(d.path) for d in via_scan} == {str(d.path) for d in via_graph}
+        assert via_graph
+        assert all(d.date == date for d in via_graph)
+
+    def test_skips_phantom_nodes_from_dangling_links(self, tmp_path):
+        """A dangling wiki-link creates a phantom node (``path=None``); the
+        adapter must never crash on it or count it as a real document."""
+        adr_dir = tmp_path / ".vault" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "2026-04-01-broken-link-adr.md").write_text(
+            "---\ntags:\n  - '#adr'\n  - '#broken-link'\ndate: '2026-04-01'\n"
+            "related:\n  - '[[nonexistent-target-xyz]]'\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        graph = self._graph(tmp_path)
+        assert any(n.phantom for n in graph.nodes.values()), (
+            "fixture must actually produce a phantom node"
+        )
+
+        docs = _docs_from_graph(graph)
+        assert len(docs) == 1
+        assert docs[0].name == "2026-04-01-broken-link-adr"
+
+    def test_stem_collision_name_uses_bare_stem(self, tmp_path):
+        """A stem collision re-keys the graph node's ``name`` as
+        ``doctype/stem``; the adapter must derive the document ``name``
+        from ``node.path.stem`` instead, matching ``VaultDocument.name``."""
+        stem = "2026-04-02-collide-x"
+        for dtype in ("adr", "plan"):
+            d = tmp_path / ".vault" / dtype
+            d.mkdir(parents=True)
+            (d / f"{stem}.md").write_text(
+                f"---\ntags:\n  - '#{dtype}'\n  - '#collide-feat'\n"
+                "date: '2026-04-02'\n---\n\nBody.\n",
+                encoding="utf-8",
+            )
+
+        graph = self._graph(tmp_path)
+        assert any(len(v) > 1 for v in graph._stem_index.values()), (
+            "fixture must actually produce a stem collision"
+        )
+
+        docs = _docs_from_graph(graph)
+        names = {d.name for d in docs}
+        assert names == {stem}, (
+            f"expected the bare stem {stem!r} for both documents, got {names}"
+        )
+        assert len(docs) == 2
+
+    def test_bare_feature_field_fallback(self, tmp_path):
+        """A document with no non-directory tag but a bare top-level
+        ``feature:`` key must resolve the same feature via both paths."""
+        adr_dir = tmp_path / ".vault" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "2026-04-03-bare-feature-adr.md").write_text(
+            "---\ntags:\n  - '#adr'\nfeature: 'legacy-widget'\n"
+            "date: '2026-04-03'\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        via_scan = list_documents(tmp_path)
+        via_graph = _docs_from_graph(self._graph(tmp_path))
+
+        assert len(via_scan) == 1
+        assert len(via_graph) == 1
+        assert via_scan[0].feature == "legacy-widget"
+        assert via_graph[0].feature == "legacy-widget"
+
+    def test_filename_date_fallback(self, tmp_path):
+        """A document with no frontmatter ``date:`` key still resolves its
+        date from the dated filename prefix, identically via both paths."""
+        adr_dir = tmp_path / ".vault" / "adr"
+        adr_dir.mkdir(parents=True)
+        (adr_dir / "2026-04-04-no-date-field-adr.md").write_text(
+            "---\ntags:\n  - '#adr'\n  - '#no-date-field'\n---\n\nBody.\n",
+            encoding="utf-8",
+        )
+
+        via_scan = list_documents(tmp_path)
+        via_graph = _docs_from_graph(self._graph(tmp_path))
+
+        assert len(via_scan) == 1
+        assert len(via_graph) == 1
+        assert via_scan[0].date == "2026-04-04"
+        assert via_graph[0].date == "2026-04-04"
+
+
+class TestGetStatsGraphPath:
+    """``get_stats`` now reads the graph by default; its totals must still
+    match an independent ``list_documents``-based computation."""
+
+    def test_totals_match_list_documents(self, vault_project: CorpusManifest):
+        docs = list_documents(vault_project.root)
+        stats = get_stats(vault_project.root)
+
+        counts: dict[str, int] = {}
+        features: set[str] = set()
+        for d in docs:
+            counts[d.doc_type] = counts.get(d.doc_type, 0) + 1
+            if d.feature:
+                features.add(d.feature)
+
+        assert stats["total_docs"] == len(docs)
+        assert stats["counts_by_type"] == counts
+        assert stats["total_features"] == len(features)
+
+    def test_explicit_graph_matches_implicit_build(self, vault_project: CorpusManifest):
+        from ...graph import VaultGraph
+
+        graph = VaultGraph(vault_project.root)
+        assert get_stats(vault_project.root, graph=graph) == get_stats(
+            vault_project.root
+        )
+
+    def test_orphaned_pseudo_type_still_works_with_graph_present(
+        self, vault_project: CorpusManifest
+    ):
+        from ...graph import VaultGraph
+
+        graph = VaultGraph(vault_project.root)
+        stats = get_stats(vault_project.root, doc_type="orphaned", graph=graph)
+        assert "total_docs" in stats
+
+
+class TestListDocumentsGraphParity:
+    """``list_documents`` reads from the graph but must answer identically.
+
+    The graph-backed listing reuses frontmatter the ingress read already
+    parsed instead of reading and parsing every document a second time. It
+    is only a safe substitution if it returns exactly what the disk scan
+    returns, for every filter shape.
+    """
+
+    @staticmethod
+    def _key(docs: list[VaultDocument]) -> list[tuple]:
+        return sorted((d.name, d.doc_type, d.feature, d.date) for d in docs)
+
+    @pytest.mark.parametrize(
+        "doc_type", [None, "adr", "plan", "exec", "research", "reference"]
+    )
+    def test_graph_listing_matches_disk_scan(
+        self, vault_project: CorpusManifest, doc_type: str | None
+    ) -> None:
+        from ..query import _scan_all
+
+        via_graph = list_documents(vault_project.root, doc_type=doc_type)
+        via_disk = _scan_all(vault_project.root, doc_type=doc_type)
+
+        assert self._key(via_graph) == self._key(via_disk)
+
+    def test_feature_and_date_filters_match_disk_scan(
+        self, vault_project: CorpusManifest
+    ) -> None:
+        from ..query import _scan_all
+
+        all_disk = _scan_all(vault_project.root)
+        feature = next((d.feature for d in all_disk if d.feature), None)
+        date = next((d.date for d in all_disk if d.date), None)
+        assert feature is not None and date is not None
+
+        by_feature = list_documents(vault_project.root, feature=feature)
+        by_date = list_documents(vault_project.root, date=date)
+
+        assert self._key(by_feature) == self._key(
+            [d for d in all_disk if d.feature == feature]
+        )
+        assert self._key(by_date) == self._key([d for d in all_disk if d.date == date])
+
+    def test_supplied_graph_matches_internally_built_one(
+        self, vault_project: CorpusManifest
+    ) -> None:
+        from ...graph import VaultGraph
+
+        graph = VaultGraph(vault_project.root)
+
+        assert self._key(list_documents(vault_project.root, graph=graph)) == self._key(
+            list_documents(vault_project.root)
+        )
+
+    def test_listing_reads_from_the_graph_not_the_corpus(
+        self, vault_project: CorpusManifest
+    ) -> None:
+        """Proven by deleting the corpus: only a graph-backed read survives.
+
+        No patching - the documents are removed from disk after the graph is
+        built, so any fallback to a disk rescan returns nothing and fails.
+        """
+        import shutil
+
+        from ...graph import VaultGraph
+
+        graph = VaultGraph(vault_project.root)
+        expected = self._key(list_documents(vault_project.root, graph=graph))
+        assert expected, "fixture produced no documents to assert on"
+
+        shutil.rmtree(vault_project.root / ".vault")
+
+        assert self._key(list_documents(vault_project.root, graph=graph)) == expected


### PR DESCRIPTION
## Summary

Closes the two items left open by #273, and fixes a correctness bug in that release found while doing so.

| metric | before | after |
|---|---|---|
| body-schema provenance warnings | 1,034 | **0** |
| total vault warnings | 1,040 | **6** |
| `_scan_all` calls per `status` | 3 | **0** |
| `status` on a 12k-document corpus | 25.6s | **2.6s** |

## The attestation decision

The body-sections check warned on every document that neither declares a `body_schema` nor has a hash-attested baseline entry, flagging 1,034 legacy documents with no verb to resolve them. A resolution whose source is `missing` makes no provenance claim, so there is nothing to contradict; it is now silent. Warnings remain for `attestation_required` and `unknown`, where a claim exists that the evidence disagrees with.

Auto-populating a ledger was considered and **rejected**: at least eight `legacy-*` schemas are heading-identical to `body-v1`, so matching on headings would fabricate provenance rather than attest it. Recorded in `.vault/adr/2026-07-27-body-schema-attestation-adr.md` (status `proposed`, pending ratification).

## Single-ingress listings

`get_stats`, `collect_all_statuses`, `ExecRecordIndex.build`, and `list_documents` now read from the already-built graph instead of re-reading and re-parsing the corpus.

## Correctness bug fixed (present in the shipped 0.1.52)

A document that fails to read or decode never becomes a usable node, and those failures were **not persisted in the graph cache**. Consequences, both reproduced:

- `vault check all` reported **zero encoding findings on any warm-cache run**, even with non-UTF-8 documents present. Only the first, cold run ever saw them.
- The graph-backed listing counted corrupt files that the disk scan drops, so `get_stats` and `status` disagreed with `list_documents`.

Encoding failures now round-trip through the cache (schema v3 → v4) and graph-derived paths skip them. Cold, warm, and standalone runs agree.

## Verification

- **1,960 unit tests pass**, `ty` clean, all prek hooks green
- Listing parity asserted against the disk scan across every filter shape
- A corpus-deleted-after-build test proves the listing is served from the graph, not a rescan (no patching)
- Encoding agreement asserted across cold, warm, and standalone

## Notes

- Found by an adversarial review lens that returned FAIL on the first implementation; the two defects it reported were reproduced and are what led to the cache bug.
- `vault list` no longer rescans, but only improved 5.8s → 5.5s because its remaining cost is rendering 11,918 Rich rows. Capping listings is D6 policy not yet applied to this surface, and is left as a follow-up rather than widened into this change.
