### PR TITLE
ci: guard against the release lockfile race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,28 @@ env:
   FORCE_COLOR: "0"
 
 jobs:
+  # Every other job installs with --locked, so a lockfile that has drifted from
+  # pyproject.toml fails all of them at once, inside "Install dependencies",
+  # where the cause is easy to miss. This job isolates that one question and
+  # answers it in seconds, so the drift reads as itself rather than as a
+  # repository-wide outage.
+  lockfile:
+    name: Lockfile In Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Verify uv.lock matches pyproject.toml
+        run: |
+          if ! uv lock --locked; then
+            echo "::error::uv.lock has drifted from pyproject.toml. Every job that installs with --locked will fail until this is fixed. Run 'uv lock' and commit the result."
+            exit 1
+          fi
+
   workflow-lint:
     name: Workflow Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,17 +26,17 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      - name: Update uv.lock on release branch
+      - name: Check out the release branch
         if: steps.release.outputs.pr && !steps.release.outputs.release_created
         uses: actions/checkout@v6
         with:
           ref: ${{ fromJSON(steps.release.outputs.pr).headBranchName }}
 
-      - name: Regenerate lockfile
+      - name: Set up uv for the release branch
         if: steps.release.outputs.pr && !steps.release.outputs.release_created
         uses: astral-sh/setup-uv@v7
 
-      - name: Push updated lockfile
+      - name: Regenerate and push uv.lock onto the release branch
         if: steps.release.outputs.pr && !steps.release.outputs.release_created
         run: |
           uv lock
@@ -49,6 +49,46 @@ jobs:
             git commit -m "chore: update uv.lock for release"
             git push
           fi
+
+      # The push above lands a few seconds after release-please makes the pull
+      # request mergeable, so a release merged inside that window ships the
+      # previous version's lockfile and leaves main failing every job at
+      # dependency install. Main is ruleset-protected and cannot be pushed to
+      # directly, so reconcile through a pull request instead of assuming the
+      # window was never hit.
+      - name: Check out main to verify the released lockfile
+        if: steps.release.outputs.release_created == 'true'
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Set up uv for the lockfile verification
+        if: steps.release.outputs.release_created == 'true'
+        uses: astral-sh/setup-uv@v7
+
+      - name: Open a reconciling pull request when the lockfile drifted
+        if: steps.release.outputs.release_created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          if uv lock --locked; then
+            echo "uv.lock on main matches the released version"
+            exit 0
+          fi
+          echo "::warning::uv.lock on main did not match the released version; opening a reconciling pull request"
+          uv lock
+          BRANCH="chore/reconcile-uv-lock-${TAG}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${BRANCH}"
+          git add uv.lock
+          git commit -m "chore(deps): reconcile uv.lock with ${TAG}"
+          git push --set-upstream origin "${BRANCH}"
+          gh pr create --base main --head "${BRANCH}" \
+            --title "chore(deps): reconcile uv.lock with ${TAG}" \
+            --body "The release for \`${TAG}\` was merged before the lockfile update reached its branch, so main carries the previous version's \`uv.lock\`. Every job installing with \`--locked\` fails until this merges."
+          echo "Opened a lockfile reconciliation pull request for ${TAG}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Dispatch PyPI publish workflow
         if: steps.release.outputs.release_created == 'true'


### PR DESCRIPTION
## What happened

Releasing 0.1.53 left main carrying 0.1.52's `uv.lock`. Every job installs with `--locked`, so **every pull request against main failed at dependency install**, regardless of content. A documents-only PR came back 7 of 8 red.

## Root cause: a race, not a missing mechanism

The release job already regenerates the lockfile. It does so as a push onto the release branch, which lands a few seconds *after* release-please makes the PR mergeable:

| time | event |
|---|---|
| 22:51:36 | release PR created |
| 22:51:41 | lockfile push step starts |
| **22:51:43** | **release PR merged** |
| 22:51:44 | lockfile push completes, onto an already-merged branch |

Merged one second early, so the lock commit never reached main.

## Why not fix it atomically

I tested making the lockfile part of release-please's own commit via `extra-files` with a `x-release-please-version` annotation. **uv strips the annotation whenever it actually rewrites the lockfile** (verified: survives a no-op `uv lock`, lost on a real version bump). That mechanism would silently disable itself on the first dependency change, so it was rejected.

## The two guards

**`Lockfile In Sync` job** — isolates the one question and answers it in seconds. The drift now names itself instead of surfacing inside every other job's install step as a mysterious repo-wide outage.

**Post-release reconciliation** — the window cannot be closed from inside the action, so the release job now verifies main's lockfile against the released version and opens a reconciling PR when it drifted. Main is ruleset-protected (`pull_request` required), so it reconciles *through* a PR rather than pushing directly.

Also renames three existing steps that each described the step after the one they named: "Update uv.lock on release branch" was the checkout, "Regenerate lockfile" was the uv setup.

## Verification

`actionlint` clean on both workflows, prek hooks green, and `uv lock --locked` passes on a clean tree as the new job expects.

## Follow-up for you

- Consider adding **`Lockfile In Sync`** to the ruleset's required status checks so drift blocks a merge rather than only reporting.
- The reconciling PR is opened by `GITHUB_TOKEN`, so like release PRs it receives no CI and needs `--admin` to merge. Its content is mechanically generated, but worth knowing.
