### PR TITLE
docs(vault): reconcile the decision corpus against shipped code

### DIFF
--- a/.vault/adr/2026-07-27-body-schema-attestation-adr.md
+++ b/.vault/adr/2026-07-27-body-schema-attestation-adr.md
@@ -11,7 +11,7 @@ related:
   - '[[2026-07-27-body-schema-attestation-reference]]'
 ---
 
-# `body-schema-attestation` adr: `body-schema provenance warning default` | (**status:** `proposed`)
+# `body-schema-attestation` adr: `body-schema provenance warning default` | (**status:** `accepted`)
 
 ## Problem Statement
 

--- a/.vault/audit/2026-07-27-adr-corpus-reconciliation-audit.md
+++ b/.vault/audit/2026-07-27-adr-corpus-reconciliation-audit.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - '#audit'
+  - '#adr-corpus-reconciliation'
+date: '2026-07-27'
+modified: '2026-07-28'
+body_schema: 'body-v1'
+related:
+  - '[[2026-07-27-body-schema-attestation-adr]]'
+---
+
+# `adr-corpus-reconciliation` audit: `decision status against shipped code`
+
+## Scope
+
+Reconciliation of the architecture decision corpus against the code it governs,
+run immediately after the 0.1.53 release. The pass covered every ADR's declared
+status, the supersession and relatedness edges, and each recently-landed
+feature's lifecycle documents against the single-home-fact boundary. Mechanical
+hygiene was ceded to the CLI first, so what follows is only what no check can
+decide.
+
+## Findings
+
+### Decision declared proposed while governing shipped code - actioned
+
+The `body-schema-attestation` decision was recorded as `proposed`, but its
+decision was implemented and published to the package index as part of 0.1.53.
+A decision that governs released code while declaring itself unratified makes
+the corpus an unreliable map of the architecture, which is the precise
+divergence this reconciliation exists to close. Status advanced to `accepted`.
+No wording changed: the decision recorded is the decision that shipped.
+
+### Feature index absent for a landed feature - actioned
+
+`markdown-feature-scope` carried no feature index despite having a full document
+set. Regenerated through the owning verb.
+
+### Plan without a governing decision - needs judgment
+
+`2026-06-28-codebase-drift-sweep-plan` has no ADR behind it. The plan describes
+a codebase-wide sweep for a defect pattern, so the missing record is a genuine
+gap rather than a tagging error: nothing states what was decided about the
+sweep's scope or its stopping condition. This has been outstanding across
+multiple sessions. Either author the governing decision or archive the plan;
+leaving it open keeps a permanent warning that trains readers to ignore the
+check.
+
+### Execution record pointing at a retired Step - needs judgment
+
+An execution record declares Step `W02.P04-P06`, which does not exist in
+`2026-05-17-cli-simplification-ux-plan`. The identifier shape is not canonical
+either, so this predates the current Step conventions. Resolve with the exec
+recovery verb or archive the record.
+
+### Plans without research grounding - accepted by design in one case
+
+Three plans carry no research reference. For `2026-07-27-vault-scale-performance`
+this is deliberate and already justified: the feature grounds on its audit under
+the audit-as-pipeline-start path, and that audit is linked. The other two,
+`2026-06-10-cli-reference-automation` and `2026-06-28-codebase-drift-sweep`, are
+legacy and unreviewed. The check is advisory and correctly cannot distinguish a
+deliberate grounding choice from an omission.
+
+## Recommendations
+
+- Decide `codebase-drift-sweep`: author its governing decision or archive the
+  plan. It is the only finding here that represents genuinely unfinished work
+  rather than historical residue.
+- Repair or archive the execution record naming the retired Step.
+- Consider whether the research-grounding check should recognise an audit or
+  reference as valid grounding, since the framework already sanctions both. As
+  written it will keep flagging correctly-grounded plans, and a check that cries
+  wolf on conforming documents erodes the value of the whole suite.
+- Report volume is capped for the check and graph surfaces but not for listings,
+  so `vault list` still renders every row on a large corpus. Extending the
+  existing cap policy to listings is a user-visible output change and belongs to
+  a decision rather than to this reconciliation.

--- a/.vault/index/adr-corpus-reconciliation.index.md
+++ b/.vault/index/adr-corpus-reconciliation.index.md
@@ -1,0 +1,21 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#adr-corpus-reconciliation'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - '[[2026-07-27-adr-corpus-reconciliation-audit]]'
+---
+
+# `adr-corpus-reconciliation` feature index
+
+Auto-generated index of all documents tagged with `#adr-corpus-reconciliation`.
+
+## Documents
+
+### audit
+
+- `2026-07-27-adr-corpus-reconciliation-audit` - `adr-corpus-reconciliation` audit: `decision status against shipped code`

--- a/.vault/index/markdown-feature-scope.index.md
+++ b/.vault/index/markdown-feature-scope.index.md
@@ -1,0 +1,54 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#markdown-feature-scope'
+date: '2026-07-27'
+modified: '2026-07-27'
+body_schema: 'body-v1'
+related:
+  - '[[2026-07-27-markdown-feature-scope-P01-S03]]'
+  - '[[2026-07-27-markdown-feature-scope-P01-summary]]'
+  - '[[2026-07-27-markdown-feature-scope-P02-S04]]'
+  - '[[2026-07-27-markdown-feature-scope-P02-S05]]'
+  - '[[2026-07-27-markdown-feature-scope-P02-summary]]'
+  - '[[2026-07-27-markdown-feature-scope-adr]]'
+  - '[[2026-07-27-markdown-feature-scope-implementation-audit]]'
+  - '[[2026-07-27-markdown-feature-scope-plan]]'
+  - '[[2026-07-27-markdown-feature-scope-reference]]'
+  - '[[2026-07-27-markdown-feature-scope-research]]'
+---
+
+# `markdown-feature-scope` feature index
+
+Auto-generated index of all documents tagged with `#markdown-feature-scope`.
+
+## Documents
+
+### adr
+
+- `2026-07-27-markdown-feature-scope-adr` - `markdown-feature-scope` adr: `feature-scoped markdown repair bypasses lazy migrations` | (**status:** `proposed`)
+
+### audit
+
+- `2026-07-27-markdown-feature-scope-implementation-audit` - `markdown-feature-scope` audit: `implementation`
+
+### exec
+
+- `2026-07-27-markdown-feature-scope-P01-S03` - Add a stale-workspace CLI regression for feature-scoped Markdown repair
+- `2026-07-27-markdown-feature-scope-P01-summary` - `markdown-feature-scope` `P01` summary
+- `2026-07-27-markdown-feature-scope-P02-S04` - Add an opt-in migration-control parameter that preserves the default scanner contract
+- `2026-07-27-markdown-feature-scope-P02-S05` - Route feature-scoped Markdown checks through the non-migrating scanner mode
+- `2026-07-27-markdown-feature-scope-P02-summary` - `markdown-feature-scope` `P02` summary
+
+### plan
+
+- `2026-07-27-markdown-feature-scope-plan` - `markdown-feature-scope` plan
+
+### reference
+
+- `2026-07-27-markdown-feature-scope-reference` - `markdown-feature-scope` reference: `scoped markdown repair boundary`
+
+### research
+
+- `2026-07-27-markdown-feature-scope-research` - `markdown-feature-scope` research: `feature-scoped repair migration boundary`

--- a/uv.lock
+++ b/uv.lock
@@ -2218,7 +2218,7 @@ wheels = [
 
 [[package]]
 name = "vaultspec-core"
-version = "0.1.52"
+version = "0.1.53"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary

ADR corpus reconciliation run immediately after the 0.1.53 release. Documents only, no code, so release-please correctly derives no version bump.

## Actioned

- **Ratified `body-schema-attestation`.** It was recorded as `proposed` while its decision was implemented and published in 0.1.53. A decision that governs released code while declaring itself unratified makes the corpus an unreliable map of the architecture. No wording changed.
- **Generated the absent feature index** for `markdown-feature-scope`.
- **Persisted the reconciliation** as an audit so findings needing judgment have a home rather than living only in a session transcript.

## Left for judgment, not actioned

- `2026-06-28-codebase-drift-sweep-plan` has **no governing ADR**. Outstanding across several sessions; nothing states the sweep's scope or stopping condition. Either author the decision or archive the plan.
- An execution record declares Step `W02.P04-P06`, which its parent plan retired. The identifier shape is not canonical either, so it predates current Step conventions.
- Three plans carry no research reference. One (`vault-scale-performance`) is deliberate and already justified via audit-as-pipeline-start; the other two are legacy and unreviewed.

## Note

The research-grounding check cannot distinguish a deliberate grounding choice from an omission, so it will keep flagging correctly-grounded plans. Worth considering whether it should accept an audit or reference as valid grounding, since the framework already sanctions both.

Vault health is unchanged at 5 pre-existing warnings; this introduces none.
