### PR TITLE
feat(dev): platform-agnostic development harness and quality-gate parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,22 +82,85 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Install dependencies
-        run: just dev deps sync
+        run: just deps sync
 
       - name: Ruff
-        run: just dev lint python
+        run: just lint python
 
       - name: Ty
-        run: just dev lint type
+        run: just lint type
 
       - name: Taplo
-        run: just dev lint toml
+        run: just lint toml
 
       - name: Lychee
-        run: just dev lint links
+        run: just lint links
 
       - name: pymarkdown
-        run: just dev lint markdown
+        run: just lint markdown
+
+      # Baseline-ratcheted gates. Each threshold sits at this tree's worst
+      # current offender (see the census comments in pyproject.toml), so these
+      # are green today and fail only on a NEW record-breaking offender. They
+      # run after the cheap checks because they are the slow ones.
+      #
+      # `if: always()` on every gate below is deliberate. These steps
+      # previously did not exist, and the failure mode they guard against is
+      # real: a gate placed behind a red step never runs at all, so a
+      # regression it would have caught reaches the default branch unseen. Each
+      # gate must report its own verdict independently of its neighbours.
+      - name: Cognitive complexity
+        if: always()
+        run: just lint complexity
+
+      - name: Nesting depth
+        if: always()
+        run: just lint nesting
+
+      - name: Module and class size
+        if: always()
+        run: just lint size
+
+      # ADVISORY, not gating: strict typing reports annotation debt spread
+      # across nearly every module. `continue-on-error` keeps the burndown
+      # visible in the job log without blocking merges, and this step becomes a
+      # real gate - by deleting that key - once the count reaches zero.
+      - name: Strict types (advisory)
+        if: always()
+        continue-on-error: true
+        run: just lint type-strict
+
+  code-health:
+    name: Code Health (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: taiki-e/install-action@just
+
+      - name: Install dependencies
+        run: just deps sync
+
+      # Measurement only - every target exits 0. This is the instrument the
+      # earlier health audits lacked: it ranks the worst offenders per
+      # dimension so the ratchet has a target list rather than an intention.
+      - name: Advisory audit dimensions
+        run: just audit all
+
+      - name: Code-health report
+        run: just health fast
 
   tests:
     name: Tests
@@ -120,10 +183,20 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Install dependencies
-        run: just dev deps sync
+        run: just deps sync
 
       - name: Run tests
-        run: just dev test python
+        run: just test unit
+
+      - name: Run development harness guards
+        run: just test harness
+
+      # The repository-root tests/ tree holds the automation contracts and the
+      # test-suite-quality guards. No CI lane named it until now, and the
+      # doubles guard inside it had been failing unobserved as a result. A
+      # guard nothing runs is not a guard.
+      - name: Run repository automation and suite-quality guards
+        run: just test repo
 
   broad-tests:
     name: broad (${{ matrix.os }})
@@ -162,11 +235,11 @@ jobs:
         # bash is available on windows-latest via Git Bash; using it on both
         # OSes keeps the just invocation and argument quoting identical.
         shell: bash
-        run: just dev deps sync
+        run: just deps sync
 
       - name: Run broad test suite
         shell: bash
-        run: uv run pytest src/vaultspec_core -q -m "not gemini and not claude and not network"
+        run: just test broad
 
   windows-vault-repair:
     name: Windows Vault Repair Tests
@@ -189,10 +262,10 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Install dependencies
-        run: just dev deps sync
+        run: just deps sync
 
       - name: Run vault repair regression tests
-        run: uv run pytest src/vaultspec_core/tests/cli/test_vault_repair.py src/vaultspec_core/vaultcore/checks/tests/test_structure_case_rename.py -q
+        run: just test vault-repair
 
   vault-audit:
     name: Vault Audit
@@ -215,7 +288,7 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Install dependencies
-        run: just dev deps sync
+        run: just deps sync
 
       - name: Bootstrap framework
         # The source repo tracks .vaultspec/ framework config, but the install
@@ -225,10 +298,10 @@ jobs:
         # --force to repair/create the manifest from the tracked config and
         # scaffold provider outputs, the way a consumer recovering a missing
         # manifest would.
-        run: just prod install --force
+        run: just framework install
 
       - name: Verify vault structure and links
-        run: just prod vault check all
+        run: just vault check
 
   dependency-audit:
     name: Dependency Audit (uv audit)
@@ -251,7 +324,7 @@ jobs:
         uses: taiki-e/install-action@just
 
       - name: Install dependencies
-        run: just dev deps sync
+        run: just deps sync
 
       - name: Python dependency vulnerability audit
-        run: just dev audit deps
+        run: just audit deps

--- a/.vault/_archive/research/2026-07-28-dev-scaffolding-parity-research.md
+++ b/.vault/_archive/research/2026-07-28-dev-scaffolding-parity-research.md
@@ -1,0 +1,56 @@
+---
+tags:
+  - '#research'
+  - '#dev-scaffolding-parity'
+date: '2026-07-28'
+modified: '2026-07-28'
+body_schema: 'body-v1'
+related: []
+---
+
+<!-- FRONTMATTER RULES:
+     tags: one directory tag (hardcoded #research) and one feature tag.
+     Replace dev-scaffolding-parity with a kebab-case feature tag, e.g. #foo-bar.
+     Additional tags may be appended below the required pair.
+
+     Related: use wiki-links as '[[yyyy-mm-dd-foo-bar]]'.
+
+     modified: CLI-maintained last-modified stamp; set at scaffold time,
+     refreshed by mutating CLI verbs and vault check fix; never hand-edit.
+
+     DO NOT add fields beyond those scaffolded; metadata lives
+     only in the frontmatter. -->
+
+<!-- LINK RULES:
+     - [[wiki-links]] are ONLY for .vault/ documents in the related: field above.
+     - NEVER use [[wiki-links]] or markdown [label](path) links in the document body.
+     - Cite external sources as bare URLs. Cite code, commits, packages, and
+       standards as inline backtick locators: `src/module.py:42`, commit
+       `abc1234`, `package@1.2.3`, RFC 9110. -->
+
+<!-- DOCUMENT BOUNDARY:
+     Research grounds; the ADR decides. Frame the option space with evidence
+     and trade-offs; at most name the option the evidence favors and what
+     the ADR must settle. Never record the decision here - a decision
+     outside the ADR forks and goes stale when the ADR chooses otherwise. -->
+
+# `dev-scaffolding-parity` research: `{topic}`
+
+<!-- Lead: the question, why it matters to `dev-scaffolding-parity`, and what was
+     concluded - the evidence picture, not a decision. -->
+
+## Findings
+
+<!-- One ### subsection per line of inquiry. Claim first, evidence after.
+     Anchor every non-obvious claim to a re-fetchable locator (URL,
+     `file:line`, commit SHA, `package@version`, RFC number). Link, do not
+     copy. Pin versions, dates, numbers. State each fact once: link what a
+     related vault document already records; do not repeat what an earlier
+     section establishes. Name alternatives and why kept or rejected. State
+     what was not investigated. Cut anything that changes no decision. -->
+
+## Sources
+
+<!-- Each locator cited above, once: `path:line` backtick locators for code,
+     bare URLs for external references. Flag unverified general-knowledge
+     claims. -->

--- a/.vault/adr/2026-07-28-dev-scaffolding-parity-adr.md
+++ b/.vault/adr/2026-07-28-dev-scaffolding-parity-adr.md
@@ -1,0 +1,127 @@
+---
+tags:
+  - '#adr'
+  - '#dev-scaffolding-parity'
+date: '2026-07-28'
+modified: '2026-07-28'
+body_schema: 'body-v1'
+related:
+  - '[[2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research]]'
+---
+
+# `dev-scaffolding-parity` adr: `baseline-ratcheted quality gates` | (**status:** `accepted`)
+
+## Problem Statement
+
+This project's sibling repositories enforce a substantially stricter quality
+bar than this one does. Where they gate cognitive complexity, module length,
+class shape, cyclomatic complexity, strict typing, dead code, security posture,
+and dependency drift, this repository gates style and fast type-checking only.
+The gap is not theoretical: the census recorded in
+`2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research` measures
+this tree well outside the range its siblings hold, and none of it was visible
+because nothing measured it.
+
+A decision is needed now because adopting the sibling gate set naively fails
+closed on day one. Every threshold the siblings run at would reject this
+repository immediately, and a gate that cannot be landed green is a gate that
+gets disabled.
+
+## Considerations
+
+- The measured distance to the siblings' thresholds is large enough that
+  landing at their values is not an option; see the census in
+  `2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research`.
+- A gate whose documented contract and actual exit code disagree is worse than
+  no gate, so each dimension must state plainly whether it gates or advises.
+- Prior health work under the `health-audit` and `codebase-audit` features
+  produced findings but no standing instrument, so regressions after those
+  audits were unobservable.
+- The siblings' own configuration carries a latent defect this adoption must
+  not inherit, recorded in the grounding survey.
+
+## Considered options
+
+- **Adopt the sibling thresholds directly.** Rejected: fails closed on landing
+  across every new dimension, which forces either an immediate large refactor
+  or disabling the gates.
+- **Land every dimension advisory-only and promote later.** Rejected: nothing
+  distinguishes a dimension that is genuinely clean from one nobody has looked
+  at, and promotion never has a forcing function.
+- **Baseline-ratcheted gates.** Chosen: each threshold is calibrated at this
+  tree's current worst offender, so the gate is green on landing, blocks any
+  regression beyond today's worst, and can only ever be lowered.
+- **Skip the dimensions this tree scores badly on.** Rejected: the dimensions
+  scoring worst are precisely the ones carrying the most risk.
+
+## Constraints
+
+- Two dimensions cannot run here at all: both read configuration through
+  `configparser`, which fails on this repository's pytest log format before
+  either inspects a file. The cognitive-complexity dimension covers the
+  overlapping signal; the grounding survey records the detail.
+- Strict type checking cannot gate at adoption. The volume recorded in the
+  survey is annotation debt spread across nearly every module, so it lands
+  advisory with the burndown tracked separately.
+- The import-convention dimension the sibling enforces does not transfer: this
+  package is mixed between absolute and relative intra-package imports, and
+  picking a side is an independent decision needing its own record, not a lint
+  flag set in passing.
+- No parent feature blocks this; the gates are configuration over existing
+  tooling.
+
+## Implementation
+
+Every threshold is declared in `pyproject.toml` beside a census comment
+recording the distribution it was calibrated from, so a future reader can see
+both the number and the distance left to the tool's own default. The
+development harness invokes each gate directly rather than reimplementing any
+threshold, which is what keeps the harness and the gate from disagreeing.
+
+The dimensions split by consequence rather than by tool. Gating dimensions are
+read-only and fail the build. Advisory dimensions report and exit zero, because
+each yields a lead to confirm rather than a verdict: reachability analysis
+cannot see dynamic dispatch, the security scanner reports this project's
+deliberate subprocess design alongside anything real, and dependency drift is a
+supply-chain risk rather than a build break. A dimension graduates from
+advisory to gating once its finding count reaches zero and can hold there.
+
+A standing aggregate report ranks the worst offenders across every dimension
+and always exits zero. It is the measurement instrument the earlier audits
+lacked, and it carries a census mode that regenerates the calibration
+distributions so a ratchet step is a measurement rather than a guess.
+
+## Rationale
+
+Baseline calibration wins on a knockout criterion the alternatives fail: it is
+the only option that is simultaneously green on landing and strictly binding.
+Setting each threshold at the current worst offender means the tree passes
+today, yet any change that makes any dimension worse than its worst current
+case fails immediately. The ratchet direction is enforced by convention rather
+than by tooling, which is why every threshold carries its census inline: raising
+one is visible in review as a deleted measurement.
+
+The advisory band is not a weaker gate but a different claim. It reports
+dimensions whose findings need human confirmation, and stating the exit code
+explicitly in the harness prevents the failure mode where a step labelled
+report-only silently gates, or a gate never runs because an earlier red step
+aborted the job.
+
+## Consequences
+
+The tree gains standing measurement across every dimension its siblings gate,
+and regression past today's worst case now fails the build rather than landing
+unseen. The aggregate report gives the burndown a target list ordered by
+severity instead of a general intention to improve.
+
+Honestly framed, the thresholds this lands at are loose. Several sit far enough
+above the tools' defaults that they will not catch a merely bad new function,
+only a record-breaking one. The gates are therefore a floor that stops decay,
+not a bar that enforces quality, and they only become the latter as the
+burndown ratchets them down. That burndown is real work across many sessions,
+concentrated in the largest modules, and until it progresses the strict-typing
+dimension in particular reports a volume large enough to be easy to ignore.
+
+The ratchet also creates a maintenance obligation: every extraction that pays
+down a hotspot should lower the corresponding threshold in the same change, or
+the headroom silently reopens for the next regression.

--- a/.vault/index/dev-scaffolding-parity.index.md
+++ b/.vault/index/dev-scaffolding-parity.index.md
@@ -1,0 +1,23 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#dev-scaffolding-parity'
+date: '2026-07-28'
+modified: '2026-07-28'
+body_schema: 'body-v1'
+related:
+  - '[[2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research]]'
+  - '[[2026-07-28-dev-scaffolding-parity-research]]'
+---
+
+# `dev-scaffolding-parity` feature index
+
+Auto-generated index of all documents tagged with `#dev-scaffolding-parity`.
+
+## Documents
+
+### research
+
+- `2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research` - `dev-scaffolding-parity` research: `rag aeat toolchain survey`
+- `2026-07-28-dev-scaffolding-parity-research` - `dev-scaffolding-parity` research: `{topic}`

--- a/.vault/plan/2026-07-28-dev-scaffolding-parity-plan.md
+++ b/.vault/plan/2026-07-28-dev-scaffolding-parity-plan.md
@@ -1,0 +1,125 @@
+---
+tags:
+  - '#plan'
+  - '#dev-scaffolding-parity'
+date: '2026-07-28'
+modified: '2026-07-28'
+tier: L3
+related:
+  - '[[2026-07-28-dev-scaffolding-parity-adr]]'
+  - '[[2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research]]'
+---
+
+# `dev-scaffolding-parity` plan
+
+## Wave `W01` - split the oversized modules
+
+Break the twelve production modules over 1000 lines into cohesive units, starting with the four over 1500. Every later Wave depends on this one: extraction redistributes functions, so complexity hotspots ranked before the split may not survive it. Authorized by 2026-07-28-dev-scaffolding-parity-adr.
+
+### Phase `W01.P01` - extract the four modules over 1500 lines
+
+Split the four largest production modules into cohesive units and lower the module-length ceiling to the new worst.
+
+- [ ] `W01.P01.S01` - Extract the spec command module into cohesive units; `src/vaultspec_core/cli/spec_cmd.py`.
+- [ ] `W01.P01.S02` - Extract the vault command module into cohesive units; `src/vaultspec_core/cli/vault_cmd.py`.
+- [ ] `W01.P01.S03` - Extract the core commands module along its install and sync seams; `src/vaultspec_core/core/commands.py`.
+- [ ] `W01.P01.S04` - Extract the graph api module into query and rendering units; `src/vaultspec_core/graph/api.py`.
+- [ ] `W01.P01.S05` - Lower the module-length ceiling to the post-extraction worst and regenerate its census; `pyproject.toml`.
+
+### Phase `W01.P02` - extract the eight modules over 1000 lines
+
+Bring the remaining four-figure modules under 1000 lines and ratchet the ceiling again.
+
+- [ ] `W01.P02.S06` - Bring the remaining eight production modules under one thousand lines; `src/vaultspec_core`.
+- [ ] `W01.P02.S07` - Ratchet the module-length ceiling again and regenerate its census; `pyproject.toml`.
+
+## Wave `W02` - pay down the per-function complexity hotspots
+
+Reduce cognitive and cyclomatic complexity toward the tool defaults of 15 and 10, working the ranked offender list the health report produces after W01 has redistributed the largest modules. Feeds W03 by shrinking the functions that must then be annotated. Authorized by 2026-07-28-dev-scaffolding-parity-adr.
+
+### Phase `W02.P03` - flatten the functions above cognitive 30
+
+Extract the 57 functions scoring above 30 and lower the cognitive ceiling toward 25.
+
+- [ ] `W02.P03.S08` - Flatten the fifty-seven production functions scoring above cognitive thirty; `src/vaultspec_core`.
+- [ ] `W02.P03.S09` - Lower the cognitive-complexity ceiling toward twenty-five and regenerate its census; `pyproject.toml`.
+
+### Phase `W02.P04` - close the ruff function-size gap
+
+Bring statements, branches, returns, and arguments down toward ruff's own defaults.
+
+- [ ] `W02.P04.S10` - Reduce the worst statement branch return and argument counts toward the ruff defaults; `src/vaultspec_core`.
+- [ ] `W02.P04.S11` - Lower the mccabe and function-size ceilings and regenerate their census; `pyproject.toml`.
+
+## Wave `W03` - close the strict-typing burndown
+
+Annotate the codebase until basedpyright strict reports zero, then promote the dimension from advisory to gating by deleting the continue-on-error key in CI. Runs last because annotating a function that W01 or W02 is about to move or split is wasted work. Authorized by 2026-07-28-dev-scaffolding-parity-adr.
+
+### Phase `W03.P05` - annotate the five dominant strict-typing rules
+
+Clear the 7950 errors concentrated in the five reportUnknown/reportMissing rules.
+
+- [ ] `W03.P05.S12` - Annotate the parameters the missing-parameter-type rule reports; `src/vaultspec_core`.
+- [ ] `W03.P05.S13` - Resolve the unknown member argument variable and parameter type errors; `src/vaultspec_core`.
+
+### Phase `W03.P06` - promote strict typing to a gate
+
+Resolve the residual tail, including the genuine possibly-unbound findings, then make the dimension gating.
+
+- [ ] `W03.P06.S14` - Resolve the possibly-unbound and attribute-access findings which can denote real defects; `src/vaultspec_core`.
+- [ ] `W03.P06.S15` - Promote strict typing to a gate by removing its continue-on-error key; `.github/workflows/ci.yml`.
+
+## Description
+
+The gates themselves are landed and green. `2026-07-28-dev-scaffolding-parity-adr`
+chose baseline calibration precisely so they could land green, which means every
+threshold currently sits at this tree's worst offender rather than at a bar worth
+holding. This plan is the burndown that turns the floor into a bar; the distance
+to cover per dimension is the census in
+`2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research`.
+
+One ADR governs the whole plan. The Waves are ordered by the ratio of risk
+removed to code disturbed: structural extraction of the largest modules first,
+because every later dimension improves as a side effect of it; then the
+per-function complexity hotspots; then the annotation debt, which is the largest
+count but the lowest risk per change.
+
+Every Step in this plan closes by lowering the corresponding threshold in
+`pyproject.toml` in the same change. A Step that pays down a hotspot without
+lowering the ceiling has reopened the headroom for the next regression and is
+not complete.
+
+## Steps
+
+## Parallelization
+
+The Waves are strictly sequenced, and the ordering is load-bearing rather than
+conventional. Splitting an oversized module redistributes its functions, so
+measuring per-function complexity before that split ranks hotspots that will not
+exist afterwards. Annotating a function that is about to be extracted wastes the
+annotation.
+
+Within a Wave, Steps that name disjoint modules parallelize freely and are the
+natural unit for a dispatched executor. Steps naming the same module must
+serialize: these are large files and concurrent extraction produces conflicts
+that are expensive to resolve correctly.
+
+One hard constraint cuts across every Wave: only one agent may hold
+`pyproject.toml` at a time, because every Step closes by editing a threshold in
+it. Batch the threshold edits at the end of each Phase rather than per Step.
+
+## Verification
+
+- Every Step closed, and for each, the corresponding threshold in
+  `pyproject.toml` lowered in the same change with its census comment
+  regenerated by `just health census`.
+- `just lint all` green, plus `just lint complexity`, `just lint nesting`, and
+  `just lint size` green, at the reduced thresholds.
+- `just test broad` green on Linux and Windows; these Waves touch install, sync,
+  and CLI paths where platform behaviour differs.
+- No threshold anywhere in `pyproject.toml` higher than the value this plan
+  started from. A raised ceiling is a failed Step, not a tradeoff.
+- Wave `W03` additionally requires the strict-typing step in
+  `.github/workflows/ci.yml` to have its `continue-on-error` key deleted, which
+  is what promotes the dimension from advisory to gating.
+- `vaultspec-code-review` sign-off on each Wave before the next begins.

--- a/.vault/research/2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research.md
+++ b/.vault/research/2026-07-28-dev-scaffolding-parity-rag-aeat-toolchain-survey-research.md
@@ -1,0 +1,162 @@
+---
+tags:
+  - '#research'
+  - '#dev-scaffolding-parity'
+date: '2026-07-28'
+modified: '2026-07-28'
+body_schema: 'body-v1'
+related: []
+---
+
+# `dev-scaffolding-parity` research: `rag aeat toolchain survey`
+
+Two sibling repositories enforce a quality bar this one does not, and the
+question was which of their dimensions transfer here and at what thresholds.
+The evidence picture: every dimension transfers except two that cannot run and
+one that encodes a convention this package does not hold, and none of them can
+land at the siblings' own values because this tree measures well outside them.
+
+## Findings
+
+### The sibling toolchains differ in packaging, not in dimension
+
+Both siblings gate the same dimensions. The semantic-search sibling declares
+them in `pyproject.toml` and invokes each from a development harness recipe.
+The larger application sibling adds a first-party `dev/` Python package holding
+custom audit implementations, committed baselines, and a red/amber health
+verdict, plus architectural-boundary contracts and a custom pattern-scanner
+rule set. The dimension list is otherwise the same, so the packaging choice is
+independent of which checks run.
+
+Dimensions surveyed and their disposition here:
+
+| Dimension                  | Tool                                   | Transfers              |
+| -------------------------- | -------------------------------------- | ---------------------- |
+| Cognitive complexity       | `complexipy@6.2`                       | yes, gating            |
+| Cyclomatic complexity      | ruff `C901`                            | yes, gating            |
+| Function-size limits       | ruff `PLR0911/0912/0913/0915`          | yes, gating            |
+| Module length, class shape | `pylint@4.0` `C0302 R0902 R0904 R0916` | yes, gating            |
+| Strict typing              | `basedpyright@1.39`                    | yes, advisory          |
+| Dead code                  | `vulture@2.16`                         | yes, advisory          |
+| Security posture           | `bandit@1.9.4`                         | yes, advisory          |
+| Dependency drift           | `deptry@0.25.1`                        | yes, advisory          |
+| Cyclomatic rank ceilings   | `xenon`, `radon` CLI                   | no, cannot run         |
+| Import convention          | scoped grep gate                       | no, no such convention |
+
+### Two dimensions cannot run in this repository at all
+
+`xenon` and `radon` both discover configuration by feeding every `[tool.*]`
+table of `pyproject.toml` into a `%`-interpolating `configparser`. This
+repository's `[tool.pytest.ini_options]` sets `log_cli_format` to
+`%(asctime)s [%(levelname)8s] %(name)s: %(message)s`, which raises an
+interpolation error before either tool inspects a single file. `radon` is still
+usable through its Python API, which performs no configuration discovery, and
+that is how the aggregate report reaches it. The cognitive-complexity and ruff
+`C901` dimensions cover the overlapping signal, so nothing is lost by dropping
+the two CLIs.
+
+### The import-convention gate encodes a convention this package does not hold
+
+The semantic-search sibling forbids absolute intra-package imports and gates on
+it. This package is mixed: 1274 `from vaultspec_core.` absolute imports against
+941 relative ones. Neither direction is a majority large enough to call it the
+existing convention, so adopting either gate would be a rename campaign across
+roughly a thousand sites justified by a lint flag. Ruff's `TID252` is the rule
+that would enforce the relative-import direction and is disabled for the same
+reason.
+
+### Both siblings carry a latent ignore-pattern defect
+
+Both declare their test-tree exclusion as a TOML basic string,
+`".*[\\/]tests[\\/].*"`. TOML basic-string escape processing turns `\\` into a
+single backslash, so the regex the tool receives is `.*[\/]tests[\/].*`, whose
+character class `[\/]` contains only a forward slash - the backslash is read as
+an escape of `/`, not as a member. On Windows the pattern therefore never
+matches, and the test tree the exclusion names silently enters the gate. This
+was observed directly here: before the fix, `pylint` reported four test modules
+including a 47-public-method test factory that would have set the class-shape
+baseline. The TOML literal-string form `'.*[\\/]tests[\\/].*'` passes both
+separators through and matches on either platform.
+
+### This tree measures far outside the sibling thresholds
+
+Census taken 2026-07-28 against `src/vaultspec_core`, production only, 172
+modules. The right column is the sibling's own worst production value or the
+tool default, for scale.
+
+| Dimension               | Worst here            | Count over tool default | Sibling worst |
+| ----------------------- | --------------------- | ----------------------- | ------------- |
+| Cognitive complexity    | 253                   | 177 over 15             | 20            |
+| Cyclomatic complexity   | 84                    | 191 over 10             | not measured  |
+| Statements per function | 214                   | -                       | not measured  |
+| Branches per function   | 63                    | -                       | not measured  |
+| Arguments per function  | 20                    | -                       | not measured  |
+| Module length           | 2782                  | 12 over 1000            | 2955          |
+| Instance attributes     | 21                    | -                       | 28            |
+| Strict-typing errors    | 8242 across 348 files | -                       | 0             |
+
+Distribution for the two dimensions where the shape matters most. Cognitive
+complexity: 57 functions over 30, 76 over 25, 109 over 20, 134 over 18, 166
+over 16, 177 over 15. Module length: 3 modules over 2000, 7 over 1500, 8 over
+1200, 12 over 1000, 35 over 500. The longest production module is
+`src/vaultspec_core/cli/spec_cmd.py` at 2782 lines.
+
+The strict-typing volume is concentrated in five rules -
+`reportUnknownMemberType` 2362, `reportUnknownArgumentType` 1756,
+`reportUnknownVariableType` 1374, `reportUnknownParameterType` 1269,
+`reportMissingParameterType` 1189 - which together are 91% of the total and are
+all annotation debt rather than defects. The remaining tail includes 10
+`reportPossiblyUnboundVariable` and 2 `reportAttributeAccessIssue`, which are
+the only entries that can denote real bugs.
+
+### The advisory dimensions are nearly clean
+
+`vulture` reports 2 findings, both `__exit__` protocol-fixed parameter names at
+`src/vaultspec_core/vaultcore/rename_engine.py:188`, and neither is dead.
+`deptry` reports 17, of which 4 are runtime declarations for a transport stack
+no first-party module imports and 13 are a legacy `[project.optional-dependencies]`
+dev extra duplicating the PEP 735 dev group. `bandit` reports 40, of which 38
+are LOW and dominated by this project's deliberate subprocess design.
+
+Neither non-LOW finding was a defect, and both are instructive about how the
+scanner reads code rather than about this code:
+
+- The B506 "unsafe yaml load" at `src/vaultspec_core/vaultcore/parser.py:73`
+  was a FALSE POSITIVE. The loader was already `yaml.CSafeLoader`, falling back
+  to `yaml.SafeLoader`; both derive from `yaml.constructor.SafeConstructor`,
+  which is exactly what refuses the `!!python/object` tags that would
+  instantiate arbitrary objects out of frontmatter. The module bound it to a
+  private alias `_SafeLoader`, and bandit's B506 check matches on the loader
+  NAME at the call site, so the alias defeated recognition. Dropping the alias
+  resolved the finding without changing a single semantic - the safety became
+  visible to the scanner instead of being suppressed from it. This is the
+  preferred shape of a false-positive resolution here: no `# nosec`, no config
+  skip, just code that states its own safety.
+- The B108 insecure-temp-path finding was in `hooks/tests/`, which the scan
+  should never have measured. See the scoping defect below.
+
+The `bandit` invocation excluded `src/vaultspec_core/tests` by path, which does
+not cover nested test trees such as `src/vaultspec_core/hooks/tests/`. Three
+findings, including that B108, came from test code the exclusion named but
+never reached. A `*/tests/*` glob covers every depth and drops all three.
+
+### Not investigated
+
+The larger sibling's architectural-boundary contracts and custom
+pattern-scanner rules were surveyed but not costed for adoption here; both
+require declaring a layer model this package has not defined. Duplication
+scanning was not measured. Whether the four transport dependencies are
+deliberate version floors or removable cruft was referred to a separate
+investigation rather than settled here.
+
+## Sources
+
+- `pyproject.toml` (this repository), `[tool.pytest.ini_options]` `log_cli_format`
+- `src/vaultspec_core/cli/spec_cmd.py`
+- `src/vaultspec_core/vaultcore/rename_engine.py:188`
+- `src/vaultspec_core/vaultcore/parser.py:73`
+- `complexipy@6.2`, `pylint@4.0`, `basedpyright@1.39.9`, `vulture@2.16`,
+  `bandit@1.9.4`, `deptry@0.25.1`, `radon@6.0.1`, `xenon@0.9.3`
+- TOML v1.0.0 basic-string escape rules, https://toml.io/en/v1.0.0#string
+- Census figures produced by `tools/health_report.py --census` in this
+  repository on 2026-07-28.

--- a/dev/__init__.py
+++ b/dev/__init__.py
@@ -1,0 +1,26 @@
+"""Platform-agnostic backend for the repository's ``justfile`` harness.
+
+The ``justfile`` declares *what* each development verb is; this package
+implements *how* it runs. Every recipe body is therefore a single portable
+command - ``uv run --no-sync python -m dev <verb> <target>`` - with no shell
+branching, no ``sh``-versus-PowerShell dialect, and no platform-specific
+script backing it.
+
+The split matters because the alternative drifts. Encoding the toolchain in
+shell means writing every non-trivial recipe twice, once per dialect, and the
+two copies diverge the moment one is edited. Here the branching that genuinely
+exists - a tool being present or falling back to its Docker image, a chain
+stopping at its first failure, an advisory scan reporting without gating -
+lives in one place, in :mod:`dev.runner`, and is exercised identically on
+every platform.
+
+This package imports only the standard library. It is the entry point a fresh
+clone reaches before any dependency is installed, so a third-party import here
+would make the harness unable to bootstrap the environment it needs.
+
+Modules:
+    :mod:`dev.runner`: Process execution, tool resolution, Docker fallback.
+    :mod:`dev.toolchain`: The declarative verb and target registry.
+"""
+
+from __future__ import annotations

--- a/dev/__main__.py
+++ b/dev/__main__.py
@@ -1,0 +1,148 @@
+"""The ``python -m dev`` entry point behind every justfile recipe.
+
+Usage::
+
+    python -m dev <verb> [target]
+    python -m dev <verb> help
+    python -m dev help
+
+Exit codes are the point of this module: a gating target propagates the exit
+code of whichever step failed, so ``just`` and CI both see the real result. An
+advisory target reports its findings and exits 0 regardless, because a scan
+that yields leads rather than verdicts must not gate a build.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+
+from dev.runner import Cmd, Echo, Ref, ToolOrDocker, run, run_tool_or_docker
+from dev.toolchain import (
+    DEFAULTS,
+    VERBS,
+    Target,
+    Verb,
+    find_verb,
+    public_targets,
+)
+
+
+def _print_verb_help(verb: Verb) -> None:
+    """Print a verb's usage, targets, and note.
+
+    Args:
+        verb: The verb whose help to render.
+    """
+    print(f"usage: just {verb.name} <target>")
+    print(f"  {verb.summary}")
+    print()
+    width = max(len(name) for name in public_targets(verb))
+    for target in verb.targets:
+        if target.name.startswith("_"):
+            continue
+        flag = " (advisory)" if target.advisory and target.name != "all" else ""
+        print(f"  {target.name:<{width}}  {target.summary}{flag}")
+    if verb.note:
+        print()
+        print(
+            textwrap.fill(
+                verb.note, width=88, initial_indent="  ", subsequent_indent="  "
+            )
+        )
+
+
+def _print_root_help() -> None:
+    """Print the list of every verb."""
+    print("usage: python -m dev <verb> [target]")
+    print()
+    width = max(len(verb.name) for verb in VERBS)
+    for verb in VERBS:
+        print(f"  {verb.name:<{width}}  {verb.summary}")
+    print()
+    print("  Run 'python -m dev <verb> help' for a verb's targets.")
+
+
+def _execute(verb: Verb, target: Target) -> int:
+    """Run one target's steps and return the resulting exit code.
+
+    Args:
+        verb: The owning verb, used to resolve :class:`~dev.runner.Ref` steps.
+        target: The target to execute.
+
+    Returns:
+        0 when the target is advisory, otherwise the exit code of the first
+        failing step (or of the last step when none failed).
+    """
+    worst = 0
+    for step in target.steps:
+        if isinstance(step, Echo):
+            print(f"\n{step.text}", flush=True)
+            continue
+        if isinstance(step, Ref):
+            referenced = verb.find(step.target)
+            if referenced is None:
+                print(
+                    f"internal error: {verb.name} references undefined target "
+                    f"'{step.target}'",
+                    file=sys.stderr,
+                )
+                return 1
+            code = _execute(verb, referenced)
+        elif isinstance(step, ToolOrDocker):
+            code = run_tool_or_docker(step)
+        elif isinstance(step, Cmd):
+            code = run(step.argv, step.env)
+        else:
+            print(f"internal error: unknown step {step!r}", file=sys.stderr)
+            return 1
+
+        if code != 0:
+            worst = code
+            if not target.keep_going:
+                break
+
+    return 0 if target.advisory else worst
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Dispatch a verb and target from the argument vector.
+
+    Args:
+        argv: The argument vector, or ``None`` to read :data:`sys.argv`.
+
+    Returns:
+        The process exit code.
+    """
+    args = list(sys.argv[1:] if argv is None else argv)
+
+    if not args or args[0] in {"help", "--help", "-h"}:
+        _print_root_help()
+        return 0
+
+    verb_name, *rest = args
+    verb = find_verb(verb_name)
+    if verb is None:
+        print(f"unknown verb: {verb_name}", file=sys.stderr)
+        print(f"  verbs: {' '.join(v.name for v in VERBS)}", file=sys.stderr)
+        return 1
+
+    target_name = rest[0] if rest else DEFAULTS.get(verb.name, "all")
+
+    if target_name in {"help", "--help", "-h"}:
+        _print_verb_help(verb)
+        return 0
+
+    target = verb.find(target_name)
+    if target is None or target.name.startswith("_"):
+        print(f"unknown {verb.name} target: {target_name}", file=sys.stderr)
+        print(f"  targets: {' '.join(public_targets(verb))}", file=sys.stderr)
+        if verb.note:
+            print(f"  {verb.note}", file=sys.stderr)
+        return 1
+
+    return _execute(verb, target)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dev/runner.py
+++ b/dev/runner.py
@@ -1,0 +1,162 @@
+"""Process-execution primitives shared by every development verb.
+
+Each step type below is a small, declarative description of one action. They
+are data rather than code so :mod:`dev.toolchain` can state the toolchain as a
+table, and so the platform-specific parts - executable resolution, Docker
+fallback, environment overlay - are implemented once here instead of being
+re-expressed in each recipe.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+#: Exit code for "the required tool is not installed and has no fallback".
+#: 127 is the conventional shell status for command-not-found, which keeps the
+#: meaning legible to CI logs and to anyone reading the exit code directly.
+TOOL_MISSING = 127
+
+
+@dataclass(frozen=True)
+class Cmd:
+    """A single subprocess invocation.
+
+    Args:
+        argv: The full argument vector, already split. Never a shell string -
+            passing a list is what keeps quoting identical on every platform.
+        env: Environment variables overlaid on the inherited environment.
+    """
+
+    argv: tuple[str, ...]
+    env: Mapping[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ToolOrDocker:
+    """An external tool, falling back to its Docker image when absent.
+
+    ``taplo``, ``lychee``, and ``actionlint`` are native binaries rather than
+    Python packages, so they cannot be pinned in the lockfile and may simply
+    be missing. Rather than fail, the harness runs the pinned image with the
+    working tree mounted at ``/repo``, which is also what CI does when it has
+    not installed the binary directly.
+
+    Args:
+        tool: Executable name to look for on ``PATH``.
+        argv: Arguments passed to the native executable.
+        image: Docker image reference used when the executable is absent.
+        docker_argv: Arguments passed to the container. Defaults to ``argv``,
+            and differs only where the container needs repo-absolute paths.
+    """
+
+    tool: str
+    argv: tuple[str, ...]
+    image: str
+    docker_argv: tuple[str, ...] | None = None
+
+
+@dataclass(frozen=True)
+class Echo:
+    """A section header printed between the steps of an aggregate target."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class Ref:
+    """A reference to another target within the same verb.
+
+    Aggregates such as ``lint all`` are expressed as references rather than by
+    repeating their steps, so a target and its use in an aggregate cannot drift
+    apart.
+    """
+
+    target: str
+
+
+Step = Cmd | ToolOrDocker | Echo | Ref
+
+
+def run(argv: Sequence[str], env: Mapping[str, str] | None = None) -> int:
+    """Run one subprocess and return its exit code.
+
+    Args:
+        argv: The argument vector to execute.
+        env: Variables overlaid on the inherited environment.
+
+    Returns:
+        The child process exit code, or :data:`TOOL_MISSING` when the
+        executable does not exist.
+    """
+    merged = {**os.environ, **(env or {})}
+    printable = " ".join(argv)
+    print(f"$ {printable}", flush=True)
+    try:
+        return subprocess.run(list(argv), env=merged, check=False).returncode
+    except FileNotFoundError:
+        print(f"{argv[0]} not found on PATH", file=sys.stderr, flush=True)
+        return TOOL_MISSING
+
+
+def run_tool_or_docker(step: ToolOrDocker) -> int:
+    """Run a native tool, or its Docker image when the tool is unavailable.
+
+    Args:
+        step: The tool description to execute.
+
+    Returns:
+        The exit code of whichever form ran, or :data:`TOOL_MISSING` when
+        neither the tool nor Docker is present.
+    """
+    if shutil.which(step.tool):
+        return run([step.tool, *step.argv])
+    if shutil.which("docker"):
+        mount = f"{Path.cwd()}:/repo"
+        container_argv = step.docker_argv if step.docker_argv is not None else step.argv
+        return run(
+            [
+                "docker",
+                "run",
+                "--rm",
+                "-v",
+                mount,
+                "-w",
+                "/repo",
+                step.image,
+                *container_argv,
+            ]
+        )
+    print(
+        f"{step.tool} not found and docker is unavailable",
+        file=sys.stderr,
+        flush=True,
+    )
+    return TOOL_MISSING
+
+
+def uv_run(*argv: str) -> Cmd:
+    """Build a command that runs a tool already present in the environment.
+
+    ``--no-sync`` keeps ``uv run`` from re-resolving and rebuilding the project
+    into ``.venv``. That rebuild fails on Windows whenever a resident process -
+    an MCP server, an editor, another agent's session - holds one of the
+    console-script executables open, so every recipe that merely *uses* the
+    environment goes through here. The recipes whose purpose is to *change* the
+    environment (``uv sync``, ``uv lock``, ``uv build``) call ``uv`` directly.
+
+    Args:
+        *argv: The command and arguments to run inside the environment.
+
+    Returns:
+        The corresponding :class:`Cmd`.
+    """
+    return Cmd(("uv", "run", "--no-sync", *argv))

--- a/dev/tests/__init__.py
+++ b/dev/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Integrity guards for the development harness registry."""
+
+from __future__ import annotations

--- a/dev/tests/test_registry.py
+++ b/dev/tests/test_registry.py
@@ -1,0 +1,164 @@
+"""Integrity guards for the verb and target registry.
+
+The failure these guard against is silent: a target renamed in
+:mod:`dev.toolchain` but still referenced from an aggregate, or a verb exposed
+by the ``justfile`` that no longer exists in the registry, produces a recipe
+that only fails when someone runs that exact path. Every check below turns one
+of those into a collection-time failure instead.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from dev.runner import Ref
+from dev.toolchain import DEFAULTS, VERBS, find_verb, public_targets
+
+pytestmark = pytest.mark.unit
+
+JUSTFILE = Path(__file__).resolve().parents[2] / "justfile"
+
+#: Recipes that deliberately do not route through `python -m dev`: `bootstrap`
+#: must work before a virtual environment exists, and the rest wrap a single
+#: external entry point that has no target dispatch to model.
+NON_REGISTRY_RECIPES = frozenset({"default", "bootstrap", "analytics", "binaries"})
+
+#: Test lanes deliberately reachable only by naming them, each with its reason.
+#: Every other lane must be in `test all` or a CI step - see
+#: :func:`test_every_test_lane_is_reachable_from_an_aggregate_or_ci`.
+DELIBERATELY_MANUAL = {
+    # `-m benchmark` is deselected by the default addopts in pyproject.toml, so
+    # these never run as a correctness gate. They are slow scale benchmarks
+    # whose wall-clock measurements are the subject under test; a loaded CI
+    # runner fails them for reasons unrelated to a regression.
+    "benchmark",
+}
+
+
+@pytest.mark.parametrize("verb", VERBS, ids=lambda verb: verb.name)
+def test_every_reference_resolves(verb) -> None:
+    """Each aggregate target references a target that exists in its verb."""
+    for target in verb.targets:
+        for step in target.steps:
+            if isinstance(step, Ref):
+                assert verb.find(step.target) is not None, (
+                    f"{verb.name}.{target.name} references undefined target "
+                    f"'{step.target}'"
+                )
+
+
+def test_every_test_lane_is_reachable_from_an_aggregate_or_ci() -> None:
+    """No test lane may be runnable only by someone naming it from memory.
+
+    This guards a defect that actually shipped. The ``repo`` lane - which runs
+    the repository-root ``tests/`` tree holding the automation contracts and
+    the test-suite-quality guards - was in neither ``test all`` nor any CI job.
+    Its own registry description said so. The doubles guard inside that tree
+    had consequently been failing undetected: a guard nothing runs is not a
+    guard.
+
+    A lane is considered reachable when ``test all`` references it, a CI
+    workflow step invokes it by name, or it is named in
+    :data:`DELIBERATELY_MANUAL` below. Adding a lane and wiring it to none of
+    the three fails here rather than silently going unobserved. The exemption
+    set is explicit on purpose: a lane nobody runs and a lane deliberately left
+    manual look identical from the registry, and only one of them is fine.
+    """
+    verb = find_verb("test")
+    assert verb is not None
+
+    aggregate = verb.find("all")
+    assert aggregate is not None, "the `test` verb must expose an `all` aggregate"
+    referenced = {step.target for step in aggregate.steps if isinstance(step, Ref)}
+
+    workflows = (Path(__file__).resolve().parents[2] / ".github" / "workflows").glob(
+        "*.yml"
+    )
+    ci_text = "\n".join(path.read_text(encoding="utf-8") for path in workflows)
+
+    unreachable = [
+        target.name
+        for target in verb.targets
+        if target.name not in {"all", *referenced, *DELIBERATELY_MANUAL}
+        and f"just test {target.name}" not in ci_text
+    ]
+    assert not unreachable, (
+        "test lanes reachable from neither `test all` nor a CI step: "
+        f"{sorted(unreachable)}. Add each to the `all` aggregate in "
+        "dev/toolchain.py or name it in a workflow step."
+    )
+
+
+@pytest.mark.parametrize("verb", VERBS, ids=lambda verb: verb.name)
+def test_no_duplicate_target_names(verb) -> None:
+    """A verb never defines the same target token twice."""
+    names = verb.target_names()
+    assert len(names) == len(set(names)), f"{verb.name} has duplicate targets: {names}"
+
+
+@pytest.mark.parametrize("verb", VERBS, ids=lambda verb: verb.name)
+def test_targets_are_documented_and_executable(verb) -> None:
+    """Every target carries a summary for `help` and at least one step."""
+    for target in verb.targets:
+        assert target.summary.strip(), f"{verb.name}.{target.name} has no summary"
+        assert target.steps, f"{verb.name}.{target.name} has no steps"
+
+
+@pytest.mark.parametrize("verb", VERBS, ids=lambda verb: verb.name)
+def test_default_target_exists(verb) -> None:
+    """Each verb declares a default target, and that target is defined."""
+    assert verb.name in DEFAULTS, f"{verb.name} has no entry in DEFAULTS"
+    default = DEFAULTS[verb.name]
+    assert verb.find(default) is not None, (
+        f"{verb.name} defaults to '{default}', which is not a defined target"
+    )
+
+
+@pytest.mark.parametrize("verb", VERBS, ids=lambda verb: verb.name)
+def test_references_terminate(verb) -> None:
+    """No aggregate target can reach itself, directly or transitively."""
+
+    def walk(name: str, seen: frozenset[str]) -> None:
+        assert name not in seen, f"{verb.name}.{name} is part of a reference cycle"
+        target = verb.find(name)
+        if target is None:
+            return
+        for step in target.steps:
+            if isinstance(step, Ref):
+                walk(step.target, seen | {name})
+
+    for target in verb.targets:
+        walk(target.name, frozenset())
+
+
+def _justfile_recipe_names() -> set[str]:
+    """Return every recipe name declared in the justfile."""
+    pattern = re.compile(r"^([a-z][a-z0-9-]*)(?:\s+[^:\n]*)?:\s*$", re.MULTILINE)
+    text = JUSTFILE.read_text(encoding="utf-8")
+    return set(pattern.findall(text))
+
+
+def test_justfile_exposes_every_registry_verb() -> None:
+    """Every verb in the registry has a justfile recipe of the same name."""
+    recipes = _justfile_recipe_names()
+    missing = {verb.name for verb in VERBS} - recipes
+    assert not missing, f"registry verbs with no justfile recipe: {sorted(missing)}"
+
+
+def test_every_dispatching_recipe_has_a_verb() -> None:
+    """Every justfile recipe that dispatches to `dev` names a real verb."""
+    unknown = sorted(
+        name
+        for name in _justfile_recipe_names() - NON_REGISTRY_RECIPES
+        if find_verb(name) is None
+    )
+    assert not unknown, f"justfile recipes with no registry verb: {unknown}"
+
+
+def test_public_targets_hide_internal_helpers() -> None:
+    """Underscore-prefixed targets never appear in help output."""
+    for verb in VERBS:
+        assert all(not name.startswith("_") for name in public_targets(verb))

--- a/dev/toolchain.py
+++ b/dev/toolchain.py
@@ -1,0 +1,695 @@
+"""The declarative registry of development verbs and their targets.
+
+This module is the single source of truth for what the harness can do. The
+``justfile`` exposes each verb; everything about *what a target runs*, whether
+it gates, and how targets compose into aggregates is stated here as data.
+
+The verbs split by CONSEQUENCE, not by tool:
+
+``lint``
+    GATES. Read-only, and a finding fails the build.
+``fix``
+    MUTATES. Everything automatically repairable, in one pass.
+``audit``
+    Only ``deps`` gates. Every other target is advisory and exits 0 even with
+    findings, because each yields a lead to confirm rather than a verdict.
+``test``
+    GATES. See :data:`TEST` for what each lane proves.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dev.runner import Cmd, Echo, Ref, Step, ToolOrDocker, uv_run
+
+PACKAGE = "src/vaultspec_core"
+
+#: Python trees that carry committed source and are therefore linted. `scripts`
+#: and `statistic` were historically excluded while holding real code; the
+#: per-file-ignores in pyproject.toml already name `statistic`, so the config
+#: always intended a scope the invocation never applied. `tools` holds the
+#: code-health report, which is committed source like any other and must not
+#: lint itself into an exception.
+PYTHON_PATHS = ("src", "tests", "scripts", "statistic", "dev", "tools")
+
+#: Markers requiring credentials or live network, excluded from every gate.
+EXCLUDED_MARKERS = "not gemini and not claude and not network"
+
+#: Trees whose Markdown is formatted and linted.
+MARKDOWN_PATHS = ("README.md", "docs/", ".vault/", "src/vaultspec_core/builtins/")
+
+#: User-facing Markdown additionally held to a hard wrap.
+WRAPPED_MARKDOWN = (
+    "README.md",
+    "docs/framework.md",
+    "docs/MCP.md",
+    "docs/CLI.md",
+    "src/vaultspec_core/builtins",
+)
+
+#: complexipy emits status glyphs; Windows consoles default to a codepage that
+#: cannot encode them, which aborts the run before any finding is reported.
+UTF8 = {"PYTHONIOENCODING": "utf-8"}
+
+#: Repairing the corpus is reachable as both `fix vault` and `vault fix`, which
+#: are the same action approached from the two verbs a reader might try. The
+#: steps are defined once here so the two entry points cannot drift.
+VAULT_FIX_STEPS = (
+    uv_run("vaultspec-core", "vault", "check", "all", "--fix"),
+    uv_run("vaultspec-core", "vault", "sanitize", "annotations"),
+)
+
+
+@dataclass(frozen=True)
+class Target:
+    """One selectable behaviour within a verb.
+
+    Args:
+        name: The target token typed on the command line.
+        summary: One-line description shown by ``help``.
+        steps: The steps to run, in order.
+        advisory: When true the target reports findings but always exits 0.
+        keep_going: When true a failing step does not stop the remaining
+            steps. Aggregate dashboards set this so one red dimension does
+            not hide every dimension after it.
+    """
+
+    name: str
+    summary: str
+    steps: tuple[Step, ...]
+    advisory: bool = False
+    keep_going: bool = False
+
+
+@dataclass(frozen=True)
+class Verb:
+    """A top-level harness verb and the targets it dispatches to.
+
+    Args:
+        name: The verb token, matching the justfile recipe name.
+        summary: One-line description of the verb.
+        targets: The selectable targets, in display order.
+        note: Optional extra line appended to the verb's ``help`` output.
+    """
+
+    name: str
+    summary: str
+    targets: tuple[Target, ...]
+    note: str = ""
+
+    def target_names(self) -> tuple[str, ...]:
+        """Return every target token in display order."""
+        return tuple(target.name for target in self.targets)
+
+    def find(self, name: str) -> Target | None:
+        """Return the named target, or ``None`` when it is not defined."""
+        return next((t for t in self.targets if t.name == name), None)
+
+
+def _ruff_paths(*prefix: str) -> Cmd:
+    return uv_run("ruff", *prefix, *PYTHON_PATHS)
+
+
+DEPS = Verb(
+    name="deps",
+    summary="Manage project dependencies and the lockfile.",
+    targets=(
+        Target(
+            "sync",
+            "Install the locked dependency set.",
+            (Cmd(("uv", "sync", "--locked", "--group", "dev")),),
+        ),
+        Target(
+            "upgrade",
+            "Upgrade every dependency group.",
+            (Cmd(("uv", "sync", "--upgrade", "--all-groups")),),
+        ),
+        Target("lock", "Regenerate the lockfile.", (Cmd(("uv", "lock")),)),
+        Target(
+            "lock-upgrade",
+            "Regenerate the lockfile at the newest allowed versions.",
+            (Cmd(("uv", "lock", "--upgrade")),),
+        ),
+        Target(
+            "check",
+            "Verify the lockfile matches pyproject.toml.",
+            (Cmd(("uv", "lock", "--check")),),
+        ),
+    ),
+)
+
+LINT = Verb(
+    name="lint",
+    summary="Run gating static analysis.",
+    note=(
+        "'all' omits complexity, nesting, size, and type-strict - run those by name. "
+        "Each is a real gate whose burndown is unfinished, so adding it to the chain "
+        "would hide every dimension behind it."
+    ),
+    targets=(
+        Target(
+            "python",
+            "Ruff lint and format verification.",
+            (_ruff_paths("check"), _ruff_paths("format", "--check")),
+        ),
+        Target(
+            "type",
+            "Ty type checking.",
+            (uv_run("python", "-m", "ty", "check", PACKAGE),),
+        ),
+        Target(
+            "toml",
+            "Taplo TOML linting.",
+            (ToolOrDocker("taplo", ("lint", "*.toml"), "tamasfe/taplo:0.9"),),
+        ),
+        Target(
+            "links",
+            "Lychee link checking.",
+            (
+                ToolOrDocker(
+                    "lychee",
+                    (
+                        "--config",
+                        "lychee.toml",
+                        "README.md",
+                        "docs",
+                        ".vault",
+                        f"{PACKAGE}/builtins",
+                    ),
+                    "lycheeverse/lychee:latest",
+                    (
+                        "--config",
+                        "/repo/lychee.toml",
+                        "README.md",
+                        "docs",
+                        ".vault",
+                        f"{PACKAGE}/builtins",
+                    ),
+                ),
+            ),
+        ),
+        Target(
+            "markdown",
+            "Markdown formatting and style verification.",
+            (
+                uv_run("mdformat", "--check", *MARKDOWN_PATHS),
+                uv_run("mdformat", "--wrap", "88", "--check", *WRAPPED_MARKDOWN),
+                uv_run(
+                    "pymarkdown",
+                    "--config",
+                    ".pymarkdown.json",
+                    "scan",
+                    "-r",
+                    *MARKDOWN_PATHS,
+                ),
+            ),
+        ),
+        Target(
+            "workflow",
+            "Actionlint GitHub workflow checking.",
+            (ToolOrDocker("actionlint", (), "rhysd/actionlint:latest"),),
+        ),
+        Target(
+            "complexity",
+            "Cognitive complexity over production code.",
+            (Cmd(uv_run("complexipy", PACKAGE).argv, UTF8),),
+        ),
+        Target(
+            "nesting",
+            "Nesting depth (PLR1702, preview-scoped).",
+            (uv_run("ruff", "check", "src", "--select", "PLR1702", "--preview"),),
+        ),
+        Target(
+            "size",
+            "Module length and class design limits ruff has no rule for.",
+            (
+                uv_run(
+                    "pylint",
+                    PACKAGE,
+                    "--rcfile=pyproject.toml",
+                    "--recursive=y",
+                    "--score=n",
+                ),
+            ),
+        ),
+        Target(
+            "type-strict",
+            "Basedpyright strict-mode type checking.",
+            (uv_run("basedpyright"),),
+        ),
+        Target(
+            "all",
+            "Every gate that is green and can hold that line.",
+            # complexity/nesting/size joined this aggregate once each went green
+            # and held: the governing ADR's promotion rule is that a dimension
+            # graduates when its finding count reaches zero at the gate's
+            # threshold. Until they did, `just lint` covered six of ten
+            # dimensions while CI ran the other four as separate steps, so a
+            # contributor could push a complexity regression and only learn
+            # about it from CI. A local gate that omits what CI enforces
+            # teaches people the wrong thing about what "green" means.
+            #
+            # `type-strict` stays OUT deliberately: basedpyright still reports
+            # thousands of annotation-debt errors, so it runs advisory in CI
+            # and joins here when that burndown reaches zero.
+            tuple(
+                Ref(name)
+                for name in (
+                    "python",
+                    "type",
+                    "toml",
+                    "links",
+                    "markdown",
+                    "workflow",
+                    "complexity",
+                    "nesting",
+                    "size",
+                )
+            ),
+        ),
+    ),
+)
+
+FIX = Verb(
+    name="fix",
+    summary="Apply every available formatter and automatic fix.",
+    targets=(
+        Target(
+            "python",
+            "Format and auto-repair Python source.",
+            (_ruff_paths("format"), _ruff_paths("check", "--fix")),
+        ),
+        Target(
+            "toml",
+            "Format TOML files.",
+            (ToolOrDocker("taplo", ("fmt", "*.toml"), "tamasfe/taplo:0.9"),),
+        ),
+        Target(
+            "markdown",
+            "Format and auto-repair Markdown.",
+            (
+                uv_run("mdformat", *MARKDOWN_PATHS),
+                uv_run("mdformat", "--wrap", "88", *WRAPPED_MARKDOWN),
+                uv_run(
+                    "pymarkdown",
+                    "--config",
+                    ".pymarkdown.json",
+                    "fix",
+                    "-r",
+                    *MARKDOWN_PATHS,
+                ),
+            ),
+        ),
+        Target(
+            "vault",
+            "Repair this repository's own .vault/ corpus.",
+            VAULT_FIX_STEPS,
+        ),
+        Target(
+            "all",
+            "Run every fixer.",
+            tuple(Ref(name) for name in ("python", "toml", "markdown", "vault")),
+        ),
+    ),
+)
+
+AUDIT = Verb(
+    name="audit",
+    summary="Audit dependencies and code quality; only 'deps' gates.",
+    note=(
+        "Only 'deps' gates - a published advisory against a pinned version is a "
+        "verdict. Every other target is advisory and exits 0 even with findings."
+    ),
+    targets=(
+        Target(
+            "deps",
+            "Dependency vulnerability audit (GATES).",
+            (Cmd(("uv", "run", "python", "scripts/dependency_audit.py")),),
+        ),
+        Target(
+            "security",
+            "Bandit security scan.",
+            (
+                uv_run(
+                    "bandit",
+                    "-c",
+                    "pyproject.toml",
+                    "-r",
+                    PACKAGE,
+                    "-x",
+                    "*/tests/*",
+                    "-q",
+                ),
+            ),
+            advisory=True,
+        ),
+        Target(
+            "dead-code", "Vulture dead-code scan.", (uv_run("vulture"),), advisory=True
+        ),
+        Target(
+            "dependencies",
+            "Deptry dependency-drift scan.",
+            (uv_run("deptry", PACKAGE),),
+            advisory=True,
+        ),
+        Target(
+            "complexity",
+            "Cognitive complexity over the test tree.",
+            (Cmd(uv_run("complexipy", f"{PACKAGE}/tests").argv, UTF8),),
+            advisory=True,
+        ),
+        Target(
+            "all",
+            "Every audit dimension, as a dashboard.",
+            (
+                Echo("=== dependency advisories ==="),
+                Ref("deps"),
+                Echo("=== security ==="),
+                Ref("security"),
+                Echo("=== dead code ==="),
+                Ref("dead-code"),
+                Echo("=== undeclared dependencies ==="),
+                Ref("dependencies"),
+                Echo("=== test-tree cognitive complexity ==="),
+                Ref("complexity"),
+            ),
+            advisory=True,
+            keep_going=True,
+        ),
+    ),
+)
+
+TEST = Verb(
+    name="test",
+    summary="Run the project test suites.",
+    note=(
+        "'unit' is marker-scoped and selects a slice, not the suite - a green 'unit' "
+        "says nothing about the far larger population 'broad' runs."
+    ),
+    targets=(
+        Target(
+            "unit",
+            "The fast marker-scoped gate; first failure aborts.",
+            (
+                uv_run(
+                    "pytest",
+                    PACKAGE,
+                    "-x",
+                    "-q",
+                    "--tb=short",
+                    "-m",
+                    f"unit and {EXCLUDED_MARKERS}",
+                ),
+            ),
+        ),
+        Target(
+            "broad",
+            "The whole package suite minus credential-gated markers.",
+            (uv_run("pytest", PACKAGE, "-q", "--tb=short", "-m", EXCLUDED_MARKERS),),
+        ),
+        Target(
+            "repo",
+            "The repository-root tests/ tree (automation and suite-quality guards).",
+            (uv_run("pytest", "tests", "-q", "--tb=short", "-m", EXCLUDED_MARKERS),),
+        ),
+        Target(
+            "vault-repair",
+            "The Windows repair and case-rename regression cohort.",
+            (
+                uv_run(
+                    "pytest",
+                    f"{PACKAGE}/tests/cli/test_vault_repair.py",
+                    f"{PACKAGE}/vaultcore/checks/tests/test_structure_case_rename.py",
+                    "-q",
+                    "--tb=short",
+                ),
+            ),
+        ),
+        Target(
+            "benchmark",
+            "The slow scale benchmarks, deselected by default.",
+            (uv_run("pytest", PACKAGE, "-q", "--tb=short", "-m", "benchmark"),),
+        ),
+        Target(
+            "harness",
+            "The dev/ harness registry integrity guards.",
+            (uv_run("pytest", "dev/tests", "-q", "--tb=short"),),
+        ),
+        Target(
+            "all",
+            "The broad suite, vault-repair cohort, harness guards, and repo tests.",
+            # `repo` is in this aggregate deliberately. It was previously
+            # reachable only by naming it, and no CI lane named it either, so
+            # the tree it runs - the automation contracts and the suite-quality
+            # guards - was unobserved. A guard nothing runs is not a guard: the
+            # test-doubles check in it had been failing undetected.
+            (Ref("broad"), Ref("vault-repair"), Ref("harness"), Ref("repo")),
+        ),
+    ),
+)
+
+BUILD = Verb(
+    name="build",
+    summary="Build the Python distribution artifacts.",
+    note="The standalone binaries are 'just binaries <tag> <rust-target>'.",
+    targets=(
+        Target("python", "Build the wheel and sdist.", (Cmd(("uv", "build")),)),
+        Target("all", "Run every build.", (Ref("python"),)),
+    ),
+)
+
+PRECOMMIT = Verb(
+    name="precommit",
+    summary="Manage the prek-owned git pre-commit hooks.",
+    targets=(
+        Target("install", "Install the git hooks.", (uv_run("prek", "install"),)),
+        Target(
+            "upgrade",
+            "Update the pinned hook revisions.",
+            (uv_run("prek", "auto-update"),),
+        ),
+        Target(
+            "run",
+            "Run every hook against all files.",
+            (uv_run("prek", "run", "--all-files"),),
+        ),
+    ),
+)
+
+VAULT = Verb(
+    name="vault",
+    summary="Operate on this repository's own .vault/ development corpus.",
+    targets=(
+        Target(
+            "check",
+            "Run the vault health checks.",
+            (uv_run("vaultspec-core", "vault", "check", "all"),),
+        ),
+        Target("fix", "Repair and sanitize the corpus.", VAULT_FIX_STEPS),
+        Target(
+            "graph",
+            "Render the document graph with metrics.",
+            (uv_run("vaultspec-core", "vault", "graph", "--metrics"),),
+        ),
+        Target(
+            "index",
+            "Regenerate the auto-generated feature indexes.",
+            (uv_run("vaultspec-core", "vault", "feature", "index"),),
+        ),
+        Target(
+            "list",
+            "List every vault document.",
+            (uv_run("vaultspec-core", "vault", "list"),),
+        ),
+        Target(
+            "stats",
+            "Show corpus statistics.",
+            (uv_run("vaultspec-core", "vault", "stats"),),
+        ),
+        Target(
+            "status",
+            "Show in-flight plan orientation.",
+            (uv_run("vaultspec-core", "status"),),
+        ),
+    ),
+)
+
+FRAMEWORK = Verb(
+    name="framework",
+    summary="Operate on this repository's own .vaultspec/ framework harness.",
+    note=(
+        "'uninstall' is deliberately absent: .vaultspec/ here is the canonical "
+        "framework source, not a consumer's installed copy."
+    ),
+    targets=(
+        Target(
+            "doctor",
+            "Diagnose workspace health, failing on errors.",
+            (uv_run("vaultspec-core", "spec", "doctor", "--gate-errors"),),
+        ),
+        Target(
+            "install",
+            "Rebuild the install manifest from tracked config.",
+            (uv_run("vaultspec-core", "install", "--force"),),
+        ),
+        Target(
+            "upgrade",
+            "Refresh the installed builtin snapshots.",
+            (uv_run("vaultspec-core", "install", "--upgrade"),),
+        ),
+        Target(
+            "sync",
+            "Regenerate the provider outputs.",
+            (uv_run("vaultspec-core", "sync"),),
+        ),
+        Target(
+            "reference",
+            "Regenerate the bundled CLI reference.",
+            (uv_run("vaultspec-core", "spec", "reference", "generate"),),
+        ),
+        Target(
+            "reference-check",
+            "Verify the bundled CLI reference is current.",
+            (uv_run("vaultspec-core", "spec", "reference", "generate", "--check"),),
+        ),
+        Target(
+            "providers",
+            "Guard against committing provider artifacts.",
+            (uv_run("vaultspec-core", "check-providers"),),
+        ),
+    ),
+)
+
+ASSETS = Verb(
+    name="assets",
+    summary="Regenerate the committed README terminal renders and demo GIF.",
+    note="Both renderers drive real commands against a throwaway synthetic vault.",
+    targets=(
+        Target(
+            "readme",
+            "Regenerate the terminal-render SVGs.",
+            (uv_run("python", "scripts/render_readme_assets.py"),),
+        ),
+        Target(
+            "demo",
+            "Regenerate the pipeline demo GIF (needs agg on PATH).",
+            (uv_run("python", "scripts/render_readme_demo.py"),),
+        ),
+        Target("all", "Regenerate every asset.", (Ref("readme"), Ref("demo"))),
+    ),
+)
+
+HEALTH = Verb(
+    name="health",
+    summary="Rank the worst offenders across every code-health dimension.",
+    note=(
+        "MEASUREMENT ONLY - every target exits 0. This composes the gates rather "
+        "than re-implementing any threshold, so the report and the gate can never "
+        "disagree. 'census' regenerates the distributions each baseline ratchet in "
+        "pyproject.toml is calibrated from; run it before lowering a threshold so "
+        "the new value is a measurement rather than a guess."
+    ),
+    targets=(
+        Target(
+            "report",
+            "Worst offenders per dimension, including strict types.",
+            (Cmd(uv_run("python", "tools/health_report.py").argv, UTF8),),
+            advisory=True,
+        ),
+        Target(
+            "fast",
+            "The same report without the basedpyright section.",
+            (Cmd(uv_run("python", "tools/health_report.py", "--fast").argv, UTF8),),
+            advisory=True,
+        ),
+        Target(
+            "census",
+            "Baseline-calibration distributions for the ratchet thresholds.",
+            (Cmd(uv_run("python", "tools/health_report.py", "--census").argv, UTF8),),
+            advisory=True,
+        ),
+    ),
+)
+
+CI = Verb(
+    name="ci",
+    summary="Run the full local gate.",
+    targets=(
+        Target(
+            "all",
+            "Lint, dependency audit, vault checks, and the broad test suite.",
+            (
+                Echo("=== lint ==="),
+                Cmd(("uv", "run", "--no-sync", "python", "-m", "dev", "lint", "all")),
+                Echo("=== dependency audit ==="),
+                Cmd(("uv", "run", "--no-sync", "python", "-m", "dev", "audit", "deps")),
+                Echo("=== vault ==="),
+                Cmd(
+                    ("uv", "run", "--no-sync", "python", "-m", "dev", "vault", "check")
+                ),
+                Echo("=== tests ==="),
+                Cmd(("uv", "run", "--no-sync", "python", "-m", "dev", "test", "broad")),
+            ),
+        ),
+    ),
+)
+
+#: Every verb, in the order ``help`` lists them.
+VERBS: tuple[Verb, ...] = (
+    DEPS,
+    LINT,
+    FIX,
+    AUDIT,
+    TEST,
+    BUILD,
+    PRECOMMIT,
+    VAULT,
+    FRAMEWORK,
+    ASSETS,
+    HEALTH,
+    CI,
+)
+
+#: Default target per verb, used when the justfile passes none.
+DEFAULTS: dict[str, str] = {
+    "deps": "sync",
+    "lint": "all",
+    "fix": "all",
+    "audit": "all",
+    "test": "all",
+    "build": "python",
+    "precommit": "run",
+    "vault": "check",
+    "framework": "doctor",
+    "assets": "all",
+    "health": "report",
+    "ci": "all",
+}
+
+
+def find_verb(name: str) -> Verb | None:
+    """Return the named verb, or ``None`` when it is not defined.
+
+    Args:
+        name: The verb token to resolve.
+
+    Returns:
+        The matching :class:`Verb`, or ``None``.
+    """
+    return next((verb for verb in VERBS if verb.name == name), None)
+
+
+def public_targets(verb: Verb) -> tuple[str, ...]:
+    """Return a verb's user-selectable target names.
+
+    Targets whose name begins with an underscore are internal composition
+    helpers and are hidden from help output.
+
+    Args:
+        verb: The verb to inspect.
+
+    Returns:
+        The public target tokens in display order.
+    """
+    return tuple(name for name in verb.target_names() if not name.startswith("_"))

--- a/justfile
+++ b/justfile
@@ -1,277 +1,178 @@
+# ===========================================================================
+#  vaultspec-core development harness
+#
+#  Every entry point is a top-level verb; behaviour within a verb is selected
+#  by a `target` argument - `just lint type`, `just test broad`, `just fix
+#  markdown`. Run `just` for the annotated recipe list, and `just <verb> help`
+#  (or any unrecognised target) for that verb's targets with descriptions.
+#
+#  PLATFORM AGNOSTIC BY CONSTRUCTION. Every recipe body below is a single
+#  command with no shell branching, no pipes, no conditionals, and no `sh`
+#  versus PowerShell dialect. All of the logic - target dispatch, step
+#  chaining, tool-or-Docker fallback, advisory-versus-gating exit codes - lives
+#  in the `dev/` Python package, which imports only the standard library and
+#  therefore behaves identically on every platform. There is no shell script
+#  backing this file. To change what a target runs, edit `dev/toolchain.py`,
+#  which is the single declarative source of truth for the whole toolchain.
+#
+#  The verbs split by CONSEQUENCE, not by tool:
+#
+#    lint   GATES.    Read-only, and a finding fails the build.
+#    fix    MUTATES.  Everything automatically repairable, in one pass.
+#    audit  Only `deps` gates. Every other target is advisory and exits 0
+#           even with findings, because each yields a lead to confirm.
+#    test   GATES.    `just test help` states what each lane proves.
+#
+#  NO TOOL IS MIRRORED HERE. `vaultspec-core` and `vaultspec-rag` are finished
+#  products with their own CLIs and their own MCP servers; wrapping either one
+#  only adds a layer that can drift out of step with it. Invoke them directly
+#  (`uv run --no-sync vaultspec-core ...`, `uv run --no-sync vaultspec-rag ...`
+#  or the MCP tools). That applies to rag's whole surface - the search service,
+#  its lifecycle, and its indexes are rag's to manage, not this harness's.
+#
+#  What this file does expose is the operations the repository performs on
+#  ITSELF - its own `.vault/` corpus and its own `.vaultspec/` harness - as the
+#  `vault` and `framework` verbs, because those are development actions on this
+#  checkout rather than product usage.
+# ===========================================================================
+
 set positional-arguments := false
-set shell := ["sh", "-cu"]
-set windows-shell := ["pwsh.exe", "-NoProfile", "-c"]
+set quiet := true
 
+# just defaults to `sh -cu` on every platform, which on Windows means a Git Bash
+# `sh.exe` that is only on PATH for some Git for Windows install options. This
+# names the one interpreter every Windows machine is guaranteed to have. It is a
+# shell DECLARATION, not platform-specific logic: because each recipe body below
+# is a single command with no shell syntax, `cmd` and `sh` execute all of them
+# identically, and there is no second dialect of anything to maintain.
+set windows-shell := ["cmd.exe", "/c"]
 
+# Every recipe that merely *uses* the environment goes through `uv run
+# --no-sync`. Skipping the sync keeps `uv run` from re-resolving and rebuilding
+# the project into `.venv`, which fails on Windows whenever a resident process
+# - an MCP server, an editor, another agent's session - holds one of the
+# console-script executables open. The recipes whose purpose IS to change the
+# environment call `uv` directly, inside `dev/`.
+dev := "uv run --no-sync python -m dev"
 
+# List available recipes.
 default:
-  @echo "Available commands:"
-  @echo "  prod [args...]    Run the vaultspec-core Python CLI (pure 1:1 mirror)"
-  @echo "  dev <target>      Development toolchain (deps, lint, fix, audit, test, build, etc.)"
-  @echo "  ci                Full CI pipeline: lint → audit → vault check → test"
-  @echo ""
-  @echo "Run 'just <command> --help' for more details."
+    @just --list
 
 # ===========================================================================
-#  prod  - pure 1:1 mirror of the vaultspec-core Python CLI
+#  Bootstrap
 # ===========================================================================
 
-prod *args='':
-  @{{ if args == "--help" { "just _prod-help" } else if args == "-h" { "just _prod-help" } else if args == "help" { "just _prod-help" } else { "uv run vaultspec-core " + args } }}
+# The literal `uv sync` on the first line is deliberate: it is the only step
+# that must work before a virtual environment exists, so it cannot route
+# through `{{dev}}`. `framework install` then runs with --force because a fresh
+# checkout carries the tracked `.vaultspec/` config but not the gitignored
+# install manifest (`.vaultspec/providers.json`), and the diagnosis engine
+# reads that combination as CORRUPTED; --force rebuilds the manifest from the
+# tracked config the way a consumer recovering a lost manifest would.
 
-_prod-help:
-  @echo "Usage: just prod [args...]"
-  @echo ""
-  @echo "Runs the vaultspec-core Python CLI (pure 1:1 mirror)."
-  @echo "Examples:"
-  @echo "  just prod install . claude --force"
-  @echo "  just prod sync claude --dry-run"
-  @echo "  just prod vault check all --fix"
-  @echo "  just prod vault check all -v"
-  @echo "  just prod vault graph --metrics"
-  @echo "  just prod vault add adr -f my-feature"
-  @echo "  just prod spec rules list"
+# Provision a fresh clone or worktree: dependencies, framework, and git hooks.
+bootstrap:
+    uv sync --locked --group dev
+    {{dev}} framework install
+    {{dev}} precommit install
 
 # ===========================================================================
-#  dev  - development toolchain (linters, formatters, tests, builds)
+#  Toolchain verbs
 # ===========================================================================
 
-dev target='--help' *args='':
-  @{{ if target == "--help" { "just _dev-help" } else if target == "-h" { "just _dev-help" } else if target == "help" { "just _dev-help" } else { "just _dev-" + target + " " + args } }}
+# Manage project dependencies and the lockfile.
+deps target='sync':
+    {{dev}} deps {{target}}
 
-_dev-help:
-  @echo "Usage: just dev <target> [args...]"
-  @echo ""
-  @echo "Targets:"
-  @echo "  deps      dependency management (sync, upgrade, lock)"
-  @echo "  lint      read-only static analysis (ruff, ty, taplo, markdownlint, ...)"
-  @echo "  fix       auto-fix everything fixable (python, toml, markdown, vault)"
-  @echo "  audit     supply-chain / security checks (uv audit)"
-  @echo "  test      pytest"
-  @echo "  build     uv build"
-  @echo "  precommit pre-commit hook management (install, upgrade, run)"
+# Run gating static analysis: style, types, config, links, and markdown.
+lint target='all':
+    {{dev}} lint {{target}}
+
+# Apply every available formatter and automatic fix.
+fix target='all':
+    {{dev}} fix {{target}}
+
+# Audit dependencies and code quality; only 'deps' gates.
+audit target='all':
+    {{dev}} audit {{target}}
+
+# Run the project test suites.
+test target='all':
+    {{dev}} test {{target}}
+
+# Build the Python distribution artifacts.
+build target='python':
+    {{dev}} build {{target}}
+
+# Manage the prek-owned git pre-commit hooks.
+precommit target='run':
+    {{dev}} precommit {{target}}
 
 # ===========================================================================
-#  ci  - full pipeline: lint → audit → vault check → test
+#  This checkout's own vaultspec records and harness
 # ===========================================================================
 
-ci *args='':
-  @{{ if args == "--help" { "just _ci-help" } else if args == "-h" { "just _ci-help" } else if args == "help" { "just _ci-help" } else { "just _ci-run" } }}
+# Operate on this repository's own .vault/ development corpus.
+vault target='check':
+    {{dev}} vault {{target}}
 
-_ci-help:
-  @echo "Usage: just ci"
-  @echo ""
-  @echo "Runs the full CI pipeline: lint → audit → vault check → test"
+# Operate on this repository's own .vaultspec/ framework harness.
+framework target='doctor':
+    {{dev}} framework {{target}}
 
-_ci-run:
-  just dev lint all
-  just dev audit deps
-  just prod vault check all
-  just dev test all
+# ===========================================================================
+#  Assets and analytics
+# ===========================================================================
 
-# ---------------------------------------------------------------------------
-#  Internal recipes (prefixed with _ to hide from --list)
-# ---------------------------------------------------------------------------
+# Regenerate the committed README terminal renders and demo GIF.
+assets target='all':
+    {{dev}} assets {{target}}
 
-_dev-deps target='--help':
-  @{{ if target == "--help" { "just _dev-deps-help" } else if target == "-h" { "just _dev-deps-help" } else if target == "help" { "just _dev-deps-help" } else { "just _dev-deps-" + target } }}
+# MEASUREMENT ONLY - always exits 0. Composes the gates rather than
+# re-implementing any threshold, so the report and the gate cannot disagree.
+# `just health census` regenerates the distributions each baseline ratchet in
+# pyproject.toml is calibrated from; run it before lowering a threshold.
 
-_dev-deps-help:
-  @echo "Usage: just dev deps <target>"
-  @echo ""
-  @echo "Targets:"
-  @echo "  sync          Sync dependencies"
-  @echo "  upgrade       Upgrade all dependencies"
-  @echo "  lock          Lock dependencies"
-  @echo "  lock-upgrade  Upgrade and lock dependencies"
+# Rank the worst offenders across every code-health dimension.
+health target='report':
+    {{dev}} health {{target}}
 
-_dev-deps-sync:
-  uv sync --locked --group dev
+# Dev-only and unshipped: it reads the operator's own ~/.claude and ~/.codex
+# transcripts and writes into the gitignored statistic/out/. Every
+# machine-varying input is a flag with a home-derived default, so the bare
+# invocation is the normal one. Pass --help for the flag list.
 
-_dev-deps-upgrade:
-  uv sync --upgrade --all-groups
+# Report CLI usage analytics from the local agent transcript corpora.
+analytics *args='':
+    uv run --no-sync python -m statistic {{args}}
 
-_dev-deps-lock:
-  uv lock
+# ===========================================================================
+#  Release artifacts
+# ===========================================================================
 
-_dev-deps-lock-upgrade:
-  uv lock --upgrade
+# Parameterised rather than a fixed `build` target, and a release-workflow
+# action rather than a routine local build. The binaries resolve
+# `vaultspec-core==<tag>` from PyPI on first launch, so the tag must already be
+# published for the result to bootstrap. `tag` is the release tag (e.g.
+# vaultspec-core-v0.1.53); `rust_target` is a cargo triple (e.g.
+# x86_64-pc-windows-msvc).
 
-# ---------------------------------------------------------------------------
+# `--no-project` matches .github/workflows/binaries.yml exactly: the binary
+# build runs against a bare interpreter with no project environment, so a local
+# reproduction and the release workflow invoke the script identically.
 
-_dev-lint target='--help':
-  @{{ if target == "--help" { "just _dev-lint-help" } else if target == "-h" { "just _dev-lint-help" } else if target == "help" { "just _dev-lint-help" } else { "just _dev-lint-" + target } }}
+# Build the standalone PyApp binaries for one release tag and Rust target.
+binaries tag rust_target outdir='dist-bin':
+    uv run --no-project --python 3.13 -- python scripts/build_pyapp.py --tag {{tag}} --target {{rust_target}} --outdir {{outdir}}
 
-_dev-lint-help:
-  @echo "Usage: just dev lint <target>"
-  @echo ""
-  @echo "Targets:"
-  @echo "  python    Run Ruff on Python source"
-  @echo "  type      Run Ty (type checker) on Python source"
-  @echo "  links     Run Lychee link checker"
-  @echo "  toml      Run Taplo TOML linter"
-  @echo "  markdown  Run Markdown linting and formatting checks"
-  @echo "  workflow  Run Actionlint on GitHub workflows"
-  @echo "  all       Run all linters"
+# ===========================================================================
+#  Aggregate pipeline
+# ===========================================================================
 
-_dev-lint-python:
-  uv run ruff check src tests
-  uv run ruff format --check src tests
+# `test broad` rather than `test unit` on purpose - see `just test help`. This
+# mirrors what CI proves, so a green run here means what a green CI run means.
 
-_dev-lint-type:
-  uv run python -m ty check src/vaultspec_core
-
-_dev-lint-links:
-  @{{ if os() == "windows" { \
-    "if (Get-Command lychee -ErrorAction SilentlyContinue) { lychee --config lychee.toml README.md docs .vault src/vaultspec_core/builtins } elseif (Get-Command docker -ErrorAction SilentlyContinue) { docker run --rm -v '${PWD}:/repo' -w /repo lycheeverse/lychee:latest --config /repo/lychee.toml README.md docs .vault src/vaultspec_core/builtins } else { Write-Error 'lychee not found and docker is unavailable'; exit 127 }" \
-  } else { \
-    "if command -v lychee >/dev/null 2>&1; then lychee --config lychee.toml README.md docs .vault src/vaultspec_core/builtins; elif command -v docker >/dev/null 2>&1; then docker run --rm -v \"$PWD:/repo\" -w /repo lycheeverse/lychee:latest --config /repo/lychee.toml README.md docs .vault src/vaultspec_core/builtins; else echo 'lychee not found and docker is unavailable' >&2; exit 127; fi" \
-  } }}
-
-_dev-lint-toml:
-  @{{ if os() == "windows" { \
-    "if (Get-Command taplo -ErrorAction SilentlyContinue) { taplo lint *.toml } elseif (Get-Command docker -ErrorAction SilentlyContinue) { docker run --rm -v '${PWD}:/repo' -w /repo tamasfe/taplo:0.9 lint *.toml } else { Write-Error 'taplo not found and docker is unavailable'; exit 127 }" \
-  } else { \
-    "if command -v taplo >/dev/null 2>&1; then taplo lint *.toml; elif command -v docker >/dev/null 2>&1; then docker run --rm -v \"$PWD:/repo\" -w /repo tamasfe/taplo:0.9 lint *.toml; else echo 'taplo not found and docker is unavailable' >&2; exit 127; fi" \
-  } }}
-
-_dev-lint-markdown:
-  uv run mdformat --check README.md docs/ .vault/ src/vaultspec_core/builtins/
-  uv run mdformat --wrap 88 --check README.md docs/framework.md docs/MCP.md docs/CLI.md src/vaultspec_core/builtins
-  uv run pymarkdown --config .pymarkdown.json scan -r README.md docs/ .vault/ src/vaultspec_core/builtins/
-
-_dev-lint-workflow:
-  @{{ if os() == "windows" { \
-    "if (Get-Command actionlint -ErrorAction SilentlyContinue) { actionlint } elseif (Get-Command docker -ErrorAction SilentlyContinue) { docker run --rm -v '${PWD}:/repo' -w /repo rhysd/actionlint:latest } else { Write-Error 'actionlint not found and docker is unavailable'; exit 127 }" \
-  } else { \
-    "if command -v actionlint >/dev/null 2>&1; then actionlint; elif command -v docker >/dev/null 2>&1; then docker run --rm -v \"$PWD:/repo\" -w /repo rhysd/actionlint:latest; else echo 'actionlint not found and docker is unavailable' >&2; exit 127; fi" \
-  } }}
-
-_dev-lint-all:
-  just _dev-lint-python
-  just _dev-lint-type
-  just _dev-lint-links
-  just _dev-lint-toml
-  just _dev-lint-markdown
-  just _dev-lint-workflow
-
-# ---------------------------------------------------------------------------
-
-_dev-fix target='--help':
-  @{{ if target == "--help" { "just _dev-fix-help" } else if target == "-h" { "just _dev-fix-help" } else if target == "help" { "just _dev-fix-help" } else { "just _dev-fix-" + target } }}
-
-_dev-fix-help:
-  @echo "Usage: just dev fix <target>"
-  @echo ""
-  @echo "Targets:"
-  @echo "  python    Auto-fix and format Python source"
-  @echo "  toml      Auto-format TOML files"
-  @echo "  markdown  Auto-format Markdown files"
-  @echo "  vault     Auto-fix vault issues"
-  @echo "  all       Run all fixers"
-
-_dev-fix-python:
-  uv run ruff format src tests
-  uv run ruff check --fix src tests
-
-_dev-fix-toml:
-  @{{ if os() == "windows" { \
-    "if (Get-Command taplo -ErrorAction SilentlyContinue) { taplo fmt *.toml } elseif (Get-Command docker -ErrorAction SilentlyContinue) { docker run --rm -v '${PWD}:/repo' -w /repo tamasfe/taplo:0.9 fmt *.toml } else { Write-Error 'taplo not found and docker is unavailable'; exit 127 }" \
-  } else { \
-    "if command -v taplo >/dev/null 2>&1; then taplo fmt *.toml; elif command -v docker >/dev/null 2>&1; then docker run --rm -v \"$PWD:/repo\" -w /repo tamasfe/taplo:0.9 fmt *.toml; else echo 'taplo not found and docker is unavailable' >&2; exit 127; fi" \
-  } }}
-
-_dev-fix-markdown:
-  uv run mdformat README.md docs/ .vault/ src/vaultspec_core/builtins/
-  uv run mdformat --wrap 88 README.md docs/framework.md docs/MCP.md docs/CLI.md src/vaultspec_core/builtins
-  uv run pymarkdown --config .pymarkdown.json fix -r README.md docs/ .vault/ src/vaultspec_core/builtins/
-
-_dev-fix-vault:
-  uv run vaultspec-core vault check all --fix
-  uv run vaultspec-core vault sanitize annotations
-
-_dev-fix-all:
-  just _dev-fix-python
-  just _dev-fix-toml
-  just _dev-fix-markdown
-  just _dev-fix-vault
-
-# ---------------------------------------------------------------------------
-
-_dev-audit target='--help':
-  @{{ if target == "--help" { "just _dev-audit-help" } else if target == "-h" { "just _dev-audit-help" } else if target == "help" { "just _dev-audit-help" } else { "just _dev-audit-" + target } }}
-
-_dev-audit-help:
-  @echo "Usage: just dev audit <target>"
-  @echo ""
-  @echo "Targets:"
-  @echo "  deps      Run uv audit on locked dependencies"
-
-# The supply-chain gate runs `uv audit` -- uv's native, preview-feature OSV
-# scanner -- and never shells out to pip. The cross-platform wrapper lives in
-# scripts/dependency_audit.py; it fails the gate on real findings (uv audit
-# itself exits 0 even when advisories are present) and, when uv's preview
-# decoder aborts on a malformed upstream OSV record, independently repeats the
-# bulk OSV query to confirm the only affected advisories are ones already
-# triaged. See that script's module docstring for the full rationale,
-# including the disputed, unfixable pyjwt advisory PYSEC-2025-183.
-_dev-audit-deps:
-  uv run python scripts/dependency_audit.py
-
-# ---------------------------------------------------------------------------
-
-_dev-test target='--help':
-  @{{ if target == "--help" { "just _dev-test-help" } else if target == "-h" { "just _dev-test-help" } else if target == "help" { "just _dev-test-help" } else { "just _dev-test-" + target } }}
-
-_dev-test-help:
-  @echo "Usage: just dev test <target>"
-  @echo ""
-  @echo "Targets:"
-  @echo "  python    Run pytest on Python source"
-  @echo "  all       Run all tests"
-
-_dev-test-python:
-  uv run pytest src/vaultspec_core -x -q --tb=short -m "unit and not gemini and not claude and not network"
-
-_dev-test-all:
-  just _dev-test-python
-
-# ---------------------------------------------------------------------------
-
-_dev-build target='--help':
-  @{{ if target == "--help" { "just _dev-build-help" } else if target == "-h" { "just _dev-build-help" } else if target == "help" { "just _dev-build-help" } else { "just _dev-build-" + target } }}
-
-_dev-build-help:
-  @echo "Usage: just dev build <target>"
-  @echo ""
-  @echo "Targets:"
-  @echo "  python    Build Python package"
-  @echo "  all       Run all builds"
-
-_dev-build-python:
-  uv build
-
-_dev-build-all:
-  just _dev-build-python
-
-# ---------------------------------------------------------------------------
-
-_dev-precommit target='--help':
-  @{{ if target == "--help" { "just _dev-precommit-help" } else if target == "-h" { "just _dev-precommit-help" } else if target == "help" { "just _dev-precommit-help" } else { "just _dev-precommit-" + target } }}
-
-_dev-precommit-help:
-  @echo "Usage: just dev precommit <target>"
-  @echo ""
-  @echo "Targets:"
-  @echo "  install   Install pre-commit hooks"
-  @echo "  upgrade   Upgrade pre-commit hooks"
-  @echo "  run       Run pre-commit hooks on all files"
-
-_dev-precommit-install:
-  uv run prek install
-
-_dev-precommit-upgrade:
-  uv run prek auto-update
-
-_dev-precommit-run:
-  uv run prek run --all-files
+# Run the full local gate: lint, dependency audit, vault checks, broad tests.
+ci:
+    {{dev}} ci all

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,22 +77,37 @@ version = "0.1.53"
 # become runtime or published-extra dependencies of vaultspec-core. The cu130
 # torch source pin in [tool.uv.sources] applies because torch is a direct dep here.
 dev = [
+  "bandit>=1.9.4",
+  "basedpyright>=1.39",
+  # Cognitive complexity - how much state a reader must hold to follow a
+  # function, as distinct from the number of paths through it that xenon
+  # measures. Configured from [tool.complexipy] below.
+  "complexipy>=6.2",
+  "deptry>=0.25.1",
   "identify>=2.0.0",
   "mdformat>=1.0.0",
   "mdformat-frontmatter>=2.0.10",
   "mdformat-gfm>=1.0.0",
   "mdformat-gfm-alerts>=1.0.0",
   "prek>=0.3.2",
+  # Module length and the class-shape design limits ruff has no rule for
+  # (C0302, R0902, R0904, R0916). Everything else pylint would report is
+  # already covered by ruff and stays disabled.
+  "pylint>=4.0",
   "pymarkdownlnt>=0.9.0",
   "pytest>=9.0.2",
   "pytest-asyncio>=1.3.0",
   "pytest-durations>=1.0.0",
   "pytest-reportlog>=0.4.0",
   "pytest-timeout>=2.4.0",
+  "pytest-xdist>=3.8.0",
+  "radon>=6.0.1",
   "ruff>=0.15.2",
   "torch>=2.4",
   "ty>=0.0.15",
   "vaultspec-rag[mcp]>=0.3.8",
+  "vulture>=2.16",
+  "xenon>=0.9.3",
 ]
 
 [tool.hatch.metadata]
@@ -130,21 +145,69 @@ line-length = 88
 target-version = "py313"
 
   [tool.ruff.lint]
+  # NOTE: preview is deliberately OFF here - enabling it globally changes the
+  # behavior of stable rules and surfaces findings unrelated to the rule being
+  # added. The preview-only nesting-depth rule (PLR1702) is gated separately by
+  # `just lint nesting`, which runs a scoped `--select PLR1702 --preview`.
+  #
+  # TID252 (relative-imports) is off: this package is mixed - 1274 absolute and
+  # 941 relative intra-package imports - and picking a side is an import-
+  # convention decision that needs its own ADR and campaign, not a lint flag.
+  # TID251 (banned-api) stays on.
+  ignore = ["TID252"]
   select = [
-    "E",   # pycodestyle errors
-    "W",   # pycodestyle warnings
-    "F",   # pyflakes
-    "I",   # isort
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "UP",  # pyupgrade
-    "ARG", # flake8-unused-arguments
-    "SIM", # flake8-simplify
-    "TCH", # flake8-type-checking
-    "RUF", # ruff-specific rules
-    "N",   # pep8-naming
+    "E",       # pycodestyle errors
+    "W",       # pycodestyle warnings
+    "F",       # pyflakes
+    "I",       # isort
+    "B",       # flake8-bugbear
+    "C4",      # flake8-comprehensions
+    "UP",      # pyupgrade
+    "ARG",     # flake8-unused-arguments
+    "SIM",     # flake8-simplify
+    "TCH",     # flake8-type-checking
+    "RUF",     # ruff-specific rules
+    "N",       # pep8-naming
+    "TID",     # flake8-tidy-imports
+    "C90",     # mccabe complexity
+    "PLR0911", # too-many-return-statements
+    "PLR0912", # too-many-branches
+    "PLR0913", # too-many-arguments
+    "PLR0915", # too-many-statements
   ]
   unfixable = ["B"]
+
+    # BASELINE-CALIBRATED (census 2026-07-28, `just health --census`). Each
+    # threshold sits at today's worst PRODUCTION offender, so the gate is green
+    # on landing and can only ever be ratcheted DOWN. ruff's own defaults are
+    # mccabe 10, returns 6, branches 12, args 5, statements 50 - the distance
+    # between those and the numbers below is the burndown backlog.
+    #
+    # Cyclomatic census (production blocks):
+    #     over 25:  12      over 15:  87      over 10: 196   <- the default
+    [tool.ruff.lint.mccabe]
+    max-complexity = 35 # RATCHETED 58 -> 57 -> 35
+
+    # Worst production value per rule at the census: returns 10, branches 34,
+    # args 17, statements 142.
+    #
+    # `max-args` has a FLOOR that the other rules do not. A Typer command's
+    # parameters are the CLI's flags, so its signature length is the published
+    # interface, not debt: 38 of the 102 offenders are commands or callbacks,
+    # and the current worst (17) is `vault add`. The remaining 64 are plain
+    # helpers and are ordinary debt - keep ratcheting on those. Do not chase
+    # ruff's default of 5 here by deleting user-facing flags, and do not add a
+    # per-file-ignore for the command modules, which would also mask genuine
+    # helper bloat living in those same files.
+    #
+    # PLR1702 (nesting depth) is NOT listed here: it reached ruff's own default
+    # of 5 and is gated at that default by `just lint nesting`. It is the first
+    # dimension to finish its burndown; the rest are still above default.
+    [tool.ruff.lint.pylint]
+    max-args = 17        # RATCHETED 20 -> 17 (floor is the worst Typer command)
+    max-branches = 34    # RATCHETED 63 -> 62 -> 34
+    max-returns = 10     # RATCHETED 13 -> 10
+    max-statements = 142 # RATCHETED 214 -> 142
 
     [tool.ruff.lint.per-file-ignores]
     "**/test_*.py" = ["ARG"]
@@ -170,9 +233,225 @@ target-version = "py313"
     [tool.ruff.lint.isort]
     known-first-party = ["vaultspec_core"]
 
+    [tool.ruff.lint.flake8-type-checking]
+    # Pydantic resolves a model's annotations when the class is created, so a
+    # type used only in a field annotation is still needed at RUNTIME. Without
+    # this, TC001 tells you to defer an import the model then cannot resolve.
+    runtime-evaluated-base-classes = ["pydantic.BaseModel"]
+
 [tool.ty.environment]
 python-version = "3.13"
 root = [".", "src"]
+
+# Strict-mode type checking. Landed ADVISORY (`just lint type-strict` is not in
+# the `lint all` chain yet) and promoted to gating once the burndown reaches
+# zero. `ty` stays the fast pre-commit gate.
+[tool.basedpyright]
+include = ["src/vaultspec_core"]
+pythonVersion = "3.13"
+typeCheckingMode = "strict"
+
+  # Tests legitimately reach into the private internals of the modules they
+  # exercise, so reportPrivateUsage is a trust-boundary false positive inside
+  # the test tree (fixing it by making internals public would damage the
+  # design). Every other strict rule stays ON for tests.
+  [[tool.basedpyright.executionEnvironments]]
+  reportPrivateUsage = false
+  root = "src/vaultspec_core/tests"
+
+# Cognitive complexity - how much state a reader must hold to follow a
+# function, as distinct from the number of paths through it that `xenon`
+# measures. Nesting compounds the score here, so a deeply-indented function
+# ranks far worse than a flat one with the same branch count.
+#
+# BASELINE-CALIBRATED (census 2026-07-28): RATCHETED 253 -> 166 -> 154 -> 56.
+# Never raise. Long-term target: 15, the tool's own default.
+#
+# The 253 -> 166 step cost no work of its own: it fell out of the PLR1702
+# nesting burndown. Cognitive complexity compounds with indentation depth, so
+# flattening a deeply-nested function pays down this dimension far faster than
+# its own branch count would suggest. Prefer nesting reduction over branch
+# extraction when both are available on the same hotspot.
+#
+# The distance to the target, measured at the same time:
+#
+#     over  30:   46 functions
+#     over  25:   65
+#     over  20:  101
+#     over  18:  129
+#     over  16:  164
+#     over  15:  178      <- the target
+#
+# Production only. Tests are measured by `just audit complexity`, which reports
+# without failing: the worst scores belong to guard tests that walk the AST of
+# every module, and that shape is what the guard IS, not debt to pay down.
+[tool.complexipy]
+exclude = ["**/tests/**"]
+max-complexity-allowed = 56
+
+# pylint runs with every check off except the four that ruff has no rule for.
+# It is not a second general-purpose linter here - enabling more would produce
+# findings ruff already reports, under a different code, with no new signal.
+# The ignore pattern is a TOML LITERAL string on purpose. As a basic string,
+# "[\\/]" decodes to the regex `[\/]`, whose character class is just a forward
+# slash - so it never matched a Windows path and the test tree leaked into the
+# gate. The literal form keeps both separators in the class.
+[tool.pylint.main]
+ignore-paths = ['.*[\\/]tests[\\/].*']
+jobs = 0
+
+[tool.pylint."messages control"]
+disable = ["all"]
+# C0302 too-many-lines               - module length; ruff has no rule for it
+# R0902 too-many-instance-attributes - class state a reader must track
+# R0904 too-many-public-methods      - class surface area
+# R0916 too-many-boolean-expressions - condition legibility
+enable = ["C0302", "R0902", "R0904", "R0916"]
+
+# Module length. The ceiling is a ratchet, not a target - lower it whenever an
+# extraction lands, and never raise it. The census counts PRODUCTION modules
+# only, because `ignore-paths` above means those are the only ones this gate
+# measures. Count what the gate counts.
+#
+# Census (2026-07-28, 174 production modules):
+#
+#     over 2000:   3      <- the enforced ceiling sits at the worst of these
+#     over 1500:   7
+#     over 1200:   8
+#     over 1000:  12
+#     over  500:  36      <- where modules should settle
+#
+# Longest production module: cli/spec_cmd.py at 2782 lines.
+#
+# This dimension has NOT moved, and that is the honest reading: the complexity
+# waves extracted helpers within these modules rather than out of them, so
+# per-function scores fell while physical length did not. Only a genuine split
+# into sibling modules moves this number. Measure with `just health census`,
+# which counts physical lines the way pylint's C0302 does - a count that skips
+# blank lines reads ~375 lines short on the longest module here and will set a
+# ceiling the tree cannot meet.
+[tool.pylint.format]
+max-module-lines = 2782
+
+# BASELINE-CALIBRATED (census 2026-07-28): each sits at the current worst
+# production offender, so the gate is green today and can only be ratcheted
+# DOWN. pylint defaults: max-attributes=7, max-public-methods=20,
+# max-bool-expr=5.
+[tool.pylint.design]
+max-attributes = 21     # baseline worst: 21 (core/diagnosis/diagnosis.py)
+max-bool-expr = 5       # RATCHETED 6 -> 5, the pylint default: the three
+                        # 6-expression conditions were extracted into named
+                        # predicates, so this dimension is now fully paid off.
+max-public-methods = 20 # already at the pylint default; no production class exceeds it
+
+# Dead code. Advisory, not gating: vulture infers reachability and cannot see
+# dynamic dispatch, so a finding is a lead to confirm rather than a verdict.
+# Confidence 80 drops the guess-heavy tier that reports decorated and
+# lazily-bound callables as unused.
+[tool.vulture]
+exclude = ["*/tests/*", "*test_*.py"]
+ignore_decorators = [
+  "@app.command",
+  "@app.callback",
+  "@click.command",
+  "@click.group",
+  "@pytest.fixture",
+  "@field_validator",
+  "@model_validator",
+  "@property",
+]
+# Every name here is fixed by a protocol this code implements, or is reachable
+# only through a string the scanner cannot follow. None is dead. Each was
+# confirmed by reading the site before being listed - the list is not a way to
+# quiet a finding that has not been read.
+#
+# - exc_val/exc_tb: `__exit__` fixes the names of its three trailing
+#   parameters, so a context manager that inspects only `exc_type` - as
+#   `vaultcore/rename_engine.py:188` does - reports the other two as unused.
+ignore_names = ["exc_val", "exc_tb"]
+min_confidence = 80
+paths = ["src/vaultspec_core"]
+
+# Security. Advisory: this project spawns subprocesses (the MCP gateway's
+# `invoke` verb, the provider sync shells) and builds filesystem paths by
+# construction, so the subprocess and path families report the design rather
+# than a defect. They stay ENABLED and are read per finding - suppressing a
+# family wholesale would also hide the first real one.
+#
+# The test tree is excluded by the `-x` flag in the `just audit security`
+# recipe, NOT by an `exclude_dirs` key here: bandit reads `skips` from this
+# table but silently ignores `exclude_dirs` from it. A suppression that does
+# not suppress is worse than none, so the exclusion lives where it takes effect.
+[tool.bandit]
+# B101: `assert` is pytest's contract, and the excluded test tree is where it
+# is load-bearing. Production invariants that must survive `-O` raise instead.
+skips = ["B101"]
+
+# Dependency drift. Reports imports that resolve only transitively - a
+# transitive bump can withdraw one without any change here.
+#
+# The test tree is excluded because it ships INSIDE the package, at
+# `src/vaultspec_core/tests/`. deptry classifies by path, not by marker, so it
+# reads every `import pytest` there as production code reaching for a dev
+# dependency and reports the whole tree under DEP004.
+#
+# `extend_exclude` is a TOML LITERAL string for the same reason as pylint's
+# `ignore-paths` above: the basic-string form decodes to a character class of
+# forward slash only and never matches a Windows path.
+[tool.deptry]
+extend_exclude = ['.*[\\/]tests[\\/].*']
+known_first_party = ["vaultspec_core"]
+
+  # Each entry is a deliberate declaration the scanner cannot infer, not a
+  # finding waved through.
+  [tool.deptry.per_rule_ignores]
+  # DEP002 is "declared but never imported".
+  #
+  # httpx / sse-starlette / starlette / uvicorn are declared in
+  # [project.dependencies] but serve no first-party import, and the evidence
+  # says they are redundant rather than deliberate:
+  #
+  #   - The MCP server is STDIO-ONLY. `mcp_server/app.py` calls a bare
+  #     `mcp.run()`, whose default transport is stdio, and the module's own
+  #     comments name the stdio lifetime contract throughout. The HTTP and SSE
+  #     transport stack is never constructed.
+  #   - `mcp@1.28.1` already requires all four itself, so removing the direct
+  #     declarations would not change a single resolved environment.
+  #   - The only first-party `import httpx` is in `scripts/dependency_audit.py`,
+  #     a dev script that is not shipped; that import argues for the dev group,
+  #     not for [project.dependencies].
+  #
+  # They are NOT removed here only because a direct declaration of a transitive
+  # package is also how one pins a security floor, and whether any of these four
+  # was pinned for an advisory is an intent question the code cannot answer.
+  # Resolve that, then delete them from [project.dependencies] and drop these
+  # four names from the list below - do not leave the ignores standing as the
+  # permanent answer.
+  #
+  # The remaining names are the legacy `[project.optional-dependencies] dev`
+  # extra, which duplicates the PEP 735 `dev` dependency group below it. They
+  # are dev tools, so no production module imports them. Collapsing the two dev
+  # surfaces onto the dependency group is tracked separately; until then the
+  # scanner reports every one of them.
+  DEP002 = [
+    "httpx",
+    "sse-starlette",
+    "starlette",
+    "uvicorn",
+    "identify",
+    "mdformat",
+    "mdformat-frontmatter",
+    "mdformat-gfm",
+    "mdformat-gfm-alerts",
+    "prek",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-durations",
+    "pytest-reportlog",
+    "pytest-timeout",
+    "ruff",
+    "ty",
+  ]
 
 [[tool.uv.index]]
 name = "pytorch-cu130"

--- a/src/vaultspec_core/cli/_add_ops.py
+++ b/src/vaultspec_core/cli/_add_ops.py
@@ -1,0 +1,452 @@
+"""Operations backing ``vaultspec-core vault add``.
+
+The ``add`` verb is the single ingress for scaffolding ``.vault/`` records, so
+its Typer callback in :mod:`.vault_cmd` carries a wide option surface and a
+long validate-resolve-scaffold-emit sequence. This module owns the sequence:
+each helper validates or resolves one input, renders its own operator message,
+and raises :class:`typer.Exit` on refusal, leaving the callback as the ordered
+composition of those steps.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import replace
+from typing import TYPE_CHECKING, NoReturn
+
+import typer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator, Mapping, Sequence
+    from pathlib import Path
+
+    from rich.console import Console
+
+    from vaultspec_core.cli.rendering import OutcomeItem
+    from vaultspec_core.plan.parser import Plan, Step
+    from vaultspec_core.vaultcore.hydration import (
+        DocumentIdentity,
+        ParentPlan,
+        TemplateFields,
+        WritePolicy,
+    )
+    from vaultspec_core.vaultcore.models import DocType
+    from vaultspec_core.vaultcore.query import VaultDocument
+
+#: Plan tiers accepted by ``--tier``.
+_PLAN_TIERS = frozenset({"L1", "L2", "L3", "L4"})
+
+
+def fail(console: Console, message: str) -> NoReturn:
+    """Render an operator error and exit with code 1."""
+    console.print(f"[red]{message}[/red]")
+    raise typer.Exit(code=1)
+
+
+def resolve_doc_type(console: Console, doc_type: str) -> DocType:
+    """Resolve the positional document-type argument to its enum member."""
+    from vaultspec_core.vaultcore.models import DocType
+
+    try:
+        dt = DocType(doc_type)
+    except ValueError:
+        valid = ", ".join(d.value for d in DocType if d is not DocType.INDEX)
+        console.print(
+            f"[red]Unknown document type '{doc_type}'. Valid types: {valid}[/red]"
+        )
+        raise typer.Exit(code=1) from None
+    if dt is DocType.INDEX:
+        console.print(
+            "[red]'index' documents are auto-generated. "
+            "Use 'vaultspec-core vault feature index' instead of "
+            "'vaultspec-core vault add index'.[/red]"
+        )
+        raise typer.Exit(code=1)
+    return dt
+
+
+def validate_step_flags(
+    console: Console,
+    dt: DocType,
+    *,
+    step: str | None,
+    all_steps: bool,
+    summary: bool,
+    phase: str | None,
+) -> None:
+    """Reject step-aware flag combinations the scaffolder cannot honour."""
+    from vaultspec_core.vaultcore.models import DocType
+
+    step_route = step is not None or all_steps or summary
+    if step_route and dt is not DocType.EXEC:
+        fail(
+            console,
+            "Error: --step, --all-steps, and --summary options are only "
+            "valid when creating 'exec' documents.",
+        )
+    if step is not None and all_steps:
+        fail(console, "Error: --step and --all-steps options are mutually exclusive.")
+    if summary and (step is not None or all_steps):
+        fail(
+            console,
+            "Error: --summary cannot be combined with --step or --all-steps.",
+        )
+    if summary and phase is None:
+        fail(
+            console,
+            "Error: --summary requires --phase <P##> naming the Phase to summarise.",
+        )
+    if phase is not None and not summary:
+        fail(console, "Error: --phase is only valid together with --summary.")
+
+
+def validate_tier(console: Console, dt: DocType, tier: str) -> None:
+    """Reject an out-of-range ``--tier`` value on a plan document."""
+    from vaultspec_core.vaultcore.models import DocType
+
+    if dt is DocType.PLAN and tier not in _PLAN_TIERS:
+        fail(console, f"Invalid tier '{tier}'. Allowed values: L1, L2, L3, L4.")
+
+
+def normalize_topic(console: Console, dt: DocType, topic: str | None) -> str | None:
+    """Validate the narrative filename infix for the doc types that admit one.
+
+    The topic is held to the same kebab-case discipline as the feature tag.
+    """
+    from vaultspec_core.vaultcore.models import DocType
+    from vaultspec_core.vaultcore.normalize import normalize_feature_tag
+
+    if topic is None:
+        return None
+    if dt not in (DocType.ADR, DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH):
+        fail(
+            console,
+            "Error: --topic is only valid for 'adr', 'audit', 'reference', "
+            "and 'research' documents.",
+        )
+    result = normalize_feature_tag(topic, label="topic")
+    if not result.ok or result.value is None:
+        fail(console, str(result.error))
+    return result.value
+
+
+def normalize_feature(console: Console, feature: str) -> str:
+    """Validate the feature tag through the shared vaultcore normalizer.
+
+    The one validator the MCP surface also converges on.
+    """
+    from vaultspec_core.vaultcore.normalize import normalize_feature_tag
+
+    result = normalize_feature_tag(feature)
+    if not result.ok or result.value is None:
+        fail(console, str(result.error))
+    return result.value
+
+
+def normalize_extra_tags(console: Console, tags: list[str] | None) -> list[str] | None:
+    """Validate additional ``--tags`` through the same shared normalizer."""
+    from vaultspec_core.vaultcore.normalize import normalize_feature_tag
+
+    if not tags:
+        return None
+    extra_tags: list[str] = []
+    for tag in tags:
+        result = normalize_feature_tag(tag, label="tag")
+        if not result.ok:
+            fail(console, str(result.error))
+        extra_tags.append(f"#{result.value}")
+    return extra_tags
+
+
+def resolve_related(
+    console: Console, related: list[str] | None, root_dir: Path
+) -> list[str] | None:
+    """Resolve ``--related`` inputs to ``[[wiki-link]]`` form."""
+    from vaultspec_core.vaultcore.resolve import (
+        RelatedResolutionError,
+        resolve_related_inputs,
+    )
+
+    if not related:
+        return None
+    try:
+        return resolve_related_inputs(related, root_dir)
+    except RelatedResolutionError as exc:
+        for failure in exc.failures:
+            console.print(f"[red]Cannot resolve related document: '{failure}'[/red]")
+        console.print(
+            "[dim]Accepted formats: absolute path, relative path, "
+            "filename, stem, or [[wiki-link]][/dim]"
+        )
+        raise typer.Exit(code=1) from None
+
+
+def report_dependency_diagnostics(
+    console: Console,
+    root_dir: Path,
+    dt: DocType,
+    feature: str,
+    *,
+    json_output: bool,
+) -> None:
+    """Emit the feature-lifecycle diagnostics and stop on any hard error."""
+    from vaultspec_core.vaultcore.resolve import validate_feature_dependencies
+
+    diagnostics = validate_feature_dependencies(root_dir, dt, feature)
+    errors = [d for d in diagnostics if d.startswith("ERROR:")]
+
+    if json_output:
+        _echo_dependency_json(diagnostics, errors)
+    else:
+        _print_dependency_text(console, diagnostics)
+
+    if errors:
+        raise typer.Exit(code=1)
+
+
+def _print_dependency_text(console: Console, diagnostics: Sequence[str]) -> None:
+    """Print every lifecycle diagnostic, errors in red and advisories in yellow."""
+    for diag in diagnostics:
+        style = "red" if diag.startswith("ERROR:") else "yellow"
+        console.print(f"[{style}]{diag}[/{style}]")
+
+
+def _echo_dependency_json(diagnostics: Sequence[str], errors: Sequence[str]) -> None:
+    """Route advisories to stderr and any errors to the failure envelope."""
+    for diag in diagnostics:
+        if not diag.startswith("ERROR:"):
+            typer.echo(diag, err=True)
+    if not errors:
+        return
+
+    import json
+
+    from vaultspec_core.cli.rendering import json_envelope
+
+    typer.echo(
+        json.dumps(
+            json_envelope("vault.add", "failed", {"message": " ".join(errors)}),
+            indent=2,
+        )
+    )
+
+
+def resolve_parent_plan(
+    console: Console,
+    root_dir: Path,
+    feature: str,
+    resolved_related: list[str] | None,
+) -> VaultDocument:
+    """Resolve the plan document an execution record belongs to.
+
+    An explicit ``--related`` stem wins; otherwise the feature must own
+    exactly one plan.
+    """
+    from vaultspec_core.vaultcore.query import list_documents
+
+    named = _plan_named_by_related(root_dir, resolved_related)
+    if named is not None:
+        return named
+
+    plan_docs = list_documents(root_dir, doc_type="plan", feature=feature)
+    if len(plan_docs) == 1:
+        return plan_docs[0]
+    if len(plan_docs) > 1:
+        names = ", ".join(d.path.name for d in plan_docs)
+        fail(
+            console,
+            f"Multiple plans found for feature '{feature}': {names}. "
+            "Specify the parent plan using --related.",
+        )
+    fail(
+        console,
+        f"No plan found for feature '{feature}'. "
+        "Create a plan document before adding execution records.",
+    )
+
+
+def _plan_named_by_related(
+    root_dir: Path, resolved_related: list[str] | None
+) -> VaultDocument | None:
+    """Return the first plan document named by a resolved wiki-link, if any."""
+    from vaultspec_core.vaultcore.query import list_documents
+
+    for rel in resolved_related or []:
+        stem = rel.lstrip("[").rstrip("]")
+        for doc in list_documents(root_dir, doc_type="plan"):
+            if doc.path.stem == stem:
+                return doc
+    return None
+
+
+def resolve_step_row(console: Console, plan: Plan, step: str) -> Step:
+    """Resolve ``--step`` to one Step row of the parent plan."""
+    from vaultspec_core.plan.commands.step_ops import (
+        AmbiguousStepError,
+        StepNotFoundError,
+        find_step,
+    )
+
+    try:
+        return find_step(plan, step)
+    except (StepNotFoundError, AmbiguousStepError) as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1) from None
+
+
+def resolve_phase_display_path(console: Console, plan: Plan, phase: str) -> str:
+    """Resolve ``--phase`` to the summarised Phase's display path."""
+    from vaultspec_core.plan.commands.phase_ops import PhaseNotFoundError, find_phase
+
+    try:
+        return find_phase(plan, phase).display_path
+    except PhaseNotFoundError as exc:
+        console.print(f"[red]Error: {exc}[/red]")
+        raise typer.Exit(code=1) from None
+
+
+@contextmanager
+def suppress_logging(*, active: bool) -> Iterator[None]:
+    """Silence library logging while a machine-readable payload is emitted."""
+    import logging
+
+    if not active:
+        yield
+        return
+    previous = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logging.disable(previous)
+
+
+def scaffold_all_steps(
+    steps: Sequence[Step],
+    *,
+    root_dir: Path,
+    identity: DocumentIdentity,
+    fields: TemplateFields,
+    plan: ParentPlan,
+    write: WritePolicy,
+    json_output: bool,
+) -> int:
+    """Scaffold one execution record per Step row and return the exit code."""
+    from vaultspec_core.cli.rendering import emit_outcomes
+
+    items: list[OutcomeItem] = []
+    with suppress_logging(active=json_output):
+        for step in steps:
+            items.append(
+                _scaffold_step_record(
+                    step,
+                    root_dir=root_dir,
+                    identity=identity,
+                    fields=fields,
+                    plan=plan,
+                    write=write,
+                )
+            )
+
+    if not write.dry_run and items:
+        from vaultspec_core.cli._cache_hook import invalidate_graph_cache
+
+        invalidate_graph_cache(root_dir)
+
+    return emit_outcomes(
+        items,
+        command="vault.add",
+        title="Scaffold Execution Steps",
+        json_output=json_output,
+    )
+
+
+def _scaffold_step_record(
+    step: Step,
+    *,
+    root_dir: Path,
+    identity: DocumentIdentity,
+    fields: TemplateFields,
+    plan: ParentPlan,
+    write: WritePolicy,
+) -> OutcomeItem:
+    """Scaffold one Step's execution record and report its outcome."""
+    from vaultspec_core.cli.rendering import Outcome, OutcomeItem
+    from vaultspec_core.vaultcore.hydration import ExecBinding, create_vault_doc
+
+    binding = ExecBinding(
+        plan=plan,
+        step_id=step.canonical_id,
+        step_display_path=step.display_path,
+        step_scope=step.scope,
+        step_action=step.action,
+    )
+
+    # Resolve the target path first so the outcome can distinguish a fresh
+    # record from an overwrite before anything is written.
+    target_path = create_vault_doc(
+        root_dir,
+        identity,
+        fields,
+        exec_binding=binding,
+        write=replace(write, force=True, dry_run=True),
+    )
+    rel_name = str(target_path.relative_to(root_dir))
+    exists = target_path.exists()
+
+    if exists and not write.force:
+        return OutcomeItem(
+            name=rel_name, outcome=Outcome.SKIPPED, detail="skipped; exists"
+        )
+
+    if exists:
+        outcome = Outcome.UPDATED
+        detail = "overwritten" if not write.dry_run else "would overwrite"
+    else:
+        outcome = Outcome.CREATED
+        detail = "created" if not write.dry_run else "would create"
+
+    if not write.dry_run:
+        create_vault_doc(
+            root_dir,
+            identity,
+            fields,
+            exec_binding=binding,
+            write=write,
+        )
+
+    return OutcomeItem(name=rel_name, outcome=outcome, detail=detail)
+
+
+def emit_add_result(
+    console: Console,
+    path: Path,
+    doc_type: str,
+    *,
+    json_output: bool,
+    dry_run: bool = False,
+    hints: Mapping[str, object] | None = None,
+) -> None:
+    """Emit the created (or previewed) document as text or the JSON envelope."""
+    if not json_output:
+        label = "[dim]Would create:[/dim]" if dry_run else "[green]Created:[/green]"
+        console.print(f"{label} {path}")
+        return
+
+    import json
+
+    from vaultspec_core.cli.rendering import json_envelope
+
+    data: dict[str, object] = {
+        "path": str(path),
+        "type": doc_type,
+        "name": path.stem,
+    }
+    if dry_run:
+        data["dry_run"] = True
+    typer.echo(
+        json.dumps(
+            json_envelope("vault.add", "created", data, hints=hints),
+            indent=2,
+        )
+    )

--- a/src/vaultspec_core/cli/_repair_render.py
+++ b/src/vaultspec_core/cli/_repair_render.py
@@ -1,0 +1,211 @@
+"""Presentation layer for the ``vaultspec-core vault repair`` pipeline.
+
+Turns a :class:`vaultspec_core.vaultcore.repair.RepairRun` into either the
+operator-facing console report (:func:`render_repair_run`) or the ``--json``
+payload (:func:`repair_payload`). Pure rendering: nothing here touches the
+filesystem or mutates the run, so :mod:`.vault_cmd` keeps only the Typer
+wiring for the ``repair`` verb.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+    from vaultspec_core.vaultcore.repair import RepairRun
+
+
+#: Maximum rows printed per unbounded report section before elision.
+_PLANNED_FIX_LIMIT = 20
+_CHANGED_FILE_LIMIT = 30
+_UNRESOLVED_LIMIT = 20
+_DIAGNOSTIC_LIMIT = 10
+
+
+def repair_payload(run: RepairRun) -> dict:
+    """Convert a :class:`RepairRun` to a JSON-serializable mapping."""
+    return {
+        "dry_run": run.dry_run,
+        "feature": run.feature,
+        "include_index": run.include_index,
+        "partial_failure": run.partial_failure,
+        "phases": run.phases,
+        "journal": run.journal,
+        "changed_files": run.changed_files,
+        "generated_indexes": run.generated_indexes,
+        "planned_fixes": run.planned_fixes,
+        "unresolved": run.unresolved,
+        "root_causes": run.root_causes,
+        "error_count": run.error_count,
+        "warning_count": run.warning_count,
+        "fixed_count": run.fixed_count,
+    }
+
+
+def render_repair_run(run: RepairRun, *, verbose: bool = False) -> None:
+    """Render a repair run for human operators."""
+    from vaultspec_core.console import get_console
+
+    console = get_console()
+    _render_heading(console, run)
+    for phase in run.phases:
+        _render_phase(console, phase, verbose=verbose)
+    _render_planned_fixes(console, run)
+    _render_root_causes(console, run)
+    _render_changed_files(console, run)
+    _render_unresolved(console, run, verbose=verbose)
+
+
+def _render_heading(console: Console, run: RepairRun) -> None:
+    title = "Vault Repair Preview" if run.dry_run else "Vault Repair"
+    if run.feature:
+        title += f" - #{run.feature}"
+    console.print(f"[bold]{title}[/bold]")
+    if run.partial_failure:
+        console.print("[red]  partial repair: at least one phase failed[/red]")
+
+
+def _render_phase(console: Console, phase: dict, *, verbose: bool) -> None:
+    """Dispatch one pipeline phase to its renderer; unknown phases are silent."""
+    name = phase.get("phase", "unknown")
+    if name == "preflight":
+        _render_preflight_phase(console, phase)
+        return
+    if name in {"check", "fix", "postcheck"}:
+        _render_check_phase(console, phase, verbose=verbose)
+        return
+    if name == "index":
+        _render_index_phase(console, phase, verbose=verbose)
+        return
+    if name == "summary":
+        _render_summary_phase(console, phase)
+
+
+def _render_preflight_phase(console: Console, phase: dict) -> None:
+    status = phase.get("migration_status", "unknown")
+    platform = phase.get("platform", {})
+    case_probe = platform.get("case_sensitive_probe", "unknown")
+    console.print(f"  [bold]preflight[/bold]: migrations {status}")
+    console.print(f"    filesystem case probe: {case_probe}")
+    pending = phase.get("pending_migrations", [])
+    if pending:
+        console.print(f"    pending migrations: {', '.join(pending)}")
+    for migration in phase.get("applied_migrations", []):
+        console.print(f"    applied migration: {migration['summary']}")
+    if phase.get("message"):
+        console.print(f"    [yellow]{phase['message']}[/yellow]")
+
+
+def _render_check_phase(console: Console, phase: dict, *, verbose: bool) -> None:
+    errors = phase.get("error_count", 0)
+    warnings = phase.get("warning_count", 0)
+    fixed = phase.get("fixed_count", 0)
+    summary = f"{errors} errors, {warnings} warnings"
+    if fixed:
+        summary += f", {fixed} fixed"
+    if phase.get("dry_run"):
+        summary += ", preview only"
+    name = phase.get("phase", "unknown")
+    console.print(f"  [bold]{name}[/bold]: {summary}")
+    if verbose:
+        _render_phase_diagnostics(console, phase)
+
+
+def _render_index_phase(console: Console, phase: dict, *, verbose: bool) -> None:
+    if phase.get("skipped"):
+        console.print(f"  [bold]index[/bold]: skipped ({phase.get('reason')})")
+        return
+    if phase.get("dry_run"):
+        paths = phase.get("planned", [])
+        console.print(f"  [bold]index[/bold]: {len(paths)} planned")
+    else:
+        paths = phase.get("generated", [])
+        console.print(f"  [bold]index[/bold]: {len(paths)} refreshed")
+    if not verbose:
+        return
+    for path in paths:
+        console.print(f"    {path}")
+
+
+def _render_summary_phase(console: Console, phase: dict) -> None:
+    changed = phase.get("changed_files", [])
+    unresolved = phase.get("unresolved_count", 0)
+    console.print(f"  [bold]summary[/bold]: {len(changed)} changed files")
+    console.print(f"    unresolved diagnostics: {unresolved}")
+    if phase.get("partial_failure"):
+        console.print("    [red]partial failure: true[/red]")
+    if phase.get("journal_count"):
+        console.print(f"    journal entries: {phase['journal_count']}")
+
+
+def _render_planned_fixes(console: Console, run: RepairRun) -> None:
+    if not run.planned_fixes or not run.dry_run:
+        return
+    console.print()
+    console.print(f"[bold]Planned mechanical fixes[/bold] ({len(run.planned_fixes)})")
+    for item in run.planned_fixes[:_PLANNED_FIX_LIMIT]:
+        path = f"{item['path']}: " if item.get("path") else ""
+        console.print(f"  - {path}{item['fix_description'] or item['message']}")
+    _render_elision(console, len(run.planned_fixes), _PLANNED_FIX_LIMIT, "more")
+
+
+def _render_root_causes(console: Console, run: RepairRun) -> None:
+    if not run.root_causes:
+        return
+    console.print()
+    console.print("[bold]Root-cause groups[/bold]")
+    for group in run.root_causes:
+        console.print(f"  - {group['root_cause']}: {group['count']}")
+
+
+def _render_changed_files(console: Console, run: RepairRun) -> None:
+    if not run.changed_files:
+        return
+    console.print()
+    console.print("[bold]Changed files[/bold]")
+    for path in run.changed_files[:_CHANGED_FILE_LIMIT]:
+        console.print(f"  - {path}")
+    _render_elision(console, len(run.changed_files), _CHANGED_FILE_LIMIT, "more")
+
+
+def _render_unresolved(console: Console, run: RepairRun, *, verbose: bool) -> None:
+    if not run.unresolved:
+        return
+    console.print()
+    console.print("[bold]Unresolved work[/bold]")
+    severity_rank = {"error": 0, "warning": 1, "info": 2}
+    display_items = [
+        item for item in run.unresolved if verbose or item.get("severity") != "info"
+    ]
+    hidden_info = len(run.unresolved) - len(display_items)
+    display_items.sort(key=lambda item: severity_rank.get(str(item.get("severity")), 3))
+    for item in display_items[:_UNRESOLVED_LIMIT]:
+        path = f"{item['path']}: " if item.get("path") else ""
+        console.print(f"  - [{item['severity']}] {path}{item['message']}")
+    if hidden_info:
+        console.print(
+            f"  ... {hidden_info} INFO diagnostics hidden; "
+            "rerun with --verbose to show them."
+        )
+    _render_elision(
+        console, len(display_items), _UNRESOLVED_LIMIT, "more non-INFO diagnostics"
+    )
+
+
+def _render_elision(console: Console, total: int, limit: int, noun: str) -> None:
+    """Print the ``... N more`` tail when a section was truncated."""
+    if total > limit:
+        console.print(f"  ... {total - limit} {noun}")
+
+
+def _render_phase_diagnostics(console: Console, phase: dict) -> None:
+    for check in phase.get("checks", []):
+        diagnostics = check.get("diagnostics", [])
+        if not diagnostics:
+            continue
+        console.print(f"    {check['check_name']}:")
+        for diag in diagnostics[:_DIAGNOSTIC_LIMIT]:
+            path = f"{diag['path']}: " if diag.get("path") else ""
+            console.print(f"      - [{diag['severity']}] {path}{diag['message']}")

--- a/src/vaultspec_core/cli/root.py
+++ b/src/vaultspec_core/cli/root.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path  # noqa: TC003 - Typer evaluates the root --target annotation.
-from typing import TYPE_CHECKING, Annotated
+from typing import TYPE_CHECKING, Annotated, Any
 
 import typer
 
@@ -26,7 +26,10 @@ from vaultspec_core.cli._target import (
 from vaultspec_core.core.enums import CliAction, InstallMode
 
 if TYPE_CHECKING:
+    from rich.console import Console
+
     from vaultspec_core.cli.rendering import OutcomeItem
+    from vaultspec_core.core.enums import Tool
     from vaultspec_core.core.types import SyncResult
 
 logger = logging.getLogger(__name__)
@@ -570,6 +573,198 @@ def cmd_uninstall(
         console.print("Nothing to remove  - vaultspec is not installed at this path.")
 
 
+def _reject_core_sync_target(provider: str) -> None:
+    """Refuse ``core`` as a sync target; it is not a provider output.
+
+    Raises:
+        typer.Exit: Code 1, when ``provider`` is ``"core"``.
+    """
+    if provider != "core":
+        return
+    typer.echo(
+        "Error: 'core' is not a valid sync target. "
+        "The sync source is .vaultspec/ (core) itself.\n"
+        "  Hint: use 'vaultspec-core sync all' to sync all providers, "
+        "or 'vaultspec-core install --upgrade' to update the framework.",
+        err=True,
+    )
+    raise typer.Exit(code=1)
+
+
+def _render_sync_dry_run(
+    results: list[SyncResult],
+    provider: str,
+    skip: list[str],
+    json_output: bool,
+    console: Console,
+) -> None:
+    """Render a sync ``--dry-run`` preview and exit.
+
+    Args:
+        results: Per-provider sync results collected in preview mode.
+        provider: The provider argument as passed to ``cmd_sync``.
+        skip: Components excluded from the sync, as passed to ``cmd_sync``.
+        json_output: Whether to emit the machine-readable JSON envelope.
+        console: The Rich console to render human-readable output to.
+
+    Raises:
+        typer.Exit: Always; a dry run never falls through to a live sync.
+    """
+    if json_output:
+        import json
+
+        from vaultspec_core.cli.rendering import json_envelope, outcomes_as_json
+
+        outcomes = _collect_sync_outcomes(results, provider, skip)
+        inner = outcomes_as_json(outcomes)
+        envelope = json_envelope(
+            "sync", str(inner["status"]), {"items": inner["items"]}
+        )
+        typer.echo(json.dumps(envelope, indent=2))
+        raise typer.Exit(0)
+
+    from vaultspec_core.cli.rendering import render_dry_run_tree
+    from vaultspec_core.core.dry_run import DryRunItem, DryRunStatus
+    from vaultspec_core.core.types import get_context
+
+    action_map = {
+        "[ADD]": DryRunStatus.NEW,
+        "[UPDATE]": DryRunStatus.UPDATE,
+        "[UNCHANGED]": DryRunStatus.EXISTS,
+        "[SKIP]": DryRunStatus.EXISTS,
+        "[DELETE]": DryRunStatus.DELETE,
+    }
+    all_items = [
+        DryRunItem(
+            path=item_path,
+            status=action_map.get(action, DryRunStatus.UPDATE),
+            label=_infer_label(item_path),
+        )
+        for r in results
+        for item_path, action in r.items
+    ]
+    if not all_items:
+        console.print("[dim]Sync preview: no changes[/dim]")
+        raise typer.Exit(0)
+
+    target_dir = get_context().target_dir
+    title = f"Sync preview -> {target_dir}"
+    if provider != "all":
+        title = f"Sync preview ({provider}) -> {target_dir}"
+    render_dry_run_tree(all_items, title=title)
+    raise typer.Exit(0)
+
+
+def _resolve_active_sync_names(
+    active_configs: dict[Tool, Any], provider: str, skip: list[str]
+) -> list[str]:
+    """Return the enabled provider config names selected for this sync.
+
+    Args:
+        active_configs: Mapping of provider tool to its installed config, as
+            returned by :func:`~vaultspec_core.core.manifest.installed_tool_configs`.
+        provider: The provider argument as passed to ``cmd_sync``.
+        skip: Components excluded from the sync, as passed to ``cmd_sync``.
+
+    Returns:
+        The config names selected by ``provider`` and not excluded by ``skip``.
+    """
+    if provider == "all":
+        return [
+            cfg.name
+            for tool, cfg in active_configs.items()
+            if tool.value not in skip and cfg.name not in skip
+        ]
+    return [
+        cfg.name
+        for tool, cfg in active_configs.items()
+        if (tool.value == provider or cfg.name == provider)
+        and tool.value not in skip
+        and cfg.name not in skip
+    ]
+
+
+def _render_sync_post_notices(
+    console: Console,
+    sync_target: Path,
+    results: list[SyncResult],
+    all_warnings: list[str],
+    code: int,
+    active_names: list[str],
+) -> None:
+    """Render the advisory notices shown after a non-JSON, non-dry-run sync.
+
+    Covers three independent notices: builtins newer than ``.vaultspec/``,
+    provider-content warnings that ``--force`` would resolve, and a
+    zero-files-produced warning for an otherwise clean run.
+
+    Args:
+        console: The Rich console to render to.
+        sync_target: The resolved sync target directory.
+        results: Per-provider sync results from the live sync pass.
+        all_warnings: Warnings collected across ``results``.
+        code: The exit code ``emit_outcomes`` computed for the sync.
+        active_names: The provider config names selected for this sync.
+    """
+    from vaultspec_core.builtins import check_outdated
+
+    vaultspec_dir = sync_target / ".vaultspec"
+    outdated = check_outdated(vaultspec_dir) if vaultspec_dir.is_dir() else []
+    if outdated:
+        console.print()
+        console.print(
+            f"[bold yellow]Upgrade available:[/bold yellow] "
+            f"{len(outdated)} builtin(s) in the installed "
+            f"vaultspec-core package are newer than .vaultspec/:"
+        )
+        for path in outdated:
+            console.print(f"  [yellow]-[/yellow] {path}")
+        from vaultspec_core.cli.rendering import hints_suppressed, render_next_actions
+
+        if not hints_suppressed():
+            render_next_actions(
+                [
+                    (
+                        "Update builtins to the packaged version",
+                        "vaultspec-core install --upgrade",
+                    ),
+                    ("Re-sync after upgrading", "vaultspec-core sync"),
+                ]
+            )
+
+    if all_warnings:
+        console.print()
+        console.print(
+            f"[bold yellow]Warning:[/bold yellow] "
+            f"{len(all_warnings)} item(s) differ from .vaultspec/ source. "
+            f"Use [bold]--force[/bold] to resolve:"
+        )
+        for warning in all_warnings:
+            console.print(f"  [yellow]-[/yellow] {warning}")
+
+    # Warn only when a clean run genuinely found nothing to project.
+    total_changes = sum(r.added + r.updated for r in results)
+    total_skipped = sum(r.skipped for r in results)
+    total_unchanged = sum(r.unchanged for r in results)
+    ran_clean = code == 0 and not all_warnings
+    projected_nothing = (
+        total_changes == 0 and total_skipped == 0 and total_unchanged == 0
+    )
+    if not (ran_clean and active_names and projected_nothing):
+        return
+
+    console.print(
+        "\n[bold yellow]Warning:[/bold yellow] Sync produced 0 files. "
+        "The .vaultspec/ source directories may be empty."
+    )
+    from vaultspec_core.cli.rendering import hints_suppressed, render_next_actions
+
+    if not hints_suppressed():
+        render_next_actions(
+            [("Re-seed builtin content", "vaultspec-core install --upgrade")]
+        )
+
+
 @app.command("sync")
 def cmd_sync(
     provider: Annotated[
@@ -612,15 +807,7 @@ def cmd_sync(
     """
     skip = list(skip or [])
     apply_target(target, split_source=True, json_output=json_output)
-    if provider == "core":
-        typer.echo(
-            "Error: 'core' is not a valid sync target. "
-            "The sync source is .vaultspec/ (core) itself.\n"
-            "  Hint: use 'vaultspec-core sync all' to sync all providers, "
-            "or 'vaultspec-core install --upgrade' to update the framework.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
+    _reject_core_sync_target(provider)
 
     from vaultspec_core.core.types import get_context
 
@@ -654,56 +841,7 @@ def cmd_sync(
     console = get_console()
 
     if dry_run:
-        if json_output:
-            import json
-
-            from vaultspec_core.cli.rendering import (
-                json_envelope,
-                outcomes_as_json,
-            )
-
-            outcomes = _collect_sync_outcomes(results, provider, skip)
-            inner = outcomes_as_json(outcomes)
-            envelope = json_envelope(
-                "sync", str(inner["status"]), {"items": inner["items"]}
-            )
-            typer.echo(json.dumps(envelope, indent=2))
-            raise typer.Exit(0)
-
-        from vaultspec_core.cli.rendering import render_dry_run_tree
-        from vaultspec_core.core.dry_run import (
-            DryRunItem,
-            DryRunStatus,
-        )
-        from vaultspec_core.core.types import get_context
-
-        action_map = {
-            "[ADD]": DryRunStatus.NEW,
-            "[UPDATE]": DryRunStatus.UPDATE,
-            "[UNCHANGED]": DryRunStatus.EXISTS,
-            "[SKIP]": DryRunStatus.EXISTS,
-            "[DELETE]": DryRunStatus.DELETE,
-        }
-        all_items = []
-        for r in results:
-            for item_path, action in r.items:
-                status = action_map.get(action, DryRunStatus.UPDATE)
-                all_items.append(
-                    DryRunItem(
-                        path=item_path,
-                        status=status,
-                        label=_infer_label(item_path),
-                    )
-                )
-        if all_items:
-            _target_dir = get_context().target_dir
-            title = f"Sync preview -> {_target_dir}"
-            if provider != "all":
-                title = f"Sync preview ({provider}) -> {_target_dir}"
-            render_dry_run_tree(all_items, title=title)
-        else:
-            console.print("[dim]Sync preview: no changes[/dim]")
-        raise typer.Exit(0)
+        _render_sync_dry_run(results, provider, skip, json_output, console)
 
     # Non-dry-run: route every provider through the canonical outcome
     # renderer. Per the cli-sync-vocabulary ADR (audit findings
@@ -714,20 +852,7 @@ def cmd_sync(
     from vaultspec_core.core.manifest import installed_tool_configs
 
     active_configs = installed_tool_configs()
-    if provider == "all":
-        active_names = [
-            cfg.name
-            for tool, cfg in active_configs.items()
-            if tool.value not in skip and cfg.name not in skip
-        ]
-    else:
-        active_names = [
-            cfg.name
-            for tool, cfg in active_configs.items()
-            if (tool.value == provider or cfg.name == provider)
-            and tool.value not in skip
-            and cfg.name not in skip
-        ]
+    active_names = _resolve_active_sync_names(active_configs, provider, skip)
 
     if not active_names and not json_output:
         console.print("[dim]No enabled providers to sync.[/dim]")
@@ -746,71 +871,9 @@ def cmd_sync(
     )
 
     if not json_output:
-        from vaultspec_core.builtins import check_outdated
-
-        vaultspec_dir = sync_target / ".vaultspec"
-        outdated = check_outdated(vaultspec_dir) if vaultspec_dir.is_dir() else []
-        if outdated:
-            console.print()
-            console.print(
-                f"[bold yellow]Upgrade available:[/bold yellow] "
-                f"{len(outdated)} builtin(s) in the installed "
-                f"vaultspec-core package are newer than .vaultspec/:"
-            )
-            for path in outdated:
-                console.print(f"  [yellow]-[/yellow] {path}")
-            from vaultspec_core.cli.rendering import (
-                hints_suppressed,
-                render_next_actions,
-            )
-
-            if not hints_suppressed():
-                render_next_actions(
-                    [
-                        (
-                            "Update builtins to the packaged version",
-                            "vaultspec-core install --upgrade",
-                        ),
-                        ("Re-sync after upgrading", "vaultspec-core sync"),
-                    ]
-                )
-
-        if all_warnings:
-            console.print()
-            console.print(
-                f"[bold yellow]Warning:[/bold yellow] "
-                f"{len(all_warnings)} item(s) differ from .vaultspec/ source. "
-                f"Use [bold]--force[/bold] to resolve:"
-            )
-            for warning in all_warnings:
-                console.print(f"  [yellow]-[/yellow] {warning}")
-
-        # Warn only when a clean run genuinely found nothing to project:
-        # no changes, no skips, and no files already in place.
-        total_changes = sum(r.added + r.updated for r in results)
-        total_skipped = sum(r.skipped for r in results)
-        total_unchanged = sum(r.unchanged for r in results)
-        if (
-            code == 0
-            and active_names
-            and total_changes == 0
-            and total_skipped == 0
-            and total_unchanged == 0
-            and not all_warnings
-        ):
-            console.print(
-                "\n[bold yellow]Warning:[/bold yellow] Sync produced 0 files. "
-                "The .vaultspec/ source directories may be empty."
-            )
-            from vaultspec_core.cli.rendering import (
-                hints_suppressed,
-                render_next_actions,
-            )
-
-            if not hints_suppressed():
-                render_next_actions(
-                    [("Re-seed builtin content", "vaultspec-core install --upgrade")]
-                )
+        _render_sync_post_notices(
+            console, sync_target, results, all_warnings, code, active_names
+        )
 
     raise typer.Exit(code)
 

--- a/src/vaultspec_core/cli/vault_cmd.py
+++ b/src/vaultspec_core/cli/vault_cmd.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
 
     from vaultspec_core.graph.api import VaultGraph
     from vaultspec_core.vaultcore.checks._base import CheckResult
-    from vaultspec_core.vaultcore.repair import RepairRun
 
 
 vault_app = make_app(
@@ -185,423 +184,128 @@ def cmd_add(
     apply_target(target)
     from datetime import UTC, datetime
 
+    from vaultspec_core.cli import _add_ops
     from vaultspec_core.console import get_console
     from vaultspec_core.core.types import get_context as _get_ctx
-    from vaultspec_core.vaultcore.hydration import create_vault_doc
-    from vaultspec_core.vaultcore.models import DocType
-    from vaultspec_core.vaultcore.normalize import normalize_feature_tag
-    from vaultspec_core.vaultcore.resolve import (
-        RelatedResolutionError,
-        resolve_related_inputs,
-        validate_feature_dependencies,
+    from vaultspec_core.vaultcore.hydration import (
+        DocumentIdentity,
+        ExecBinding,
+        ParentPlan,
+        TemplateFields,
+        WritePolicy,
+        create_vault_doc,
     )
+    from vaultspec_core.vaultcore.models import DocType
 
     console = get_console()
+    root_dir = _get_ctx().target_dir
 
-    # Resolve doc type enum
-    try:
-        dt = DocType(doc_type)
-    except ValueError:
-        valid = ", ".join(d.value for d in DocType if d is not DocType.INDEX)
-        console.print(
-            f"[red]Unknown document type '{doc_type}'. Valid types: {valid}[/red]"
-        )
-        raise typer.Exit(code=1) from None
-    if dt is DocType.INDEX:
-        console.print(
-            "[red]'index' documents are auto-generated. "
-            "Use 'vaultspec-core vault feature index' instead of "
-            "'vaultspec-core vault add index'.[/red]"
-        )
-        raise typer.Exit(code=1)
-
-    # Validate step-aware flags
-    if (step is not None or all_steps or summary) and dt is not DocType.EXEC:
-        console.print(
-            "[red]Error: --step, --all-steps, and --summary options are only "
-            "valid when creating 'exec' documents.[/red]"
-        )
-        raise typer.Exit(code=1)
-
-    if step is not None and all_steps:
-        console.print(
-            "[red]Error: --step and --all-steps options are mutually exclusive.[/red]"
-        )
-        raise typer.Exit(code=1)
-
-    if summary and (step is not None or all_steps):
-        console.print(
-            "[red]Error: --summary cannot be combined with --step or --all-steps.[/red]"
-        )
-        raise typer.Exit(code=1)
-
-    if summary and phase is None:
-        console.print(
-            "[red]Error: --summary requires --phase <P##> naming the Phase "
-            "to summarise.[/red]"
-        )
-        raise typer.Exit(code=1)
-
-    if phase is not None and not summary:
-        console.print(
-            "[red]Error: --phase is only valid together with --summary.[/red]"
-        )
-        raise typer.Exit(code=1)
-
-    # Validate tier for plan documents
-    if dt is DocType.PLAN and tier not in {"L1", "L2", "L3", "L4"}:
-        console.print(
-            f"[red]Invalid tier '{tier}'. Allowed values: L1, L2, L3, L4.[/red]"
-        )
-        raise typer.Exit(code=1)
-
-    # Validate the topic infix for standalone decision and narrative records,
-    # holding it to the same kebab-case discipline as the feature tag.
-    topic_value: str | None = None
-    if topic is not None:
-        if dt not in (DocType.ADR, DocType.AUDIT, DocType.REFERENCE, DocType.RESEARCH):
-            console.print(
-                "[red]Error: --topic is only valid for 'adr', 'audit', 'reference', "
-                "and 'research' documents.[/red]"
-            )
-            raise typer.Exit(code=1)
-        topic_result = normalize_feature_tag(topic, label="topic")
-        if not topic_result.ok or topic_result.value is None:
-            console.print(f"[red]{topic_result.error}[/red]")
-            raise typer.Exit(code=1)
-        topic_value = topic_result.value
-
-    # Validate feature tag through the shared vaultcore normalizer (the one
-    # validator the MCP surface also converges on).
-    feature_result = normalize_feature_tag(feature)
-    if not feature_result.ok or feature_result.value is None:
-        console.print(f"[red]{feature_result.error}[/red]")
-        raise typer.Exit(code=1)
-    feat = feature_result.value
+    dt = _add_ops.resolve_doc_type(console, doc_type)
+    _add_ops.validate_step_flags(
+        console, dt, step=step, all_steps=all_steps, summary=summary, phase=phase
+    )
+    _add_ops.validate_tier(console, dt, tier)
+    topic_value = _add_ops.normalize_topic(console, dt, topic)
+    feat = _add_ops.normalize_feature(console, feature)
+    extra_tags = _add_ops.normalize_extra_tags(console, tags)
+    resolved_related = _add_ops.resolve_related(console, related, root_dir)
+    _add_ops.report_dependency_diagnostics(
+        console, root_dir, dt, feat, json_output=json_output
+    )
 
     # Default date to today (UTC for deterministic vault doc dates)
     date_str = date or datetime.now(UTC).strftime("%Y-%m-%d")
 
-    # Validate extra tags format through the same shared normalizer.
-    extra_tags: list[str] | None = None
-    if tags:
-        extra_tags = []
-        for tag in tags:
-            tag_result = normalize_feature_tag(tag, label="tag")
-            if not tag_result.ok:
-                console.print(f"[red]{tag_result.error}[/red]")
-                raise typer.Exit(code=1)
-            extra_tags.append(f"#{tag_result.value}")
-
-    # Resolve related paths to wiki-links
-    resolved_related: list[str] | None = None
-    if related:
-        try:
-            resolved_related = resolve_related_inputs(related, _get_ctx().target_dir)
-        except RelatedResolutionError as exc:
-            for failure in exc.failures:
-                console.print(
-                    f"[red]Cannot resolve related document: '{failure}'[/red]"
-                )
-            console.print(
-                "[dim]Accepted formats: absolute path, relative path, "
-                "filename, stem, or [[wiki-link]][/dim]"
-            )
-            raise typer.Exit(code=1) from None
-
-    # Validate feature dependencies (lifecycle rules)
-    dep_diagnostics = validate_feature_dependencies(_get_ctx().target_dir, dt, feat)
-    dep_errors = [d for d in dep_diagnostics if d.startswith("ERROR:")]
-
-    if json_output:
-        for diag in dep_diagnostics:
-            if not diag.startswith("ERROR:"):
-                typer.echo(diag, err=True)
-        if dep_errors:
-            import json
-
-            from vaultspec_core.cli.rendering import json_envelope
-
-            typer.echo(
-                json.dumps(
-                    json_envelope(
-                        "vault.add", "failed", {"message": " ".join(dep_errors)}
-                    ),
-                    indent=2,
-                )
-            )
-            raise typer.Exit(code=1)
-    else:
-        for diag in dep_diagnostics:
-            style = "red" if diag.startswith("ERROR:") else "yellow"
-            console.print(f"[{style}]{diag}[/{style}]")
-        if dep_errors:
-            raise typer.Exit(code=1)
-
-    # Handle parent plan resolution if step-aware route is active
-    plan_date_arg = None
-    plan_stem_arg = None
-    step_id_arg = None
-    step_display_path_arg = None
-    step_scope_arg = None
-    step_action_arg = None
-    phase_display_arg = None
+    identity = DocumentIdentity(
+        doc_type=dt, feature=feat, date=date_str, topic=topic_value
+    )
+    fields = TemplateFields(
+        title=title,
+        related=resolved_related,
+        extra_tags=extra_tags,
+        tier=tier if dt is DocType.PLAN else None,
+    )
+    write = WritePolicy(force=force, dry_run=dry_run)
+    exec_binding = ExecBinding(summary=summary)
 
     if dt is DocType.EXEC and (step is not None or all_steps or summary):
-        from vaultspec_core.vaultcore.query import list_documents
-
-        parent_plan_doc = None
-        if resolved_related:
-            for rel in resolved_related:
-                stem = rel.lstrip("[").rstrip("]")
-                plan_docs = list_documents(_get_ctx().target_dir, doc_type="plan")
-                for doc in plan_docs:
-                    if doc.path.stem == stem:
-                        parent_plan_doc = doc
-                        break
-                if parent_plan_doc:
-                    break
-
-        if parent_plan_doc is None:
-            plan_docs = list_documents(
-                _get_ctx().target_dir, doc_type="plan", feature=feat
-            )
-            if len(plan_docs) == 1:
-                parent_plan_doc = plan_docs[0]
-            elif len(plan_docs) > 1:
-                names = ", ".join(d.path.name for d in plan_docs)
-                console.print(
-                    f"[red]Multiple plans found for feature '{feat}': {names}. "
-                    "Specify the parent plan using --related.[/red]"
-                )
-                raise typer.Exit(code=1)
-            else:
-                console.print(
-                    f"[red]No plan found for feature '{feat}'. "
-                    "Create a plan document before adding execution records.[/red]"
-                )
-                raise typer.Exit(code=1)
-
         from vaultspec_core.plan.parser import parse_plan
 
+        parent_plan_doc = _add_ops.resolve_parent_plan(
+            console, root_dir, feat, resolved_related
+        )
         parsed_plan = parse_plan(parent_plan_doc.path)
         plan_stem_arg = parent_plan_doc.path.stem
-        plan_date_arg = parent_plan_doc.date or plan_stem_arg[:10]
+        parent_plan = ParentPlan(
+            date=parent_plan_doc.date or plan_stem_arg[:10], stem=plan_stem_arg
+        )
 
+        if all_steps:
+            raise typer.Exit(
+                code=_add_ops.scaffold_all_steps(
+                    parsed_plan.steps,
+                    root_dir=root_dir,
+                    identity=identity,
+                    fields=fields,
+                    plan=parent_plan,
+                    write=write,
+                    json_output=json_output,
+                )
+            )
         if step is not None:
-            from vaultspec_core.plan.commands.step_ops import (
-                AmbiguousStepError,
-                StepNotFoundError,
-                find_step,
+            target_step = _add_ops.resolve_step_row(console, parsed_plan, step)
+            exec_binding = ExecBinding(
+                plan=parent_plan,
+                step_id=target_step.canonical_id,
+                step_display_path=target_step.display_path,
+                step_scope=target_step.scope,
+                step_action=target_step.action,
+                summary=summary,
             )
-
-            try:
-                target_step = find_step(parsed_plan, step)
-            except StepNotFoundError as exc:
-                console.print(f"[red]Error: {exc}[/red]")
-                raise typer.Exit(code=1) from None
-            except AmbiguousStepError as exc:
-                console.print(f"[red]Error: {exc}[/red]")
-                raise typer.Exit(code=1) from None
-
-            step_id_arg = target_step.canonical_id
-            step_display_path_arg = target_step.display_path
-            step_scope_arg = target_step.scope
-            step_action_arg = target_step.action
-
-        elif summary:
-            from vaultspec_core.plan.commands.phase_ops import (
-                PhaseNotFoundError,
-                find_phase,
-            )
-
+        else:
             # The "--summary requires --phase" validation above guarantees a
             # non-None phase id by the time this branch runs.
             assert phase is not None
-            try:
-                target_phase = find_phase(parsed_plan, phase)
-            except PhaseNotFoundError as exc:
-                console.print(f"[red]Error: {exc}[/red]")
-                raise typer.Exit(code=1) from None
-
-            phase_display_arg = target_phase.display_path
-
-        elif all_steps:
-            # Bulk scaffolding loop
-            import logging
-
-            from vaultspec_core.cli.rendering import Outcome, OutcomeItem, emit_outcomes
-
-            items = []
-            root_dir = _get_ctx().target_dir
-
-            previous_logging_disable = logging.root.manager.disable
-            if json_output:
-                logging.disable(logging.CRITICAL)
-
-            try:
-                for s in parsed_plan.steps:
-                    target_path = create_vault_doc(
-                        root_dir=root_dir,
-                        doc_type=dt,
-                        feature=feat,
-                        date_str=date_str,
-                        title=title,
-                        related=resolved_related,
-                        extra_tags=extra_tags,
-                        force=True,
-                        dry_run=True,
-                        step_id=s.canonical_id,
-                        step_display_path=s.display_path,
-                        step_scope=s.scope,
-                        step_action=s.action,
-                        plan_date=plan_date_arg,
-                        plan_stem=plan_stem_arg,
-                    )
-
-                    rel_name = str(target_path.relative_to(root_dir))
-
-                    if target_path.exists():
-                        if not force:
-                            items.append(
-                                OutcomeItem(
-                                    name=rel_name,
-                                    outcome=Outcome.SKIPPED,
-                                    detail="skipped; exists",
-                                )
-                            )
-                            continue
-                        else:
-                            outcome_type = Outcome.UPDATED
-                            detail_msg = (
-                                "overwritten" if not dry_run else "would overwrite"
-                            )
-                    else:
-                        outcome_type = Outcome.CREATED
-                        detail_msg = "created" if not dry_run else "would create"
-
-                    if not dry_run:
-                        create_vault_doc(
-                            root_dir=root_dir,
-                            doc_type=dt,
-                            feature=feat,
-                            date_str=date_str,
-                            title=title,
-                            related=resolved_related,
-                            extra_tags=extra_tags,
-                            force=force,
-                            dry_run=False,
-                            step_id=s.canonical_id,
-                            step_display_path=s.display_path,
-                            step_scope=s.scope,
-                            step_action=s.action,
-                            plan_date=plan_date_arg,
-                            plan_stem=plan_stem_arg,
-                        )
-
-                    items.append(
-                        OutcomeItem(
-                            name=rel_name,
-                            outcome=outcome_type,
-                            detail=detail_msg,
-                        )
-                    )
-            finally:
-                if json_output:
-                    logging.disable(previous_logging_disable)
-
-            if not dry_run and items:
-                from vaultspec_core.cli._cache_hook import invalidate_graph_cache
-
-                invalidate_graph_cache(root_dir)
-
-            exit_code = emit_outcomes(
-                items,
-                command="vault.add",
-                title="Scaffold Execution Steps",
-                json_output=json_output,
+            exec_binding = ExecBinding(
+                plan=parent_plan,
+                summary=summary,
+                phase_display_path=_add_ops.resolve_phase_display_path(
+                    console, parsed_plan, phase
+                ),
             )
-            raise typer.Exit(code=exit_code)
 
-    elif dt is DocType.EXEC:
-        if not json_output:
-            console.print(
-                "[yellow]Deprecation Warning: Scaffolding a flat execution "
-                "record without --step or --all-steps is deprecated and will "
-                "be removed in a future release.[/yellow]"
-            )
+    elif dt is DocType.EXEC and not json_output:
+        console.print(
+            "[yellow]Deprecation Warning: Scaffolding a flat execution "
+            "record without --step or --all-steps is deprecated and will "
+            "be removed in a future release.[/yellow]"
+        )
 
     # Single-document scaffolding path (legacy route or --step route)
-    import logging
-
-    previous_logging_disable = logging.root.manager.disable
-    if json_output:
-        logging.disable(logging.CRITICAL)
-    try:
+    with _add_ops.suppress_logging(active=json_output):
         try:
             path = create_vault_doc(
-                root_dir=_get_ctx().target_dir,
-                doc_type=dt,
-                feature=feat,
-                date_str=date_str,
-                title=title,
-                topic=topic_value,
-                related=resolved_related,
-                extra_tags=extra_tags,
-                force=force,
-                dry_run=dry_run,
-                tier=tier if dt is DocType.PLAN else None,
-                step_id=step_id_arg,
-                step_display_path=step_display_path_arg,
-                step_scope=step_scope_arg,
-                step_action=step_action_arg,
-                plan_date=plan_date_arg,
-                plan_stem=plan_stem_arg,
-                summary=summary,
-                phase_display_path=phase_display_arg,
+                root_dir,
+                identity,
+                fields,
+                exec_binding=exec_binding,
+                write=write,
             )
-        except FileNotFoundError as exc:
-            _handle_error(exc, json_output=json_output)
-            return
         except Exception as exc:
             _handle_error(exc, json_output=json_output)
             return
-    finally:
-        if json_output:
-            logging.disable(previous_logging_disable)
-
-    # Only invalidate when the doc was actually written (not a dry-run preview).
-    # Exceptions above cause early return, so reaching here means create_vault_doc
-    # completed successfully; dry_run=False implies a real write occurred.
-    if not dry_run:
-        from vaultspec_core.cli._cache_hook import invalidate_graph_cache
-
-        invalidate_graph_cache(_get_ctx().target_dir)
 
     if dry_run:
-        if json_output:
-            import json
-
-            from vaultspec_core.cli.rendering import json_envelope
-
-            typer.echo(
-                json.dumps(
-                    json_envelope(
-                        "vault.add",
-                        "created",
-                        {
-                            "path": str(path),
-                            "type": doc_type,
-                            "name": path.stem,
-                            "dry_run": True,
-                        },
-                    ),
-                    indent=2,
-                )
-            )
-        else:
-            console.print(f"[dim]Would create:[/dim] {path}")
+        _add_ops.emit_add_result(
+            console, path, doc_type, json_output=json_output, dry_run=True
+        )
         raise typer.Exit(0)
+
+    # Reaching here means create_vault_doc wrote the document: exceptions above
+    # cause an early return and a dry-run preview already exited.
+    from vaultspec_core.cli._cache_hook import invalidate_graph_cache
+
+    invalidate_graph_cache(root_dir)
 
     # Post-creation self-validation
     _validate_created_doc(console, path)
@@ -625,24 +329,11 @@ def cmd_add(
         no_hints=no_hints,
     )
 
+    _add_ops.emit_add_result(
+        console, path, doc_type, json_output=json_output, hints=hint_dict
+    )
     if json_output:
-        import json
-
-        from vaultspec_core.cli.rendering import json_envelope
-
-        typer.echo(
-            json.dumps(
-                json_envelope(
-                    "vault.add",
-                    "created",
-                    {"path": str(path), "type": doc_type, "name": path.stem},
-                    hints=hint_dict,
-                ),
-                indent=2,
-            )
-        )
         raise typer.Exit(0)
-    console.print(f"[green]Created:[/green] {path}")
 
 
 def _validate_created_doc(console: Console, doc_path) -> None:
@@ -1173,6 +864,7 @@ def cmd_repair(
     if json_output:
         import json
 
+        from vaultspec_core.cli._repair_render import repair_payload
         from vaultspec_core.cli.rendering import json_envelope
 
         if run.error_count:
@@ -1183,159 +875,18 @@ def cmd_repair(
             repair_status = "unchanged"
         typer.echo(
             json.dumps(
-                json_envelope("vault.repair", repair_status, _repair_payload(run)),
+                json_envelope("vault.repair", repair_status, repair_payload(run)),
                 indent=2,
                 default=str,
             )
         )
         raise typer.Exit(code=1 if run.error_count else 0)
 
-    _render_repair_run(run, verbose=verbose)
+    from vaultspec_core.cli._repair_render import render_repair_run
+
+    render_repair_run(run, verbose=verbose)
     if run.error_count:
         raise typer.Exit(code=1)
-
-
-def _repair_payload(run: RepairRun) -> dict:
-    """Convert a :class:`RepairRun` to a JSON-serializable mapping."""
-    return {
-        "dry_run": run.dry_run,
-        "feature": run.feature,
-        "include_index": run.include_index,
-        "partial_failure": run.partial_failure,
-        "phases": run.phases,
-        "journal": run.journal,
-        "changed_files": run.changed_files,
-        "generated_indexes": run.generated_indexes,
-        "planned_fixes": run.planned_fixes,
-        "unresolved": run.unresolved,
-        "root_causes": run.root_causes,
-        "error_count": run.error_count,
-        "warning_count": run.warning_count,
-        "fixed_count": run.fixed_count,
-    }
-
-
-def _render_repair_run(run: RepairRun, *, verbose: bool = False) -> None:
-    """Render a repair run for human operators."""
-    from vaultspec_core.console import get_console
-
-    console = get_console()
-    title = "Vault Repair Preview" if run.dry_run else "Vault Repair"
-    if run.feature:
-        title += f" - #{run.feature}"
-    console.print(f"[bold]{title}[/bold]")
-    if run.partial_failure:
-        console.print("[red]  partial repair: at least one phase failed[/red]")
-
-    for phase in run.phases:
-        name = phase.get("phase", "unknown")
-        if name == "preflight":
-            status = phase.get("migration_status", "unknown")
-            pending = phase.get("pending_migrations", [])
-            platform = phase.get("platform", {})
-            case_probe = platform.get("case_sensitive_probe", "unknown")
-            console.print(f"  [bold]preflight[/bold]: migrations {status}")
-            console.print(f"    filesystem case probe: {case_probe}")
-            if pending:
-                console.print(f"    pending migrations: {', '.join(pending)}")
-            for migration in phase.get("applied_migrations", []):
-                console.print(f"    applied migration: {migration['summary']}")
-            if phase.get("message"):
-                console.print(f"    [yellow]{phase['message']}[/yellow]")
-        elif name in {"check", "fix", "postcheck"}:
-            errors = phase.get("error_count", 0)
-            warnings = phase.get("warning_count", 0)
-            fixed = phase.get("fixed_count", 0)
-            summary = f"{errors} errors, {warnings} warnings"
-            if fixed:
-                summary += f", {fixed} fixed"
-            if phase.get("dry_run"):
-                summary += ", preview only"
-            console.print(f"  [bold]{name}[/bold]: {summary}")
-            if verbose:
-                _render_phase_diagnostics(console, phase)
-        elif name == "index":
-            if phase.get("skipped"):
-                console.print(f"  [bold]index[/bold]: skipped ({phase.get('reason')})")
-            elif phase.get("dry_run"):
-                planned = phase.get("planned", [])
-                console.print(f"  [bold]index[/bold]: {len(planned)} planned")
-                if verbose:
-                    for path in planned:
-                        console.print(f"    {path}")
-            else:
-                generated = phase.get("generated", [])
-                console.print(f"  [bold]index[/bold]: {len(generated)} refreshed")
-                if verbose:
-                    for path in generated:
-                        console.print(f"    {path}")
-        elif name == "summary":
-            changed = phase.get("changed_files", [])
-            unresolved = phase.get("unresolved_count", 0)
-            console.print(f"  [bold]summary[/bold]: {len(changed)} changed files")
-            console.print(f"    unresolved diagnostics: {unresolved}")
-            if phase.get("partial_failure"):
-                console.print("    [red]partial failure: true[/red]")
-            if phase.get("journal_count"):
-                console.print(f"    journal entries: {phase['journal_count']}")
-
-    if run.planned_fixes and run.dry_run:
-        console.print()
-        console.print(
-            f"[bold]Planned mechanical fixes[/bold] ({len(run.planned_fixes)})"
-        )
-        for item in run.planned_fixes[:20]:
-            path = f"{item['path']}: " if item.get("path") else ""
-            console.print(f"  - {path}{item['fix_description'] or item['message']}")
-        if len(run.planned_fixes) > 20:
-            console.print(f"  ... {len(run.planned_fixes) - 20} more")
-
-    if run.root_causes:
-        console.print()
-        console.print("[bold]Root-cause groups[/bold]")
-        for group in run.root_causes:
-            console.print(f"  - {group['root_cause']}: {group['count']}")
-
-    if run.changed_files:
-        console.print()
-        console.print("[bold]Changed files[/bold]")
-        for path in run.changed_files[:30]:
-            console.print(f"  - {path}")
-        if len(run.changed_files) > 30:
-            console.print(f"  ... {len(run.changed_files) - 30} more")
-
-    if run.unresolved:
-        console.print()
-        console.print("[bold]Unresolved work[/bold]")
-        severity_rank = {"error": 0, "warning": 1, "info": 2}
-        display_items = [
-            item for item in run.unresolved if verbose or item.get("severity") != "info"
-        ]
-        hidden_info = len(run.unresolved) - len(display_items)
-        display_items.sort(
-            key=lambda item: severity_rank.get(str(item.get("severity")), 3)
-        )
-        for item in display_items[:20]:
-            path = f"{item['path']}: " if item.get("path") else ""
-            console.print(f"  - [{item['severity']}] {path}{item['message']}")
-        if hidden_info:
-            console.print(
-                f"  ... {hidden_info} INFO diagnostics hidden; "
-                "rerun with --verbose to show them."
-            )
-        if len(display_items) > 20:
-            console.print(f"  ... {len(display_items) - 20} more non-INFO diagnostics")
-
-
-def _render_phase_diagnostics(console, phase: dict) -> None:
-    for check in phase.get("checks", []):
-        diagnostics = check.get("diagnostics", [])
-        if not diagnostics:
-            continue
-        console.print(f"    {check['check_name']}:")
-        for diag in diagnostics[:10]:
-            path = f"{diag['path']}: " if diag.get("path") else ""
-            console.print(f"      - [{diag['severity']}] {path}{diag['message']}")
 
 
 @check_app.command("all")

--- a/src/vaultspec_core/core/adr.py
+++ b/src/vaultspec_core/core/adr.py
@@ -7,13 +7,169 @@ import logging
 import re
 from pathlib import Path
 
-from ..vaultcore import VaultConstants, parse_vault_metadata, refresh_modified_stamp
+from ..vaultcore import (
+    DocumentMetadata,
+    VaultConstants,
+    parse_vault_metadata,
+    refresh_modified_stamp,
+)
 from . import types as _t
 from .enums import AdrStatus
 from .exceptions import ResourceNotFoundError, VaultSpecError
 from .helpers import atomic_write
 
 logger = logging.getLogger(__name__)
+
+#: Frontmatter keys ``adr_supersede`` understands and rebuilds explicitly; any other
+#: key in an ADR's frontmatter block is preserved verbatim, in place, by
+#: :func:`_preserve_unknown_frontmatter_keys`.
+_KNOWN_ADR_FRONTMATTER_KEYS = frozenset(
+    {
+        "tags",
+        "date",
+        "related",
+        "feature",
+        "supersedes",
+        "superseded_by",
+        "derived_from",
+        "promoted_to",
+        "archived",
+    }
+)
+
+_ADR_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", re.DOTALL)
+_ADR_STATUS_HEADING_RE = re.compile(
+    r"^(#\s+.*\|\s+\(\*\*status:\*\*\s+`?)([^`)]+)(`?\)\s*)$"
+)
+
+
+def _preserve_unknown_frontmatter_keys(yaml_block: str) -> list[str]:
+    """Return the raw lines of frontmatter keys not covered by known ADR fields.
+
+    Args:
+        yaml_block: The original YAML frontmatter block (without the ``---``
+            fences).
+
+    Returns:
+        The lines belonging to unrecognized top-level keys, verbatim, so the
+        frontmatter rebuild in :func:`_rewrite_adr_frontmatter` can append them
+        unchanged.
+    """
+    preserved: list[str] = []
+    in_unknown_key = False
+    for line in yaml_block.split("\n"):
+        stripped = line.strip()
+        if ":" in stripped and not stripped.startswith("-"):
+            key = stripped.split(":", 1)[0].strip()
+            in_unknown_key = key not in _KNOWN_ADR_FRONTMATTER_KEYS
+            if in_unknown_key:
+                preserved.append(line)
+            continue
+        if stripped.startswith("-"):
+            if in_unknown_key:
+                preserved.append(line)
+            continue
+        if in_unknown_key and stripped:
+            preserved.append(line)
+        in_unknown_key = False
+    return preserved
+
+
+def _rebuild_frontmatter_lines(meta: DocumentMetadata, yaml_block: str) -> list[str]:
+    """Rebuild an ADR's frontmatter lines from its known metadata fields.
+
+    Args:
+        meta: The parsed (and possibly mutated) document metadata.
+        yaml_block: The original YAML frontmatter block, used to recover any
+            keys not modeled by :class:`DocumentMetadata`.
+
+    Returns:
+        The rebuilt frontmatter lines, opening ``---`` fence included and
+        closing fence omitted (the caller appends body content before closing
+        the block).
+    """
+    fm_lines = ["---"]
+    if meta.tags:
+        fm_lines.append("tags:")
+        for tag in meta.tags:
+            fm_lines.append(f'  - "{tag}"')
+    if meta.date:
+        fm_lines.append(f"date: '{meta.date}'")
+    if meta.related:
+        fm_lines.append("related:")
+        for link in meta.related:
+            fm_lines.append(f'  - "{link}"')
+    if meta.supersedes:
+        fm_lines.append("supersedes:")
+        for stem in meta.supersedes:
+            fm_lines.append(f"  - '{stem}'")
+    if meta.superseded_by:
+        fm_lines.append(f"superseded_by: '{meta.superseded_by}'")
+    if meta.derived_from:
+        fm_lines.append("derived_from:")
+        for stem in meta.derived_from:
+            fm_lines.append(f"  - '{stem}'")
+    if meta.promoted_to:
+        fm_lines.append("promoted_to:")
+        for rule in meta.promoted_to:
+            fm_lines.append(f"  - '{rule}'")
+    if meta.archived:
+        fm_lines.append(f"archived: '{meta.archived}'")
+
+    fm_lines.extend(_preserve_unknown_frontmatter_keys(yaml_block))
+    return fm_lines
+
+
+def _rewrite_adr_frontmatter(
+    normalized: str, meta: DocumentMetadata, source_file: Path
+) -> str:
+    """Rebuild an ADR document's frontmatter block, preserving body and unknown keys.
+
+    Args:
+        normalized: The document text, normalized to ``\\n`` line endings.
+        meta: The parsed (and possibly mutated) document metadata to render.
+        source_file: The document's path, used only for the parse-error message.
+
+    Returns:
+        The rebuilt document text (still ``\\n``-normalized).
+
+    Raises:
+        VaultSpecError: If ``normalized`` has no parseable frontmatter block.
+    """
+    match = _ADR_FRONTMATTER_RE.match(normalized.lstrip())
+    if not match:
+        raise VaultSpecError(f"Could not parse frontmatter of ADR '{source_file}'.")
+    yaml_block, body_content = match.group(1), match.group(2)
+    leading = normalized[: len(normalized) - len(normalized.lstrip())]
+
+    fm_lines = _rebuild_frontmatter_lines(meta, yaml_block)
+    fm_lines.append("---")
+    if body_content:
+        fm_lines.append(body_content)
+
+    return leading + "\n".join(fm_lines)
+
+
+def _supersede_status_heading(normalized: str) -> str:
+    """Rewrite the first ADR H1 status token to ``superseded``.
+
+    Args:
+        normalized: The document text, normalized to ``\\n`` line endings.
+
+    Returns:
+        The document text with its status token rewritten, or unchanged if no
+        H1 heading matches the expected ``|  (**status:** \\`...\\`)`` shape.
+    """
+    lines_list = normalized.split("\n")
+    for i, line in enumerate(lines_list):
+        if not line.startswith("# "):
+            continue
+        match = _ADR_STATUS_HEADING_RE.match(line)
+        if not match:
+            continue
+        lines_list[i] = f"{match.group(1)}{AdrStatus.SUPERSEDED.value}{match.group(3)}"
+        break
+    return "\n".join(lines_list)
 
 
 def adr_supersede(
@@ -63,95 +219,10 @@ def adr_supersede(
     old_meta, _ = parse_vault_metadata(old_normalized)
     old_meta.superseded_by = new_stem
 
-    # Rewrite H1 status line: replace accepted/proposed/etc with superseded
-    # Pattern: # `tag` adr: `Title` | (**status:** `accepted`) or similar
-    # Using the regex: r"^(#\s+.*\|\s+\(\*\*status:\*\*\s+`?)([^`)]+)(`?\)\s*)$"
-    lines_list = old_normalized.split("\n")
-    for i, line in enumerate(lines_list):
-        if line.startswith("# "):
-            match = re.match(
-                r"^(#\s+.*\|\s+\(\*\*status:\*\*\s+`?)([^`)]+)(`?\)\s*)$", line
-            )
-            if match:
-                lines_list[i] = (
-                    f"{match.group(1)}{AdrStatus.SUPERSEDED.value}{match.group(3)}"
-                )
-                break
-
-    old_normalized_body = "\n".join(lines_list)
-    match = re.match(
-        r"^---\s*\n(.*?)\n---\s*\n?(.*)$", old_normalized_body.lstrip(), re.DOTALL
+    old_normalized_body = _supersede_status_heading(old_normalized)
+    final_old_content = _rewrite_adr_frontmatter(
+        old_normalized_body, old_meta, old_file
     )
-    if not match:
-        raise VaultSpecError(f"Could not parse frontmatter of old ADR '{old_file}'.")
-    old_yaml_block = match.group(1)
-    old_body_content = match.group(2)
-    old_leading = old_normalized_body[
-        : len(old_normalized_body) - len(old_normalized_body.lstrip())
-    ]
-
-    # Rebuild frontmatter keys
-    old_fm_lines = ["---"]
-    if old_meta.tags:
-        old_fm_lines.append("tags:")
-        for tag in old_meta.tags:
-            old_fm_lines.append(f'  - "{tag}"')
-    if old_meta.date:
-        old_fm_lines.append(f"date: '{old_meta.date}'")
-    if old_meta.related:
-        old_fm_lines.append("related:")
-        for link in old_meta.related:
-            old_fm_lines.append(f'  - "{link}"')
-    if old_meta.supersedes:
-        old_fm_lines.append("supersedes:")
-        for stem in old_meta.supersedes:
-            old_fm_lines.append(f"  - '{stem}'")
-    if old_meta.superseded_by:
-        old_fm_lines.append(f"superseded_by: '{old_meta.superseded_by}'")
-    if old_meta.derived_from:
-        old_fm_lines.append("derived_from:")
-        for stem in old_meta.derived_from:
-            old_fm_lines.append(f"  - '{stem}'")
-    if old_meta.promoted_to:
-        old_fm_lines.append("promoted_to:")
-        for rule in old_meta.promoted_to:
-            old_fm_lines.append(f"  - '{rule}'")
-    if old_meta.archived:
-        old_fm_lines.append(f"archived: '{old_meta.archived}'")
-
-    # Preserve unknown keys
-    known_keys = {
-        "tags",
-        "date",
-        "related",
-        "feature",
-        "supersedes",
-        "superseded_by",
-        "derived_from",
-        "promoted_to",
-        "archived",
-    }
-    in_unknown_key = False
-    for line in old_yaml_block.split("\n"):
-        stripped = line.strip()
-        if ":" in stripped and not stripped.startswith("-"):
-            key = stripped.split(":", 1)[0].strip()
-            in_unknown_key = key not in known_keys
-            if in_unknown_key:
-                old_fm_lines.append(line)
-        elif stripped.startswith("-"):
-            if in_unknown_key:
-                old_fm_lines.append(line)
-        else:
-            if in_unknown_key and stripped:
-                old_fm_lines.append(line)
-            in_unknown_key = False
-
-    old_fm_lines.append("---")
-    if old_body_content:
-        old_fm_lines.append(old_body_content)
-
-    final_old_content = old_leading + "\n".join(old_fm_lines)
     if old_newline == "\r\n":
         final_old_content = final_old_content.replace("\n", "\r\n")
 
@@ -165,65 +236,7 @@ def adr_supersede(
     if old_stem not in new_meta.supersedes:
         new_meta.supersedes.append(old_stem)
 
-    match = re.match(
-        r"^---\s*\n(.*?)\n---\s*\n?(.*)$", new_normalized.lstrip(), re.DOTALL
-    )
-    if not match:
-        raise VaultSpecError(f"Could not parse frontmatter of new ADR '{new_file}'.")
-    new_yaml_block = match.group(1)
-    new_body_content = match.group(2)
-    new_leading = new_normalized[: len(new_normalized) - len(new_normalized.lstrip())]
-
-    new_fm_lines = ["---"]
-    if new_meta.tags:
-        new_fm_lines.append("tags:")
-        for tag in new_meta.tags:
-            new_fm_lines.append(f'  - "{tag}"')
-    if new_meta.date:
-        new_fm_lines.append(f"date: '{new_meta.date}'")
-    if new_meta.related:
-        new_fm_lines.append("related:")
-        for link in new_meta.related:
-            new_fm_lines.append(f'  - "{link}"')
-    if new_meta.supersedes:
-        new_fm_lines.append("supersedes:")
-        for stem in new_meta.supersedes:
-            new_fm_lines.append(f"  - '{stem}'")
-    if new_meta.superseded_by:
-        new_fm_lines.append(f"superseded_by: '{new_meta.superseded_by}'")
-    if new_meta.derived_from:
-        new_fm_lines.append("derived_from:")
-        for stem in new_meta.derived_from:
-            new_fm_lines.append(f"  - '{stem}'")
-    if new_meta.promoted_to:
-        new_fm_lines.append("promoted_to:")
-        for rule in new_meta.promoted_to:
-            new_fm_lines.append(f"  - '{rule}'")
-    if new_meta.archived:
-        new_fm_lines.append(f"archived: '{new_meta.archived}'")
-
-    # Preserve unknown keys
-    in_unknown_key = False
-    for line in new_yaml_block.split("\n"):
-        stripped = line.strip()
-        if ":" in stripped and not stripped.startswith("-"):
-            key = stripped.split(":", 1)[0].strip()
-            in_unknown_key = key not in known_keys
-            if in_unknown_key:
-                new_fm_lines.append(line)
-        elif stripped.startswith("-"):
-            if in_unknown_key:
-                new_fm_lines.append(line)
-        else:
-            if in_unknown_key and stripped:
-                new_fm_lines.append(line)
-            in_unknown_key = False
-
-    new_fm_lines.append("---")
-    if new_body_content:
-        new_fm_lines.append(new_body_content)
-
-    final_new_content = new_leading + "\n".join(new_fm_lines)
+    final_new_content = _rewrite_adr_frontmatter(new_normalized, new_meta, new_file)
     if new_newline == "\r\n":
         final_new_content = final_new_content.replace("\n", "\r\n")
 

--- a/src/vaultspec_core/core/commands.py
+++ b/src/vaultspec_core/core/commands.py
@@ -770,6 +770,70 @@ def _dump_precommit_yaml(handler: YAML, data: object) -> str:
     return buffer.getvalue()
 
 
+def _drop_managed_hook_entries(repos: list[Any]) -> bool:
+    """Delete vaultspec-managed hooks from the ``repos`` sequence in place.
+
+    Mutates the loaded structure so surviving non-vaultspec hooks keep their
+    comments and quoting, and drops any local repo left without hooks.
+
+    Returns:
+        ``True`` when a managed hook was deleted.
+    """
+    changed = False
+    for r in list(repos):
+        if not (isinstance(r, dict) and r.get("repo") == "local"):
+            continue
+        hooks = r.get("hooks", [])
+        if not isinstance(hooks, list):
+            continue
+        managed_idx = [
+            i
+            for i, h in enumerate(hooks)
+            if isinstance(h, dict) and h.get("id") in _ALL_MANAGED_HOOK_IDS
+        ]
+        for i in reversed(managed_idx):
+            del hooks[i]
+        if managed_idx:
+            changed = True
+        if not hooks:
+            repos.remove(r)
+    return changed
+
+
+def _strip_managed_precommit_hooks(config_file: Path) -> bool:
+    """Remove vaultspec-managed hooks from an existing ``.pre-commit-config.yaml``.
+
+    The file is rewritten in place, or deleted when nothing but the managed
+    hooks remained.  Read, parse, and write failures are absorbed: uninstall
+    residue removal is best-effort and never fails the run.
+
+    Returns:
+        ``True`` when the config was rewritten or deleted.
+    """
+    handler = _precommit_yaml()
+    try:
+        data = handler.load(config_file.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return False
+        repos = data.get("repos", [])
+        if not isinstance(repos, list):
+            return False
+        if not _drop_managed_hook_entries(repos):
+            return False
+
+        if repos:
+            atomic_write(config_file, _dump_precommit_yaml(handler, data))
+            return True
+        del data["repos"]
+        if data:
+            atomic_write(config_file, _dump_precommit_yaml(handler, data))
+        else:
+            config_file.unlink()
+    except (YAMLError, OSError):
+        return False
+    return True
+
+
 def _scaffold_precommit(
     target: Path, *, dry_run: bool = False, mode: InstallMode | None = None
 ) -> list[tuple[str, str]]:
@@ -872,20 +936,20 @@ def _scaffold_precommit(
 
                 for canonical in canonical_hooks:
                     hook_id = str(canonical["id"])
-                    if hook_id in existing_by_id:
-                        existing = existing_by_id[hook_id]
-                        if existing.get("entry") != canonical["entry"]:
-                            existing["entry"] = canonical["entry"]
-                            logger.info(
-                                "Updated pre-commit hook '%s' entry"
-                                " to canonical pattern",
-                                hook_id,
-                            )
-                            changed = True
-                    else:
+                    existing = existing_by_id.get(hook_id)
+                    if existing is None:
                         existing_hooks.append(dict(canonical))
                         logger.info("Added pre-commit hook '%s'", str(canonical["id"]))
                         changed = True
+                        continue
+                    if existing.get("entry") == canonical["entry"]:
+                        continue
+                    existing["entry"] = canonical["entry"]
+                    logger.info(
+                        "Updated pre-commit hook '%s' entry to canonical pattern",
+                        hook_id,
+                    )
+                    changed = True
 
                 if not changed:
                     return []
@@ -1132,6 +1196,335 @@ def _ensure_tool_configs(path: Path) -> None:
         shutil.rmtree(tmp, ignore_errors=True)
 
 
+def _preview_upgrade_items(
+    path: Path, provider: str, skip: set[str], *, skip_core: bool
+) -> list[tuple[str, str]]:
+    """Enumerate what ``install --upgrade --dry-run`` would change.
+
+    The real upgrade re-seeds builtins AND runs the provider sync, which
+    backfills new provider files and structural directories. Preview that
+    provider-side work too so the dry-run enumerates what the real run
+    changes rather than only the builtin seed (issue #134). Only the
+    changed entries are surfaced to keep the preview signal-dense; an
+    unchanged provider tree contributes nothing.
+
+    Raises:
+        VaultSpecError: If the provider reconciliation preview fails.
+    """
+    _ensure_tool_configs(path)
+    items: list[tuple[str, str]] = []
+    if not skip_core:
+        from vaultspec_core.builtins import seed_builtins
+
+        items = seed_builtins(path / ".vaultspec", force=True, dry_run=True)
+
+    if not path.joinpath(".vaultspec").exists():
+        return items
+
+    sync_target = provider if provider not in ("all", "core") else "all"
+    try:
+        sync_results = sync_provider(sync_target, dry_run=True, skip=skip)
+    except OSError as exc:
+        raise VaultSpecError(
+            "Provider reconciliation preview failed.", hint=str(exc)
+        ) from exc
+    _require_reconciliation_success(
+        sync_results,
+        operation="Provider reconciliation preview",
+    )
+    seen_preview = {rel for rel, _ in items}
+    for sync_result in sync_results:
+        for rel, action in sync_result.items:
+            if action in ("[UNCHANGED]", "[SKIP]"):
+                continue
+            if rel in seen_preview:
+                continue
+            seen_preview.add(rel)
+            items.append((rel, action))
+    return items
+
+
+def _preview_install_manifest(
+    path: Path,
+    provider: str,
+    skip: set[str],
+    *,
+    skip_core: bool,
+    resolved_mode: InstallMode,
+) -> list[tuple[str, str]]:
+    """Enumerate the files a fresh ``install --dry-run`` would create.
+
+    Raises:
+        VaultSpecError: If the MCP enrollment preview fails.
+    """
+    _ensure_tool_configs(path)
+
+    manifest: list[tuple[str, str]] = []
+    if not skip_core:
+        manifest = _scaffold_core(path, dry_run=True)
+
+        # Include builtin files that would be seeded
+        from vaultspec_core.builtins import list_builtins
+
+        for builtin_rel in list_builtins():
+            manifest.append((f".vaultspec/{builtin_rel}", "builtin"))
+
+    tools = _filter_tools(_PROVIDER_TO_TOOLS.get(provider, []), skip)
+    for tool in tools:
+        manifest.extend(_scaffold_provider(path, tool, dry_run=True))
+    if "mcp" not in skip:
+        manifest.extend(
+            _preview_mcp_targets(
+                path, tuple(tools), skip_core=skip_core, resolved_mode=resolved_mode
+            )
+        )
+    if "precommit" not in skip:
+        manifest.extend(_scaffold_precommit(path, dry_run=True, mode=resolved_mode))
+
+    # Deduplicate preserving order (by relative path)
+    seen: dict[str, str] = {}
+    for rel, label in manifest:
+        seen.setdefault(rel, label)
+    return list(seen.items())
+
+
+def _preview_mcp_targets(
+    path: Path,
+    selected: tuple[Tool, ...],
+    *,
+    skip_core: bool,
+    resolved_mode: InstallMode,
+) -> list[tuple[str, str]]:
+    """Enumerate the native MCP targets a fresh install would enroll.
+
+    Raises:
+        VaultSpecError: If the MCP enrollment preview fails.
+    """
+    from .mcps import mcp_sync, resolve_mcp_targets
+
+    mcp_result = mcp_sync(
+        dry_run=True,
+        mode=resolved_mode,
+        target_dir=path,
+        enrolled=selected,
+    )
+    _require_reconciliation_success(
+        mcp_result,
+        operation="MCP provider-native enrollment preview",
+    )
+    entries: list[tuple[str, str]] = []
+    for mcp_target in resolve_mcp_targets(target_dir=path, enrolled=selected):
+        provider_result = mcp_result.per_tool.get(mcp_target.provider.value)
+        if not skip_core or (provider_result and provider_result.items):
+            entries.append((_rel(path, mcp_target.path), "mcp"))
+    return entries
+
+
+def _detect_precommit_managed(path: Path) -> bool:
+    """Report whether *path* still carries vaultspec-managed pre-commit hooks."""
+    from .diagnosis.collectors import collect_precommit_state
+    from .diagnosis.signals import PrecommitSignal
+
+    return collect_precommit_state(path) not in (
+        PrecommitSignal.NO_FILE,
+        PrecommitSignal.NO_HOOKS,
+    )
+
+
+def _reseed_builtins(path: Path) -> list[tuple[str, str]]:
+    """Re-seed the builtin corpus and re-snapshot it for revert support."""
+    from vaultspec_core.builtins import seed_builtins
+
+    from .revert import snapshot_builtins
+
+    fw_dir = path / ".vaultspec"
+    seeded = seed_builtins(fw_dir, force=True)
+    snapshot_builtins(fw_dir)
+    return seeded
+
+
+def _migrate_mcp_launch_shape(path: Path, resolved_mode: InstallMode) -> None:
+    """Force every declared package's managed MCP entry into *resolved_mode*.
+
+    Closes the mode-flip force-gate asymmetry: when the mode flipped, the
+    force-gated MCP pass skipped every stale managed entry declared in the
+    workspace, not just core's own. Forcing them here migrates all three
+    renderers atomically in this run; user-owned entries and the foreign-entry
+    discipline remain untouched.
+
+    Raises:
+        VaultSpecError: If the reconciliation reports a failure.
+    """
+    from .mcps import mcp_sync
+    from .workspace_mode import read_package_declarations
+
+    declared_packages = frozenset(read_package_declarations(path))
+    mcp_result = mcp_sync(
+        mode=resolved_mode,
+        force_managed=declared_packages or frozenset({"vaultspec-core"}),
+    )
+    _require_reconciliation_success(
+        mcp_result,
+        operation="MCP mode-migration reconciliation",
+    )
+
+
+def _finalize_upgrade_manifest(
+    path: Path, *, force: bool, resolved_mode: InstallMode
+) -> None:
+    """Stamp manifest state and reconcile the git index after an upgrade."""
+    import datetime
+
+    mdata = read_manifest_data(path)
+    if not mdata.installed_at:
+        mdata.installed_at = datetime.datetime.now(tz=datetime.UTC).isoformat()
+    _stamp_manifest_version_no_downgrade(mdata)
+
+    for orphan in prune_orphaned_lock_sentinels(path):
+        logger.info("Removed orphaned lock sentinel %s", orphan)
+
+    # Re-opt-in gitignore management on --upgrade --force
+    if force:
+        ensure_gitignore_block(
+            path,
+            get_recommended_entries(path),
+            state=ManagedState.PRESENT,
+        )
+        mdata.gitignore_managed = True
+
+    mdata.precommit_managed = _detect_precommit_managed(path)
+
+    _persist_resolved_mode(path, mdata, resolved_mode)
+    write_manifest_data(path, mdata)
+
+    # Reconcile git index with the managed gitignore block so that
+    # historically-committed state files (e.g. .vaultspec/providers.json
+    # from a pre-managed-block install) stop showing up as dirty on
+    # every subsequent run.
+    _untrack_managed_paths(path, get_recommended_entries(path))
+
+
+def _run_upgrade(
+    path: Path,
+    provider: str,
+    skip: set[str],
+    *,
+    skip_core: bool,
+    mode: InstallMode | None,
+    force: bool,
+) -> dict[str, Any]:
+    """Re-seed builtins, migrate schema, and reconcile providers in place.
+
+    Raises:
+        WorkspaceNotInitializedError: If *path* is not an initialized workspace.
+        VaultSpecError: If provider or MCP reconciliation reports a failure.
+    """
+    from vaultspec_core.config.workspace import WorkspaceError, resolve_workspace
+    from vaultspec_core.core.types import init_paths
+
+    from .workspace_mode import dependency_leak_advisory, newly_establishes_dependency
+
+    try:
+        layout = resolve_workspace(target_override=path)
+        init_paths(layout)
+    except WorkspaceError as e:
+        raise WorkspaceNotInitializedError(
+            f"Cannot upgrade: {e}",
+            hint=f"Run 'vaultspec-core install {path}' first.",
+        ) from e
+
+    # Q6 migration: refine the provision-time resolution with this
+    # workspace's deployed state. A legacy workspace carries no persisted
+    # mode, so infer it from the observed hook shape and the pyproject
+    # dependency listing; a workspace that already declares a mode keeps it,
+    # which is what makes a repeated upgrade idempotent. This supersedes the
+    # value resolve_install_mode computed at entry, since only here is the
+    # deployed hook shape folded in - so the leak advisory is recomputed from
+    # the inferred provenance too: a persisted dependency declaration stays
+    # silent, a freshly inferred one warns.
+    inferred = _infer_upgrade_mode(path, mode)
+    resolved_mode = inferred.mode
+    leak_warnings = (
+        [dependency_leak_advisory()] if newly_establishes_dependency(inferred) else []
+    )
+
+    seeded: list[tuple[str, str]] = [] if skip_core else _reseed_builtins(path)
+
+    # Run pending schema migrations BEFORE the sync. ``sync_provider``
+    # ends with ``mdata.vaultspec_version = package_version()``, which
+    # would otherwise mask any migration whose ``target_version``
+    # equals the running release: ``run_pending_migrations`` would
+    # read the just-bumped version and find nothing pending. Running
+    # the driver first preserves the pre-upgrade manifest version so
+    # the registry sees the real "needs migration" state, applies
+    # the pending entries, and then ``sync_provider`` re-bumps to
+    # the running version on its way out.
+    from ..migrations import run_pending_migrations
+
+    run_pending_migrations(path)
+
+    # Persist the inferred declaration BEFORE the provider sync and the hook
+    # scaffold re-render their artifacts. Both renderers resolve their mode
+    # from the committed declaration (via resolve_render_mode); on a legacy
+    # workspace with no declaration that fallback renders dependency mode, so
+    # an inference that landed tool mode would otherwise leave uv-run-shaped
+    # artifacts contradicting the tool-mode declaration written moments
+    # later. Writing it here threads the inferred mode into this same run's
+    # rendering, mirroring the fresh-install ordering. The manifest echo and
+    # floor reconciliation still run once, later, via _persist_resolved_mode.
+    _write_mode_declaration(path, resolved_mode)
+
+    # Detect a mode flip before the sync below re-renders any artifact.
+    # The pre-commit and declaration renderers rewrite unconditionally, but
+    # the MCP sync runs force-gated: a pre-existing MANAGED vaultspec-core
+    # entry still carrying the old mode's launch shape is skipped unless
+    # --force, which would leave the migration non-atomic across the three
+    # renderers until a later forced re-sync (mode-flip-force-asymmetry
+    # audit finding). Captured here against the still-old .mcp.json, this
+    # flags whether the deployed MCP launch shape disagrees with the mode
+    # this upgrade resolved to; the targeted force below closes the gap.
+    from .diagnosis.collectors import _observed_mcp_mode
+
+    observed_mcp_mode = _observed_mcp_mode(path)
+    mcp_mode_flipped = (
+        observed_mcp_mode is not None and observed_mcp_mode != resolved_mode
+    )
+
+    sync_target = provider if provider not in ("all", "core") else "all"
+    # `sync_provider` rejects `core` in its skip set (`allow_core=False`).
+    # `install_run` accepts `core` because it skips the framework scaffold;
+    # filter it out before forwarding to the sync pass.
+    # Forward `force`: `--upgrade` and `--force` are separate flags;
+    # `install --upgrade` (without `--force`) must preserve user-authored
+    # content. The pre-collapse hardcoded `force=True` was an asymmetry
+    # against the fresh-install path and silently overwrote user content
+    # on every upgrade. See PR #116 review thread r3260188496.
+    sync_results = sync_provider(sync_target, force=force, skip=skip - {"core"})
+    _require_reconciliation_success(
+        sync_results,
+        operation="Provider reconciliation during upgrade",
+    )
+
+    if "precommit" not in skip:
+        _scaffold_precommit(path, mode=resolved_mode)
+
+    # Skipped when --force already rewrote it, when the mode did not flip
+    # (preserving today's force-gated semantics for a same-mode divergent entry,
+    # now handled by the fingerprint-verified refresh path in the sync above), or
+    # when mcp sync is skipped outright.
+    if mcp_mode_flipped and not force and "mcp" not in skip:
+        _migrate_mcp_launch_shape(path, resolved_mode)
+
+    _finalize_upgrade_manifest(path, force=force, resolved_mode=resolved_mode)
+
+    return {
+        "action": "upgrade",
+        "items": seeded,
+        "path": path,
+        "warnings": leak_warnings,
+    }
+
+
 def install_run(
     path: Path,
     provider: str = "all",
@@ -1172,7 +1565,7 @@ def install_run(
         ResourceExistsError: If already installed and *force*/*upgrade* not set.
     """
     from vaultspec_core.config import reset_config
-    from vaultspec_core.config.workspace import WorkspaceError, resolve_workspace
+    from vaultspec_core.config.workspace import resolve_workspace
     from vaultspec_core.core.types import init_paths
 
     from .exceptions import ResourceExistsError
@@ -1234,268 +1627,37 @@ def install_run(
     )
 
     if upgrade and dry_run:
-        _ensure_tool_configs(path)
-        items: list[tuple[str, str]] = []
-        if not skip_core:
-            from vaultspec_core.builtins import seed_builtins
-
-            items = seed_builtins(path / ".vaultspec", force=True, dry_run=True)
-
-        # The real upgrade re-seeds builtins AND runs the provider sync, which
-        # backfills new provider files and structural directories. Preview that
-        # provider-side work too so the dry-run enumerates what the real run
-        # changes rather than only the builtin seed (issue #134). Only the
-        # changed entries are surfaced to keep the preview signal-dense; an
-        # unchanged provider tree contributes nothing.
-        if path.joinpath(".vaultspec").exists():
-            sync_target = provider if provider not in ("all", "core") else "all"
-            try:
-                sync_results = sync_provider(sync_target, dry_run=True, skip=skip)
-            except OSError as exc:
-                raise VaultSpecError(
-                    "Provider reconciliation preview failed.", hint=str(exc)
-                ) from exc
-            _require_reconciliation_success(
-                sync_results,
-                operation="Provider reconciliation preview",
-            )
-            seen_preview = {rel for rel, _ in items}
-            for sync_result in sync_results:
-                for rel, action in sync_result.items:
-                    if action in ("[UNCHANGED]", "[SKIP]"):
-                        continue
-                    if rel in seen_preview:
-                        continue
-                    seen_preview.add(rel)
-                    items.append((rel, action))
-
         return {
             "action": "upgrade",
-            "items": items,
+            "items": _preview_upgrade_items(path, provider, skip, skip_core=skip_core),
             "path": path,
             "dry_run": True,
             "warnings": leak_warnings,
         }
 
     if dry_run:
-        _ensure_tool_configs(path)
-
-        manifest: list[tuple[str, str]] = []
-
-        if not skip_core:
-            manifest = _scaffold_core(path, dry_run=True)
-
-            # Include builtin files that would be seeded
-            from vaultspec_core.builtins import list_builtins
-
-            for builtin_rel in list_builtins():
-                manifest.append((f".vaultspec/{builtin_rel}", "builtin"))
-
-        tools = _filter_tools(_PROVIDER_TO_TOOLS.get(provider, []), skip)
-        for tool in tools:
-            manifest.extend(_scaffold_provider(path, tool, dry_run=True))
-        if "mcp" not in skip:
-            from .mcps import mcp_sync, resolve_mcp_targets
-
-            selected = tuple(tools)
-            mcp_result = mcp_sync(
-                dry_run=True,
-                mode=resolved_mode,
-                target_dir=path,
-                enrolled=selected,
-            )
-            _require_reconciliation_success(
-                mcp_result,
-                operation="MCP provider-native enrollment preview",
-            )
-            for mcp_target in resolve_mcp_targets(
-                target_dir=path,
-                enrolled=selected,
-            ):
-                provider_result = mcp_result.per_tool.get(mcp_target.provider.value)
-                if not skip_core or (provider_result and provider_result.items):
-                    manifest.append((_rel(path, mcp_target.path), "mcp"))
-        if "precommit" not in skip:
-            manifest.extend(_scaffold_precommit(path, dry_run=True, mode=resolved_mode))
-
-        # Deduplicate preserving order (by relative path)
-        seen: dict[str, str] = {}
-        for rel, label in manifest:
-            seen.setdefault(rel, label)
-
         return {
             "action": "dry_run",
-            "items": list(seen.items()),
+            "items": _preview_install_manifest(
+                path,
+                provider,
+                skip,
+                skip_core=skip_core,
+                resolved_mode=resolved_mode,
+            ),
             "path": path,
             "warnings": leak_warnings,
         }
 
     if upgrade:
-        try:
-            layout = resolve_workspace(target_override=path)
-            init_paths(layout)
-        except WorkspaceError as e:
-            raise WorkspaceNotInitializedError(
-                f"Cannot upgrade: {e}",
-                hint=f"Run 'vaultspec-core install {path}' first.",
-            ) from e
-
-        # Q6 migration: refine the provision-time resolution with this
-        # workspace's deployed state. A legacy workspace carries no persisted
-        # mode, so infer it from the observed hook shape and the pyproject
-        # dependency listing; a workspace that already declares a mode keeps it,
-        # which is what makes a repeated upgrade idempotent. This supersedes the
-        # value resolve_install_mode computed at entry, since only here is the
-        # deployed hook shape folded in - so the leak advisory is recomputed from
-        # the inferred provenance too: a persisted dependency declaration stays
-        # silent, a freshly inferred one warns.
-        inferred = _infer_upgrade_mode(path, mode)
-        resolved_mode = inferred.mode
-        leak_warnings = (
-            [dependency_leak_advisory()]
-            if newly_establishes_dependency(inferred)
-            else []
+        return _run_upgrade(
+            path,
+            provider,
+            skip,
+            skip_core=skip_core,
+            mode=mode,
+            force=force,
         )
-
-        seeded: list[tuple[str, str]] = []
-        if not skip_core:
-            # Re-seed builtins (force=True overwrites existing)
-            from vaultspec_core.builtins import seed_builtins
-
-            fw_dir = path / ".vaultspec"
-            seeded = seed_builtins(fw_dir, force=True)
-
-            # Re-snapshot builtins for revert support
-            from .revert import snapshot_builtins
-
-            snapshot_builtins(fw_dir)
-
-        # Run pending schema migrations BEFORE the sync. ``sync_provider``
-        # ends with ``mdata.vaultspec_version = package_version()``, which
-        # would otherwise mask any migration whose ``target_version``
-        # equals the running release: ``run_pending_migrations`` would
-        # read the just-bumped version and find nothing pending. Running
-        # the driver first preserves the pre-upgrade manifest version so
-        # the registry sees the real "needs migration" state, applies
-        # the pending entries, and then ``sync_provider`` re-bumps to
-        # the running version on its way out.
-        from ..migrations import run_pending_migrations
-
-        run_pending_migrations(path)
-
-        # Persist the inferred declaration BEFORE the provider sync and the hook
-        # scaffold re-render their artifacts. Both renderers resolve their mode
-        # from the committed declaration (via resolve_render_mode); on a legacy
-        # workspace with no declaration that fallback renders dependency mode, so
-        # an inference that landed tool mode would otherwise leave uv-run-shaped
-        # artifacts contradicting the tool-mode declaration written moments
-        # later. Writing it here threads the inferred mode into this same run's
-        # rendering, mirroring the fresh-install ordering. The manifest echo and
-        # floor reconciliation still run once, later, via _persist_resolved_mode.
-        _write_mode_declaration(path, resolved_mode)
-
-        # Detect a mode flip before the sync below re-renders any artifact.
-        # The pre-commit and declaration renderers rewrite unconditionally, but
-        # the MCP sync runs force-gated: a pre-existing MANAGED vaultspec-core
-        # entry still carrying the old mode's launch shape is skipped unless
-        # --force, which would leave the migration non-atomic across the three
-        # renderers until a later forced re-sync (mode-flip-force-asymmetry
-        # audit finding). Captured here against the still-old .mcp.json, this
-        # flags whether the deployed MCP launch shape disagrees with the mode
-        # this upgrade resolved to; the targeted force below closes the gap.
-        from .diagnosis.collectors import _observed_mcp_mode
-
-        observed_mcp_mode = _observed_mcp_mode(path)
-        mcp_mode_flipped = (
-            observed_mcp_mode is not None and observed_mcp_mode != resolved_mode
-        )
-
-        sync_target = provider if provider not in ("all", "core") else "all"
-        # `sync_provider` rejects `core` in its skip set (`allow_core=False`).
-        # `install_run` accepts `core` because it skips the framework scaffold;
-        # filter it out before forwarding to the sync pass.
-        # Forward `force`: `--upgrade` and `--force` are separate flags;
-        # `install --upgrade` (without `--force`) must preserve user-authored
-        # content. The pre-collapse hardcoded `force=True` was an asymmetry
-        # against the fresh-install path and silently overwrote user content
-        # on every upgrade. See PR #116 review thread r3260188496.
-        sync_results = sync_provider(sync_target, force=force, skip=skip - {"core"})
-        _require_reconciliation_success(
-            sync_results,
-            operation="Provider reconciliation during upgrade",
-        )
-
-        if "precommit" not in skip:
-            _scaffold_precommit(path, mode=resolved_mode)
-
-        # Close the mode-flip force-gate asymmetry: when the mode flipped, the
-        # force-gated MCP pass above skipped every stale managed entry declared
-        # in the workspace, not just core's own. Force every declared package's
-        # managed entry into the new mode's launch shape so all three renderers
-        # migrate atomically in this run; user-owned entries and the
-        # foreign-entry discipline remain untouched. Skipped when --force
-        # already rewrote it, when the mode did not flip (preserving today's
-        # force-gated semantics for a same-mode divergent entry, now handled by
-        # the fingerprint-verified refresh path in the sync above), or when
-        # mcp sync is skipped outright.
-        if mcp_mode_flipped and not force and "mcp" not in skip:
-            from .mcps import mcp_sync
-            from .workspace_mode import read_package_declarations
-
-            declared_packages = frozenset(read_package_declarations(path))
-            mcp_result = mcp_sync(
-                mode=resolved_mode,
-                force_managed=declared_packages or frozenset({"vaultspec-core"}),
-            )
-            _require_reconciliation_success(
-                mcp_result,
-                operation="MCP mode-migration reconciliation",
-            )
-
-        # Update manifest timestamps and version
-        import datetime
-
-        mdata = read_manifest_data(path)
-        if not mdata.installed_at:
-            mdata.installed_at = datetime.datetime.now(tz=datetime.UTC).isoformat()
-        _stamp_manifest_version_no_downgrade(mdata)
-
-        for orphan in prune_orphaned_lock_sentinels(path):
-            logger.info("Removed orphaned lock sentinel %s", orphan)
-
-        # Re-opt-in gitignore management on --upgrade --force
-        if force:
-            ensure_gitignore_block(
-                path,
-                get_recommended_entries(path),
-                state=ManagedState.PRESENT,
-            )
-            mdata.gitignore_managed = True
-
-        from .diagnosis.collectors import collect_precommit_state
-        from .diagnosis.signals import PrecommitSignal
-
-        pc_signal = collect_precommit_state(path)
-        mdata.precommit_managed = pc_signal not in (
-            PrecommitSignal.NO_FILE,
-            PrecommitSignal.NO_HOOKS,
-        )
-
-        _persist_resolved_mode(path, mdata, resolved_mode)
-        write_manifest_data(path, mdata)
-
-        # Reconcile git index with the managed gitignore block so that
-        # historically-committed state files (e.g. .vaultspec/providers.json
-        # from a pre-managed-block install) stop showing up as dirty on
-        # every subsequent run.
-        _untrack_managed_paths(path, get_recommended_entries(path))
-
-        return {
-            "action": "upgrade",
-            "items": seeded,
-            "path": path,
-            "warnings": leak_warnings,
-        }
 
     fw_dir = path / ".vaultspec"
     if fw_dir.exists() and not force and not skip_core and not adopting:
@@ -1584,40 +1746,12 @@ def install_run(
     # Populate v2.0 manifest fields
     import datetime
 
-    gi_path = path / ".gitignore"
-    ga_path = path / ".gitattributes"
     mdata = read_manifest_data(path, strict=True)
 
     # Robust detection: if it's there, it's managed.
-    block_present = False
-    if gi_path.exists():
-        try:
-            content = gi_path.read_text(encoding="utf-8")
-            begins, ends = _find_markers(content.splitlines())
-            block_present = len(begins) == 1 and len(ends) == 1 and begins[0] < ends[0]
-
-        except (OSError, UnicodeDecodeError):
-            pass
-
-    ga_block_present = False
-    if ga_path.exists():
-        try:
-            content = ga_path.read_text(encoding="utf-8")
-            ga_block_present = _ga_has_valid_block(content.splitlines())
-        except (OSError, UnicodeDecodeError):
-            pass
-
-    mdata.gitignore_managed = block_present
-    mdata.gitattributes_managed = ga_block_present
-
-    from .diagnosis.collectors import collect_precommit_state
-    from .diagnosis.signals import PrecommitSignal
-
-    pc_signal = collect_precommit_state(path)
-    mdata.precommit_managed = pc_signal not in (
-        PrecommitSignal.NO_FILE,
-        PrecommitSignal.NO_HOOKS,
-    )
+    mdata.gitignore_managed = _has_gitignore_block(path / ".gitignore")
+    mdata.gitattributes_managed = _has_gitattributes_block(path / ".gitattributes")
+    mdata.precommit_managed = _detect_precommit_managed(path)
 
     mdata.vaultspec_version = _fresh_install_schema_version()
     mdata.installed_at = datetime.datetime.now(tz=datetime.UTC).isoformat()
@@ -1645,6 +1779,305 @@ def install_run(
     if post_errors:
         result["errors"] = post_errors
     return result
+
+
+# Map directory names → component owners (for skip filtering).
+# .agents/ is shared by antigravity, gemini, and codex (all place skills there
+# via init_paths), so it must be preserved when any of its owners is skipped.
+_UNINSTALL_DIR_OWNERS: dict[str, list[str]] = {
+    ".vaultspec": ["core"],
+    ".vault": ["vault"],
+    ".claude": ["claude"],
+    ".gemini": ["gemini"],
+    ".agents": ["antigravity", "gemini", "codex"],
+    ".codex": ["codex"],
+}
+_UNINSTALL_DIR_LABELS: dict[str, str] = {
+    ".vaultspec": "core",
+    ".vault": "vault",
+    ".claude": "claude",
+    ".gemini": "gemini",
+    ".agents": "antigravity",
+    ".codex": "codex",
+}
+_UNINSTALL_FILE_LABELS: dict[str, str] = {
+    "CLAUDE.md": "claude (config)",
+    "GEMINI.md": "gemini (config)",
+    "AGENTS.md": "codex (config)",
+    ".mcp.json": "mcp",
+}
+# Map file names → owning component for skip checks
+_UNINSTALL_FILE_OWNERS: dict[str, str] = {
+    "CLAUDE.md": "claude",
+    "GEMINI.md": "gemini",
+    "AGENTS.md": "codex",
+}
+
+
+def _delete_managed_dir(
+    root: Path, directory: Path, *, dry_run: bool, errors: list[str]
+) -> bool:
+    """Delete *directory*, or preview the deletion under *dry_run*.
+
+    Returns:
+        ``True`` when the removal succeeded (or was previewed) and the caller
+        should record it, ``False`` when it failed and was reported in *errors*.
+    """
+    if dry_run:
+        return True
+    try:
+        _rmtree_robust(directory)
+    except OSError as exc:
+        errors.append(f"Failed to remove {_rel(root, directory)}: {exc}")
+        return False
+    return True
+
+
+def _delete_managed_file(
+    root: Path, file: Path, *, dry_run: bool, errors: list[str]
+) -> bool:
+    """Delete *file*, or preview the deletion under *dry_run*.
+
+    Returns:
+        ``True`` when the removal succeeded (or was previewed) and the caller
+        should record it, ``False`` when it failed and was reported in *errors*.
+    """
+    if dry_run:
+        return True
+    try:
+        file.unlink()
+    except OSError as exc:
+        errors.append(f"Failed to remove {_rel(root, file)}: {exc}")
+        return False
+    return True
+
+
+def _uninstall_mcp_targets(
+    root: Path,
+    *,
+    enrolled: tuple[Tool, ...],
+    provider: Tool | str = "all",
+    dry_run: bool,
+    removed: list[tuple[str, str]],
+    errors: list[str],
+) -> None:
+    """Retire vaultspec's native MCP enrollment from the *enrolled* hosts.
+
+    Appends every reconciled target to *removed* and any host-level failure to
+    *errors*.
+    """
+    from .mcps import mcp_uninstall, resolve_mcp_targets
+
+    uninstalled = mcp_uninstall(
+        root,
+        dry_run=dry_run,
+        provider=provider,
+        enrolled=enrolled,
+    )
+    errors.extend(uninstalled.errors)
+    for target in resolve_mcp_targets(
+        provider=provider,
+        target_dir=root,
+        enrolled=enrolled,
+    ):
+        target_result = uninstalled.per_tool.get(target.provider.value)
+        if target_result and target_result.items:
+            removed.append((_rel(root, target.path), "mcp"))
+
+
+def _uninstall_precommit_hooks(
+    root: Path, *, dry_run: bool, removed: list[tuple[str, str]]
+) -> None:
+    """Strip vaultspec-managed hooks from a legacy ``.pre-commit-config.yaml``.
+
+    This deliberately runs even when ``prek.toml`` owns the hook boundary
+    (:func:`collect_prek_boundary`): install and sync refuse to write the YAML
+    under prek, but uninstall stripping vaultspec hooks from a legacy YAML is
+    residue removal - leave-no-trace semantics - not management of the file.
+    """
+    precommit_path = root / ".pre-commit-config.yaml"
+    if not precommit_path.exists():
+        return
+
+    if dry_run:
+        try:
+            raw = precommit_path.read_text(encoding="utf-8")
+        except OSError:
+            return
+        if any(f"id: {hid}" in raw for hid in _ALL_MANAGED_HOOK_IDS):
+            removed.append((_rel(root, precommit_path), "precommit"))
+        return
+
+    if not _strip_managed_precommit_hooks(precommit_path):
+        return
+    removed.append((_rel(root, precommit_path), "precommit"))
+    try:
+        mdata = read_manifest_data(root)
+        if mdata.precommit_managed:
+            mdata.precommit_managed = False
+            write_manifest_data(root, mdata)
+    except (YAMLError, OSError):
+        pass
+
+
+def _uninstall_everything(
+    root: Path,
+    *,
+    skip: set[str],
+    keep_vault: bool,
+    dry_run: bool,
+    removed: list[tuple[str, str]],
+    errors: list[str],
+) -> None:
+    """Remove every managed directory, config file, and hook block under *root*.
+
+    Honours *skip* per component and appends what was removed to *removed*.
+    """
+    # .vaultspec is deleted LAST so the manifest survives partial failures.
+    managed_dirs = [
+        root / ".claude",
+        root / ".gemini",
+        root / ".agents",
+        root / ".codex",
+    ]
+    if not keep_vault:
+        managed_dirs.append(root / ".vault")
+    managed_dirs.append(root / ".vaultspec")
+
+    # Reconcile native MCP targets before provider directories and
+    # ownership state are removed.
+    if "mcp" not in skip:
+        active_ctx = _t.get_context()
+        _uninstall_mcp_targets(
+            root,
+            enrolled=tuple(
+                tool
+                for tool, config in active_ctx.tool_configs.items()
+                if ProviderCapability.MCPS in config.capabilities
+                and tool.value not in skip
+            ),
+            dry_run=dry_run,
+            removed=removed,
+            errors=errors,
+        )
+
+    for directory in managed_dirs:
+        skipped = [
+            owner
+            for owner in _UNINSTALL_DIR_OWNERS.get(directory.name, [])
+            if owner in skip
+        ]
+        if skipped:
+            logger.info("Skipping %s (--skip %s)", directory.name, ", ".join(skipped))
+            continue
+        if not directory.exists():
+            continue
+        if _delete_managed_dir(root, directory, dry_run=dry_run, errors=errors):
+            label = _UNINSTALL_DIR_LABELS.get(directory.name, "")
+            removed.append((str(directory).replace("\\", "/") + "/", label))
+
+    for file in (root / "CLAUDE.md", root / "GEMINI.md", root / "AGENTS.md"):
+        owner = _UNINSTALL_FILE_OWNERS.get(file.name, "")
+        if owner in skip:
+            logger.info("Skipping %s (--skip %s)", file.name, owner)
+            continue
+        if not file.exists():
+            continue
+        if _delete_managed_file(root, file, dry_run=dry_run, errors=errors):
+            label = _UNINSTALL_FILE_LABELS.get(file.name, "")
+            removed.append((str(file).replace("\\", "/"), label))
+
+    if "precommit" not in skip:
+        _uninstall_precommit_hooks(root, dry_run=dry_run, removed=removed)
+
+
+def _uninstall_provider_artifacts(
+    root: Path,
+    provider: str,
+    *,
+    skip: set[str],
+    dry_run: bool,
+    removed: list[tuple[str, str]],
+    errors: list[str],
+) -> None:
+    """Remove one provider's artifacts, preserving directories still shared.
+
+    Directories and files another installed provider still owns are logged and
+    left in place; the manifest is updated once every tool is off disk.
+    """
+    tools = _filter_tools(_PROVIDER_TO_TOOLS.get(provider, []), skip)
+
+    if "mcp" not in skip:
+        active_ctx = _t.get_context()
+        mcp_tools = tuple(
+            tool
+            for tool in tools
+            if ProviderCapability.MCPS in active_ctx.tool_configs[tool].capabilities
+        )
+        if mcp_tools:
+            _uninstall_mcp_targets(
+                root,
+                enrolled=mcp_tools,
+                provider=provider,
+                dry_run=dry_run,
+                removed=removed,
+                errors=errors,
+            )
+
+    for tool in tools:
+        dirs, files = _collect_provider_artifacts(root, tool)
+
+        for directory in dirs:
+            if not directory.exists():
+                continue
+            sharing = providers_sharing_dir(root, directory, exclude=provider)
+            if sharing:
+                logger.info(
+                    "Preserving %s (still used by: %s)",
+                    directory.relative_to(root),
+                    ", ".join(sorted(sharing)),
+                )
+                continue
+            if _delete_managed_dir(root, directory, dry_run=dry_run, errors=errors):
+                removed.append((str(directory).replace("\\", "/") + "/", tool.value))
+
+        for file in files:
+            if not file.exists():
+                continue
+            sharing = providers_sharing_file(root, file, exclude=provider)
+            if sharing:
+                logger.info(
+                    "Preserving %s (still used by: %s)",
+                    file.relative_to(root),
+                    ", ".join(sorted(sharing)),
+                )
+                continue
+            if _delete_managed_file(root, file, dry_run=dry_run, errors=errors):
+                removed.append((str(file).replace("\\", "/"), f"{tool.value} (config)"))
+
+    # Update manifest once after all tools are removed from disk
+    if not dry_run:
+        for tool in tools:
+            remove_provider(root, tool.value)
+
+
+def _reconcile_uninstall_git_blocks(
+    root: Path, *, keep_vault: bool, was_gitignore_managed: bool
+) -> None:
+    """Re-sync the managed gitignore and gitattributes blocks after removal."""
+    try:
+        mdata_after = read_manifest_data(root)
+    except Exception:
+        mdata_after = ManifestData()
+
+    recommended = get_recommended_entries(root)
+    # If no providers remain and we are not keeping the vault, remove the block.
+    # Otherwise, we sync it if it was managed before.
+    if not mdata_after.installed and not keep_vault:
+        ensure_gitignore_block(root, [], state=ManagedState.ABSENT)
+        ensure_gitattributes_block(root, state=ManagedState.ABSENT)
+    elif recommended and was_gitignore_managed:
+        ensure_gitignore_block(root, recommended, state=ManagedState.PRESENT)
 
 
 def uninstall_run(
@@ -1702,40 +2135,6 @@ def uninstall_run(
     effective_provider = "all" if provider == "core" else provider
 
     removed: list[tuple[str, str]] = []  # (path, label)
-
-    # Map directory names → component owners (for skip filtering).
-    # .agents/ is shared by antigravity, gemini, and codex (all place
-    # skills there via init_paths), so it must be preserved when any of
-    # its owners is skipped.
-    _dir_owners: dict[str, list[str]] = {
-        ".vaultspec": ["core"],
-        ".vault": ["vault"],
-        ".claude": ["claude"],
-        ".gemini": ["gemini"],
-        ".agents": ["antigravity", "gemini", "codex"],
-        ".codex": ["codex"],
-    }
-    dir_labels: dict[str, str] = {
-        ".vaultspec": "core",
-        ".vault": "vault",
-        ".claude": "claude",
-        ".gemini": "gemini",
-        ".agents": "antigravity",
-        ".codex": "codex",
-    }
-    file_labels: dict[str, str] = {
-        "CLAUDE.md": "claude (config)",
-        "GEMINI.md": "gemini (config)",
-        "AGENTS.md": "codex (config)",
-        ".mcp.json": "mcp",
-    }
-    # Map file names → owning component for skip checks
-    _file_owner: dict[str, str] = {
-        "CLAUDE.md": "claude",
-        "GEMINI.md": "gemini",
-        "AGENTS.md": "codex",
-    }
-
     errors: list[str] = []
 
     # Capture manifest state before potential destruction
@@ -1746,245 +2145,31 @@ def uninstall_run(
         mdata_before = ManifestData()
 
     if effective_provider == "all":
-        from .helpers import atomic_write
-
-        # Remove everything (respecting skip).
-        # .vaultspec is deleted LAST so the manifest survives partial failures.
-        managed_dirs = [
-            path / ".claude",
-            path / ".gemini",
-            path / ".agents",
-            path / ".codex",
-        ]
-        if not keep_vault:
-            managed_dirs.append(path / ".vault")
-        managed_dirs.append(path / ".vaultspec")
-
-        managed_files = [
-            path / "CLAUDE.md",
-            path / "GEMINI.md",
-            path / "AGENTS.md",
-        ]
-
-        # Reconcile native MCP targets before provider directories and
-        # ownership state are removed.
-        if "mcp" not in skip:
-            from .mcps import mcp_uninstall, resolve_mcp_targets
-
-            active_ctx = _t.get_context()
-            mcp_tools = tuple(
-                tool
-                for tool, config in active_ctx.tool_configs.items()
-                if ProviderCapability.MCPS in config.capabilities
-                and tool.value not in skip
-            )
-            uninstalled = mcp_uninstall(
-                path,
-                dry_run=dry_run,
-                enrolled=mcp_tools,
-            )
-            errors.extend(uninstalled.errors)
-            for target in resolve_mcp_targets(
-                target_dir=path,
-                enrolled=mcp_tools,
-            ):
-                target_result = uninstalled.per_tool.get(target.provider.value)
-                if target_result and target_result.items:
-                    removed.append((_rel(path, target.path), "mcp"))
-
-        for d in managed_dirs:
-            owners = _dir_owners.get(d.name, [])
-            if owners and any(o in skip for o in owners):
-                skipped = [o for o in owners if o in skip]
-                logger.info("Skipping %s (--skip %s)", d.name, ", ".join(skipped))
-                continue
-            owner = dir_labels.get(d.name, "")
-            if d.exists():
-                if not dry_run:
-                    try:
-                        _rmtree_robust(d)
-                    except OSError as exc:
-                        errors.append(f"Failed to remove {_rel(path, d)}: {exc}")
-                        continue
-                removed.append((str(d).replace("\\", "/") + "/", owner))
-
-        for f in managed_files:
-            owner = _file_owner.get(f.name, "")
-            if owner in skip:
-                logger.info("Skipping %s (--skip %s)", f.name, owner)
-                continue
-            if f.exists():
-                if not dry_run:
-                    try:
-                        f.unlink()
-                    except OSError as exc:
-                        errors.append(f"Failed to remove {_rel(path, f)}: {exc}")
-                        continue
-                label = file_labels.get(f.name, "")
-                removed.append((str(f).replace("\\", "/"), label))
-
-        # Surgical .pre-commit-config.yaml cleanup: remove vaultspec-core
-        # hooks. This deliberately runs even when prek.toml owns the hook
-        # boundary (collect_prek_boundary): install and sync refuse to write
-        # the YAML under prek, but uninstall stripping vaultspec hooks from a
-        # legacy YAML is residue removal - leave-no-trace semantics - not
-        # management of the file.
-        precommit_path = path / ".pre-commit-config.yaml"
-        if "precommit" not in skip:
-            if precommit_path.exists() and not dry_run:
-                handler = _precommit_yaml()
-                try:
-                    raw = precommit_path.read_text(encoding="utf-8")
-                    data = handler.load(raw)
-                    if isinstance(data, dict):
-                        repos = data.get("repos", [])
-                        if isinstance(repos, list):
-                            changed = False
-                            # Mutate the loaded structure in place so surviving
-                            # non-vaultspec hooks keep their comments and quoting.
-                            for r in list(repos):
-                                if not (
-                                    isinstance(r, dict) and r.get("repo") == "local"
-                                ):
-                                    continue
-                                hooks = r.get("hooks", [])
-                                if not isinstance(hooks, list):
-                                    continue
-                                managed_idx = [
-                                    i
-                                    for i, h in enumerate(hooks)
-                                    if isinstance(h, dict)
-                                    and h.get("id") in _ALL_MANAGED_HOOK_IDS
-                                ]
-                                for i in reversed(managed_idx):
-                                    del hooks[i]
-                                if managed_idx:
-                                    changed = True
-                                if not hooks:
-                                    repos.remove(r)
-
-                            if changed:
-                                if repos:
-                                    atomic_write(
-                                        precommit_path,
-                                        _dump_precommit_yaml(handler, data),
-                                    )
-                                else:
-                                    del data["repos"]
-                                    if not data:
-                                        precommit_path.unlink()
-                                    else:
-                                        atomic_write(
-                                            precommit_path,
-                                            _dump_precommit_yaml(handler, data),
-                                        )
-                                removed.append(
-                                    (_rel(path, precommit_path), "precommit")
-                                )
-                                mdata_u = read_manifest_data(path)
-                                if mdata_u.precommit_managed:
-                                    mdata_u.precommit_managed = False
-                                    write_manifest_data(path, mdata_u)
-                except (YAMLError, OSError):
-                    pass
-            elif precommit_path.exists() and dry_run:
-                try:
-                    raw = precommit_path.read_text(encoding="utf-8")
-                    if any(f"id: {hid}" in raw for hid in _ALL_MANAGED_HOOK_IDS):
-                        removed.append((_rel(path, precommit_path), "precommit"))
-                except OSError:
-                    pass
-
+        _uninstall_everything(
+            path,
+            skip=skip,
+            keep_vault=keep_vault,
+            dry_run=dry_run,
+            removed=removed,
+            errors=errors,
+        )
     else:
-        # Per-provider uninstall with shared directory protection
-        tools = _filter_tools(_PROVIDER_TO_TOOLS.get(effective_provider, []), skip)
-        if "mcp" not in skip:
-            from .mcps import mcp_uninstall, resolve_mcp_targets
-
-            active_ctx = _t.get_context()
-            mcp_tools = tuple(
-                tool
-                for tool in tools
-                if ProviderCapability.MCPS in active_ctx.tool_configs[tool].capabilities
-            )
-            if mcp_tools:
-                uninstalled = mcp_uninstall(
-                    path,
-                    dry_run=dry_run,
-                    provider=effective_provider,
-                    enrolled=mcp_tools,
-                )
-                errors.extend(uninstalled.errors)
-                for target in resolve_mcp_targets(
-                    provider=effective_provider,
-                    target_dir=path,
-                    enrolled=mcp_tools,
-                ):
-                    target_result = uninstalled.per_tool.get(target.provider.value)
-                    if target_result and target_result.items:
-                        removed.append((_rel(path, target.path), "mcp"))
-        for tool in tools:
-            dirs, files = _collect_provider_artifacts(path, tool)
-
-            for d in dirs:
-                if not d.exists():
-                    continue
-                sharing = providers_sharing_dir(path, d, exclude=effective_provider)
-                if sharing:
-                    logger.info(
-                        "Preserving %s (still used by: %s)",
-                        d.relative_to(path),
-                        ", ".join(sorted(sharing)),
-                    )
-                    continue
-
-                if not dry_run:
-                    try:
-                        _rmtree_robust(d)
-                    except OSError as exc:
-                        errors.append(f"Failed to remove {_rel(path, d)}: {exc}")
-                        continue
-                removed.append((str(d).replace("\\", "/") + "/", tool.value))
-
-            for f in files:
-                if not f.exists():
-                    continue
-                sharing = providers_sharing_file(path, f, exclude=effective_provider)
-                if sharing:
-                    logger.info(
-                        "Preserving %s (still used by: %s)",
-                        f.relative_to(path),
-                        ", ".join(sorted(sharing)),
-                    )
-                    continue
-                if not dry_run:
-                    try:
-                        f.unlink()
-                    except OSError as exc:
-                        errors.append(f"Failed to remove {_rel(path, f)}: {exc}")
-                        continue
-                removed.append((str(f).replace("\\", "/"), f"{tool.value} (config)"))
-
-        # Update manifest once after all tools are removed from disk
-        if not dry_run:
-            for tool in tools:
-                remove_provider(path, tool.value)
+        _uninstall_provider_artifacts(
+            path,
+            effective_provider,
+            skip=skip,
+            dry_run=dry_run,
+            removed=removed,
+            errors=errors,
+        )
 
     # Re-sync gitignore and gitattributes blocks
     if not dry_run:
-        try:
-            mdata_after = read_manifest_data(path)
-        except Exception:
-            mdata_after = ManifestData()
-
-        recommended = get_recommended_entries(path)
-        # If no providers remain and we are not keeping the vault, remove the block.
-        # Otherwise, we sync it if it was managed before.
-        if not mdata_after.installed and not keep_vault:
-            ensure_gitignore_block(path, [], state=ManagedState.ABSENT)
-            ensure_gitattributes_block(path, state=ManagedState.ABSENT)
-        elif recommended and mdata_before.gitignore_managed:
-            ensure_gitignore_block(path, recommended, state=ManagedState.PRESENT)
+        _reconcile_uninstall_git_blocks(
+            path,
+            keep_vault=keep_vault,
+            was_gitignore_managed=mdata_before.gitignore_managed,
+        )
 
     action = "dry_run" if dry_run else "uninstall"
     result: dict[str, Any] = {
@@ -2082,6 +2267,289 @@ def hooks_run(event: str, path: str | None = None) -> list[dict[str, Any]]:
 # Valid sync provider targets exposed to the CLI.
 SYNC_PROVIDERS = VALID_PROVIDERS - {"core"}
 
+# Single-provider sync targets mapped to the tool they narrow the context to.
+_SYNC_PROVIDER_TOOLS: dict[str, Tool] = {
+    "claude": Tool.CLAUDE,
+    "gemini": Tool.GEMINI,
+    "antigravity": Tool.ANTIGRAVITY,
+    "codex": Tool.CODEX,
+}
+
+
+def _empty_sync_results() -> list[_t.SyncResult]:
+    """Return the positional no-op result set for a fully skipped sync."""
+    return [_t.SyncResult() for _ in range(5)]
+
+
+def _has_gitignore_block(gi_path: Path) -> bool:
+    """Report whether *gi_path* carries exactly one well-formed managed block."""
+    if not gi_path.exists():
+        return False
+    try:
+        content = gi_path.read_text(encoding="utf-8")
+        begins, ends = _find_markers(content.splitlines())
+    except (OSError, UnicodeDecodeError):
+        return False
+    return len(begins) == 1 and len(ends) == 1 and begins[0] < ends[0]
+
+
+def _has_gitattributes_block(ga_path: Path) -> bool:
+    """Report whether *ga_path* carries a well-formed managed block."""
+    if not ga_path.exists():
+        return False
+    try:
+        content = ga_path.read_text(encoding="utf-8")
+        return _ga_has_valid_block(content.splitlines())
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _backfill_structures(*, skip: set[str], dry_run: bool) -> _t.SyncResult:
+    """Create missing structural provider directories during sync (#133).
+
+    Content files are backfilled by the per-resource sync passes (their
+    ``apply_file_sync`` adds any missing destination), but a content-less
+    structural directory such as a provider's ``workflows/`` is only ever
+    created by ``install``/``_scaffold_provider``. After an upgrade that
+    introduces such a directory, ``sync`` left the provider ``partial``
+    while reporting success ("will be addressed by sync") - a no-op. This
+    backfill makes that promise real: it creates only directories that are
+    missing, never overwriting existing content, so it is safe at every
+    ``--force`` level and previews correctly under ``--dry-run``.
+    """
+    result = _t.SyncResult()
+    active_ctx = _t.get_context()
+    target = active_ctx.target_dir
+    installed = read_manifest_data(target).installed
+    for tool, cfg in active_ctx.tool_configs.items():
+        # Only backfill providers the operator actually enrolled; never
+        # materialise a provider directory a core-only or partial install
+        # deliberately omitted.
+        if tool.value in skip or tool.value not in installed:
+            continue
+        caps = cfg.capabilities
+        structural: list[Path] = []
+        if ProviderCapability.RULES in caps and cfg.rules_dir:
+            structural.append(cfg.rules_dir)
+        if ProviderCapability.SKILLS in caps and cfg.skills_dir:
+            structural.append(cfg.skills_dir)
+        if ProviderCapability.AGENTS in caps and cfg.agents_dir:
+            structural.append(cfg.agents_dir)
+        if ProviderCapability.WORKFLOWS in caps and cfg.workflows_dir:
+            structural.append(cfg.workflows_dir)
+        for directory in structural:
+            if directory.exists():
+                continue
+            result.items.append((_rel(target, directory).replace("\\", "/"), "[ADD]"))
+            result.added += 1
+            if not dry_run:
+                ensure_dir(directory)
+    return result
+
+
+def _mcp_sync_pass(
+    *,
+    skip: set[str],
+    dry_run: bool,
+    force: bool,
+    mcp_provider: Tool | str,
+) -> tuple[Callable[[], _t.SyncResult], str]:
+    """Build the MCP reconciliation pass for :func:`_run_all_syncs`."""
+    from .mcps import mcp_sync as _mcp_sync
+
+    active_ctx = _t.get_context()
+    installed = read_manifest(active_ctx.target_dir)
+    enrolled = tuple(
+        tool
+        for tool in active_ctx.tool_configs
+        if tool.value in installed and tool.value not in skip
+    )
+    return (
+        lambda: _mcp_sync(
+            dry_run=dry_run,
+            force=force,
+            prune=force,
+            provider=mcp_provider,
+            target_dir=active_ctx.target_dir,
+            enrolled=enrolled,
+        ),
+        "mcps",
+    )
+
+
+def _run_all_syncs(
+    *,
+    skip: set[str],
+    dry_run: bool,
+    force: bool,
+    include_mcp: bool = True,
+    mcp_provider: Tool | str = "all",
+) -> list[_t.SyncResult]:
+    """Run every resource sync pass, isolating each pass's failure.
+
+    A pass that raises is reported as an error-carrying :class:`SyncResult` in
+    its positional slot so the remaining passes still run.
+    """
+    from .agents import agents_sync
+    from .config_gen import config_sync
+    from .rules import rules_sync
+    from .skills import skills_sync
+    from .system import system_sync
+
+    results: list[_t.SyncResult] = []
+    sync_passes: list[tuple[Callable[[], _t.SyncResult], str]] = [
+        (lambda: rules_sync(prune=force, dry_run=dry_run), "rules"),
+        (lambda: skills_sync(prune=force, dry_run=dry_run), "skills"),
+        (lambda: agents_sync(prune=force, dry_run=dry_run), "agents"),
+        (lambda: system_sync(dry_run=dry_run, force=force), "system"),
+        (lambda: config_sync(dry_run=dry_run, force=force), "config"),
+    ]
+    if include_mcp and "mcp" not in skip:
+        sync_passes.append(
+            _mcp_sync_pass(
+                skip=skip,
+                dry_run=dry_run,
+                force=force,
+                mcp_provider=mcp_provider,
+            )
+        )
+    if "hooks" not in skip:
+        from .provider_hooks import provider_hooks_sync
+
+        sync_passes.append((lambda: provider_hooks_sync(dry_run=dry_run), "hooks"))
+    for sync_fn, label in sync_passes:
+        try:
+            results.append(sync_fn())
+        except Exception as exc:
+            logger.error("Sync pass '%s' failed: %s", label, exc)
+            error_result = _t.SyncResult()
+            error_result.errors.append(f"{label} sync failed: {exc}")
+            results.append(error_result)
+    # Structural backfill runs last and is appended after the positional
+    # resource passes; renderers treat any result beyond the known pass
+    # labels as structural (issue #133).
+    results.append(_backfill_structures(skip=skip, dry_run=dry_run))
+    return results
+
+
+def _reconcile_precommit_management(target_dir: Path) -> None:
+    """Re-scaffold managed pre-commit hooks, or stand down if the user removed them."""
+    mdata = read_manifest_data(target_dir)
+    if not mdata.precommit_managed:
+        return
+
+    from .diagnosis.collectors import collect_precommit_state
+    from .diagnosis.signals import PrecommitSignal
+
+    signal = collect_precommit_state(target_dir)
+    if signal in (PrecommitSignal.NO_HOOKS, PrecommitSignal.NO_FILE):
+        mdata.precommit_managed = False
+        write_manifest_data(target_dir, mdata)
+        logger.info("Pre-commit hooks removed by user, disabling management")
+        return
+    _scaffold_precommit(target_dir)
+
+
+def _reconcile_gitignore_opt_out(target_dir: Path) -> None:
+    """Re-sync the managed ``.gitignore`` block, honouring a user opt-out.
+
+    Checks whether the user removed the managed block BEFORE re-creating it.
+    If the block is gone but the manifest still says ``managed=True``, the user
+    opted out -- honour that by flipping the flag.
+    """
+    mdata = read_manifest_data(target_dir)
+    if not mdata.gitignore_managed:
+        return
+    if _has_gitignore_block(target_dir / ".gitignore"):
+        ensure_gitignore_block(target_dir, get_recommended_entries(target_dir))
+        return
+    mdata.gitignore_managed = False
+    write_manifest_data(target_dir, mdata)
+
+
+def _reconcile_gitattributes_opt_out(target_dir: Path) -> None:
+    """Re-sync the managed ``.gitattributes`` block (same pattern as gitignore)."""
+    mdata = read_manifest_data(target_dir)
+    if not mdata.gitattributes_managed:
+        return
+    if _has_gitattributes_block(target_dir / ".gitattributes"):
+        ensure_gitattributes_block(target_dir)
+        return
+    mdata.gitattributes_managed = False
+    write_manifest_data(target_dir, mdata)
+
+
+def _stamp_last_synced(target_dir: Path, candidates: Iterable[str]) -> None:
+    """Record a ``last_synced`` timestamp for every installed name in *candidates*."""
+    import datetime
+
+    now = datetime.datetime.now(tz=datetime.UTC).isoformat()
+    mdata = read_manifest_data(target_dir)
+    for name in candidates:
+        if name not in mdata.installed:
+            continue
+        mdata.provider_state.setdefault(name, {})
+        mdata.provider_state[name]["last_synced"] = now
+    _stamp_manifest_version_no_downgrade(mdata)
+    write_manifest_data(target_dir, mdata)
+
+
+def _sync_all_providers(
+    ctx: _t.WorkspaceContext,
+    *,
+    skip: set[str],
+    dry_run: bool,
+    force: bool,
+) -> list[_t.SyncResult]:
+    """Sync every enrolled provider, then reconcile workspace-level state."""
+
+    def _sync_all_with_configs(
+        narrowed_configs: dict[Tool, _t.ToolConfig] | None,
+    ) -> list[_t.SyncResult]:
+        if narrowed_configs is not None:
+            _t.set_context(replace(ctx, tool_configs=narrowed_configs))
+        logger.info("Syncing all resources...")
+        results = _run_all_syncs(skip=skip, dry_run=dry_run, force=force)
+        if not dry_run:
+            from vaultspec_core.hooks import fire_hooks
+
+            fire_hooks(
+                "config.synced",
+                {"root": str(ctx.target_dir), "event": "config.synced"},
+            )
+            logger.info("Done.")
+        return results
+
+    # When skipping providers, narrow tool_configs in a copied context
+    skipped_tools = {Tool(name) for name in skip if name in {t.value for t in Tool}}
+    narrowed_configs: dict[Tool, _t.ToolConfig] | None = None
+    if skipped_tools:
+        narrowed_configs = {
+            k: v for k, v in ctx.tool_configs.items() if k not in skipped_tools
+        }
+
+    copied = contextvars.copy_context()
+    results = copied.run(_sync_all_with_configs, narrowed_configs)
+
+    if dry_run:
+        return results
+
+    if "precommit" not in skip:
+        _reconcile_precommit_management(ctx.target_dir)
+
+    for orphan in prune_orphaned_lock_sentinels(ctx.target_dir):
+        logger.info("Removed orphaned lock sentinel %s", orphan)
+
+    _reconcile_gitignore_opt_out(ctx.target_dir)
+    _reconcile_gitattributes_opt_out(ctx.target_dir)
+
+    # Update last_synced timestamps for installed providers only
+    _stamp_last_synced(
+        ctx.target_dir,
+        [tool.value for tool in ctx.tool_configs if tool.value not in skip],
+    )
+    return results
+
 
 def sync_provider(
     provider: str,
@@ -2122,243 +2590,23 @@ def sync_provider(
 
     skip = _validate_skip(skip, allow_core=False)
 
-    from .agents import agents_sync
-    from .config_gen import config_sync
-    from .mcps import mcp_sync as _mcp_sync
-    from .rules import rules_sync
-    from .skills import skills_sync
-    from .system import system_sync
-
     ctx = _t.get_context()
 
-    def _empty_sync_results() -> list[_t.SyncResult]:
-        return [_t.SyncResult() for _ in range(5)]
-
-    def _backfill_structures() -> _t.SyncResult:
-        """Create missing structural provider directories during sync (#133).
-
-        Content files are backfilled by the per-resource sync passes (their
-        ``apply_file_sync`` adds any missing destination), but a content-less
-        structural directory such as a provider's ``workflows/`` is only ever
-        created by ``install``/``_scaffold_provider``. After an upgrade that
-        introduces such a directory, ``sync`` left the provider ``partial``
-        while reporting success ("will be addressed by sync") - a no-op. This
-        backfill makes that promise real: it creates only directories that are
-        missing, never overwriting existing content, so it is safe at every
-        ``--force`` level and previews correctly under ``--dry-run``.
-        """
-        result = _t.SyncResult()
-        active_ctx = _t.get_context()
-        target = active_ctx.target_dir
-        installed = read_manifest_data(target).installed
-        for tool, cfg in active_ctx.tool_configs.items():
-            # Only backfill providers the operator actually enrolled; never
-            # materialise a provider directory a core-only or partial install
-            # deliberately omitted.
-            if tool.value in skip or tool.value not in installed:
-                continue
-            caps = cfg.capabilities
-            structural: list[Path] = []
-            if ProviderCapability.RULES in caps and cfg.rules_dir:
-                structural.append(cfg.rules_dir)
-            if ProviderCapability.SKILLS in caps and cfg.skills_dir:
-                structural.append(cfg.skills_dir)
-            if ProviderCapability.AGENTS in caps and cfg.agents_dir:
-                structural.append(cfg.agents_dir)
-            if ProviderCapability.WORKFLOWS in caps and cfg.workflows_dir:
-                structural.append(cfg.workflows_dir)
-            for directory in structural:
-                if directory.exists():
-                    continue
-                result.items.append(
-                    (_rel(target, directory).replace("\\", "/"), "[ADD]")
-                )
-                result.added += 1
-                if not dry_run:
-                    ensure_dir(directory)
-        return result
-
-    def _run_all_syncs(
-        *,
-        include_mcp: bool = True,
-        mcp_provider: Tool | str = "all",
-    ) -> list[_t.SyncResult]:
-        results: list[_t.SyncResult] = []
-        sync_passes: list[tuple[Callable[[], _t.SyncResult], str]] = [
-            (lambda: rules_sync(prune=force, dry_run=dry_run), "rules"),
-            (lambda: skills_sync(prune=force, dry_run=dry_run), "skills"),
-            (lambda: agents_sync(prune=force, dry_run=dry_run), "agents"),
-            (lambda: system_sync(dry_run=dry_run, force=force), "system"),
-            (lambda: config_sync(dry_run=dry_run, force=force), "config"),
-        ]
-        if include_mcp and "mcp" not in skip:
-            active_ctx = _t.get_context()
-            installed = read_manifest(active_ctx.target_dir)
-            enrolled = tuple(
-                tool
-                for tool in active_ctx.tool_configs
-                if tool.value in installed and tool.value not in (skip or set())
-            )
-            sync_passes.append(
-                (
-                    lambda: _mcp_sync(
-                        dry_run=dry_run,
-                        force=force,
-                        prune=force,
-                        provider=mcp_provider,
-                        target_dir=active_ctx.target_dir,
-                        enrolled=enrolled,
-                    ),
-                    "mcps",
-                )
-            )
-        if "hooks" not in skip:
-            from .provider_hooks import provider_hooks_sync
-
-            sync_passes.append((lambda: provider_hooks_sync(dry_run=dry_run), "hooks"))
-        for sync_fn, label in sync_passes:
-            try:
-                results.append(sync_fn())
-            except Exception as exc:
-                logger.error("Sync pass '%s' failed: %s", label, exc)
-                error_result = _t.SyncResult()
-                error_result.errors.append(f"{label} sync failed: {exc}")
-                results.append(error_result)
-        # Structural backfill runs last and is appended after the positional
-        # resource passes; renderers treat any result beyond the known pass
-        # labels as structural (issue #133).
-        results.append(_backfill_structures())
-        return results
-
     # Guard: refuse to sync if vaultspec isn't installed at the target
-    vaultspec_dir = ctx.target_dir / ".vaultspec"
-    if not vaultspec_dir.exists():
+    if not (ctx.target_dir / ".vaultspec").exists():
         raise WorkspaceNotInitializedError(
             f"No .vaultspec/ found at {ctx.target_dir}.",
             hint=f"Run 'vaultspec-core install {ctx.target_dir}' first.",
         )
 
     if provider == "all":
-        # When skipping providers, narrow tool_configs in a copied context
-        skipped_tools = {Tool(name) for name in skip if name in {t.value for t in Tool}}
-
-        def _sync_all_with_configs(
-            narrowed_configs: dict[Tool, _t.ToolConfig] | None,
-        ) -> list[_t.SyncResult]:
-            if narrowed_configs is not None:
-                _t.set_context(replace(ctx, tool_configs=narrowed_configs))
-            logger.info("Syncing all resources...")
-            results = _run_all_syncs()
-            if not dry_run:
-                from vaultspec_core.hooks import fire_hooks
-
-                fire_hooks(
-                    "config.synced",
-                    {"root": str(ctx.target_dir), "event": "config.synced"},
-                )
-                logger.info("Done.")
-            return results
-
-        narrowed_configs: dict[Tool, _t.ToolConfig] | None = None
-        if skipped_tools:
-            narrowed_configs = {
-                k: v for k, v in ctx.tool_configs.items() if k not in skipped_tools
-            }
-
-        copied = contextvars.copy_context()
-        results = copied.run(_sync_all_with_configs, narrowed_configs)
-
-        if not dry_run:
-            import datetime
-
-            from .gitignore import ensure_gitignore_block
-
-            if "precommit" not in skip:
-                pc_mdata = read_manifest_data(ctx.target_dir)
-                if pc_mdata.precommit_managed:
-                    from .diagnosis.collectors import collect_precommit_state
-                    from .diagnosis.signals import PrecommitSignal
-
-                    pc_signal = collect_precommit_state(ctx.target_dir)
-                    if pc_signal in (
-                        PrecommitSignal.NO_HOOKS,
-                        PrecommitSignal.NO_FILE,
-                    ):
-                        pc_mdata.precommit_managed = False
-                        write_manifest_data(ctx.target_dir, pc_mdata)
-                        logger.info(
-                            "Pre-commit hooks removed by user, disabling management"
-                        )
-                    else:
-                        _scaffold_precommit(ctx.target_dir)
-
-            for orphan in prune_orphaned_lock_sentinels(ctx.target_dir):
-                logger.info("Removed orphaned lock sentinel %s", orphan)
-
-            # Respect gitignore opt-out: check whether the user removed
-            # the managed block BEFORE re-creating it.  If the block is
-            # gone but the manifest still says managed=True, the user
-            # opted out -- honour that by flipping the flag.
-            mdata = read_manifest_data(ctx.target_dir)
-            if mdata.gitignore_managed:
-                gi_path = ctx.target_dir / ".gitignore"
-                block_present = False
-                if gi_path.exists():
-                    try:
-                        content = gi_path.read_text(encoding="utf-8")
-                        begins, ends = _find_markers(content.splitlines())
-                        block_present = (
-                            len(begins) == 1 and len(ends) == 1 and begins[0] < ends[0]
-                        )
-                    except (OSError, UnicodeDecodeError):
-                        block_present = False
-
-                if block_present:
-                    ensure_gitignore_block(
-                        ctx.target_dir,
-                        get_recommended_entries(ctx.target_dir),
-                    )
-                else:
-                    mdata.gitignore_managed = False
-                    write_manifest_data(ctx.target_dir, mdata)
-
-            # Respect gitattributes opt-out (same pattern as gitignore).
-            mdata = read_manifest_data(ctx.target_dir)
-            if mdata.gitattributes_managed:
-                ga_path = ctx.target_dir / ".gitattributes"
-                ga_block_present = False
-                if ga_path.exists():
-                    try:
-                        content = ga_path.read_text(encoding="utf-8")
-                        ga_block_present = _ga_has_valid_block(content.splitlines())
-                    except (OSError, UnicodeDecodeError):
-                        pass
-
-                if ga_block_present:
-                    ensure_gitattributes_block(ctx.target_dir)
-                else:
-                    mdata.gitattributes_managed = False
-                    write_manifest_data(ctx.target_dir, mdata)
-
-            # Update last_synced timestamps for installed providers only
-            now = datetime.datetime.now(tz=datetime.UTC).isoformat()
-            mdata = read_manifest_data(ctx.target_dir)
-            for tool_type in ctx.tool_configs:
-                name = tool_type.value
-                if name in skip or name not in mdata.installed:
-                    continue
-                mdata.provider_state.setdefault(name, {})
-                mdata.provider_state[name]["last_synced"] = now
-            _stamp_manifest_version_no_downgrade(mdata)
-            write_manifest_data(ctx.target_dir, mdata)
-
-        return results
-
-    provider_skipped = provider in skip
+        return _sync_all_providers(ctx, skip=skip, dry_run=dry_run, force=force)
 
     # Validate provider is installed unless the provider was explicitly skipped.
     installed = read_manifest(ctx.target_dir)
-    if not provider_skipped and installed and provider not in installed:
+    if provider in skip:
+        return _empty_sync_results()
+    if installed and provider not in installed:
         raise ProviderNotInstalledError(
             f"Provider '{provider}' is not installed.",
             hint=(
@@ -2368,18 +2616,8 @@ def sync_provider(
         )
 
     # Per-provider sync: filter tool_configs to only the requested tool.
-    requested: set[Tool] = set()
-    if not provider_skipped:
-        if provider == "claude":
-            requested = {Tool.CLAUDE}
-        elif provider == "gemini":
-            requested = {Tool.GEMINI}
-        elif provider == "antigravity":
-            requested = {Tool.ANTIGRAVITY}
-        elif provider == "codex":
-            requested = {Tool.CODEX}
-    else:
-        return _empty_sync_results()
+    tool = _SYNC_PROVIDER_TOOLS.get(provider)
+    requested: set[Tool] = {tool} if tool is not None else set()
 
     def _sync_single_provider(
         provider_configs: dict[Tool, _t.ToolConfig],
@@ -2391,6 +2629,9 @@ def sync_provider(
             for config in provider_configs.values()
         )
         results = _run_all_syncs(
+            skip=skip,
+            dry_run=dry_run,
+            force=force,
             include_mcp=include_mcp,
             mcp_provider=provider,
         )
@@ -2403,17 +2644,6 @@ def sync_provider(
     results = copied.run(_sync_single_provider, narrowed)
 
     if not dry_run:
-        import datetime
-
-        now = datetime.datetime.now(tz=datetime.UTC).isoformat()
-        mdata = read_manifest_data(ctx.target_dir)
-        for tool_type in requested:
-            name = tool_type.value
-            if name not in mdata.installed:
-                continue
-            mdata.provider_state.setdefault(name, {})
-            mdata.provider_state[name]["last_synced"] = now
-        _stamp_manifest_version_no_downgrade(mdata)
-        write_manifest_data(ctx.target_dir, mdata)
+        _stamp_last_synced(ctx.target_dir, [tool_type.value for tool_type in requested])
 
     return results

--- a/src/vaultspec_core/core/diagnosis/collectors.py
+++ b/src/vaultspec_core/core/diagnosis/collectors.py
@@ -11,7 +11,7 @@ import json
 import logging
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .signals import (
     BuiltinVersionSignal,
@@ -30,7 +30,7 @@ from .signals import (
 )
 
 if TYPE_CHECKING:
-    from ..enums import InstallMode
+    from ..enums import InstallMode, Tool
 
 logger = logging.getLogger(__name__)
 
@@ -204,6 +204,33 @@ def collect_manifest_coherence(target: Path) -> dict[str, ManifestEntrySignal]:
     return result
 
 
+def _provider_children(target: Path, tool_value: str) -> list[Path] | None:
+    """Return the entries of a provider's directory.
+
+    Args:
+        target: Workspace root directory.
+        tool_value: The :class:`~vaultspec_core.core.enums.Tool` ``.value``
+            string (e.g. ``"claude"``).
+
+    Returns:
+        The directory's entries, or ``None`` when the provider has no known
+        directory, the directory does not exist, or it cannot be read.
+    """
+    dir_name = _TOOL_DIR.get(tool_value)
+    if dir_name is None:
+        return None
+
+    provider_dir = target / dir_name
+    if not provider_dir.exists():
+        return None
+
+    try:
+        return list(provider_dir.iterdir())
+    except OSError as exc:
+        logger.warning("Cannot read provider directory %s: %s", provider_dir, exc)
+        return None
+
+
 def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSignal:
     """Assess the completeness of a provider's configuration directory.
 
@@ -219,19 +246,8 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
     from ..enums import Tool
     from ..types import get_context
 
-    dir_name = _TOOL_DIR.get(tool_value)
-    if dir_name is None:
-        return ProviderDirSignal.MISSING
-
-    provider_dir = target / dir_name
-    if not provider_dir.exists():
-        return ProviderDirSignal.MISSING
-
-    # Check if directory is empty
-    try:
-        children = list(provider_dir.iterdir())
-    except OSError as exc:
-        logger.warning("Cannot read provider directory %s: %s", provider_dir, exc)
+    children = _provider_children(target, tool_value)
+    if children is None:
         return ProviderDirSignal.MISSING
 
     if not children:
@@ -326,10 +342,7 @@ def collect_provider_dir_state(target: Path, tool_value: str) -> ProviderDirSign
     if has_foreign:
         return ProviderDirSignal.MIXED
 
-    if all_present:
-        return ProviderDirSignal.COMPLETE
-
-    return ProviderDirSignal.PARTIAL
+    return ProviderDirSignal.COMPLETE if all_present else ProviderDirSignal.PARTIAL
 
 
 def collect_builtin_version_state(target: Path) -> BuiltinVersionSignal:
@@ -363,6 +376,19 @@ def collect_builtin_version_state(target: Path) -> BuiltinVersionSignal:
     return BuiltinVersionSignal.CURRENT
 
 
+def _provider_config_file(tool: Tool) -> Path | None:
+    """Return a provider's root config file path, or ``None`` when unresolvable."""
+    from ..types import get_context
+
+    try:
+        ctx = get_context()
+        cfg = ctx.tool_configs.get(tool)
+    except LookupError:
+        return None
+
+    return cfg.config_file if cfg is not None else None
+
+
 def collect_config_state(tool_value: str) -> ConfigSignal:
     """Assess the state of a provider's root configuration file.
 
@@ -375,24 +401,9 @@ def collect_config_state(tool_value: str) -> ConfigSignal:
         reflecting the observed state.
     """
     from ..enums import Tool
-    from ..types import get_context
 
-    tool = Tool(tool_value)
-
-    try:
-        ctx = get_context()
-        cfg = ctx.tool_configs.get(tool)
-    except LookupError:
-        return ConfigSignal.MISSING
-
-    if cfg is None:
-        return ConfigSignal.MISSING
-
-    config_file = cfg.config_file
-    if config_file is None:
-        return ConfigSignal.MISSING
-
-    if not config_file.exists():
+    config_file = _provider_config_file(Tool(tool_value))
+    if config_file is None or not config_file.exists():
         return ConfigSignal.MISSING
 
     try:
@@ -408,6 +419,49 @@ def collect_config_state(tool_value: str) -> ConfigSignal:
     return ConfigSignal.FOREIGN
 
 
+def _read_mcp_servers(mcp_path: Path) -> dict[str, object] | None:
+    """Return the ``mcpServers`` mapping from an ``.mcp.json`` file.
+
+    Args:
+        mcp_path: Path to the MCP configuration file.
+
+    Returns:
+        The deployed server entries, or ``None`` when the file is absent,
+        unreadable, or does not carry a ``mcpServers`` mapping.
+    """
+    if not mcp_path.exists():
+        return None
+
+    try:
+        raw = json.loads(mcp_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Cannot read MCP config %s: %s", mcp_path, exc)
+        return None
+
+    if not isinstance(raw, dict):
+        return None
+
+    servers = raw.get("mcpServers")
+    if not isinstance(servers, dict):
+        return None
+
+    return servers
+
+
+def _registry_mcp_signal(
+    servers: dict[str, object],
+    registry: dict[str, tuple[Path, dict[str, Any]]],
+) -> ConfigSignal:
+    """Classify deployed MCP entries against the rendered registry definitions."""
+    for name, (_path, expected_config) in registry.items():
+        if name not in servers or servers[name] != expected_config:
+            return ConfigSignal.REGISTRY_DRIFT
+
+    if set(servers.keys()) - set(registry.keys()):
+        return ConfigSignal.USER_MCP
+    return ConfigSignal.OK
+
+
 def collect_mcp_config_state(target: Path) -> ConfigSignal:
     """Assess the state of the ``.mcp.json`` MCP configuration.
 
@@ -418,21 +472,8 @@ def collect_mcp_config_state(target: Path) -> ConfigSignal:
         :class:`~vaultspec_core.core.diagnosis.signals.ConfigSignal`
         reflecting the observed MCP configuration state.
     """
-    mcp_path = target / ".mcp.json"
-    if not mcp_path.exists():
-        return ConfigSignal.PARTIAL_MCP
-
-    try:
-        raw = json.loads(mcp_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Cannot read MCP config %s: %s", mcp_path, exc)
-        return ConfigSignal.PARTIAL_MCP
-
-    if not isinstance(raw, dict):
-        return ConfigSignal.PARTIAL_MCP
-
-    servers = raw.get("mcpServers")
-    if not isinstance(servers, dict):
+    servers = _read_mcp_servers(target / ".mcp.json")
+    if servers is None:
         return ConfigSignal.PARTIAL_MCP
 
     # Check registry drift: compare deployed entries against definitions
@@ -446,17 +487,7 @@ def collect_mcp_config_state(target: Path) -> ConfigSignal:
 
     registry = collect_mcp_servers(mode=resolve_render_mode(target), target=target)
     if registry:
-        managed_names = set(registry.keys())
-        for name, (_path, expected_config) in registry.items():
-            if name not in servers:
-                return ConfigSignal.REGISTRY_DRIFT
-            if servers[name] != expected_config:
-                return ConfigSignal.REGISTRY_DRIFT
-
-        has_user_entries = bool(set(servers.keys()) - managed_names)
-        if has_user_entries:
-            return ConfigSignal.USER_MCP
-        return ConfigSignal.OK
+        return _registry_mcp_signal(servers, registry)
 
     # Fallback when no registry is available (pre-registry workspace)
     if "vaultspec-core" not in servers:
@@ -562,10 +593,8 @@ def collect_gitignore_state(target: Path) -> GitignoreSignal:
 
     # Check if all recommended entries are present in the block.
     # We allow extra entries (idempotency is handled by ensure_gitignore_block).
-    if all(entry in block_entries for entry in recommended):
-        return GitignoreSignal.COMPLETE
-
-    return GitignoreSignal.PARTIAL
+    complete = all(entry in block_entries for entry in recommended)
+    return GitignoreSignal.COMPLETE if complete else GitignoreSignal.PARTIAL
 
 
 def collect_content_integrity(tool_value: str) -> dict[str, ContentSignal]:
@@ -817,10 +846,47 @@ def collect_precommit_state(target: Path) -> PrecommitSignal:
     return PrecommitSignal.UNREFRESHABLE
 
 
-def _collect_precommit_yaml_state(target: Path) -> PrecommitSignal:
-    """Assess ``.pre-commit-config.yaml`` hook state, ignoring ``prek.toml``."""
+def _local_precommit_hooks(config_path: Path) -> list[dict[str, object]] | None:
+    """Return the hook mappings declared by ``repo: local`` entries.
+
+    Args:
+        config_path: Path to ``.pre-commit-config.yaml``.
+
+    Returns:
+        The local hook mappings, or ``None`` when the file is absent or cannot
+        be parsed. An empty list means the config parsed but declares no local
+        hooks, which includes a config whose top level or ``repos`` key carries
+        an unexpected shape.
+    """
     import yaml
 
+    if not config_path.exists():
+        return None
+
+    try:
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError) as exc:
+        logger.warning("Cannot read .pre-commit-config.yaml %s: %s", config_path, exc)
+        return None
+
+    if not isinstance(data, dict):
+        return []
+
+    repos = data.get("repos", [])
+    if not isinstance(repos, list):
+        return []
+
+    local_hooks: list[dict[str, object]] = []
+    for repo in repos:
+        if isinstance(repo, dict) and repo.get("repo") == "local":
+            hooks = repo.get("hooks", [])
+            if isinstance(hooks, list):
+                local_hooks.extend(h for h in hooks if isinstance(h, dict))
+    return local_hooks
+
+
+def _collect_precommit_yaml_state(target: Path) -> PrecommitSignal:
+    """Assess ``.pre-commit-config.yaml`` hook state, ignoring ``prek.toml``."""
     from ..commands import CANONICAL_HOOK_IDS, canonical_hook_entries_for_mode
     from ..workspace_mode import resolve_render_mode
 
@@ -831,30 +897,9 @@ def _collect_precommit_yaml_state(target: Path) -> PrecommitSignal:
     # expectations. P04 layers a dedicated mode-mismatch signal on top of this.
     expected_entries = canonical_hook_entries_for_mode(resolve_render_mode(target))
 
-    config_path = target / ".pre-commit-config.yaml"
-    if not config_path.exists():
+    local_hooks = _local_precommit_hooks(target / ".pre-commit-config.yaml")
+    if local_hooks is None:
         return PrecommitSignal.NO_FILE
-
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    except (yaml.YAMLError, OSError) as exc:
-        logger.warning("Cannot read .pre-commit-config.yaml %s: %s", config_path, exc)
-        return PrecommitSignal.NO_FILE
-
-    if not isinstance(data, dict):
-        return PrecommitSignal.NO_HOOKS
-
-    repos = data.get("repos", [])
-    if not isinstance(repos, list):
-        return PrecommitSignal.NO_HOOKS
-
-    # Collect all hooks from local repos
-    local_hooks: list[dict[str, object]] = []
-    for repo in repos:
-        if isinstance(repo, dict) and repo.get("repo") == "local":
-            hooks = repo.get("hooks", [])
-            if isinstance(hooks, list):
-                local_hooks.extend(h for h in hooks if isinstance(h, dict))
 
     found_ids = {
         str(h.get("id")) for h in local_hooks if h.get("id") in CANONICAL_HOOK_IDS
@@ -907,8 +952,6 @@ def _observed_precommit_mode(
         canonical hook entry agrees on, or ``None`` when there is no config, no
         canonical hook, the entries disagree, or *package* is not core.
     """
-    import yaml
-
     from ..commands import CANONICAL_HOOK_IDS, entry_prefix_for_mode
     from ..enums import InstallMode
     from ..workspace_mode import CORE_DISTRIBUTION_NAME, _canonical_distribution_name
@@ -917,18 +960,8 @@ def _observed_precommit_mode(
     if _canonical_distribution_name(pkg) != CORE_DISTRIBUTION_NAME:
         return None
 
-    config_path = target / ".pre-commit-config.yaml"
-    if not config_path.exists():
-        return None
-    try:
-        data = yaml.safe_load(config_path.read_text(encoding="utf-8"))
-    except (yaml.YAMLError, OSError) as exc:
-        logger.warning("Cannot read .pre-commit-config.yaml %s: %s", config_path, exc)
-        return None
-    if not isinstance(data, dict):
-        return None
-    repos = data.get("repos", [])
-    if not isinstance(repos, list):
+    local_hooks = _local_precommit_hooks(target / ".pre-commit-config.yaml")
+    if local_hooks is None:
         return None
 
     # Longest prefix first so tool mode's "uvx --from vaultspec-core
@@ -940,20 +973,14 @@ def _observed_precommit_mode(
     )
 
     observed: set[InstallMode] = set()
-    for repo in repos:
-        if not isinstance(repo, dict) or repo.get("repo") != "local":
+    for hook in local_hooks:
+        if hook.get("id") not in CANONICAL_HOOK_IDS:
             continue
-        hooks = repo.get("hooks", [])
-        if not isinstance(hooks, list):
-            continue
-        for hook in hooks:
-            if not isinstance(hook, dict) or hook.get("id") not in CANONICAL_HOOK_IDS:
-                continue
-            entry = str(hook.get("entry", ""))
-            for prefix, mode in prefixes:
-                if entry.startswith(prefix):
-                    observed.add(mode)
-                    break
+        entry = str(hook.get("entry", ""))
+        for prefix, mode in prefixes:
+            if entry.startswith(prefix):
+                observed.add(mode)
+                break
 
     if len(observed) == 1:
         return next(iter(observed))
@@ -976,6 +1003,25 @@ def _legacy_dependency_args(module: str) -> list[str]:
 
     _, current_args = render_launch_for_mode(InstallMode.DEPENDENCY, "", module)
     return [arg for arg in current_args if arg != "--no-sync"]
+
+
+def _launch_module(args: list[Any]) -> str | None:
+    """Return the runnable module a deployed launch argv names after ``-m``.
+
+    Args:
+        args: The ``args`` list of a deployed MCP server entry.
+
+    Returns:
+        The module name, or ``None`` when the argv carries no ``-m`` token, the
+        token is last, or the value after it is not a string.
+    """
+    if "-m" not in args:
+        return None
+    module_index = args.index("-m") + 1
+    if module_index >= len(args):
+        return None
+    module = args[module_index]
+    return module if isinstance(module, str) else None
 
 
 def _observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode | None:
@@ -1016,18 +1062,8 @@ def _observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode 
 
     pkg = package if package is not None else CORE_DISTRIBUTION_NAME
 
-    mcp_path = target / ".mcp.json"
-    if not mcp_path.exists():
-        return None
-    try:
-        raw = json.loads(mcp_path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
-        logger.warning("Cannot read MCP config %s: %s", mcp_path, exc)
-        return None
-    if not isinstance(raw, dict):
-        return None
-    servers = raw.get("mcpServers")
-    if not isinstance(servers, dict):
+    servers = _read_mcp_servers(target / ".mcp.json")
+    if servers is None:
         return None
     entry = servers.get(pkg)
     if not isinstance(entry, dict):
@@ -1035,13 +1071,8 @@ def _observed_mcp_mode(target: Path, package: str | None = None) -> InstallMode 
 
     command = entry.get("command")
     args = entry.get("args")
-    if not isinstance(args, list) or "-m" not in args:
-        return None
-    module_index = args.index("-m") + 1
-    if module_index >= len(args):
-        return None
-    module = args[module_index]
-    if not isinstance(module, str):
+    module = _launch_module(args) if isinstance(args, list) else None
+    if module is None:
         return None
 
     for mode in (InstallMode.TOOL, InstallMode.DEPENDENCY):

--- a/src/vaultspec_core/core/hooks.py
+++ b/src/vaultspec_core/core/hooks.py
@@ -12,7 +12,7 @@ import shutil
 import sys
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from . import types as _t
 from .exceptions import ResourceExistsError, ResourceNotFoundError
@@ -313,6 +313,32 @@ def hooks_sync(dry_run: bool = False, prune: bool = False) -> SyncResult:
     return result
 
 
+def _action_warnings(name: str, actions: Any) -> list[str]:
+    """Return compliance warnings for one hook definition's ``actions`` list."""
+    if not isinstance(actions, list) or not actions:
+        return [f"Hook '{name}' has no defined actions."]
+
+    warnings: list[str] = []
+    for idx, act in enumerate(actions):
+        if not isinstance(act, dict):
+            warnings.append(
+                f"Hook '{name}': action at index {idx} is not a dictionary."
+            )
+            continue
+        act_dict = cast("dict[str, Any]", act)
+        if act_dict.get("type") != "shell":
+            warnings.append(
+                f"Hook '{name}': action at index {idx} "
+                f"has unknown type '{act_dict.get('type')}'."
+            )
+        elif not act_dict.get("command"):
+            warnings.append(
+                f"Hook '{name}': shell action at index {idx} "
+                "is missing 'command' field."
+            )
+    return warnings
+
+
 def hooks_status() -> dict[str, Any]:
     """Perform deep compliancy verification of YAML hook definitions."""
     from vaultspec_core.hooks import SUPPORTED_EVENTS
@@ -353,30 +379,7 @@ def hooks_status() -> dict[str, Any]:
                         f"Hook '{path.name}' has unsupported event '{event}'."
                     )
 
-                actions = data.get("actions", [])
-                if not isinstance(actions, list) or not actions:
-                    warnings.append(f"Hook '{path.name}' has no defined actions.")
-                else:
-                    for idx, act in enumerate(actions):
-                        if not isinstance(act, dict):
-                            warnings.append(
-                                f"Hook '{path.name}': action at index {idx} "
-                                "is not a dictionary."
-                            )
-                        else:
-                            from typing import cast
-
-                            act_dict = cast("dict[str, Any]", act)
-                            if act_dict.get("type") != "shell":
-                                warnings.append(
-                                    f"Hook '{path.name}': action at index {idx} "
-                                    f"has unknown type '{act_dict.get('type')}'."
-                                )
-                            elif not act_dict.get("command"):
-                                warnings.append(
-                                    f"Hook '{path.name}': shell action at index "
-                                    f"{idx} is missing 'command' field."
-                                )
+                warnings.extend(_action_warnings(path.name, data.get("actions", [])))
 
             except Exception as e:
                 # A hook that fails to parse cannot be classified; list it and

--- a/src/vaultspec_core/core/mcps.py
+++ b/src/vaultspec_core/core/mcps.py
@@ -1493,6 +1493,59 @@ def mcp_sync(
     return result
 
 
+def _uninstall_json_target(
+    target: McpTarget,
+    root: Path,
+    requested: set[str],
+    *,
+    dry_run: bool,
+    result: SyncResult,
+) -> None:
+    """Drop *requested* owned servers from a Claude or Antigravity JSON target."""
+    raw = json.loads(target.path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise VaultSpecError("JSON root is not an object.")
+    servers = _json_server_map(raw, target, root)
+    present = requested & set(servers)
+    result.pruned += len(present)
+    result.items.extend((name, "[DELETE]") for name in sorted(present))
+    if dry_run:
+        return
+    for name in present:
+        servers.pop(name, None)
+    raw.pop(_LEGACY_MANAGED_KEY, None)
+    _write_json_target(target.path, raw, target, root)
+
+
+def _uninstall_toml_target(
+    target: McpTarget,
+    requested: set[str],
+    *,
+    dry_run: bool,
+    result: SyncResult,
+) -> None:
+    """Drop *requested* owned servers from a Codex TOML target."""
+    content = target.path.read_text(encoding="utf-8")
+    block_servers = _toml_servers(_managed_toml_content(content))
+    present = requested & set(block_servers)
+    result.pruned += len(present)
+    result.items.extend((name, "[DELETE]") for name in sorted(present))
+    if dry_run:
+        return
+    for name in present:
+        block_servers.pop(name, None)
+    rendered = _render_codex_servers(block_servers)
+    updated = (
+        upsert_block(content, _TOML_BLOCK_TYPE, rendered, comment_prefix="# ")
+        if rendered
+        else strip_block(content, _TOML_BLOCK_TYPE)
+    )
+    if updated:
+        atomic_write(target.path, updated)
+    else:
+        target.path.unlink()
+
+
 def mcp_uninstall(
     target_dir: Path,
     *,
@@ -1542,42 +1595,20 @@ def mcp_uninstall(
             with _target_lock(target.path, dry_run=dry_run):
                 try:
                     if target.format is McpTargetFormat.JSON:
-                        raw = json.loads(target.path.read_text(encoding="utf-8"))
-                        if not isinstance(raw, dict):
-                            raise VaultSpecError("JSON root is not an object.")
-                        servers = _json_server_map(raw, target, target_dir)
-                        present = requested & set(servers)
-                        sub.pruned += len(present)
-                        sub.items.extend((name, "[DELETE]") for name in sorted(present))
-                        if not dry_run:
-                            for name in present:
-                                servers.pop(name, None)
-                            raw.pop(_LEGACY_MANAGED_KEY, None)
-                            _write_json_target(target.path, raw, target, target_dir)
+                        _uninstall_json_target(
+                            target,
+                            target_dir,
+                            requested,
+                            dry_run=dry_run,
+                            result=sub,
+                        )
                     else:
-                        content = target.path.read_text(encoding="utf-8")
-                        block_servers = _toml_servers(_managed_toml_content(content))
-                        present = requested & set(block_servers)
-                        sub.pruned += len(present)
-                        sub.items.extend((name, "[DELETE]") for name in sorted(present))
-                        if not dry_run:
-                            for name in present:
-                                block_servers.pop(name, None)
-                            rendered = _render_codex_servers(block_servers)
-                            updated = (
-                                upsert_block(
-                                    content,
-                                    _TOML_BLOCK_TYPE,
-                                    rendered,
-                                    comment_prefix="# ",
-                                )
-                                if rendered
-                                else strip_block(content, _TOML_BLOCK_TYPE)
-                            )
-                            if updated:
-                                atomic_write(target.path, updated)
-                            else:
-                                target.path.unlink()
+                        _uninstall_toml_target(
+                            target,
+                            requested,
+                            dry_run=dry_run,
+                            result=sub,
+                        )
                     succeeded = True
                 except (
                     json.JSONDecodeError,

--- a/src/vaultspec_core/core/resolver.py
+++ b/src/vaultspec_core/core/resolver.py
@@ -212,6 +212,11 @@ def resolve(
 # ---------------------------------------------------------------------------
 
 
+#: The actions the framework rules act on. An action outside this set falls
+#: through to the unhandled-signal warning, whatever the signal.
+_FRAMEWORK_ACTIONS = (CliAction.INSTALL, CliAction.SYNC, CliAction.UNINSTALL)
+
+
 def _resolve_framework(
     plan: ResolutionPlan,
     signal: FrameworkSignal,
@@ -230,66 +235,73 @@ def _resolve_framework(
         )
         return
 
-    if signal == FrameworkSignal.MISSING:
-        if action == CliAction.INSTALL:
-            # Proceed normally - install will scaffold
-            return
-        if action == CliAction.SYNC:
-            plan.conflicts.append(
-                "Framework not installed. Run 'vaultspec-core install' first."
-            )
-            return
-        if action == CliAction.UNINSTALL:
-            plan.warnings.append("Nothing to remove - framework is not installed.")
-            return
+    if signal == FrameworkSignal.MISSING and action in _FRAMEWORK_ACTIONS:
+        _resolve_framework_missing(plan, action)
+        return
 
-    if signal == FrameworkSignal.CORRUPTED:
-        if action == CliAction.INSTALL:
-            if force:
-                plan.steps.append(
-                    ResolutionStep(
-                        action=ResolutionAction.REPAIR_MANIFEST,
-                        target="manifest",
-                        reason="Manifest corrupted, repairing before install",
-                    )
-                )
-            else:
-                plan.conflicts.append("Manifest is corrupted. Use --force to repair.")
-            return
-        if action == CliAction.SYNC:
-            plan.steps.append(
-                ResolutionStep(
-                    action=ResolutionAction.REPAIR_MANIFEST,
-                    target="manifest",
-                    reason="Manifest corrupted, repairing before sync",
-                )
-            )
-            plan.steps.append(
-                ResolutionStep(
-                    action=ResolutionAction.SYNC,
-                    target="all",
-                    reason="Sync after manifest repair",
-                )
-            )
-            return
-        if action == CliAction.UNINSTALL:
-            if force:
-                plan.steps.append(
-                    ResolutionStep(
-                        action=ResolutionAction.REPAIR_MANIFEST,
-                        target="manifest",
-                        reason="Corrupted manifest - repairing before uninstall",
-                    )
-                )
-            else:
-                plan.conflicts.append(
-                    "Manifest is corrupted. Use --force to proceed with uninstall."
-                )
-            return
+    if signal == FrameworkSignal.CORRUPTED and action in _FRAMEWORK_ACTIONS:
+        _resolve_framework_corrupted(plan, action, force=force)
+        return
 
     # All FrameworkSignal values are handled above; this is unreachable
     # unless a new enum member is added without updating the resolver.
     logger.warning("Unknown FrameworkSignal member: %s (action=%s)", signal, action)
+
+
+def _resolve_framework_missing(plan: ResolutionPlan, action: CliAction) -> None:
+    """Apply resolution rules for a workspace with no framework installed."""
+    if action == CliAction.SYNC:
+        plan.conflicts.append(
+            "Framework not installed. Run 'vaultspec-core install' first."
+        )
+    elif action == CliAction.UNINSTALL:
+        plan.warnings.append("Nothing to remove - framework is not installed.")
+    # Install proceeds normally - it will scaffold.
+
+
+def _resolve_framework_corrupted(
+    plan: ResolutionPlan,
+    action: CliAction,
+    *,
+    force: bool,
+) -> None:
+    """Apply resolution rules for a corrupted framework manifest."""
+    if action == CliAction.SYNC:
+        plan.steps.append(
+            ResolutionStep(
+                action=ResolutionAction.REPAIR_MANIFEST,
+                target="manifest",
+                reason="Manifest corrupted, repairing before sync",
+            )
+        )
+        plan.steps.append(
+            ResolutionStep(
+                action=ResolutionAction.SYNC,
+                target="all",
+                reason="Sync after manifest repair",
+            )
+        )
+        return
+
+    if action == CliAction.INSTALL:
+        reason = "Manifest corrupted, repairing before install"
+        conflict = "Manifest is corrupted. Use --force to repair."
+    elif action == CliAction.UNINSTALL:
+        reason = "Corrupted manifest - repairing before uninstall"
+        conflict = "Manifest is corrupted. Use --force to proceed with uninstall."
+    else:
+        return
+
+    if force:
+        plan.steps.append(
+            ResolutionStep(
+                action=ResolutionAction.REPAIR_MANIFEST,
+                target="manifest",
+                reason=reason,
+            )
+        )
+    else:
+        plan.conflicts.append(conflict)
 
 
 #: Cap on the number of diverged paths spelled out in the adoption conflict.
@@ -513,16 +525,9 @@ def _resolve_provider_dir(
         )
         return
 
-    if is_syncable and action == CliAction.INSTALL:
+    if is_syncable and action in (CliAction.INSTALL, CliAction.UNINSTALL):
         # Empty/partial during install: install will scaffold and sync.
-        return
-
-    if is_syncable and action == CliAction.UNINSTALL:
         # Empty/partial during uninstall: the directory will be removed.
-        return
-
-    if signal == ProviderDirSignal.MIXED and action == CliAction.UNINSTALL:
-        # Already handled above (MIXED + uninstall with force check).
         return
 
     # All ProviderDirSignal values are handled above.
@@ -878,6 +883,32 @@ def _resolve_gitattributes(
 # ---------------------------------------------------------------------------
 
 
+#: Repair reason per pre-commit signal, for the signals install and sync can
+#: repair in place. ``{entry_prefix}`` is filled with the mode-appropriate
+#: canonical hook entry prefix. NO_FILE is absent: scaffolding an entirely
+#: missing config is a sync-only repair with its own reason.
+_PRECOMMIT_REPAIR_REASONS: dict[PrecommitSignal, str] = {
+    PrecommitSignal.NO_HOOKS: "No vaultspec-core hooks found in pre-commit config",
+    PrecommitSignal.INCOMPLETE: "Missing canonical hooks in pre-commit config",
+    PrecommitSignal.NON_CANONICAL: (
+        "Hook entries use non-canonical pattern; should use '{entry_prefix}'"
+    ),
+}
+
+#: Signals that describe a coherent boundary no resolution step acts on.
+#: UNREFRESHABLE means ``prek.toml`` owns the boundary and lacks the canonical
+#: hooks, so sync cannot repair anything - the doctor surface renders the
+#: actionable advisory (``spec precommit migrate``) instead. ORPHANED means the
+#: hooks live safely in ``prek.toml`` and the leftover
+#: ``.pre-commit-config.yaml`` is superseded and operator-owned; removal is
+#: operator-gated, never a sync-time repair.
+_PRECOMMIT_INERT_SIGNALS = (
+    PrecommitSignal.COMPLETE,
+    PrecommitSignal.UNREFRESHABLE,
+    PrecommitSignal.ORPHANED,
+)
+
+
 def _resolve_precommit(
     plan: ResolutionPlan,
     signal: PrecommitSignal,
@@ -891,11 +922,11 @@ def _resolve_precommit(
     _ = force  # precommit repairs are unconditional
     if not precommit_managed:
         return
-    if signal == PrecommitSignal.COMPLETE:
+    if signal in _PRECOMMIT_INERT_SIGNALS:
         return
 
     if signal == PrecommitSignal.NO_FILE:
-        if precommit_managed and action == CliAction.SYNC:
+        if action == CliAction.SYNC:
             plan.steps.append(
                 ResolutionStep(
                     action=ResolutionAction.REPAIR_PRECOMMIT,
@@ -905,53 +936,16 @@ def _resolve_precommit(
             )
         return
 
-    if signal == PrecommitSignal.NO_HOOKS:
+    reason = _PRECOMMIT_REPAIR_REASONS.get(signal)
+    if reason is not None:
         if action in (CliAction.INSTALL, CliAction.SYNC):
             plan.steps.append(
                 ResolutionStep(
                     action=ResolutionAction.REPAIR_PRECOMMIT,
                     target=".pre-commit-config.yaml",
-                    reason="No vaultspec-core hooks found in pre-commit config",
+                    reason=reason.format(entry_prefix=expected_entry_prefix),
                 )
             )
-        return
-
-    if signal == PrecommitSignal.INCOMPLETE:
-        if action in (CliAction.INSTALL, CliAction.SYNC):
-            plan.steps.append(
-                ResolutionStep(
-                    action=ResolutionAction.REPAIR_PRECOMMIT,
-                    target=".pre-commit-config.yaml",
-                    reason="Missing canonical hooks in pre-commit config",
-                )
-            )
-        return
-
-    if signal == PrecommitSignal.NON_CANONICAL:
-        if action in (CliAction.INSTALL, CliAction.SYNC):
-            plan.steps.append(
-                ResolutionStep(
-                    action=ResolutionAction.REPAIR_PRECOMMIT,
-                    target=".pre-commit-config.yaml",
-                    reason=(
-                        "Hook entries use non-canonical pattern; "
-                        f"should use '{expected_entry_prefix}'"
-                    ),
-                )
-            )
-        return
-
-    if signal == PrecommitSignal.UNREFRESHABLE:
-        # ``prek.toml`` owns this boundary and lacks the canonical hooks,
-        # so sync cannot repair anything here. The doctor surface renders
-        # the actionable advisory (``spec precommit migrate``); resolution
-        # must leave the workspace unchanged.
-        return
-
-    if signal == PrecommitSignal.ORPHANED:
-        # Hooks live safely in ``prek.toml``; the leftover
-        # ``.pre-commit-config.yaml`` is superseded and operator-owned.
-        # Removal is operator-gated, never a sync-time repair.
         return
 
     logger.warning("Unknown PrecommitSignal member: %s (action=%s)", signal, action)

--- a/src/vaultspec_core/graph/cache.py
+++ b/src/vaultspec_core/graph/cache.py
@@ -266,6 +266,55 @@ def validate(
     return seen == manifest.keys()
 
 
+def _is_fingerprint_row(value: object) -> bool:
+    """Return ``True`` when *value* is a serialised :data:`Fingerprint`.
+
+    A manifest value round-trips through JSON as the three-element list
+    ``[st_size, st_mtime_ns, sha256_hex]``.  The shape check precedes the
+    per-element checks so element access is only reached once *value* is
+    known to be a list of exactly three items.
+
+    Args:
+        value: A decoded JSON value from a cache file's manifest.
+
+    Returns:
+        ``True`` when the row can be read back as a fingerprint.
+    """
+    if not isinstance(value, list) or len(value) != 3:
+        return False
+    size, mtime_ns, content_hash = value
+    return (
+        isinstance(size, int)
+        and isinstance(mtime_ns, int)
+        and isinstance(content_hash, str)
+    )
+
+
+def _is_encoding_issue_row(row: object) -> bool:
+    """Return ``True`` when *row* is a serialised encoding-issue tuple.
+
+    An encoding issue round-trips through JSON as the four-element list
+    ``[path, kind, detail, start]``, where ``start`` is the optional byte
+    offset of the failure and so may be ``null``.  As above, the shape
+    check precedes the per-element checks.
+
+    Args:
+        row: A decoded JSON value from a cache file's issue list.
+
+    Returns:
+        ``True`` when the row can be read back as an encoding issue.
+    """
+    if not isinstance(row, list) or len(row) != 4:
+        return False
+    doc_path, kind, detail, start = row
+    return (
+        isinstance(doc_path, str)
+        and isinstance(kind, str)
+        and isinstance(detail, str)
+        and (start is None or isinstance(start, int))
+    )
+
+
 def load(path: Path) -> GraphCachePayload | None:
     """Read and parse a cache file, returning ``None`` on any failure.
 
@@ -312,14 +361,7 @@ def load(path: Path) -> GraphCachePayload | None:
 
     manifest: dict[str, Fingerprint] = {}
     for key, value in raw_manifest.items():
-        if (
-            not isinstance(key, str)
-            or not isinstance(value, list)
-            or len(value) != 3
-            or not isinstance(value[0], int)
-            or not isinstance(value[1], int)
-            or not isinstance(value[2], str)
-        ):
+        if not isinstance(key, str) or not _is_fingerprint_row(value):
             logger.debug("Graph cache manifest entry %r is malformed; ignoring", key)
             return None
         manifest[key] = (value[0], value[1], value[2])
@@ -336,14 +378,7 @@ def load(path: Path) -> GraphCachePayload | None:
 
     encoding: list[tuple[str, str, str, int | None]] = []
     for row in raw_encoding:
-        if (
-            not isinstance(row, list)
-            or len(row) != 4
-            or not isinstance(row[0], str)
-            or not isinstance(row[1], str)
-            or not isinstance(row[2], str)
-            or not (row[3] is None or isinstance(row[3], int))
-        ):
+        if not _is_encoding_issue_row(row):
             logger.debug(
                 "Graph cache encoding-issue row %r is malformed; ignoring", row
             )

--- a/src/vaultspec_core/graph/tests/test_cache.py
+++ b/src/vaultspec_core/graph/tests/test_cache.py
@@ -17,6 +17,8 @@ content hash.  The tests prove each trigger independently:
 - an added file appears in the next build;
 - a removed file disappears from the next build;
 - a corrupt or truncated cache file degrades silently to a full rebuild;
+- a cache file whose manifest or encoding-issue rows are structurally
+  malformed is rejected whole rather than partly trusted;
 - a cache hit reconstructs a graph behaviourally identical to a fresh build;
 - a real CLI mutation refreshes the cache so the next build is not stale.
 
@@ -274,6 +276,119 @@ class TestCorruptCacheRebuilds:
 
         rebuilt = VaultGraph(vault_root)
         assert rebuilt.digraph.number_of_nodes() == expected_nodes
+
+
+class TestMalformedPayloadRowsRejected:
+    """A structurally valid JSON cache with a bad row is still a miss.
+
+    ``load`` is the only gate between cache bytes and the restored corpus,
+    so a row that cannot be read back as its declared type must reject the
+    whole payload. Accepting the file and dropping the row would restore a
+    corpus that quietly differs from the one the cache was built over.
+    Every case writes a real cache file and reads it back through ``load``.
+    """
+
+    def _write(self, tmp_path: Path, payload: dict) -> Path:
+        cache_file = tmp_path / "graph.json"
+        cache_file.write_text(json.dumps(payload), encoding="utf-8")
+        return cache_file
+
+    def _payload(self) -> dict:
+        """Return a minimal payload that satisfies every documented shape."""
+        return {
+            "schema": cache_mod.CACHE_SCHEMA,
+            "manifest": {".vault/research/a.md": [128, 1700000000123456789, "ab12"]},
+            "graph": {"nodes": [], "edges": []},
+            "dangling_links": [["a", "b"]],
+            "encoding_issues": [
+                [".vault/research/a.md", "decode", "invalid start byte", 41],
+                [".vault/research/b.md", "read", "permission denied", None],
+            ],
+        }
+
+    def test_well_formed_payload_round_trips(self, tmp_path: Path) -> None:
+        loaded = cache_mod.load(self._write(tmp_path, self._payload()))
+
+        assert loaded is not None
+        assert loaded.manifest == {
+            ".vault/research/a.md": (128, 1700000000123456789, "ab12")
+        }
+        assert loaded.dangling_links == [["a", "b"]]
+        assert loaded.encoding_issues == [
+            (".vault/research/a.md", "decode", "invalid start byte", 41),
+            (".vault/research/b.md", "read", "permission denied", None),
+        ]
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            [128, 1700000000123456789],
+            [128, 1700000000123456789, "ab12", "extra"],
+            [128, 1700000000.5, "ab12"],
+            ["128", 1700000000123456789, "ab12"],
+            [128, 1700000000123456789, None],
+            {"size": 128},
+            "128",
+        ],
+        ids=[
+            "too-short",
+            "too-long",
+            "float-mtime",
+            "string-size",
+            "null-hash",
+            "object-not-list",
+            "scalar-not-list",
+        ],
+    )
+    def test_malformed_manifest_row_rejects_payload(
+        self, tmp_path: Path, row: object
+    ) -> None:
+        payload = self._payload()
+        payload["manifest"] = {".vault/research/a.md": row}
+
+        assert cache_mod.load(self._write(tmp_path, payload)) is None
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            [".vault/research/a.md", "decode", "invalid start byte"],
+            [".vault/research/a.md", "decode", "invalid start byte", 41, "extra"],
+            [None, "decode", "invalid start byte", 41],
+            [".vault/research/a.md", 7, "invalid start byte", 41],
+            [".vault/research/a.md", "decode", None, 41],
+            [".vault/research/a.md", "decode", "invalid start byte", 41.5],
+            [".vault/research/a.md", "decode", "invalid start byte", "41"],
+            "decode",
+        ],
+        ids=[
+            "too-short",
+            "too-long",
+            "null-path",
+            "int-kind",
+            "null-detail",
+            "float-start",
+            "string-start",
+            "scalar-not-list",
+        ],
+    )
+    def test_malformed_encoding_row_rejects_payload(
+        self, tmp_path: Path, row: object
+    ) -> None:
+        payload = self._payload()
+        payload["encoding_issues"] = [row]
+
+        assert cache_mod.load(self._write(tmp_path, payload)) is None
+
+    def test_null_start_is_accepted_on_every_encoding_row(self, tmp_path: Path) -> None:
+        payload = self._payload()
+        payload["encoding_issues"] = [[".vault/research/a.md", "read", "gone", None]]
+
+        loaded = cache_mod.load(self._write(tmp_path, payload))
+
+        assert loaded is not None
+        assert loaded.encoding_issues == [
+            (".vault/research/a.md", "read", "gone", None)
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaultspec_core/mcp_server/tools/documents.py
+++ b/src/vaultspec_core/mcp_server/tools/documents.py
@@ -199,41 +199,27 @@ def _create_one(
     Returns:
         A two-tuple ``(item_result, affected_feature_or_None)``.
     """
-    from ...vaultcore.hydration import create_vault_doc
     from ...vaultcore.normalize import normalize_feature_tag
-    from ...vaultcore.resolve import (
-        RelatedResolutionError,
-        resolve_related_inputs,
-        validate_feature_dependencies,
-    )
+    from ...vaultcore.resolve import RelatedResolutionError, resolve_related_inputs
 
     type_str = spec.type or "research"
     target = f"{type_str}:{spec.feature}"
 
-    def _failed(message: str, **extra: Any) -> tuple[ItemResult, None]:
-        return (
-            build_item(
-                index,
-                status="failed",
-                target=target,
-                error={"message": message, **extra},
-            ),
-            None,
-        )
-
     norm = normalize_feature_tag(spec.feature)
     if not norm.ok or norm.value is None:
-        return _failed(norm.error or "invalid feature")
+        return _create_failure(index, target, norm.error or "invalid feature")
     feature = norm.value
 
     try:
         doc_type = DocType(type_str)
     except ValueError:
-        return _failed(f"Invalid document type: {type_str}")
+        return _create_failure(index, target, f"Invalid document type: {type_str}")
     if doc_type is DocType.INDEX:
-        return _failed(
+        return _create_failure(
+            index,
+            target,
             "'index' documents are auto-generated. "
-            "Use 'vaultspec-core vault feature index', not create."
+            "Use 'vaultspec-core vault feature index', not create.",
         )
 
     extra_tags: list[str] | None = None
@@ -242,7 +228,7 @@ def _create_one(
         for tag in spec.tags:
             tag_norm = normalize_feature_tag(tag, label="tag")
             if not tag_norm.ok or tag_norm.value is None:
-                return _failed(tag_norm.error or "invalid tag")
+                return _create_failure(index, target, tag_norm.error or "invalid tag")
             extra_tags.append(f"#{tag_norm.value}")
 
     resolved_related: list[str] | None = None
@@ -250,62 +236,110 @@ def _create_one(
         try:
             resolved_related = resolve_related_inputs(spec.related, root_dir)
         except RelatedResolutionError as exc:
-            return _failed(
+            return _create_failure(
+                index,
+                target,
                 "Cannot resolve related document(s): " + "; ".join(exc.failures),
                 failures=exc.failures,
             )
 
-    # Lifecycle-dependency validation runs against the on-disk vault, which
-    # already includes any earlier same-batch items - they were written
-    # sequentially before this one - so an intra-batch dependency (create the
-    # ADR then the plan in one call) is satisfied without special tracking.
-    warnings: list[str] = []
-    for diag in validate_feature_dependencies(root_dir, doc_type, feature):
-        if diag.startswith("ERROR:"):
-            return _failed(diag)
-        if diag.startswith("WARNING:"):
-            warnings.append(diag)
+    return _scaffold_one(
+        root_dir,
+        index,
+        target,
+        today,
+        spec,
+        doc_type,
+        feature,
+        extra_tags=extra_tags,
+        resolved_related=resolved_related,
+    )
+
+
+def _create_failure(
+    index: int, target: str, message: str, **extra: Any
+) -> tuple[ItemResult, None]:
+    """Fold one failed ``create`` item into its result envelope."""
+    return (
+        build_item(
+            index,
+            status="failed",
+            target=target,
+            error={"message": message, **extra},
+        ),
+        None,
+    )
+
+
+def _scaffold_one(
+    root_dir: Path,
+    index: int,
+    target: str,
+    today: str,
+    spec: DocumentSpec,
+    doc_type: DocType,
+    feature: str,
+    *,
+    extra_tags: list[str] | None,
+    resolved_related: list[str] | None,
+) -> tuple[ItemResult, str | None]:
+    """Validate the type-dependent spec fields and write the document.
+
+    Args:
+        root_dir: The project root whose ``.vault/`` receives the document.
+        index: The item's zero-based batch position.
+        target: The item's ``type:feature`` address.
+        today: The default ISO date used when the spec omits one.
+        spec: The document specification.
+        doc_type: The spec's resolved document type.
+        feature: The spec's normalized feature name.
+        extra_tags: The spec's normalized extra tags, if any.
+        resolved_related: The spec's resolved ``[[wiki-link]]`` related
+            entries, if any.
+
+    Returns:
+        A two-tuple ``(item_result, affected_feature_or_None)``.
+    """
+    from ...vaultcore.hydration import (
+        DocumentIdentity,
+        TemplateFields,
+        create_vault_doc,
+    )
+
+    warnings, dependency_error = _dependency_diagnostics(root_dir, doc_type, feature)
+    if dependency_error is not None:
+        return _create_failure(index, target, dependency_error)
 
     tier: str | None = None
     if doc_type is DocType.PLAN:
         tier = spec.tier or "L1"
         if tier not in ("L1", "L2", "L3", "L4"):
-            return _failed(f"Invalid tier '{tier}'. Allowed values: L1, L2, L3, L4.")
-
-    topic: str | None = None
-    if spec.topic is not None:
-        if doc_type not in (
-            DocType.ADR,
-            DocType.AUDIT,
-            DocType.REFERENCE,
-            DocType.RESEARCH,
-        ):
-            return _failed(
-                "topic is only valid for 'adr', 'audit', 'reference', and "
-                "'research' documents."
+            return _create_failure(
+                index, target, f"Invalid tier '{tier}'. Allowed values: L1, L2, L3, L4."
             )
-        topic_norm = normalize_feature_tag(spec.topic, label="topic")
-        if not topic_norm.ok or topic_norm.value is None:
-            return _failed(topic_norm.error or "invalid topic")
-        topic = topic_norm.value
+
+    topic, topic_error = _resolve_topic(spec, doc_type)
+    if topic_error is not None:
+        return _create_failure(index, target, topic_error)
 
     date_str = spec.date or today
     try:
         created = create_vault_doc(
             root_dir,
-            doc_type,
-            feature,
-            date_str,
-            spec.title,
-            topic=topic,
-            related=resolved_related,
-            extra_tags=extra_tags,
-            tier=tier,
+            DocumentIdentity(
+                doc_type=doc_type, feature=feature, date=date_str, topic=topic
+            ),
+            TemplateFields(
+                title=spec.title,
+                related=resolved_related,
+                extra_tags=extra_tags,
+                tier=tier,
+            ),
         )
     except FileNotFoundError as exc:
-        return _failed(f"Template unavailable: {exc}")
+        return _create_failure(index, target, f"Template unavailable: {exc}")
     except Exception as exc:  # ResourceExistsError, scaffold-validation, write
-        return _failed(str(exc))
+        return _create_failure(index, target, str(exc))
 
     seed_warnings = _apply_seed_content(root_dir, created, spec.content)
     warnings.extend(seed_warnings)
@@ -321,6 +355,51 @@ def _create_one(
         warnings=warnings,
     )
     return item, feature
+
+
+def _dependency_diagnostics(
+    root_dir: Path, doc_type: DocType, feature: str
+) -> tuple[list[str], str | None]:
+    """Split lifecycle-dependency diagnostics into warnings and a blocker.
+
+    Validation runs against the on-disk vault, which already includes any
+    earlier same-batch items - they were written sequentially before this one
+    - so an intra-batch dependency (create the ADR then the plan in one call)
+    is satisfied without special tracking.
+    """
+    from ...vaultcore.resolve import validate_feature_dependencies
+
+    warnings: list[str] = []
+    for diag in validate_feature_dependencies(root_dir, doc_type, feature):
+        if diag.startswith("ERROR:"):
+            return warnings, diag
+        if diag.startswith("WARNING:"):
+            warnings.append(diag)
+    return warnings, None
+
+
+def _resolve_topic(
+    spec: DocumentSpec, doc_type: DocType
+) -> tuple[str | None, str | None]:
+    """Normalize the optional narrative topic infix for the types allowing it."""
+    from ...vaultcore.normalize import normalize_feature_tag
+
+    if spec.topic is None:
+        return None, None
+    if doc_type not in (
+        DocType.ADR,
+        DocType.AUDIT,
+        DocType.REFERENCE,
+        DocType.RESEARCH,
+    ):
+        return None, (
+            "topic is only valid for 'adr', 'audit', 'reference', and "
+            "'research' documents."
+        )
+    topic_norm = normalize_feature_tag(spec.topic, label="topic")
+    if not topic_norm.ok or topic_norm.value is None:
+        return None, topic_norm.error or "invalid topic"
+    return topic_norm.value, None
 
 
 def _apply_seed_content(

--- a/src/vaultspec_core/mcp_server/tools/plan.py
+++ b/src/vaultspec_core/mcp_server/tools/plan.py
@@ -27,6 +27,7 @@ from ...core.types import get_context as _get_ctx
 from ..isolation import isolated_context as _isolated_context
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
     from pathlib import Path
 
     from mcp.server.fastmcp import FastMCP
@@ -492,50 +493,82 @@ def _apply_plan_edit(plan: Plan, op: PlanEditOperation) -> PlanEditItemResult:
         The per-operation :class:`PlanEditItemResult`.
     """
     from ...plan.commands._errors import PlanCommandError
-    from ...plan.commands.step_ops import add_step, edit_step, insert_step, remove_step
 
-    def _fail(message: str) -> PlanEditItemResult:
-        return PlanEditItemResult(
-            operation=op.operation, status="failed", error={"message": message}
-        )
-
+    handler = _PLAN_EDIT_HANDLERS.get(op.operation)
+    if handler is None:
+        return _plan_edit_failure(op, f"Unknown plan_edit operation: {op.operation!r}")
     try:
-        if op.operation == "add":
-            if op.action is None or op.scope is None:
-                return _fail("'add' requires 'action' and 'scope'")
-            step = add_step(
-                plan, action=op.action, scope=op.scope, phase_id=op.phase_id
-            )
-            return PlanEditItemResult(
-                operation="add", status="created", step_id=step.canonical_id
-            )
-        if op.operation == "insert":
-            if op.action is None or op.scope is None:
-                return _fail("'insert' requires 'action' and 'scope'")
-            step = insert_step(
-                plan,
-                action=op.action,
-                scope=op.scope,
-                before=op.before,
-                after=op.after,
-            )
-            return PlanEditItemResult(
-                operation="insert", status="created", step_id=step.canonical_id
-            )
-        if op.operation == "edit":
-            if op.step_id is None:
-                return _fail("'edit' requires 'step_id'")
-            step = edit_step(plan, op.step_id, action=op.action, scope=op.scope)
-            return PlanEditItemResult(
-                operation="edit", status="updated", step_id=step.canonical_id
-            )
-        if op.operation == "remove":
-            if op.step_id is None:
-                return _fail("'remove' requires 'step_id'")
-            retired = remove_step(plan, op.step_id)
-            return PlanEditItemResult(
-                operation="remove", status="removed", step_id=retired
-            )
-        return _fail(f"Unknown plan_edit operation: {op.operation!r}")
+        return handler(plan, op)
     except PlanCommandError as exc:
-        return _fail(str(exc))
+        return _plan_edit_failure(op, str(exc))
+
+
+def _plan_edit_failure(op: PlanEditOperation, message: str) -> PlanEditItemResult:
+    """Fold one failed ``plan_edit`` operation into its item result."""
+    return PlanEditItemResult(
+        operation=op.operation, status="failed", error={"message": message}
+    )
+
+
+def _plan_edit_add(plan: Plan, op: PlanEditOperation) -> PlanEditItemResult:
+    """Append a step to a phase or the document tail."""
+    from ...plan.commands.step_ops import add_step
+
+    if op.action is None or op.scope is None:
+        return _plan_edit_failure(op, "'add' requires 'action' and 'scope'")
+    step = add_step(plan, action=op.action, scope=op.scope, phase_id=op.phase_id)
+    return PlanEditItemResult(
+        operation="add", status="created", step_id=step.canonical_id
+    )
+
+
+def _plan_edit_insert(plan: Plan, op: PlanEditOperation) -> PlanEditItemResult:
+    """Place a step before or after an anchor step."""
+    from ...plan.commands.step_ops import insert_step
+
+    if op.action is None or op.scope is None:
+        return _plan_edit_failure(op, "'insert' requires 'action' and 'scope'")
+    step = insert_step(
+        plan,
+        action=op.action,
+        scope=op.scope,
+        before=op.before,
+        after=op.after,
+    )
+    return PlanEditItemResult(
+        operation="insert", status="created", step_id=step.canonical_id
+    )
+
+
+def _plan_edit_edit(plan: Plan, op: PlanEditOperation) -> PlanEditItemResult:
+    """Change a step's action and/or scope."""
+    from ...plan.commands.step_ops import edit_step
+
+    if op.step_id is None:
+        return _plan_edit_failure(op, "'edit' requires 'step_id'")
+    step = edit_step(plan, op.step_id, action=op.action, scope=op.scope)
+    return PlanEditItemResult(
+        operation="edit", status="updated", step_id=step.canonical_id
+    )
+
+
+def _plan_edit_remove(plan: Plan, op: PlanEditOperation) -> PlanEditItemResult:
+    """Retire a step, freeing nothing: its canonical id is never reused."""
+    from ...plan.commands.step_ops import remove_step
+
+    if op.step_id is None:
+        return _plan_edit_failure(op, "'remove' requires 'step_id'")
+    retired = remove_step(plan, op.step_id)
+    return PlanEditItemResult(operation="remove", status="removed", step_id=retired)
+
+
+#: The ``plan_edit`` operation verbs and the handler owning each; an
+#: unlisted verb fails the item rather than the batch.
+_PLAN_EDIT_HANDLERS: Mapping[
+    str, Callable[[Plan, PlanEditOperation], PlanEditItemResult]
+] = {
+    "add": _plan_edit_add,
+    "insert": _plan_edit_insert,
+    "edit": _plan_edit_edit,
+    "remove": _plan_edit_remove,
+}

--- a/src/vaultspec_core/plan/checks/_base.py
+++ b/src/vaultspec_core/plan/checks/_base.py
@@ -69,6 +69,7 @@ def collect_all(plan: Plan, source_text: str) -> list[Finding]:
     """
     from vaultspec_core.plan.checks.display_path_check import check_display_path
     from vaultspec_core.plan.checks.frontmatter_check import check_frontmatter
+    from vaultspec_core.plan.checks.heading_level_check import check_heading_levels
     from vaultspec_core.plan.checks.hierarchy_check import check_hierarchy
     from vaultspec_core.plan.checks.identifiers_check import check_identifiers
     from vaultspec_core.plan.checks.row_contract_check import check_row_contract
@@ -77,6 +78,9 @@ def collect_all(plan: Plan, source_text: str) -> list[Finding]:
 
     findings: list[Finding] = []
     findings.extend(check_frontmatter(plan))
+    # Runs before the model-driven rules: a mislevelled container heading is
+    # invisible in the parsed plan, so this reads the source text instead.
+    findings.extend(check_heading_levels(source_text))
     findings.extend(check_hierarchy(plan))
     findings.extend(check_identifiers(plan, source_text))
     findings.extend(check_display_path(plan))

--- a/src/vaultspec_core/plan/checks/heading_level_check.py
+++ b/src/vaultspec_core/plan/checks/heading_level_check.py
@@ -1,0 +1,82 @@
+"""Container-heading level detection rule (``PLAN070``).
+
+The parser anchors its container headings to an exact level: a Wave is
+recognised only at ``##`` and a Phase only at ``###``. A heading that
+names a container at any other level matches neither pattern, so the
+container disappears from the parsed model while the Step rows beneath
+it survive and silently re-parent to whatever container preceded it.
+Nothing in the resulting plan looks wrong: the counts are simply lower
+than the document's own text claims.
+
+This is reachable through ordinary tooling rather than hand-editing.
+A markdown formatter correcting a heading-increment warning will demote
+a Phase from ``###`` to ``##``, which reads as a cosmetic fix and costs
+the plan a whole container.
+
+The rule therefore scans the raw source for any heading that names a
+container, and reports the ones the parser cannot see. It reads the
+source text rather than the parsed model precisely because the parsed
+model is where the evidence has already been lost.
+"""
+
+from __future__ import annotations
+
+import re
+
+from vaultspec_core.plan.checks._base import Finding, Severity
+
+__all__ = ["check_heading_levels"]
+
+
+# Any heading naming a container, at any level, capturing the level so the
+# canonical one can be compared against it.
+_RE_CONTAINER_HEADING = re.compile(
+    r"^(?P<hashes>#{1,6}) +(?P<noun>Wave|Phase) +`(?P<id>[^`]+)`",
+)
+
+#: The one heading level at which the parser recognises each container.
+_CANONICAL_LEVEL = {"Wave": 2, "Phase": 3}
+
+
+def check_heading_levels(source_text: str) -> list[Finding]:
+    """Yield one Finding per container heading the parser cannot recognise.
+
+    Args:
+        source_text: Original markdown text of the plan document.
+
+    Returns:
+        A list of :class:`Finding`, one per mislevelled container heading.
+    """
+    findings: list[Finding] = []
+    for index, line in enumerate(source_text.splitlines(), start=1):
+        match = _RE_CONTAINER_HEADING.match(line)
+        if match is None:
+            continue
+
+        noun = match.group("noun")
+        level = len(match.group("hashes"))
+        canonical = _CANONICAL_LEVEL[noun]
+        if level == canonical:
+            continue
+
+        findings.append(
+            Finding(
+                code="PLAN070",
+                severity=Severity.ERROR,
+                message=(
+                    f"{noun} `{match.group('id')}` is written at heading level "
+                    f"{level}, but the parser recognises a {noun} only at level "
+                    f"{canonical}. This container is dropped from the parsed "
+                    "plan while its Step rows survive and re-parent silently, "
+                    "so the plan under-reports its own structure."
+                ),
+                line_number=index,
+                fix_hint=(
+                    f"Restore the heading to {'#' * canonical} "
+                    f"{noun} `{match.group('id')}` - and never let a markdown "
+                    "formatter change a container heading's level."
+                ),
+                autofixable=False,
+            )
+        )
+    return findings

--- a/src/vaultspec_core/tests/cli/test_check_adr_grounding.py
+++ b/src/vaultspec_core/tests/cli/test_check_adr_grounding.py
@@ -136,3 +136,72 @@ class TestAdrGroundingFix:
             tmp_path / ".vault" / "adr" / "2026-07-14-grounding-feat-adr.md"
         ).read_text(encoding="utf-8")
         assert "[[2026-07-14-grounding-feat-audit]]" in adr
+
+
+class TestPlanSchemaRules:
+    """A plan must reference an ADR and should reference research."""
+
+    def test_unlinked_plan_reports_both_rules(self, tmp_path: Path):
+        _write_doc(tmp_path, "plan", "2026-07-14-grounding-feat-plan")
+
+        result = check_schema(tmp_path, graph=VaultGraph(tmp_path))
+
+        plan_diags = [d for d in result.diagnostics if "Plan has no" in d.message]
+        assert [d.message for d in plan_diags] == [
+            "Plan has no references to ADR documents",
+            "Plan has no references to research documents",
+        ]
+        assert [d.severity.value for d in plan_diags] == ["error", "warning"]
+        assert [d.fixable for d in plan_diags] == [True, False]
+
+    def test_fix_links_adr_and_research(self, tmp_path: Path):
+        _write_doc(tmp_path, "research", "2026-07-14-grounding-feat-research")
+        _write_doc(
+            tmp_path,
+            "adr",
+            "2026-07-14-grounding-feat-adr",
+            related=["2026-07-14-grounding-feat-research"],
+        )
+        _write_doc(tmp_path, "plan", "2026-07-14-grounding-feat-plan")
+
+        result = check_schema(tmp_path, graph=VaultGraph(tmp_path), fix=True)
+
+        assert result.fixed_count == 2
+        plan = (
+            tmp_path / ".vault" / "plan" / "2026-07-14-grounding-feat-plan.md"
+        ).read_text(encoding="utf-8")
+        assert "[[2026-07-14-grounding-feat-adr]]" in plan
+        assert "[[2026-07-14-grounding-feat-research]]" in plan
+        assert not [d for d in result.diagnostics if "Plan has no" in d.message]
+
+    def test_fix_without_candidates_still_reports(self, tmp_path: Path):
+        _write_doc(tmp_path, "plan", "2026-07-14-grounding-feat-plan")
+
+        result = check_schema(tmp_path, graph=VaultGraph(tmp_path), fix=True)
+
+        assert result.fixed_count == 0
+        messages = [d.message for d in result.diagnostics if "Plan has no" in d.message]
+        assert messages == [
+            "Plan has no references to ADR documents",
+            "Plan has no references to research documents",
+        ]
+
+    def test_doc_type_filter_skips_plans(self, tmp_path: Path):
+        _write_doc(tmp_path, "plan", "2026-07-14-grounding-feat-plan")
+        _write_doc(tmp_path, "adr", "2026-07-14-grounding-feat-adr")
+
+        result = check_schema(
+            tmp_path, graph=VaultGraph(tmp_path), doc_type_filter="adr"
+        )
+
+        assert not [d for d in result.diagnostics if "Plan has no" in d.message]
+        assert _adr_diagnostics(tmp_path)
+
+    def test_feature_filter_skips_other_features(self, tmp_path: Path):
+        _write_doc(tmp_path, "plan", "2026-07-14-grounding-feat-plan")
+
+        result = check_schema(
+            tmp_path, graph=VaultGraph(tmp_path), feature="other-feature"
+        )
+
+        assert result.diagnostics == []

--- a/src/vaultspec_core/tests/cli/test_collectors.py
+++ b/src/vaultspec_core/tests/cli/test_collectors.py
@@ -15,7 +15,9 @@ from vaultspec_core.core.commands import (
     entry_prefix_for_mode,
 )
 from vaultspec_core.core.diagnosis.collectors import (
+    _collect_precommit_yaml_state,
     _observed_mcp_mode,
+    _observed_precommit_mode,
     collect_builtin_version_state,
     collect_config_state,
     collect_content_integrity,
@@ -679,6 +681,62 @@ class TestObservedMcpMode:
             ["run", "--isolated", "python", "-m", self._MODULE],
         )
         assert _observed_mcp_mode(tmp_path, "vaultspec-core") is None
+
+
+# ---------------------------------------------------------------------------
+# .pre-commit-config.yaml shapes the hook readers must tolerate
+# ---------------------------------------------------------------------------
+class TestPrecommitYamlState:
+    """Malformed and shape-surprising configs classify without crashing."""
+
+    def test_absent_config_is_no_file(self, tmp_path: Path) -> None:
+        assert _collect_precommit_yaml_state(tmp_path) == PrecommitSignal.NO_FILE
+
+    def test_unparseable_config_is_no_file(self, tmp_path: Path) -> None:
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos: [unclosed\n", encoding="utf-8"
+        )
+        assert _collect_precommit_yaml_state(tmp_path) == PrecommitSignal.NO_FILE
+
+    def test_non_mapping_document_is_no_hooks(self, tmp_path: Path) -> None:
+        """A parseable but non-mapping document declares no hooks, not no file."""
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "- first\n- second\n", encoding="utf-8"
+        )
+        assert _collect_precommit_yaml_state(tmp_path) == PrecommitSignal.NO_HOOKS
+
+    def test_non_list_repos_key_is_no_hooks(self, tmp_path: Path) -> None:
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos: not-a-list\n", encoding="utf-8"
+        )
+        assert _collect_precommit_yaml_state(tmp_path) == PrecommitSignal.NO_HOOKS
+
+    def test_remote_only_repos_is_no_hooks(self, tmp_path: Path) -> None:
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos:\n"
+            "  - repo: https://example.invalid/hooks\n"
+            "    rev: v1.0.0\n"
+            "    hooks:\n"
+            "      - id: something-else\n",
+            encoding="utf-8",
+        )
+        assert _collect_precommit_yaml_state(tmp_path) == PrecommitSignal.NO_HOOKS
+
+    def test_mode_inference_tolerates_a_non_list_repos_key(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos: not-a-list\n", encoding="utf-8"
+        )
+        assert _observed_precommit_mode(tmp_path) is None
+
+    def test_mode_inference_tolerates_an_unparseable_config(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / ".pre-commit-config.yaml").write_text(
+            "repos: [unclosed\n", encoding="utf-8"
+        )
+        assert _observed_precommit_mode(tmp_path) is None
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaultspec_core/tests/cli/test_config_editor_safety.py
+++ b/src/vaultspec_core/tests/cli/test_config_editor_safety.py
@@ -18,8 +18,8 @@ if TYPE_CHECKING:
 pytestmark = [pytest.mark.integration]
 
 
-def _write_fake_editor(directory: Path, name: str, exit_code: int = 0) -> str:
-    """Create a real, resolvable fake-editor executable on disk.
+def _write_probe_editor(directory: Path, name: str, exit_code: int = 0) -> str:
+    """Create a real, resolvable editor executable on disk.
 
     Writes a genuine platform-appropriate launcher script that accepts (and
     ignores) the file-path argument :func:`vaultspec_core.core.resources.resource_edit`
@@ -28,10 +28,16 @@ def _write_fake_editor(directory: Path, name: str, exit_code: int = 0) -> str:
     rather than a Windows-only system editor, so the assertions hold on any
     operating system.
 
+    Named a *probe* rather than a fake because that is what it is: a real
+    executable on a real ``PATH``, not a test double. The suite-quality guard in
+    ``tests/test_test_suite_quality.py`` rejects ``fake``/``stub`` in a test
+    symbol's name, and a name that misdescribes a real binary as a double both
+    trips that guard and misleads the next reader.
+
     :param directory: Directory to write the script into; prepend it to ``PATH``
         so the returned name resolves via :func:`shutil.which`.
     :param name: Bare editor name, used verbatim as the resolvable command.
-    :param exit_code: Process exit status the fake editor returns.
+    :param exit_code: Process exit status the probe editor returns.
     :returns: The bare editor name to pass to ``--editor`` or an editor env var.
     """
     if sys.platform == "win32":
@@ -135,16 +141,16 @@ class TestEditorResolution:
     def test_resolution_ladder(self, tmp_path):
         import os
 
-        # Real, resolvable fake editors - one distinct binary per ladder rung -
+        # Real, resolvable probe editors - one distinct binary per ladder rung -
         # created on disk and reachable via a PATH prepend, so precedence is
         # proven with genuine executables on any operating system.
         bindir = tmp_path / "bin"
         bindir.mkdir()
-        ed_editor = _write_fake_editor(bindir, "vsed-editor")
-        ed_visual = _write_fake_editor(bindir, "vsed-visual")
-        ed_vaultspec = _write_fake_editor(bindir, "vsed-vaultspec")
-        ed_config = _write_fake_editor(bindir, "vsed-config")
-        ed_flag = _write_fake_editor(bindir, "vsed-flag")
+        ed_editor = _write_probe_editor(bindir, "vsed-editor")
+        ed_visual = _write_probe_editor(bindir, "vsed-visual")
+        ed_vaultspec = _write_probe_editor(bindir, "vsed-vaultspec")
+        ed_config = _write_probe_editor(bindir, "vsed-config")
+        ed_flag = _write_probe_editor(bindir, "vsed-flag")
 
         # Save old values
         old_path = os.environ.get("PATH")
@@ -153,7 +159,7 @@ class TestEditorResolution:
         old_vaultspec_editor = os.environ.get("VAULTSPEC_EDITOR")
 
         try:
-            # Prepend the fake-editor dir and clear editor env vars to avoid
+            # Prepend the probe-editor dir and clear editor env vars to avoid
             # pollution from the ambient environment.
             os.environ["PATH"] = str(bindir) + os.pathsep + (old_path or "")
             os.environ.pop("VISUAL", None)
@@ -223,13 +229,13 @@ class TestEditorSubprocessSafety:
     def test_editor_failures_exits(self, runner, synthetic_project, tmp_path):
         import os
 
-        # Real fake editors that exit with the exact codes the ladder maps:
+        # Real probe editors that exit with the exact codes the ladder maps:
         # a nonexistent binary (resolution fail -> 2), a script exiting 5
         # (non-zero -> 3), and a script exiting 130 (cancellation -> 4).
         bindir = tmp_path / "bin"
         bindir.mkdir()
-        ed_fail5 = _write_fake_editor(bindir, "vsed-fail5", exit_code=5)
-        ed_cancel = _write_fake_editor(bindir, "vsed-cancel", exit_code=130)
+        ed_fail5 = _write_probe_editor(bindir, "vsed-fail5", exit_code=5)
+        ed_cancel = _write_probe_editor(bindir, "vsed-cancel", exit_code=130)
 
         old_path = os.environ.get("PATH")
         try:
@@ -253,7 +259,7 @@ class TestEditorSubprocessSafety:
 
             # Case 1: Resolution Failure -> code 2. Every rung of the ladder must
             # miss, including the terminal ``vi`` fallback which is present on
-            # many POSIX hosts. Point PATH exclusively at the fake-editor dir
+            # many POSIX hosts. Point PATH exclusively at the probe-editor dir
             # (which holds no ``vi``) so nothing resolves; resolution fails
             # before any subprocess launches, so no external binary is needed.
             # Windows keeps the system PATH prepended - ``vi`` is absent there
@@ -278,7 +284,7 @@ class TestEditorSubprocessSafety:
             assert result.exit_code == 2
             assert "Error: Could not resolve a working text editor" in result.output
 
-            # Restore the fake-editor dir plus the system PATH so the exit-code
+            # Restore the probe-editor dir plus the system PATH so the exit-code
             # cases below can launch their real editor subprocesses (and reach
             # cmd.exe on Windows).
             os.environ["PATH"] = str(bindir) + os.pathsep + (old_path or "")

--- a/src/vaultspec_core/tests/cli/test_resolver.py
+++ b/src/vaultspec_core/tests/cli/test_resolver.py
@@ -126,6 +126,27 @@ class TestFrameworkRules:
         assert ResolutionAction.REPAIR_MANIFEST in actions
         assert ResolutionAction.SYNC in actions
 
+    def test_corrupted_uninstall_no_force_conflicts(self):
+        diag = _make_diagnosis(framework=FrameworkSignal.CORRUPTED)
+        plan = resolve(diag, CliAction.UNINSTALL, force=False)
+        assert plan.blocked
+        assert plan.conflicts == [
+            "Manifest is corrupted. Use --force to proceed with uninstall."
+        ]
+        assert plan.steps == []
+
+    def test_corrupted_uninstall_force_repairs(self):
+        diag = _make_diagnosis(framework=FrameworkSignal.CORRUPTED)
+        plan = resolve(diag, CliAction.UNINSTALL, force=True)
+        assert not plan.blocked
+        assert [(s.action, s.target, s.reason) for s in plan.steps] == [
+            (
+                ResolutionAction.REPAIR_MANIFEST,
+                "manifest",
+                "Corrupted manifest - repairing before uninstall",
+            )
+        ]
+
 
 # ---------------------------------------------------------------------------
 # Manifest entry rules
@@ -208,6 +229,41 @@ class TestProviderDirRules:
         plan = resolve(diag, CliAction.SYNC, provider="claude")
         actions = [s.action for s in plan.steps]
         assert ResolutionAction.SYNC in actions
+
+    @pytest.mark.parametrize(
+        "signal", [ProviderDirSignal.EMPTY, ProviderDirSignal.PARTIAL]
+    )
+    @pytest.mark.parametrize("action", [CliAction.INSTALL, CliAction.UNINSTALL])
+    def test_syncable_states_outside_sync_are_recognized_no_ops(
+        self,
+        signal: ProviderDirSignal,
+        action: CliAction,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Install scaffolds and uninstall removes, so neither needs a step.
+
+        The absence of the unhandled-signal warning is the assertion that
+        matters: these combinations are deliberately inert, not unclassified.
+        """
+        caplog.set_level("WARNING", logger="vaultspec_core.core.resolver")
+        prov = _make_provider(dir_state=signal)
+        diag = _make_diagnosis(providers={Tool.CLAUDE: prov})
+
+        plan = resolve(diag, action, provider="claude")
+
+        assert [s for s in plan.steps if s.target == "claude"] == []
+        assert "Unknown ProviderDirSignal member" not in caplog.text
+
+    def test_mixed_uninstall_is_not_reclassified_as_unknown(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING", logger="vaultspec_core.core.resolver")
+        prov = _make_provider(dir_state=ProviderDirSignal.MIXED)
+        diag = _make_diagnosis(providers={Tool.CLAUDE: prov})
+
+        resolve(diag, CliAction.UNINSTALL, provider="claude", force=True)
+
+        assert "Unknown ProviderDirSignal member" not in caplog.text
 
 
 # ---------------------------------------------------------------------------
@@ -396,6 +452,99 @@ class TestPrecommitRules:
             )
 
         assert "Unknown PrecommitSignal member" not in caplog.text
+
+    def test_orphaned_prek_boundary_is_inert(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level("WARNING", logger="vaultspec_core.core.resolver")
+        plan = ResolutionPlan()
+
+        _resolve_precommit(plan, PrecommitSignal.ORPHANED, CliAction.SYNC, force=False)
+
+        assert plan.steps == []
+        assert "Unknown PrecommitSignal member" not in caplog.text
+
+    def test_unmanaged_workspace_gets_no_repair(self) -> None:
+        plan = ResolutionPlan()
+
+        _resolve_precommit(
+            plan,
+            PrecommitSignal.NO_HOOKS,
+            CliAction.SYNC,
+            force=False,
+            precommit_managed=False,
+        )
+
+        assert plan.steps == []
+
+    def test_missing_config_is_scaffolded_on_sync_only(self) -> None:
+        sync_plan = ResolutionPlan()
+        _resolve_precommit(
+            sync_plan, PrecommitSignal.NO_FILE, CliAction.SYNC, force=False
+        )
+        assert [(s.action, s.target, s.reason) for s in sync_plan.steps] == [
+            (
+                ResolutionAction.REPAIR_PRECOMMIT,
+                ".pre-commit-config.yaml",
+                "Pre-commit config missing but management is enabled",
+            )
+        ]
+
+        install_plan = ResolutionPlan()
+        _resolve_precommit(
+            install_plan, PrecommitSignal.NO_FILE, CliAction.INSTALL, force=False
+        )
+        assert install_plan.steps == []
+
+    @pytest.mark.parametrize(
+        ("signal", "reason"),
+        [
+            (
+                PrecommitSignal.NO_HOOKS,
+                "No vaultspec-core hooks found in pre-commit config",
+            ),
+            (
+                PrecommitSignal.INCOMPLETE,
+                "Missing canonical hooks in pre-commit config",
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("action", [CliAction.INSTALL, CliAction.SYNC])
+    def test_repairable_signal_carries_its_own_reason(
+        self, signal: PrecommitSignal, reason: str, action: CliAction
+    ) -> None:
+        plan = ResolutionPlan()
+
+        _resolve_precommit(plan, signal, action, force=False)
+
+        assert [(s.action, s.target, s.reason) for s in plan.steps] == [
+            (ResolutionAction.REPAIR_PRECOMMIT, ".pre-commit-config.yaml", reason)
+        ]
+
+    def test_non_canonical_reason_names_the_mode_entry_prefix(self) -> None:
+        plan = ResolutionPlan()
+
+        _resolve_precommit(
+            plan,
+            PrecommitSignal.NON_CANONICAL,
+            CliAction.SYNC,
+            force=False,
+            expected_entry_prefix="uvx --from vaultspec-core vaultspec-core",
+        )
+
+        assert [s.reason for s in plan.steps] == [
+            "Hook entries use non-canonical pattern; should use "
+            "'uvx --from vaultspec-core vaultspec-core'"
+        ]
+
+    def test_repairable_signal_is_inert_on_uninstall(self) -> None:
+        plan = ResolutionPlan()
+
+        _resolve_precommit(
+            plan, PrecommitSignal.NON_CANONICAL, CliAction.UNINSTALL, force=False
+        )
+
+        assert plan.steps == []
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaultspec_core/tests/cli/test_step_aware_exec.py
+++ b/src/vaultspec_core/tests/cli/test_step_aware_exec.py
@@ -296,6 +296,71 @@ def test_step_aware_bulk_scaffolding(runner, synthetic_project):
     assert "updated" in result3.output
 
 
+def test_step_aware_bulk_scaffolding_dry_run(runner, synthetic_project):
+    """A bulk dry run previews every record without writing one to disk."""
+    setup_test_plan(synthetic_project)
+    base_dir = synthetic_project / ".vault" / "exec" / "2026-05-17-test-feature"
+
+    result = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--all-steps",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "would create" in result.output
+    assert not base_dir.exists()
+
+    # An existing record is previewed as an overwrite only under --force.
+    base_dir.mkdir(parents=True)
+    existing = base_dir / "2026-05-17-test-feature-P01-S01.md"
+    existing.write_text("sentinel\n", encoding="utf-8")
+
+    skipped = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--all-steps",
+            "--dry-run",
+        ],
+    )
+    assert skipped.exit_code == 0
+    assert "skipped; exists" in skipped.output
+
+    forced = runner.invoke(
+        app,
+        [
+            "--target",
+            str(synthetic_project),
+            "vault",
+            "add",
+            "exec",
+            "--feature",
+            "test-feature",
+            "--all-steps",
+            "--dry-run",
+            "--force",
+        ],
+    )
+    assert forced.exit_code == 0
+    assert "would overwrite" in forced.output
+    assert existing.read_text(encoding="utf-8") == "sentinel\n"
+
+
 def test_step_aware_bulk_scaffolding_json(runner, synthetic_project):
     """Bulk scaffolding with --json outputs the outcome in envelope schema."""
     setup_test_plan(synthetic_project)

--- a/src/vaultspec_core/tests/cli/test_vault_repair.py
+++ b/src/vaultspec_core/tests/cli/test_vault_repair.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from vaultspec_core.cli import app
-from vaultspec_core.cli.vault_cmd import _render_repair_run
+from vaultspec_core.cli._repair_render import render_repair_run
 from vaultspec_core.config import reset_config
 from vaultspec_core.vaultcore.checks import run_all_checks
 from vaultspec_core.vaultcore.repair import (
@@ -686,7 +686,7 @@ class TestVaultRepair:
             }
         )
 
-        _render_repair_run(run)
+        render_repair_run(run)
         captured = capsys.readouterr()
         output = captured.out
 
@@ -711,7 +711,7 @@ class TestVaultRepair:
             for index in range(3)
         ]
 
-        _render_repair_run(run)
+        render_repair_run(run)
         captured = capsys.readouterr()
         output = captured.out
 

--- a/src/vaultspec_core/tests/plan/test_checks.py
+++ b/src/vaultspec_core/tests/plan/test_checks.py
@@ -8,6 +8,7 @@ import pytest
 
 from vaultspec_core.plan.checks import Severity, collect_all, has_errors
 from vaultspec_core.plan.checks.frontmatter_check import check_frontmatter
+from vaultspec_core.plan.checks.heading_level_check import check_heading_levels
 from vaultspec_core.plan.checks.hierarchy_check import check_hierarchy
 from vaultspec_core.plan.checks.identifiers_check import check_identifiers
 from vaultspec_core.plan.checks.row_contract_check import check_row_contract
@@ -413,3 +414,55 @@ def test_collect_all_runs_every_rule_without_raising(tier: str) -> None:
 
     assert all(isinstance(f.code, str) for f in findings)
     assert all(isinstance(f.severity, Severity) for f in findings)
+
+
+# ---- Container heading level (PLAN070) --------------------------------------
+
+
+def test_heading_level_check_flags_demoted_phase() -> None:
+    """A Phase demoted to `##` is reported rather than silently dropped.
+
+    The parser recognises a Phase only at `###`. A demoted heading matches
+    nothing, so the container vanishes from the parsed model while its Step
+    rows survive and re-parent to the previous container. This asserts the
+    loss is real and that the rule catches it.
+    """
+    rng = random.Random(0)
+    spec = make_clean_plan("L3", rng=rng, waves=1, phases=2, steps=2)
+    text = spec.render()
+
+    canonical_phases = len(parse_plan(text).phases)
+    demoted = text.replace("### Phase `", "## Phase `", 1)
+    demoted_plan = parse_plan(demoted)
+
+    # The loss this rule exists to surface is real.
+    assert len(demoted_plan.phases) == canonical_phases - 1
+
+    findings = check_heading_levels(demoted)
+    assert [f.code for f in findings] == ["PLAN070"]
+    assert findings[0].severity is Severity.ERROR
+    assert "heading level 2" in findings[0].message
+
+    # And the harness surfaces it as an error, not just the rule in isolation.
+    assert has_errors(collect_all(demoted_plan, demoted))
+
+
+def test_heading_level_check_flags_promoted_wave() -> None:
+    """A Wave promoted to `#` is reported; the parser expects `##`."""
+    rng = random.Random(1)
+    spec = make_clean_plan("L3", rng=rng, waves=1, phases=1, steps=1)
+    text = spec.render()
+
+    promoted = text.replace("## Wave `", "# Wave `", 1)
+    findings = check_heading_levels(promoted)
+
+    assert [f.code for f in findings] == ["PLAN070"]
+    assert "Wave" in findings[0].message
+
+
+def test_heading_level_check_silent_on_canonical_levels() -> None:
+    """Correctly levelled containers produce no findings, at every tier."""
+    for tier in ("L1", "L2", "L3", "L4"):
+        rng = random.Random(2)
+        spec = make_clean_plan(tier, rng=rng, waves=2, phases=2, steps=2)
+        assert check_heading_levels(spec.render()) == []

--- a/src/vaultspec_core/vaultcore/body_schema.py
+++ b/src/vaultspec_core/vaultcore/body_schema.py
@@ -327,34 +327,52 @@ def _parse_baseline(raw: object) -> tuple[Mapping[str, BaselineEntry], str | Non
     entries: dict[str, BaselineEntry] = {}
     previous_path: str | None = None
     for index, raw_entry in enumerate(entries_raw):
-        if not _is_json_object(raw_entry) or set(raw_entry) != {
-            "path",
-            "body_sha256",
-            "body_schema",
-        }:
-            return MappingProxyType({}), f"entry {index} has an invalid shape"
-        path = raw_entry["path"]
-        digest = raw_entry["body_sha256"]
-        schema_id = raw_entry["body_schema"]
-        if not isinstance(path, str) or not _is_canonical_vault_path(path):
-            return MappingProxyType({}), f"entry {index} has an unsafe path"
-        if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
-            return MappingProxyType({}), f"entry {index} has an invalid body_sha256"
-        if (
-            not isinstance(schema_id, str)
-            or schema_id not in BODY_SCHEMA_REGISTRY
-            or schema_id == CURRENT_BODY_SCHEMA
-        ):
-            return MappingProxyType(
-                {}
-            ), f"entry {index} names an invalid legacy body_schema"
-        if path in entries:
-            return MappingProxyType({}), f"ledger contains duplicate path {path!r}"
-        if previous_path is not None and path <= previous_path:
-            return MappingProxyType({}), "ledger entries must be sorted by path"
-        entries[path] = BaselineEntry(path, digest, schema_id)
-        previous_path = path
+        entry, entry_error = _parse_baseline_entry(index, raw_entry)
+        if entry is None:
+            return MappingProxyType({}), entry_error
+        order_error = _baseline_order_error(entry.path, entries, previous_path)
+        if order_error is not None:
+            return MappingProxyType({}), order_error
+        entries[entry.path] = entry
+        previous_path = entry.path
     return MappingProxyType(entries), None
+
+
+def _parse_baseline_entry(
+    index: int, raw_entry: object
+) -> tuple[BaselineEntry | None, str | None]:
+    """Validate one ledger entry's shape and values in isolation."""
+    if not _is_json_object(raw_entry) or set(raw_entry) != {
+        "path",
+        "body_sha256",
+        "body_schema",
+    }:
+        return None, f"entry {index} has an invalid shape"
+    path = raw_entry["path"]
+    digest = raw_entry["body_sha256"]
+    schema_id = raw_entry["body_schema"]
+    if not isinstance(path, str) or not _is_canonical_vault_path(path):
+        return None, f"entry {index} has an unsafe path"
+    if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+        return None, f"entry {index} has an invalid body_sha256"
+    if (
+        not isinstance(schema_id, str)
+        or schema_id not in BODY_SCHEMA_REGISTRY
+        or schema_id == CURRENT_BODY_SCHEMA
+    ):
+        return None, f"entry {index} names an invalid legacy body_schema"
+    return BaselineEntry(path, digest, schema_id), None
+
+
+def _baseline_order_error(
+    path: str, entries: Mapping[str, BaselineEntry], previous_path: str | None
+) -> str | None:
+    """Reject a ledger path that repeats or breaks the sorted-path order."""
+    if path in entries:
+        return f"ledger contains duplicate path {path!r}"
+    if previous_path is not None and path <= previous_path:
+        return "ledger entries must be sorted by path"
+    return None
 
 
 def _is_json_object(value: object) -> TypeGuard[dict[str, object]]:
@@ -444,6 +462,17 @@ def resolve_body_schema(
             source="missing" if schema_id is None else "attestation_required",
             diagnostic=(f"{doc_path.name} {descriptor}; it {requirement}."),
         )
+    return _resolve_attested(doc_path, metadata, body, schema_id, entry)
+
+
+def _resolve_attested(
+    doc_path: Path,
+    metadata: DocumentMetadata,
+    body: str,
+    schema_id: str | None,
+    entry: BaselineEntry,
+) -> BodySchemaResolution:
+    """Resolve a document against the ledger entry attesting its legacy body."""
     if schema_id is not None and schema_id != entry.body_schema:
         return BodySchemaResolution(
             required_sections=None,

--- a/src/vaultspec_core/vaultcore/checks/frontmatter.py
+++ b/src/vaultspec_core/vaultcore/checks/frontmatter.py
@@ -23,28 +23,174 @@ from ._base import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from ..models import DocType, DocumentMetadata
+
 __all__ = ["check_frontmatter"]
+
+
+_KNOWN_KEYS = frozenset(
+    {
+        "tags",
+        "date",
+        "modified",
+        "body_schema",
+        "related",
+        "feature",
+        "supersedes",
+        "superseded_by",
+        "derived_from",
+        "promoted_to",
+        "archived",
+    }
+)
+
+
+def _read_source_text(doc_path: Path) -> tuple[str, str] | None:
+    """Return ``(lf_content, source_newline)`` for *doc_path*, or None.
+
+    Reads as bytes so the source CRLF/LF convention is observable;
+    ``read_text`` collapses everything to ``\\n`` via universal newlines,
+    which would silently strip CRLF before we ever see it and bake LF back
+    into a previously-CRLF file. The content is normalized to LF for the
+    regex/manipulation passes; the caller restores the source newline
+    convention on the rendered output so files that arrived as CRLF leave
+    as CRLF.
+    """
+    try:
+        raw_content = doc_path.read_bytes().decode("utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+    source_newline = "\r\n" if "\r\n" in raw_content else "\n"
+    return raw_content.replace("\r\n", "\n"), source_newline
+
+
+def _normalized_tags(
+    metadata: DocumentMetadata, yaml_block: str, doc_type: DocType | None
+) -> tuple[list[str], bool, str | None]:
+    """Normalize ``#`` prefixes, or construct tags from a bare ``feature:``.
+
+    Returns the tag list, whether it differs from the parsed tags, and the
+    fix description to record (``None`` when nothing changed).
+    """
+    new_tags = [tag if tag.startswith("#") else f"#{tag}" for tag in metadata.tags]
+    if metadata.tags:
+        if new_tags == list(metadata.tags):
+            return new_tags, False, None
+        return new_tags, True, "normalized tag # prefixes"
+
+    feature_match = re.search(r"^feature:\s*(.+)$", yaml_block, re.MULTILINE)
+    if not feature_match or not doc_type:
+        return new_tags, False, None
+
+    feature_val = feature_match.group(1).strip().strip("\"'")
+    if not feature_val.startswith("#"):
+        feature_val = f"#{feature_val}"
+    return [doc_type.tag, feature_val], True, "constructed tags from feature field"
+
+
+def _normalized_date(date_val: str | None) -> tuple[str | None, bool]:
+    """Trim a date value down to its leading ``YYYY-MM-DD`` component."""
+    if not date_val:
+        return date_val, False
+    date_str = str(date_val).strip()
+    date_match = re.match(r"^(\d{4}-\d{2}-\d{2})", date_str)
+    if not date_match or date_str == date_match.group(1):
+        return date_val, False
+    return date_match.group(1), True
+
+
+def _existing_tag_lines(yaml_block: str) -> list[str]:
+    """Return the verbatim ``tags:`` lines already present in *yaml_block*."""
+    lines = []
+    for line in yaml_block.split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("tags") or (
+            stripped.startswith("-") and "#" in stripped
+        ):
+            lines.append(line)
+    return lines
+
+
+def _unknown_key_lines(yaml_block: str) -> list[str]:
+    """Return the verbatim lines of every key outside :data:`_KNOWN_KEYS`."""
+    lines = []
+    in_unknown_key = False
+    for line in yaml_block.split("\n"):
+        stripped = line.strip()
+        if ":" in stripped and not stripped.startswith("-"):
+            in_unknown_key = stripped.split(":", 1)[0].strip() not in _KNOWN_KEYS
+        elif not stripped.startswith("-"):
+            if in_unknown_key and stripped:
+                lines.append(line)
+            in_unknown_key = False
+            continue
+        if in_unknown_key:
+            lines.append(line)
+    return lines
+
+
+def _render_frontmatter_lines(
+    metadata: DocumentMetadata,
+    new_tags: list[str],
+    date_val: str | None,
+    yaml_block: str,
+    *,
+    tags_changed: bool,
+) -> list[str]:
+    """Rebuild the frontmatter block in canonical field order."""
+    lines = ["---"]
+    if new_tags:
+        lines.append("tags:")
+        lines.extend(f'  - "{tag}"' for tag in new_tags)
+    elif not tags_changed:
+        lines.extend(_existing_tag_lines(yaml_block))
+
+    if date_val:
+        lines.append(f"date: {date_val}")
+    elif metadata.date:
+        lines.append(f"date: {metadata.date}")
+
+    if metadata.modified:
+        lines.append(f"modified: '{metadata.modified}'")
+
+    if metadata.body_schema:
+        lines.append(f"body_schema: '{metadata.body_schema}'")
+
+    if metadata.related:
+        lines.append("related:")
+        lines.extend(f'  - "{link}"' for link in metadata.related)
+
+    if metadata.supersedes:
+        lines.append("supersedes:")
+        lines.extend(f"  - '{stem}'" for stem in metadata.supersedes)
+
+    if metadata.superseded_by:
+        lines.append(f"superseded_by: '{metadata.superseded_by}'")
+
+    if metadata.derived_from:
+        lines.append("derived_from:")
+        lines.extend(f"  - '{stem}'" for stem in metadata.derived_from)
+
+    if metadata.promoted_to:
+        lines.append("promoted_to:")
+        lines.extend(f"  - '{rule}'" for rule in metadata.promoted_to)
+
+    if metadata.archived:
+        lines.append(f"archived: '{metadata.archived}'")
+
+    lines.extend(_unknown_key_lines(yaml_block))
+    lines.append("---")
+    return lines
 
 
 def _fix_frontmatter(doc_path: Path, root_dir: Path) -> str | None:
     """Attempt to fix common frontmatter issues. Returns fix description or None."""
     from ..scanner import get_doc_type
 
-    try:
-        # Read as bytes so the source CRLF/LF convention is observable;
-        # ``read_text`` collapses everything to ``\n`` via universal
-        # newlines, which would silently strip CRLF before we ever see
-        # it and bake LF back into a previously-CRLF file.
-        raw = doc_path.read_bytes()
-        raw_content = raw.decode("utf-8")
-    except (OSError, UnicodeDecodeError):
+    source = _read_source_text(doc_path)
+    if source is None:
         return None
-
-    source_newline = "\r\n" if "\r\n" in raw_content else "\n"
-    # Normalize to LF for the regex/manipulation passes; we restore the
-    # source newline convention on the rendered output below so files
-    # that arrived as CRLF leave as CRLF.
-    content = raw_content.replace("\r\n", "\n")
+    content, source_newline = source
 
     match = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", content.lstrip(), re.DOTALL)
     if not match:
@@ -61,123 +207,22 @@ def _fix_frontmatter(doc_path: Path, root_dir: Path) -> str | None:
     metadata, _ = parse_vault_metadata(content)
     doc_type = get_doc_type(doc_path, root_dir)
 
-    # Fix 1: Normalize tags
-    new_tags = []
-    tags_changed = False
-    for tag in metadata.tags:
-        if not tag.startswith("#"):
-            new_tags.append(f"#{tag}")
-            tags_changed = True
-        else:
-            new_tags.append(tag)
-
-    # Fix 2: If no tags but has feature: field, construct tags
-    if not metadata.tags:
-        feature_match = re.search(r"^feature:\s*(.+)$", yaml_block, re.MULTILINE)
-        if feature_match and doc_type:
-            feature_val = feature_match.group(1).strip().strip("\"'")
-            if not feature_val.startswith("#"):
-                feature_val = f"#{feature_val}"
-            new_tags = [doc_type.tag, feature_val]
-            tags_changed = True
-            fixes_applied.append("constructed tags from feature field")
-
-    if tags_changed and not fixes_applied:
-        fixes_applied.append("normalized tag # prefixes")
+    # Fix 1 and 2: normalize tag prefixes, or construct tags from feature:
+    new_tags, tags_changed, tag_fix = _normalized_tags(metadata, yaml_block, doc_type)
+    if tag_fix:
+        fixes_applied.append(tag_fix)
 
     # Fix 3: Date format normalization
-    date_val = metadata.date
-    if date_val:
-        date_str = str(date_val).strip()
-        date_match = re.match(r"^(\d{4}-\d{2}-\d{2})", date_str)
-        if date_match and date_str != date_match.group(1):
-            date_val = date_match.group(1)
-            fixes_applied.append("normalized date format")
+    date_val, date_fixed = _normalized_date(metadata.date)
+    if date_fixed:
+        fixes_applied.append("normalized date format")
 
     if not fixes_applied:
         return None
 
-    # Rebuild frontmatter
-    lines = ["---"]
-    if new_tags:
-        lines.append("tags:")
-        for tag in new_tags:
-            lines.append(f'  - "{tag}"')
-    elif not tags_changed:
-        for line in yaml_block.split("\n"):
-            stripped = line.strip()
-            if stripped.startswith("tags") or (
-                stripped.startswith("-") and "#" in stripped
-            ):
-                lines.append(line)
-
-    if date_val:
-        lines.append(f"date: {date_val}")
-    elif metadata.date:
-        lines.append(f"date: {metadata.date}")
-
-    if metadata.modified:
-        lines.append(f"modified: '{metadata.modified}'")
-
-    if metadata.body_schema:
-        lines.append(f"body_schema: '{metadata.body_schema}'")
-
-    if metadata.related:
-        lines.append("related:")
-        for link in metadata.related:
-            lines.append(f'  - "{link}"')
-
-    if metadata.supersedes:
-        lines.append("supersedes:")
-        for stem in metadata.supersedes:
-            lines.append(f"  - '{stem}'")
-
-    if metadata.superseded_by:
-        lines.append(f"superseded_by: '{metadata.superseded_by}'")
-
-    if metadata.derived_from:
-        lines.append("derived_from:")
-        for stem in metadata.derived_from:
-            lines.append(f"  - '{stem}'")
-
-    if metadata.promoted_to:
-        lines.append("promoted_to:")
-        for rule in metadata.promoted_to:
-            lines.append(f"  - '{rule}'")
-
-    if metadata.archived:
-        lines.append(f"archived: '{metadata.archived}'")
-
-    known_keys = {
-        "tags",
-        "date",
-        "modified",
-        "body_schema",
-        "related",
-        "feature",
-        "supersedes",
-        "superseded_by",
-        "derived_from",
-        "promoted_to",
-        "archived",
-    }
-    in_unknown_key = False
-    for line in yaml_block.split("\n"):
-        stripped = line.strip()
-        if ":" in stripped and not stripped.startswith("-"):
-            key = stripped.split(":", 1)[0].strip()
-            in_unknown_key = key not in known_keys
-            if in_unknown_key:
-                lines.append(line)
-        elif stripped.startswith("-"):
-            if in_unknown_key:
-                lines.append(line)
-        else:
-            if in_unknown_key and stripped:
-                lines.append(line)
-            in_unknown_key = False
-
-    lines.append("---")
+    lines = _render_frontmatter_lines(
+        metadata, new_tags, date_val, yaml_block, tags_changed=tags_changed
+    )
     if body:
         lines.append(body)
 

--- a/src/vaultspec_core/vaultcore/checks/references.py
+++ b/src/vaultspec_core/vaultcore/checks/references.py
@@ -20,7 +20,7 @@ from ._base import CheckDiagnostic, CheckResult, Severity
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from ...graph import VaultGraph
+    from ...graph import DocNode, VaultGraph
 
 __all__ = ["check_references", "check_schema"]
 
@@ -214,6 +214,181 @@ def check_references(
     return result
 
 
+def _build_feature_type_index(graph: VaultGraph) -> dict[str, dict[str, list[DocNode]]]:
+    """Index real nodes by feature tag and document type for fix lookups."""
+    from ..models import DocType
+
+    feat_type_index: dict[str, dict[str, list[DocNode]]] = {}
+    for node in graph.nodes.values():
+        if node.phantom or not node.doc_type:
+            continue
+        for tag in node.tags:
+            if not DocType.from_tag(tag):
+                feat = tag.lstrip("#")
+                feat_type_index.setdefault(feat, {}).setdefault(
+                    node.doc_type.value, []
+                ).append(node)
+    return feat_type_index
+
+
+def _is_filtered_out(
+    node: DocNode, feature: str | None, doc_type_filter: str | None
+) -> bool:
+    """Return True when *node* falls outside the requested type/feature filter.
+
+    An untyped node cannot satisfy a type filter, so it is filtered out. The
+    caller already skips those, but stating it here keeps the helper correct
+    on its own terms rather than relying on narrowing it cannot see.
+    """
+    if doc_type_filter and (
+        node.doc_type is None or node.doc_type.value != doc_type_filter
+    ):
+        return True
+    if not feature:
+        return False
+    # Feature filter (normalize: always compare stripped values)
+    feat = feature.lstrip("#")
+    return feat not in {t.lstrip("#") for t in node.tags}
+
+
+def _linked_doc_types(graph: VaultGraph, node: DocNode) -> set[str]:
+    """Classify outgoing link targets by doc type (skip phantoms)."""
+    linked_types: set[str] = set()
+    for target_name in node.out_links:
+        target = graph.nodes.get(target_name)
+        if target and not target.phantom and target.doc_type:
+            linked_types.add(target.doc_type.value)
+    return linked_types
+
+
+def _primary_feature_name(node: DocNode) -> str | None:
+    """Return the node's first feature tag without its ``#``, if any."""
+    from ..models import DocType
+
+    feat_tags = [t for t in node.tags if not DocType.from_tag(t)]
+    return feat_tags[0].lstrip("#") if feat_tags else None
+
+
+def _fix_missing_link(
+    node: DocNode,
+    rel_path: Path,
+    feat_name: str | None,
+    feat_type_index: dict[str, dict[str, list[DocNode]]],
+    candidate_types: tuple[str, ...],
+    result: CheckResult,
+    *,
+    fix: bool,
+) -> bool:
+    """Add the first same-feature document of *candidate_types* to ``related:``.
+
+    Returns ``True`` when a link was added and the INFO diagnostic recorded,
+    ``False`` when fixing is disabled or no candidate could be linked.
+
+    A node with no working-tree path (a phantom, or a ref-scoped node whose
+    blob lives only in git) has no file to rewrite, so it is never fixable.
+    The caller already skips those; the guard is restated here so the helper
+    holds on its own terms rather than on narrowing it cannot see.
+    """
+    if not fix or not feat_name or node.path is None:
+        return False
+    by_type = feat_type_index.get(feat_name, {})
+    candidates = next((by_type[t] for t in candidate_types if by_type.get(t)), [])
+    if not candidates or not _add_related_link(node.path, candidates[0].name):
+        return False
+    result.fixed_count += 1
+    result.diagnostics.append(
+        CheckDiagnostic(
+            path=rel_path,
+            message=(f"Fixed: added [[{candidates[0].name}]] to related field"),
+            severity=Severity.INFO,
+        )
+    )
+    return True
+
+
+def _check_adr_grounding(
+    node: DocNode,
+    rel_path: Path,
+    feat_name: str | None,
+    linked_types: set[str],
+    feat_type_index: dict[str, dict[str, list[DocNode]]],
+    result: CheckResult,
+    *,
+    fix: bool,
+) -> None:
+    """Require an ADR to reference research, reference, or audit grounding."""
+    # The documentation hierarchy sanctions research, reference, and audit
+    # documents as ADR grounding; any one of them satisfies the check.
+    grounding_types = ("research", "reference", "audit")
+    if linked_types & set(grounding_types):
+        return
+
+    if _fix_missing_link(
+        node, rel_path, feat_name, feat_type_index, grounding_types, result, fix=fix
+    ):
+        return
+
+    msg = "ADR has no grounding references (research, reference, or audit documents)"
+    if feat_name:
+        msg += f" (feature: {feat_name})"
+    result.diagnostics.append(
+        CheckDiagnostic(
+            path=rel_path,
+            message=msg,
+            severity=Severity.ERROR,
+            fixable=True,
+            fix_description=(
+                "Add a research document reference in the "
+                "related field or document body"
+            ),
+        )
+    )
+
+
+def _check_plan_grounding(
+    node: DocNode,
+    rel_path: Path,
+    feat_name: str | None,
+    linked_types: set[str],
+    feat_type_index: dict[str, dict[str, list[DocNode]]],
+    result: CheckResult,
+    *,
+    fix: bool,
+) -> None:
+    """Require a plan to reference an ADR, and nudge it toward research."""
+    if "adr" not in linked_types and not _fix_missing_link(
+        node, rel_path, feat_name, feat_type_index, ("adr",), result, fix=fix
+    ):
+        result.diagnostics.append(
+            CheckDiagnostic(
+                path=rel_path,
+                message="Plan has no references to ADR documents",
+                severity=Severity.ERROR,
+                fixable=True,
+                fix_description=(
+                    "Add an ADR document reference in the "
+                    "related field or document body"
+                ),
+            )
+        )
+
+    # Plans should reference research (soft)
+    if "research" not in linked_types and not _fix_missing_link(
+        node, rel_path, feat_name, feat_type_index, ("research",), result, fix=fix
+    ):
+        result.diagnostics.append(
+            CheckDiagnostic(
+                path=rel_path,
+                message="Plan has no references to research documents",
+                severity=Severity.WARNING,
+                fix_description=(
+                    "Consider adding research document references "
+                    "for supporting evidence"
+                ),
+            )
+        )
+
+
 def check_schema(
     root_dir: Path,
     *,
@@ -252,174 +427,38 @@ def check_schema(
     result = CheckResult(check_name="schema", supports_fix=True)
 
     # Pre-build feature->type->nodes index for fix lookups (skip phantoms)
-    feat_type_index: dict[str, dict[str, list]] = {}
-    for _name, _node in graph.nodes.items():
-        if _node.phantom or not _node.doc_type:
-            continue
-        for _tag in _node.tags:
-            if not DocType.from_tag(_tag):
-                _feat = _tag.lstrip("#")
-                feat_type_index.setdefault(_feat, {}).setdefault(
-                    _node.doc_type.value, []
-                ).append(_node)
+    feat_type_index = _build_feature_type_index(graph)
 
     for _name, node in sorted(graph.nodes.items()):
         if not node.doc_type or node.path is None:
             continue
 
-        # Apply filters
-        if doc_type_filter and node.doc_type.value != doc_type_filter:
+        if _is_filtered_out(node, feature, doc_type_filter):
             continue
-        # Feature filter (normalize: always compare stripped values)
-        if feature:
-            feat = feature.lstrip("#")
-            node_features = {t.lstrip("#") for t in node.tags}
-            if feat not in node_features:
-                continue
 
-        # Classify outgoing link targets by doc type (skip phantoms)
-        linked_types: set[str] = set()
-        for target_name in node.out_links:
-            target = graph.nodes.get(target_name)
-            if target and not target.phantom and target.doc_type:
-                linked_types.add(target.doc_type.value)
-
+        linked_types = _linked_doc_types(graph, node)
         rel_path = node.path.relative_to(root_dir)
-        feat_tags = [t for t in node.tags if not DocType.from_tag(t)]
-        feat_name = feat_tags[0].lstrip("#") if feat_tags else None
+        feat_name = _primary_feature_name(node)
 
         if node.doc_type == DocType.ADR:
-            # The documentation hierarchy sanctions research, reference, and
-            # audit documents as ADR grounding; any one of them satisfies the
-            # check.
-            grounding_types = {"research", "reference", "audit"}
-            if not (linked_types & grounding_types):
-                msg = (
-                    "ADR has no grounding references "
-                    "(research, reference, or audit documents)"
-                )
-                if feat_name:
-                    msg += f" (feature: {feat_name})"
-
-                if fix and feat_name:
-                    by_type = feat_type_index.get(feat_name, {})
-                    candidates = next(
-                        (
-                            by_type[t]
-                            for t in ("research", "reference", "audit")
-                            if by_type.get(t)
-                        ),
-                        [],
-                    )
-                    if candidates and _add_related_link(node.path, candidates[0].name):
-                        result.fixed_count += 1
-                        result.diagnostics.append(
-                            CheckDiagnostic(
-                                path=rel_path,
-                                message=(
-                                    f"Fixed: added [[{candidates[0].name}]] "
-                                    f"to related field"
-                                ),
-                                severity=Severity.INFO,
-                            )
-                        )
-                        continue
-
-                result.diagnostics.append(
-                    CheckDiagnostic(
-                        path=rel_path,
-                        message=msg,
-                        severity=Severity.ERROR,
-                        fixable=True,
-                        fix_description=(
-                            "Add a research document reference in the "
-                            "related field or document body"
-                        ),
-                    )
-                )
-
+            _check_adr_grounding(
+                node,
+                rel_path,
+                feat_name,
+                linked_types,
+                feat_type_index,
+                result,
+                fix=fix,
+            )
         elif node.doc_type == DocType.PLAN:
-            if "adr" not in linked_types:
-                if fix and feat_name:
-                    candidates = feat_type_index.get(feat_name, {}).get("adr", [])
-                    if candidates and _add_related_link(node.path, candidates[0].name):
-                        result.fixed_count += 1
-                        result.diagnostics.append(
-                            CheckDiagnostic(
-                                path=rel_path,
-                                message=(
-                                    f"Fixed: added [[{candidates[0].name}]] "
-                                    f"to related field"
-                                ),
-                                severity=Severity.INFO,
-                            )
-                        )
-                    else:
-                        result.diagnostics.append(
-                            CheckDiagnostic(
-                                path=rel_path,
-                                message="Plan has no references to ADR documents",
-                                severity=Severity.ERROR,
-                                fixable=True,
-                                fix_description=(
-                                    "Add an ADR document reference in the "
-                                    "related field or document body"
-                                ),
-                            )
-                        )
-                else:
-                    result.diagnostics.append(
-                        CheckDiagnostic(
-                            path=rel_path,
-                            message="Plan has no references to ADR documents",
-                            severity=Severity.ERROR,
-                            fixable=True,
-                            fix_description=(
-                                "Add an ADR document reference in the "
-                                "related field or document body"
-                            ),
-                        )
-                    )
-
-            # Plans should reference research (soft)
-            if "research" not in linked_types:
-                if fix and feat_name:
-                    candidates = feat_type_index.get(feat_name, {}).get("research", [])
-                    if candidates and _add_related_link(node.path, candidates[0].name):
-                        result.fixed_count += 1
-                        result.diagnostics.append(
-                            CheckDiagnostic(
-                                path=rel_path,
-                                message=(
-                                    f"Fixed: added [[{candidates[0].name}]] "
-                                    f"to related field"
-                                ),
-                                severity=Severity.INFO,
-                            )
-                        )
-                    else:
-                        result.diagnostics.append(
-                            CheckDiagnostic(
-                                path=rel_path,
-                                message="Plan has no references to research documents",
-                                severity=Severity.WARNING,
-                                fix_description=(
-                                    "Consider adding research document references "
-                                    "for supporting evidence"
-                                ),
-                            )
-                        )
-                else:
-                    result.diagnostics.append(
-                        CheckDiagnostic(
-                            path=rel_path,
-                            message="Plan has no references to research documents",
-                            severity=Severity.WARNING,
-                            fix_description=(
-                                "Consider adding research document references "
-                                "for supporting evidence"
-                            ),
-                        )
-                    )
+            _check_plan_grounding(
+                node,
+                rel_path,
+                feat_name,
+                linked_types,
+                feat_type_index,
+                result,
+                fix=fix,
+            )
 
     return result

--- a/src/vaultspec_core/vaultcore/checks/tests/test_frontmatter_fields.py
+++ b/src/vaultspec_core/vaultcore/checks/tests/test_frontmatter_fields.py
@@ -152,6 +152,81 @@ archived: 2026-05-22
     assert new_content.count("body_schema:") == 1
 
 
+def test_fix_frontmatter_preserves_unknown_keys(tmp_path):
+    _make_skeleton(tmp_path)
+    doc = tmp_path / ".vault" / "adr" / "2026-05-17-unknown-adr.md"
+    doc.write_text(
+        """---
+tags:
+  - adr
+  - my-feature
+date: 2026-05-17
+custom_scalar: kept
+custom_list:
+  - one
+  - two
+
+trailing_unknown: also kept
+---
+# Content
+""",
+        encoding="utf-8",
+    )
+
+    desc = _fix_frontmatter(doc, tmp_path)
+    assert desc == "normalized tag # prefixes"
+
+    new_content = doc.read_text(encoding="utf-8")
+    assert "custom_scalar: kept" in new_content
+    assert "custom_list:" in new_content
+    assert "  - one" in new_content
+    assert "  - two" in new_content
+    assert "trailing_unknown: also kept" in new_content
+    assert new_content.count("date:") == 1
+    assert new_content.count("tags:") == 1
+
+    meta, _ = parse_vault_metadata(new_content)
+    assert meta.tags == ["#adr", "#my-feature"]
+
+
+def test_fix_frontmatter_noop_when_nothing_to_fix(tmp_path):
+    _make_skeleton(tmp_path)
+    doc = tmp_path / ".vault" / "adr" / "2026-05-17-clean-adr.md"
+    original = """---
+tags:
+  - "#adr"
+  - "#my-feature"
+date: 2026-05-17
+---
+# Content
+"""
+    doc.write_text(original, encoding="utf-8")
+
+    assert _fix_frontmatter(doc, tmp_path) is None
+    assert doc.read_text(encoding="utf-8") == original
+
+
+def test_fix_frontmatter_normalizes_date_suffix(tmp_path):
+    _make_skeleton(tmp_path)
+    doc = tmp_path / ".vault" / "adr" / "2026-05-17-date-adr.md"
+    doc.write_text(
+        """---
+tags:
+  - "#adr"
+  - "#my-feature"
+date: "2026-05-17 10:30"
+---
+# Content
+""",
+        encoding="utf-8",
+    )
+
+    assert _fix_frontmatter(doc, tmp_path) == "normalized date format"
+
+    meta, _ = parse_vault_metadata(doc.read_text(encoding="utf-8"))
+    assert meta.date == "2026-05-17"
+
+
 def test_migration_0_1_21(tmp_path):
     # Runs the additive migration which should return successfully
     res = migrate_0_1_21(tmp_path)

--- a/src/vaultspec_core/vaultcore/hydration.py
+++ b/src/vaultspec_core/vaultcore/hydration.py
@@ -13,13 +13,23 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from ..core.exceptions import ResourceExistsError
 from .body_schema import CURRENT_BODY_SCHEMA
 from .models import DocType
 
-__all__ = ["get_template_path", "hydrate_template"]
+__all__ = [
+    "DocumentIdentity",
+    "ExecBinding",
+    "ParentPlan",
+    "TemplateFields",
+    "WritePolicy",
+    "create_vault_doc",
+    "get_template_path",
+    "hydrate_template",
+]
 
 logger = logging.getLogger(__name__)
 
@@ -71,57 +81,155 @@ if TYPE_CHECKING:
     import pathlib
 
 
+@dataclass(frozen=True, slots=True)
+class DocumentIdentity:
+    """The values that name a vault document on disk.
+
+    Together these decide the target directory, the filename, and the
+    feature tag the scaffolded frontmatter carries.
+
+    Attributes:
+        doc_type: The type of vault document to create.
+        feature: Feature name in kebab-case (leading ``#`` stripped).
+        date: ISO 8601 date string (e.g. ``2026-02-06``).
+        topic: Optional kebab-case narrative infix. Admitted only for the
+            narrative trio (``audit``, ``reference``, ``research``) and
+            ``adr``; the filename resolves to
+            ``{date}-{feature}-{topic}-{type}.md``. Omitted, the filename
+            keeps its ``{date}-{feature}-{type}.md`` form.
+    """
+
+    doc_type: DocType
+    feature: str
+    date: str
+    topic: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class TemplateFields:
+    """Author-supplied values a template's placeholders resolve to.
+
+    Attributes:
+        title: Optional title that maps to the ``{title}`` and ``{topic}``
+            placeholders.
+        related: Pre-resolved ``[[wiki-link]]`` strings to inject into the
+            ``related:`` frontmatter field.
+        extra_tags: Additional ``#tag`` strings to append to the ``tags:``
+            frontmatter field (beyond the directory and feature tags).
+        tier: Optional plan tier value (``L1``..``L4``) substituted into the
+            ``{tier}`` placeholder for plan templates.
+    """
+
+    title: str | None = None
+    related: list[str] | None = None
+    extra_tags: list[str] | None = None
+    tier: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ParentPlan:
+    """The plan document an execution record hangs off.
+
+    Attributes:
+        date: The parent plan's date, used for the execution folder and
+            filename prefix. Falling back to the record's own date when
+            omitted.
+        stem: The parent plan's filename stem, used for the ``{plan_stem}``
+            placeholder and the leading ``related:`` wiki-link.
+    """
+
+    date: str | None = None
+    stem: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ExecBinding:
+    """The plan row a scaffolded execution record documents.
+
+    Every field is inert for non-execution document types, whose templates
+    carry none of the corresponding placeholders.
+
+    Attributes:
+        plan: Identity of the parent plan.
+        step_id: The Step's canonical identifier (e.g. ``S01``).
+        step_display_path: The Step's display path (e.g. ``W01.P01.S01``),
+            which supplies the filename's identifier segment.
+        step_scope: The Step's declared file or area scope.
+        step_action: The Step's verbatim action text.
+        summary: When ``True``, the record summarises a Phase rather than
+            documenting a Step, and is scaffolded from the
+            ``exec-summary.md`` template.
+        phase_display_path: Display path of the summarised Phase (e.g.
+            ``P01`` or ``W01.P01``); fills the ``{phase}`` placeholder and
+            the summary filename's identifier segment.
+    """
+
+    plan: ParentPlan = ParentPlan()
+    step_id: str | None = None
+    step_display_path: str | None = None
+    step_scope: str | None = None
+    step_action: str | None = None
+    summary: bool = False
+    phase_display_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class WritePolicy:
+    """How the scaffolder treats the target path.
+
+    Attributes:
+        force: If ``True``, overwrite an existing document.
+        dry_run: If ``True``, resolve the target path without writing.
+    """
+
+    force: bool = False
+    dry_run: bool = False
+
+
 def hydrate_template(
     template_content: str,
     feature: str,
     date: str,
-    title: str | None = None,
-    *,
-    related: list[str] | None = None,
-    extra_tags: list[str] | None = None,
-    tier: str | None = None,
-    step_id: str | None = None,
-    step_scope: str | None = None,
-    step_action: str | None = None,
-    plan_stem: str | None = None,
-    phase: str | None = None,
+    fields: TemplateFields | None = None,
+    exec_binding: ExecBinding | None = None,
 ) -> str:
     """Replace placeholders in a template string with actual values.
 
     Supports both ``{key}`` and ``<key>`` placeholder styles.  Logs a
     warning for any placeholder that remains unresolved after substitution.
 
-    When *related* is provided, the template's placeholder ``related:``
-    entries are replaced with the resolved wiki-link list. When
-    *extra_tags* is provided, those tags are appended to the ``tags:``
-    block in frontmatter. When *tier* is provided, the template's
-    ``{tier}`` placeholder is substituted; otherwise the placeholder
-    is left as-is for the caller to fill.
+    When ``fields.related`` is provided, the template's placeholder
+    ``related:`` entries are replaced with the resolved wiki-link list. When
+    ``fields.extra_tags`` is provided, those tags are appended to the
+    ``tags:`` block in frontmatter. When ``fields.tier`` is provided, the
+    template's ``{tier}`` placeholder is substituted; otherwise the
+    placeholder is left as-is for the caller to fill.
 
     Args:
         template_content: Raw template text containing placeholder tokens.
         feature: Feature name in kebab-case (e.g. ``editor-demo``).
         date: ISO 8601 date string (e.g. ``2026-02-06``).
-        title: Optional title that maps to the ``{title}`` and ``{topic}``
-            placeholders.
-        related: Pre-resolved ``[[wiki-link]]`` strings to inject into
-            the ``related:`` frontmatter field.
-        extra_tags: Additional ``#tag`` strings to append to the ``tags:``
-            frontmatter field (beyond the directory and feature tags).
-        tier: Optional plan tier value (``L1``..``L4``) substituted into
-            the ``{tier}`` placeholder for plan templates.
-        step_id: Optional step canonical identifier (e.g. ``S01``).
-        step_scope: Optional file or area scope of the step.
-        step_action: Optional verbatim action of the step.
-        plan_stem: Optional parent plan stem used in wiki-links.
-        phase: Optional Phase identifier (display path, e.g. ``P01`` or
-            ``W01.P01``) substituted into the ``{phase}`` placeholder of the
-            exec-summary template. Takes precedence over the ``{phase}``
-            alias derived from *title*.
+        fields: Author-supplied placeholder values. Defaults to an empty
+            :class:`TemplateFields`, leaving every optional placeholder
+            for the caller to fill.
+        exec_binding: The plan row an execution record documents. Defaults
+            to an empty :class:`ExecBinding`, which leaves the step-aware
+            placeholders on their generic fallbacks.
 
     Returns:
         The fully-hydrated document string.
     """
+    if fields is None:
+        fields = TemplateFields()
+    if exec_binding is None:
+        exec_binding = ExecBinding()
+
+    title = fields.title
+    tier = fields.tier
+    # The exec-summary template's `{phase}` placeholder only applies to a
+    # summary record; a Step record leaves the title-derived alias in place.
+    phase = exec_binding.phase_display_path if exec_binding.summary else None
+
     hydrated = template_content
 
     # Normalize placeholders map
@@ -159,9 +267,12 @@ def hydrate_template(
                 hydrated = hydrated.replace(pattern, value)
 
     # Hydrate step-aware placeholders
+    step_id = exec_binding.step_id
+    plan_stem = exec_binding.plan.stem
     val_step_id = step_id if step_id is not None else "{S##}"
     val_plan_stem = plan_stem if plan_stem is not None else "{yyyy-mm-dd-*-plan}"
 
+    step_action = exec_binding.step_action
     if title is not None:
         val_heading = title
     elif step_action is not None:
@@ -170,6 +281,7 @@ def hydrate_template(
         val_heading = f"{feature} <display-path>"
 
     val_scope_block = ""
+    step_scope = exec_binding.step_scope
     if step_scope:
         scopes = [
             s.strip().strip("`") for s in re.split(r"[,;]+", step_scope) if s.strip()
@@ -193,12 +305,12 @@ def hydrate_template(
     hydrated = _inject_body_schema(hydrated)
 
     # Inject resolved related links into frontmatter
-    if related is not None:
-        hydrated = _inject_related(hydrated, related)
+    if fields.related is not None:
+        hydrated = _inject_related(hydrated, fields.related)
 
     # Inject extra tags into frontmatter
-    if extra_tags:
-        hydrated = _inject_extra_tags(hydrated, extra_tags)
+    if fields.extra_tags:
+        hydrated = _inject_extra_tags(hydrated, fields.extra_tags)
 
     # Check for remaining placeholders that might have been missed.
     # Pattern matches {key} or <key> where key is alphanumeric with hyphens.
@@ -357,73 +469,55 @@ def _inject_extra_tags(content: str, extra_tags: list[str]) -> str:
 
 def create_vault_doc(
     root_dir: pathlib.Path,
-    doc_type: DocType,
-    feature: str,
-    date_str: str,
-    title: str | None = None,
+    identity: DocumentIdentity,
+    fields: TemplateFields | None = None,
     *,
-    topic: str | None = None,
-    related: list[str] | None = None,
-    extra_tags: list[str] | None = None,
+    exec_binding: ExecBinding | None = None,
+    write: WritePolicy | None = None,
     content_root: pathlib.Path | None = None,
-    force: bool = False,
-    dry_run: bool = False,
-    tier: str | None = None,
-    step_id: str | None = None,
-    step_display_path: str | None = None,
-    step_scope: str | None = None,
-    step_action: str | None = None,
-    plan_date: str | None = None,
-    plan_stem: str | None = None,
-    summary: bool = False,
-    phase_display_path: str | None = None,
 ) -> pathlib.Path:
     """Scaffold a new vault document from the appropriate template.
 
     Args:
         root_dir: Project root (output_root from workspace layout).
-        doc_type: The type of vault document to create.
-        feature: Feature name in kebab-case (leading ``#`` stripped).
-        date_str: ISO 8601 date string (e.g. ``2026-02-06``).
-        title: Optional document title.
-        topic: Optional kebab-case narrative infix. Admitted only for the
-            narrative trio (``audit``, ``reference``, ``research``); the
-            filename resolves to ``{date}-{feature}-{topic}-{type}.md``.
-            Omitted, the filename keeps its ``{date}-{feature}-{type}.md``
-            form. Raises :class:`ValueError` for any other document type
-            (adr and plan cardinality rules forbid disambiguation-by-infix;
-            exec filenames are machine-derived).
-        related: Pre-resolved ``[[wiki-link]]`` strings for the
-            ``related:`` frontmatter field.
-        extra_tags: Additional ``#tag`` strings to append to ``tags:``.
+        identity: Type, feature, date, and optional narrative infix of the
+            document to create. A ``topic`` on a type outside the admitting
+            set raises :class:`ValueError` (adr and plan cardinality rules
+            forbid disambiguation-by-infix; exec filenames are
+            machine-derived).
+        fields: Author-supplied placeholder values. Defaults to an empty
+            :class:`TemplateFields`.
+        exec_binding: The plan row an execution record documents. Defaults
+            to an empty :class:`ExecBinding`, which scaffolds the flat
+            (non-step-aware) shape.
+        write: Overwrite and dry-run policy. Defaults to a
+            :class:`WritePolicy` that refuses to overwrite and does write.
         content_root: Explicit content root for template lookup.
-        force: If ``True``, overwrite an existing document.
-        dry_run: If ``True``, return the target path without writing.
-        tier: Plan tier value (``L1``..``L4``) substituted into the plan
-            template's ``{tier}`` placeholder. Ignored for non-plan
-            doc types whose templates do not carry the placeholder.
-        step_id: Optional step canonical identifier (e.g. ``S01``).
-        step_display_path: Optional display path of the step.
-        step_scope: Optional file or area scope of the step.
-        step_action: Optional verbatim action of the step.
-        plan_date: Optional parent plan date.
-        plan_stem: Optional parent plan stem used in wiki-links.
-        summary: When ``True`` and *doc_type* is :attr:`DocType.EXEC`,
-            scaffold a Phase-summary record from the ``exec-summary.md``
-            template instead of a Step record. Requires *phase_display_path*.
-        phase_display_path: Display path of the summarised Phase (e.g.
-            ``P01`` or ``W01.P01``); fills the ``{phase}`` placeholder and the
-            summary filename's identifier segment.
 
     Returns:
         Path to the newly created (or would-be-created) document.
 
     Raises:
-        FileNotFoundError: If no template exists for the given ``doc_type``.
-        ResourceExistsError: If the target file already exists and
-            *force* is ``False``.
+        FileNotFoundError: If no template exists for the identity's type.
+        ResourceExistsError: If the target file already exists and the
+            write policy does not force an overwrite.
     """
     from ..config import get_config
+
+    if fields is None:
+        fields = TemplateFields()
+    if exec_binding is None:
+        exec_binding = ExecBinding()
+    if write is None:
+        write = WritePolicy()
+
+    doc_type = identity.doc_type
+    feature = identity.feature
+    date_str = identity.date
+    topic = identity.topic
+    summary = exec_binding.summary
+    plan_date = exec_binding.plan.date
+    plan_stem = exec_binding.plan.stem
 
     if topic is not None and doc_type not in _TOPIC_INFIX_TYPES:
         raise ValueError(
@@ -445,7 +539,7 @@ def create_vault_doc(
 
     # Default to empty related list so created documents pass validation
     # instead of keeping template placeholder entries like [[{yyyy-mm-dd-*}]]
-    effective_related = list(related) if related is not None else []
+    effective_related = list(fields.related) if fields.related is not None else []
     if plan_stem:
         plan_link = f"[[{plan_stem}]]"
         if plan_link not in effective_related:
@@ -455,7 +549,7 @@ def create_vault_doc(
     # otherwise leave the template's `{topic}`/`{title}` heading placeholder
     # unhydrated and fail the placeholder check; the humanized topic is a
     # valid concise-prose heading value, and an explicit title still wins.
-    effective_title = title
+    effective_title = fields.title
     if effective_title is None and topic is not None:
         effective_title = topic.replace("-", " ")
 
@@ -463,19 +557,12 @@ def create_vault_doc(
         content,
         feature,
         date_str,
-        effective_title,
-        related=effective_related,
-        extra_tags=extra_tags,
-        tier=tier,
-        step_id=step_id,
-        step_scope=step_scope,
-        step_action=step_action,
-        plan_stem=plan_stem,
-        phase=phase_display_path if summary else None,
+        replace(fields, title=effective_title, related=effective_related),
+        exec_binding,
     )
 
     if doc_type is DocType.EXEC and summary:
-        suffix = (phase_display_path or "P01").replace(".", "-")
+        suffix = (exec_binding.phase_display_path or "P01").replace(".", "-")
         filename = f"{plan_date or date_str}-{feature}-{suffix}-summary.md"
         target_dir = (
             root_dir
@@ -483,8 +570,9 @@ def create_vault_doc(
             / doc_type.value
             / f"{plan_date or date_str}-{feature}"
         )
-    elif doc_type is DocType.EXEC and step_id is not None:
-        suffix = step_display_path.replace(".", "-") if step_display_path else "S01"
+    elif doc_type is DocType.EXEC and exec_binding.step_id is not None:
+        display_path = exec_binding.step_display_path
+        suffix = display_path.replace(".", "-") if display_path else "S01"
         filename = f"{plan_date or date_str}-{feature}-{suffix}.md"
         target_dir = (
             root_dir
@@ -501,7 +589,7 @@ def create_vault_doc(
 
     target_path = target_dir / filename
 
-    if not force:
+    if not write.force:
         if target_path.exists():
             raise ResourceExistsError(
                 f"File already exists at {target_path}",
@@ -529,7 +617,7 @@ def create_vault_doc(
     # cli-scaffolder-integrity ADR.
     _assert_scaffolded_content_valid(hydrated, doc_type)
 
-    if dry_run:
+    if write.dry_run:
         return target_path
 
     from ..core.helpers import atomic_write

--- a/src/vaultspec_core/vaultcore/models.py
+++ b/src/vaultspec_core/vaultcore/models.py
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 #: Canonical vault date form: ``yyyy-mm-dd`` (ISO 8601 calendar date).
@@ -35,6 +36,69 @@ _YEAR_FIRST_SLASH_RE = re.compile(r"^(\d{4})/(\d{1,2})/(\d{1,2})$")
 #: Two small components and a four-digit year, ``dd-mm-yyyy`` or
 #: ``mm/dd/yyyy`` style, with a consistent ``-`` or ``/`` separator.
 _YEAR_LAST_RE = re.compile(r"^(\d{1,2})([-/])(\d{1,2})\2(\d{4})$")
+
+
+def _parse_canonical(text: str) -> tuple[bool, _dt.date | None]:
+    """Parse a canonical ``yyyy-mm-dd`` string."""
+    if not _CANONICAL_DATE_RE.match(text):
+        return False, None
+    try:
+        return True, _dt.date.fromisoformat(text)
+    except ValueError:
+        return True, None
+
+
+def _parse_iso_timestamp(text: str) -> tuple[bool, _dt.date | None]:
+    """Parse an ISO 8601 timestamp, optionally zoned, 'T' or space separated."""
+    try:
+        return True, _dt.datetime.fromisoformat(text).date()
+    except ValueError:
+        return False, None
+
+
+def _parse_year_first_slash(text: str) -> tuple[bool, _dt.date | None]:
+    """Parse a slash-separated year-first ``yyyy/mm/dd`` string."""
+    m = _YEAR_FIRST_SLASH_RE.match(text)
+    if m is None:
+        return False, None
+    year, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
+    try:
+        return True, _dt.date(year, month, day)
+    except ValueError:
+        return True, None
+
+
+def _parse_year_last(text: str) -> tuple[bool, _dt.date | None]:
+    """Parse an unambiguous year-last ``dd-mm-yyyy`` / ``mm/dd/yyyy`` string."""
+    m = _YEAR_LAST_RE.match(text)
+    if m is None:
+        return False, None
+    first, second, year = int(m.group(1)), int(m.group(3)), int(m.group(4))
+    if first > 12 and 1 <= second <= 12:
+        day, month = first, second
+    elif second > 12 and 1 <= first <= 12:
+        month, day = first, second
+    else:
+        # Both components could be a month: ambiguous - reject
+        # rather than guess (D3b).
+        return True, None
+    try:
+        return True, _dt.date(year, month, day)
+    except ValueError:
+        return True, None
+
+
+#: The string parsers in precedence order. Each reports whether it claims
+#: the text and, when it does, the date it parsed - ``None`` standing for a
+#: claimed but ambiguous or out-of-range value. The first claim wins, so a
+#: malformed value in a recognised shape is rejected rather than reparsed
+#: by a later, looser parser.
+_STRING_PARSERS: tuple[Callable[[str], tuple[bool, _dt.date | None]], ...] = (
+    _parse_canonical,
+    _parse_iso_timestamp,
+    _parse_year_first_slash,
+    _parse_year_last,
+)
 
 
 def parse_lenient_date(value: object) -> _dt.date | None:
@@ -82,10 +146,8 @@ def parse_lenient_date(value: object) -> _dt.date | None:
         :meth:`DocumentMetadata.validate` for the validation policy
         built on this helper.
     """
-    if isinstance(value, _dt.datetime):
-        return value.date()
     if isinstance(value, _dt.date):
-        return value
+        return value.date() if isinstance(value, _dt.datetime) else value
     if not isinstance(value, str):
         return None
 
@@ -93,43 +155,10 @@ def parse_lenient_date(value: object) -> _dt.date | None:
     if not text:
         return None
 
-    if _CANONICAL_DATE_RE.match(text):
-        try:
-            return _dt.date.fromisoformat(text)
-        except ValueError:
-            return None
-
-    # ISO 8601 timestamps, optionally zoned ('Z' or offset), with either
-    # a 'T' or a space separator (Python 3.11+ fromisoformat handles both).
-    try:
-        return _dt.datetime.fromisoformat(text).date()
-    except ValueError:
-        pass
-
-    m = _YEAR_FIRST_SLASH_RE.match(text)
-    if m:
-        year, month, day = int(m.group(1)), int(m.group(2)), int(m.group(3))
-        try:
-            return _dt.date(year, month, day)
-        except ValueError:
-            return None
-
-    m = _YEAR_LAST_RE.match(text)
-    if m:
-        first, second, year = int(m.group(1)), int(m.group(3)), int(m.group(4))
-        if first > 12 and 1 <= second <= 12:
-            day, month = first, second
-        elif second > 12 and 1 <= first <= 12:
-            month, day = first, second
-        else:
-            # Both components could be a month: ambiguous - reject
-            # rather than guess (D3b).
-            return None
-        try:
-            return _dt.date(year, month, day)
-        except ValueError:
-            return None
-
+    for parser in _STRING_PARSERS:
+        claimed, parsed = parser(text)
+        if claimed:
+            return parsed
     return None
 
 

--- a/src/vaultspec_core/vaultcore/orientation.py
+++ b/src/vaultspec_core/vaultcore/orientation.py
@@ -89,16 +89,28 @@ def feature_lifecycle_status(feature: ActiveFeature, doc_types: set[str]) -> str
     if "exec" in doc_types:
         return "In Progress"
     if feature.has_plan:
-        if feature.plan_step_count > 0 and feature.plan_completion_percent >= 100.0:
-            return "Completed"
-        if feature.plan_steps_completed > 0:
-            return "In Progress"
-        return "Planned"
-    if "adr" in doc_types:
-        return "Specified"
-    if "research" in doc_types:
-        return "Researching"
+        return _plan_lifecycle_status(feature)
+    for doc_type, status in _PRE_PLAN_STATUS:
+        if doc_type in doc_types:
+            return status
     return "Unknown"
+
+
+def _plan_lifecycle_status(feature: ActiveFeature) -> str:
+    """Derive the lifecycle status of a feature that already has a plan."""
+    if feature.plan_step_count > 0 and feature.plan_completion_percent >= 100.0:
+        return "Completed"
+    if feature.plan_steps_completed > 0:
+        return "In Progress"
+    return "Planned"
+
+
+#: The pre-plan lifecycle phases in precedence order: the first
+#: document type present names the feature's status.
+_PRE_PLAN_STATUS: tuple[tuple[str, str], ...] = (
+    ("adr", "Specified"),
+    ("research", "Researching"),
+)
 
 
 #: ``yyyy-mm-dd`` prefix on a vault filename stem, the third recency

--- a/src/vaultspec_core/vaultcore/parser.py
+++ b/src/vaultspec_core/vaultcore/parser.py
@@ -56,9 +56,13 @@ try:
         # times faster than the pure-Python SafeLoader with identical safe
         # semantics. Every vault scan, graph build, check, and MCP tool call
         # parses frontmatter, so this is the hottest parse path in the system.
-        from yaml import CSafeLoader as _SafeLoader
+        # Both branches bind the name ``SafeLoader`` unaliased: each derives
+        # from ``yaml.constructor.SafeConstructor``, which is what refuses the
+        # ``!!python/object`` tags that would otherwise instantiate arbitrary
+        # objects out of document frontmatter.
+        from yaml import CSafeLoader as SafeLoader
     except ImportError:  # pragma: no cover - PyYAML built without libyaml
-        from yaml import SafeLoader as _SafeLoader
+        from yaml import SafeLoader
 
     def _yaml_load_impl(text: str) -> dict[str, Any]:
         """Load YAML text via PyYAML, falling back to the simple parser on error.
@@ -70,7 +74,7 @@ try:
             Dictionary of parsed key-value pairs.
         """
         try:
-            return yaml.load(text, Loader=_SafeLoader) or {}
+            return yaml.load(text, Loader=SafeLoader) or {}
         except yaml.YAMLError as e:
             # PyYAML chokes on unquoted colons in values (e.g.
             # ``description: A test: with colons``).  Fall back to

--- a/src/vaultspec_core/vaultcore/related_surgery.py
+++ b/src/vaultspec_core/vaultcore/related_surgery.py
@@ -238,22 +238,26 @@ def append_related_entry(path: Path, wiki_link: str) -> bool:
                 inline_value = stripped if stripped not in ("", "[]") else None
                 continue
 
-            if in_related:
-                if line and line[0] not in (" ", "\t"):
-                    # New top-level key; block ended
-                    in_related = False
-                else:
-                    m = _RELATED_ENTRY_RE.match(line)
-                    if m:
-                        # Idempotency check on the bare stem: an aliased
-                        # existing entry (`[[foo|Foo]]`) must dedupe against a
-                        # plain `[[foo]]` append, so compare only the stem
-                        # left of any `|` alias pipe.
-                        existing_stem = m.group(1).split("|", 1)[0].strip()
-                        if existing_stem.lower() == stem.lower():
-                            return False
-                        last_related_item_idx = i
-                        last_related_indent = line[: len(line) - len(line.lstrip())]
+            if not in_related:
+                continue
+
+            if line and line[0] not in (" ", "\t"):
+                # New top-level key; block ended
+                in_related = False
+                continue
+
+            m = _RELATED_ENTRY_RE.match(line)
+            if not m:
+                continue
+
+            # Idempotency check on the bare stem: an aliased existing entry
+            # (`[[foo|Foo]]`) must dedupe against a plain `[[foo]]` append, so
+            # compare only the stem left of any `|` alias pipe.
+            existing_stem = m.group(1).split("|", 1)[0].strip()
+            if existing_stem.lower() == stem.lower():
+                return False
+            last_related_item_idx = i
+            last_related_indent = line[: len(line) - len(line.lstrip())]
 
     # Match the existing block's indentation so the appended item cannot
     # introduce a mixed-indent block sequence - invalid under strict YAML yet

--- a/src/vaultspec_core/vaultcore/rename_ops.py
+++ b/src/vaultspec_core/vaultcore/rename_ops.py
@@ -163,6 +163,289 @@ _RELATED_ENTRY_RE = re.compile(r'^(\s*-\s*["\']?\[\[)(.+?)(\]\]["\']?.*)$')
 _FRONTMATTER_LINE_BUDGET = 200
 
 
+def _collapse_rename_chains(raw_map: dict[str, str]) -> dict[str, str]:
+    """Resolve each rename to its terminal target, dropping cyclic chains.
+
+    Collapses ``[[A]]`` -> ``[[C]]`` when ``A -> B`` and ``B -> C`` both
+    happened in the same check run.  Cycles of any length (``A -> B -> A``,
+    ``A -> B -> C -> A``, ...) are detected by tracking the set of visited
+    nodes during the traversal: as soon as a node is encountered twice the
+    chain is a cycle and the entry is dropped from the rewrite map rather
+    than emitted as a false rewrite.
+    """
+    rename_map: dict[str, str] = {}
+    for old in raw_map:
+        visited: set[str] = {old}
+        current = raw_map[old]
+        cycle = False
+        while current in raw_map:
+            if current in visited:
+                cycle = True
+                break
+            visited.add(current)
+            current = raw_map[current]
+        if not cycle:
+            rename_map[old] = current
+    return rename_map
+
+
+def _is_skipped_document(
+    md_path: Path, vault_root: Path, non_schema_dirs: frozenset[str]
+) -> bool:
+    """Return True when *md_path* must not be rewritten.
+
+    Skips hidden internal directories (e.g. ``.obsidian/``, ``.trash/``,
+    ``.vaultspec``-style dotfile scratch) and non-schema data/log
+    directories.  These are covered by the managed gitignore block and must
+    not be mutated - Obsidian in particular keeps its own state files under
+    ``.obsidian/`` that should never be edited externally.  Symlinked
+    ``*.md`` files are skipped too: a symlinked document is not a legitimate
+    vault file, and reading/writing it would touch an out-of-bounds target
+    (or pull its bytes into the vault).
+    """
+    try:
+        rel_parts = md_path.relative_to(vault_root).parts
+    except ValueError:
+        return True
+    if any(part.startswith(".") or part in non_schema_dirs for part in rel_parts[:-1]):
+        return True
+    return md_path.is_symlink()
+
+
+def _read_document_text(md_path: Path) -> str | None:
+    """Return the decoded text of *md_path*, or None when it cannot be read."""
+    try:
+        # Read as bytes first so CRLF endings survive the decode;
+        # ``read_text`` collapses them via universal newlines.
+        return md_path.read_bytes().decode("utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.warning("Failed to read %s for ref rewrite: %s", md_path, exc)
+        return None
+
+
+def _split_link_target(target: str) -> tuple[str, str]:
+    """Split a wiki-link target into its bare stem and its trailer.
+
+    Handles the Obsidian link forms ``stem``, ``stem#heading``,
+    ``stem|alias``, and ``stem#heading|alias``.  Rename matching is always
+    on the stem alone; the anchor and alias travel in the trailer so they
+    are preserved on the rewritten line.
+    """
+    anchor_hash = target.find("#")
+    alias_pipe = target.find("|")
+    cut_candidates = [i for i in (anchor_hash, alias_pipe) if i >= 0]
+    if not cut_candidates:
+        return target, ""
+    cut = min(cut_candidates)
+    return target[:cut], target[cut:]
+
+
+def _resolve_renamed_stem(
+    stem: str, rename_map: dict[str, str], rename_map_lower: dict[str, str]
+) -> str | None:
+    """Return the terminal stem for *stem*, or None when it was not renamed.
+
+    Case-sensitive lookup first (preserves exact-case intent when both
+    ``My-Doc.md`` and ``my-doc.md`` legitimately coexist on Linux); falls
+    back to a case-insensitive match so Obsidian-style cross-case links
+    (``[[My-Doc]]`` pointing at ``my-doc.md``) are still rewritten.
+    """
+    if stem in rename_map:
+        return rename_map[stem]
+    return rename_map_lower.get(stem.lower())
+
+
+def _scan_related_block(
+    pairs: list[list[str]],
+    rename_map: dict[str, str],
+    rename_map_lower: dict[str, str],
+) -> tuple[list[tuple[bool, str, str]], list[int], bool, bool]:
+    """Rewrite matching ``related:`` entries in *pairs* in place.
+
+    Args:
+        pairs: ``[content, ending]`` line pairs for the whole document; the
+            content of rewritten lines is mutated in place.
+        rename_map: Exact-case ``old_stem`` -> terminal ``new_stem`` map.
+        rename_map_lower: Lowercased mirror of *rename_map*.
+
+    Returns:
+        A ``(events, drop_idx, budget_exceeded, fence_missing)`` tuple where
+        ``events`` holds ``(dropped, target, new_target)`` triples in line
+        order, ``drop_idx`` holds the indices of duplicate lines to delete,
+        and ``fence_missing`` is True when a frontmatter block opened but
+        never closed.
+    """
+    in_frontmatter = False
+    in_related = False
+    fence_closed = False
+    budget_exceeded = False
+    # Tracks wiki-link targets already present in the ``related:`` block so
+    # duplicate lines the rewrite would otherwise introduce can be dropped
+    # (e.g. when two sources collapse onto the same terminal or when the
+    # terminal already appeared in the list).
+    seen_targets: set[str] = set()
+    drop_idx: list[int] = []
+    events: list[tuple[bool, str, str]] = []
+
+    for idx, pair in enumerate(pairs):
+        # Guard against a missing closing fence: if the file is not a real
+        # vault document, bail out of the scan after a fixed line budget
+        # rather than scanning prose forever. ``idx`` indexes logical lines
+        # (the pairs), matching the pre-pair behaviour.
+        if in_frontmatter and idx > _FRONTMATTER_LINE_BUDGET:
+            budget_exceeded = True
+            break
+
+        line = pair[0]
+        stripped = line.strip()
+        if stripped == "---":
+            if in_frontmatter:
+                fence_closed = True
+                break
+            in_frontmatter = True
+            continue
+
+        if not in_frontmatter:
+            continue
+
+        if stripped.startswith("related:"):
+            in_related = True
+            continue
+
+        if in_related and line and not line.startswith((" ", "\t", "-")):
+            in_related = False
+
+        if not in_related:
+            continue
+
+        match = _RELATED_ENTRY_RE.match(line)
+        if not match:
+            continue
+
+        target = match.group(2)
+        stem_only, trailer = _split_link_target(target)
+        final_stem = _resolve_renamed_stem(stem_only, rename_map, rename_map_lower)
+        if final_stem is None:
+            # Remember the existing (unrewritten) full target so later
+            # rewrites can avoid creating a duplicate.  The full target -
+            # not just the stem - is used because ``[[beta]]`` and
+            # ``[[beta#heading]]`` are distinct wiki-links that should both
+            # survive side by side.
+            seen_targets.add(target)
+            continue
+
+        new_target = f"{final_stem}{trailer}"
+        # If the exact post-rewrite target is already represented by an
+        # earlier line in this related: block, drop this line to avoid
+        # emitting a duplicate entry.
+        if new_target in seen_targets:
+            drop_idx.append(idx)
+            events.append((True, target, new_target))
+            continue
+
+        pair[0] = f"{match.group(1)}{new_target}{match.group(3)}"
+        seen_targets.add(new_target)
+        events.append((False, target, new_target))
+
+    return events, drop_idx, budget_exceeded, in_frontmatter and not fence_closed
+
+
+def _rewrite_document_refs(
+    md_path: Path,
+    root_dir: Path,
+    rename_map: dict[str, str],
+    rename_map_lower: dict[str, str],
+    result: CheckResult,
+) -> None:
+    """Rewrite the ``related:`` block of a single document and write it back."""
+    from .checks._base import CheckDiagnostic, Severity
+
+    content = _read_document_text(md_path)
+    if content is None:
+        return
+
+    # Preserve a UTF-8 BOM if present; the scanner strips it so the opening
+    # ``---`` fence matches but the write-back restores it.  Use the
+    # ``﻿`` escape rather than the literal character so the source is
+    # legible in editors that hide zero-width glyphs.
+    bom = ""
+    if content.startswith("﻿"):
+        bom = "﻿"
+        content = content[1:]
+
+    # Model each line as a mutable ``[content, ending]`` pair so the rewrite
+    # touches only the content of the lines it targets and every other byte -
+    # including exotic in-line separators and a CR-only or absent trailing
+    # terminator - survives verbatim.
+    pairs = split_keepends(content)
+    events, drop_idx, budget_exceeded, fence_missing = _scan_related_block(
+        pairs, rename_map, rename_map_lower
+    )
+
+    try:
+        rel = md_path.relative_to(root_dir)
+    except ValueError:
+        rel = md_path
+
+    for dropped, target, new_target in events:
+        if dropped:
+            message = (
+                f"Dropped duplicate wiki-link: [[{target}]] "
+                f"-> [[{new_target}]] already present"
+            )
+        else:
+            result.fixed_count += 1
+            message = f"Updated wiki-link: [[{target}]] -> [[{new_target}]]"
+        result.diagnostics.append(
+            CheckDiagnostic(path=rel, message=message, severity=Severity.INFO)
+        )
+
+    # Surface a warning diagnostic when the frontmatter exceeds the line
+    # budget so operators can investigate documents whose frontmatter may
+    # have been skipped mid-scan.
+    if budget_exceeded:
+        result.diagnostics.append(
+            CheckDiagnostic(
+                path=rel,
+                message=(
+                    "Frontmatter exceeds "
+                    f"{_FRONTMATTER_LINE_BUDGET} lines; "
+                    "ref rewrite stopped at budget"
+                ),
+                severity=Severity.WARNING,
+            )
+        )
+
+    if not events:
+        return
+
+    # Drop duplicate-collapsed lines in descending order so the surviving
+    # indices stay stable while we mutate the list. Deleting the whole
+    # ``[content, ending]`` pair removes the line's terminator with it, so no
+    # stray blank line or doubled terminator is left behind.
+    for del_idx in sorted(drop_idx, reverse=True):
+        del pairs[del_idx]
+
+    # If the scan never saw a closing fence we are in unknown territory;
+    # skip writing rather than risk corrupting a file whose frontmatter
+    # layout we misread.
+    if fence_missing:
+        logger.warning(
+            "Skipping rewrite of %s: closing frontmatter fence not found",
+            md_path,
+        )
+        return
+
+    # Reassemble from the pairs: each line carries its own original
+    # terminator, so the trailing newline (or its absence) and every
+    # mixed/CR-only ending are reproduced exactly. The BOM is re-prepended.
+    new_content = bom + "".join(c + e for c, e in pairs)
+    try:
+        atomic_write(md_path, new_content)
+    except OSError as exc:
+        logger.warning("Failed to rewrite %s: %s", md_path, exc)
+
+
 def rewrite_incoming_refs(
     root_dir: Path,
     renames: list[tuple[str, str]],
@@ -205,8 +488,6 @@ def rewrite_incoming_refs(
             snapshot for rollback); the structure check passes nothing, keeping
             its whole-vault behaviour unchanged.
     """
-    from .checks._base import CheckDiagnostic, Severity
-
     if not renames:
         return
 
@@ -214,26 +495,7 @@ def rewrite_incoming_refs(
     if not raw_map:
         return
 
-    # Collapse rename chains so [[A]] -> [[C]] when ``A -> B`` and ``B -> C``
-    # both happened in the same check run.  Cycles of any length
-    # (``A -> B -> A``, ``A -> B -> C -> A``, ...) are detected by
-    # tracking the set of visited nodes during the traversal: as soon as
-    # we encounter a node we have already seen, the chain is a cycle and
-    # the entry is dropped from the rewrite map rather than emitted as a
-    # false rewrite.
-    rename_map: dict[str, str] = {}
-    for old in raw_map:
-        visited: set[str] = {old}
-        current = raw_map[old]
-        cycle = False
-        while current in raw_map:
-            if current in visited:
-                cycle = True
-                break
-            visited.add(current)
-            current = raw_map[current]
-        if not cycle:
-            rename_map[old] = current
+    rename_map = _collapse_rename_chains(raw_map)
 
     from ..config import get_config
 
@@ -255,221 +517,10 @@ def rewrite_incoming_refs(
     # by :func:`vaultspec_core.core.gitignore.get_recommended_entries`)
     # are skipped to avoid scanning large or non-vault files.  Hidden
     # directories (``.obsidian/``, ``.trash/``, ...) are skipped
-    # by the dot-prefix filter below.
+    # by the dot-prefix filter in :func:`_is_skipped_document`.
     non_schema_dirs = frozenset({"data", "logs"}) | exclude_dirs
 
     for md_path in sorted(vault_root.rglob("*.md")):
-        # Skip hidden internal directories (e.g. ``.obsidian/``,
-        # ``.trash/``, ``.vaultspec``-style dotfile scratch) and
-        # non-schema data/log directories.  These are covered by the
-        # managed gitignore block and must not be mutated - Obsidian
-        # in particular keeps its own state files under ``.obsidian/``
-        # that should never be edited externally.
-        try:
-            rel_parts = md_path.relative_to(vault_root).parts
-        except ValueError:
+        if _is_skipped_document(md_path, vault_root, non_schema_dirs):
             continue
-        if any(
-            part.startswith(".") or part in non_schema_dirs for part in rel_parts[:-1]
-        ):
-            continue
-        # Never rewrite through a symlinked document: a symlinked ``*.md`` is not
-        # a legitimate vault file, and reading/writing it would touch an
-        # out-of-bounds target (or pull its bytes into the vault).
-        if md_path.is_symlink():
-            continue
-        try:
-            # Read as bytes first so CRLF endings survive the decode;
-            # ``read_text`` collapses them via universal newlines.
-            raw = md_path.read_bytes()
-            content = raw.decode("utf-8")
-        except (OSError, UnicodeDecodeError) as exc:
-            logger.warning("Failed to read %s for ref rewrite: %s", md_path, exc)
-            continue
-
-        # Preserve a UTF-8 BOM if present; the scanner strips it so the
-        # opening ``---`` fence matches but the write-back restores it.
-        # Use the ``\ufeff`` escape rather than the literal character so
-        # the source is legible in editors that hide zero-width glyphs.
-        bom = ""
-        if content.startswith("\ufeff"):
-            bom = "\ufeff"
-            content = content[1:]
-
-        # Model each line as a mutable ``[content, ending]`` pair so the
-        # rewrite touches only the content of the lines it targets and every
-        # other byte - including exotic in-line separators and a CR-only or
-        # absent trailing terminator - survives verbatim.
-        pairs = split_keepends(content)
-        in_frontmatter = False
-        in_related = False
-        changed = False
-        fence_closed = False
-        budget_exceeded = False
-        # Tracks wiki-link targets already present in the ``related:``
-        # block so we can drop duplicate lines that the rewrite would
-        # otherwise introduce (e.g. when two sources collapse onto the
-        # same terminal or when the terminal already appeared in the
-        # list).  Anchored/aliased forms are normalised to their stem
-        # component for dedup purposes.
-        seen_targets: set[str] = set()
-        drop_idx: list[int] = []
-
-        for idx, pair in enumerate(pairs):
-            # Guard against a missing closing fence: if the file is not
-            # a real vault document, bail out of the scan after a fixed
-            # line budget rather than scanning prose forever. ``idx`` indexes
-            # logical lines (the pairs), matching the pre-pair behaviour.
-            if in_frontmatter and idx > _FRONTMATTER_LINE_BUDGET:
-                budget_exceeded = True
-                break
-
-            line = pair[0]
-            stripped = line.strip()
-            if stripped == "---":
-                if not in_frontmatter:
-                    in_frontmatter = True
-                else:
-                    fence_closed = True
-                    break
-                continue
-
-            if not in_frontmatter:
-                continue
-
-            if line.strip().startswith("related:"):
-                in_related = True
-                continue
-
-            if in_related and line and not line.startswith((" ", "\t", "-")):
-                in_related = False
-
-            if not in_related:
-                continue
-
-            match = _RELATED_ENTRY_RE.match(line)
-            if not match:
-                continue
-
-            target = match.group(2)
-            # Extract the bare stem from Obsidian link forms:
-            # ``stem``, ``stem#heading``, ``stem|alias``, or
-            # ``stem#heading|alias``.  Rename matching is always on
-            # the stem alone; the anchor and alias are preserved on
-            # the rewritten line.
-            stem_only = target
-            trailer = ""
-            anchor_hash = stem_only.find("#")
-            alias_pipe = stem_only.find("|")
-            cut_candidates = [i for i in (anchor_hash, alias_pipe) if i >= 0]
-            if cut_candidates:
-                cut = min(cut_candidates)
-                stem_only = target[:cut]
-                trailer = target[cut:]
-
-            # Case-sensitive lookup first (preserves exact-case intent
-            # when both ``My-Doc.md`` and ``my-doc.md`` legitimately
-            # coexist on Linux); fall back to case-insensitive match
-            # so Obsidian-style cross-case links (``[[My-Doc]]`` at
-            # pointing ``my-doc.md``) are still rewritten.
-            final_stem: str | None = None
-            if stem_only in rename_map:
-                final_stem = rename_map[stem_only]
-            elif stem_only.lower() in rename_map_lower:
-                final_stem = rename_map_lower[stem_only.lower()]
-            if final_stem is None:
-                # Remember the existing (unrewritten) full target so
-                # later rewrites can avoid creating a duplicate.  The
-                # full target - not just the stem - is used because
-                # ``[[beta]]`` and ``[[beta#heading]]`` are distinct
-                # wiki-links that should both survive side by side.
-                seen_targets.add(target)
-                continue
-
-            new_target = f"{final_stem}{trailer}"
-            # If the exact post-rewrite target is already represented
-            # by an earlier line in this related: block, drop this
-            # line to avoid emitting a duplicate entry.
-            if new_target in seen_targets:
-                drop_idx.append(idx)
-                changed = True
-                try:
-                    rel = md_path.relative_to(root_dir)
-                except ValueError:
-                    rel = md_path
-                result.diagnostics.append(
-                    CheckDiagnostic(
-                        path=rel,
-                        message=(
-                            f"Dropped duplicate wiki-link: [[{target}]] "
-                            f"-> [[{new_target}]] already present"
-                        ),
-                        severity=Severity.INFO,
-                    )
-                )
-                continue
-
-            pair[0] = f"{match.group(1)}{new_target}{match.group(3)}"
-            seen_targets.add(new_target)
-            changed = True
-            result.fixed_count += 1
-            try:
-                rel = md_path.relative_to(root_dir)
-            except ValueError:
-                rel = md_path
-            result.diagnostics.append(
-                CheckDiagnostic(
-                    path=rel,
-                    message=f"Updated wiki-link: [[{target}]] -> [[{new_target}]]",
-                    severity=Severity.INFO,
-                )
-            )
-
-        # Surface a warning diagnostic when the frontmatter exceeds the
-        # line budget so operators can investigate documents whose
-        # frontmatter may have been skipped mid-scan.
-        if budget_exceeded:
-            try:
-                rel_path = md_path.relative_to(root_dir)
-            except ValueError:
-                rel_path = md_path
-            result.diagnostics.append(
-                CheckDiagnostic(
-                    path=rel_path,
-                    message=(
-                        "Frontmatter exceeds "
-                        f"{_FRONTMATTER_LINE_BUDGET} lines; "
-                        "ref rewrite stopped at budget"
-                    ),
-                    severity=Severity.WARNING,
-                )
-            )
-
-        if not changed:
-            continue
-
-        # Drop duplicate-collapsed lines in descending order so the
-        # surviving indices stay stable while we mutate the list. Deleting the
-        # whole ``[content, ending]`` pair removes the line's terminator with
-        # it, so no stray blank line or doubled terminator is left behind.
-        for del_idx in sorted(drop_idx, reverse=True):
-            del pairs[del_idx]
-
-        # If the scan never saw a closing fence we are in unknown
-        # territory; skip writing rather than risk corrupting a file
-        # whose frontmatter layout we misread.
-        if in_frontmatter and not fence_closed:
-            logger.warning(
-                "Skipping rewrite of %s: closing frontmatter fence not found",
-                md_path,
-            )
-            continue
-
-        # Reassemble from the pairs: each line carries its own original
-        # terminator, so the trailing newline (or its absence) and every
-        # mixed/CR-only ending are reproduced exactly. The BOM is re-prepended.
-        new_content = bom + "".join(c + e for c, e in pairs)
-        try:
-            atomic_write(md_path, new_content)
-        except OSError as exc:
-            logger.warning("Failed to rewrite %s: %s", md_path, exc)
+        _rewrite_document_refs(md_path, root_dir, rename_map, rename_map_lower, result)

--- a/src/vaultspec_core/vaultcore/resolve.py
+++ b/src/vaultspec_core/vaultcore/resolve.py
@@ -24,6 +24,7 @@ __all__ = ["resolve_related_inputs", "validate_feature_dependencies"]
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
 
@@ -120,8 +121,6 @@ def _resolve_single(
     Returns:
         The canonical stem string, or ``None`` if unresolvable.
     """
-    import pathlib
-
     cleaned = raw.strip()
     if not cleaned:
         return None
@@ -135,52 +134,59 @@ def _resolve_single(
         inner = inner.strip()
         if inner.endswith(".md"):
             inner = inner[:-3]
-        key = inner.lower()
-        if key in stem_index:
-            return stem_index[key].stem
-        return None
+        match = stem_index.get(inner.lower())
+        return match.stem if match is not None else None
 
     # Strip .md extension if present
     if cleaned.endswith(".md"):
         cleaned = cleaned[:-3]
 
+    for key in _candidate_keys(cleaned, root_dir):
+        match = stem_index.get(key)
+        if match is not None:
+            return match.stem
+
+    return None
+
+
+def _candidate_keys(cleaned: str, root_dir: Path) -> Iterator[str]:
+    """Yield the stem-index lookup keys for one reference, in priority order.
+
+    Args:
+        cleaned: The trimmed reference with any ``.md`` extension removed.
+        root_dir: Project root directory, the base for relative paths.
+
+    Yields:
+        Lowercase stem keys: the bare stem first (the most common case),
+        then the stem of the reference read as a path, then its final
+        component.
+    """
+    import pathlib
+
     # Try as bare stem first (most common case)
-    key = cleaned.lower()
-    if key in stem_index:
-        return stem_index[key].stem
+    yield cleaned.lower()
 
     # Try as a path (absolute or relative)
     try:
         candidate = pathlib.Path(cleaned)
         # If it looks like it has directory components, resolve it
         if len(candidate.parts) > 1:
-            # Try absolute
             if candidate.is_absolute():
-                stem_key = candidate.stem.lower()
-                if stem_key in stem_index:
-                    return stem_index[stem_key].stem
+                yield candidate.stem.lower()
             else:
                 # Resolve relative to root_dir
-                resolved_path = (root_dir / candidate).resolve()
-                stem_key = resolved_path.stem.lower()
-                if stem_key in stem_index:
-                    return stem_index[stem_key].stem
+                yield (root_dir / candidate).resolve().stem.lower()
     except (OSError, ValueError):
         pass
 
     # Try matching just the final component as a stem
     try:
-        candidate = pathlib.Path(cleaned)
-        final = candidate.name
+        final = pathlib.Path(cleaned).name
         if final.endswith(".md"):
             final = final[:-3]
-        key = final.lower()
-        if key in stem_index:
-            return stem_index[key].stem
+        yield final.lower()
     except (OSError, ValueError):
         pass
-
-    return None
 
 
 def validate_feature_dependencies(

--- a/src/vaultspec_core/vaultcore/tests/test_core.py
+++ b/src/vaultspec_core/vaultcore/tests/test_core.py
@@ -9,10 +9,15 @@ preservation.
 
 from __future__ import annotations
 
+import datetime
+
 import pytest
+import yaml
+from yaml.constructor import SafeConstructor
 
 from ...protocol.providers import GeminiModels
 from .. import parse_frontmatter, parse_vault_metadata
+from ..parser import SafeLoader
 
 pytestmark = [pytest.mark.unit]
 
@@ -152,3 +157,157 @@ class TestParseVaultMetadataStepId:
         )
         meta, _body = parse_vault_metadata(content)
         assert meta.step_id is None
+
+
+class TestFrontmatterLoaderSafety:
+    """Frontmatter must never instantiate arbitrary objects.
+
+    ``.vault/`` documents are ordinary files on disk, so their frontmatter is
+    attacker-reachable whenever a vault is shared, cloned, or generated. The
+    loader therefore has to refuse the ``!!python/...`` tag family outright
+    rather than trusting the document.
+    """
+
+    def test_active_loader_uses_the_safe_constructor(self):
+        # CSafeLoader and SafeLoader do not share a loader base class, but both
+        # derive from SafeConstructor - the component that actually refuses
+        # arbitrary tags - so this holds whichever branch libyaml selected.
+        assert issubclass(SafeLoader, SafeConstructor)
+
+    def test_object_tag_is_not_instantiated(self, tmp_path):
+        document = (
+            "---\n"
+            "tags:\n"
+            "  - '#adr'\n"
+            "  - '#editor-demo'\n"
+            "payload: !!python/object/apply:datetime.date [2026, 7, 28]\n"
+            "---\n"
+            "\n"
+            "# Body\n"
+            "Prose.\n"
+        )
+        path = tmp_path / "2026-07-28-editor-demo-adr.md"
+        path.write_text(document, encoding="utf-8")
+
+        meta, body = parse_frontmatter(path.read_text(encoding="utf-8"))
+
+        # The tag is refused, so the value survives only as inert text.
+        assert not isinstance(meta["payload"], datetime.date)
+        assert meta["payload"] == "!!python/object/apply:datetime.date [2026, 7, 28]"
+        assert "# Body" in body
+
+    def test_object_tag_does_not_invoke_the_named_callable(self, tmp_path):
+        # ``apply`` tags call the named object, which is the arbitrary-execution
+        # vector proper - not merely arbitrary construction.
+        document = (
+            "---\n"
+            'evaluated: !!python/object/apply:builtins.eval ["38 + 4"]\n'
+            "---\n"
+            "Body.\n"
+        )
+        path = tmp_path / "2026-07-28-editor-demo-research.md"
+        path.write_text(document, encoding="utf-8")
+
+        meta, _body = parse_frontmatter(path.read_text(encoding="utf-8"))
+
+        assert meta["evaluated"] != 42
+        assert meta["evaluated"] == '!!python/object/apply:builtins.eval ["38 + 4"]'
+
+    def test_unsafe_loader_would_have_honored_the_tags(self):
+        # Guards the two tests above against becoming tautologies: it pins the
+        # payloads as genuinely dangerous, so those assertions are proving the
+        # loader choice rather than an inert fixture.
+        constructed = yaml.load(
+            "payload: !!python/object/apply:datetime.date [2026, 7, 28]\n",
+            Loader=yaml.UnsafeLoader,
+        )
+        assert constructed["payload"] == datetime.date(2026, 7, 28)
+
+        evaluated = yaml.load(
+            'evaluated: !!python/object/apply:builtins.eval ["38 + 4"]\n',
+            Loader=yaml.UnsafeLoader,
+        )
+        assert evaluated["evaluated"] == 42
+
+    def test_safe_loader_rejects_the_tag_rather_than_ignoring_it(self):
+        # The rejection must come from the loader itself; parse_frontmatter only
+        # degrades to the simple splitter because this raises.
+        with pytest.raises(yaml.YAMLError):
+            yaml.load(
+                "payload: !!python/object/apply:datetime.date [2026, 7, 28]\n",
+                Loader=SafeLoader,
+            )
+
+
+class TestFrontmatterRoundTrip:
+    """The shapes the vault schema actually emits must survive a real read."""
+
+    def test_canonical_vault_frontmatter_round_trips_from_disk(self, tmp_path):
+        document = (
+            "---\n"
+            "tags:\n"
+            "  - '#exec'\n"
+            "  - '#editor-demo'\n"
+            "date: '2026-07-28'\n"
+            "modified: '2026-07-28'\n"
+            "step_id: 'S07'\n"
+            "body_schema: 'exec-step'\n"
+            "related:\n"
+            "  - '[[2026-07-28-editor-demo-plan]]'\n"
+            "  - '[[2026-07-28-editor-demo-adr]]'\n"
+            "---\n"
+            "\n"
+            "# Body\n"
+            "Prose with a colon: and trailing text.\n"
+        )
+        path = tmp_path / "2026-07-28-editor-demo-P01-S07.md"
+        path.write_text(document, encoding="utf-8")
+        content = path.read_text(encoding="utf-8")
+
+        meta, body = parse_frontmatter(content)
+        assert meta["tags"] == ["#exec", "#editor-demo"]
+        assert meta["date"] == "2026-07-28"
+        assert meta["modified"] == "2026-07-28"
+        assert meta["step_id"] == "S07"
+        assert meta["body_schema"] == "exec-step"
+        assert meta["related"] == [
+            "[[2026-07-28-editor-demo-plan]]",
+            "[[2026-07-28-editor-demo-adr]]",
+        ]
+        # The closing fence is matched as ``---\s*\n?``, so the blank line that
+        # separates fence from prose is consumed with it and the body opens on
+        # the first real line.
+        assert body == "# Body\nProse with a colon: and trailing text.\n"
+
+        vault_meta, vault_body = parse_vault_metadata(content)
+        assert vault_meta.tags == ["#exec", "#editor-demo"]
+        assert vault_meta.date == "2026-07-28"
+        assert vault_meta.modified == "2026-07-28"
+        assert vault_meta.step_id == "S07"
+        assert vault_meta.body_schema == "exec-step"
+        assert vault_meta.related == [
+            "[[2026-07-28-editor-demo-plan]]",
+            "[[2026-07-28-editor-demo-adr]]",
+        ]
+        assert vault_body == body
+
+    def test_inline_list_frontmatter_round_trips_from_disk(self, tmp_path):
+        document = (
+            "---\n"
+            "tags: ['#plan', '#editor-demo']\n"
+            "date: '2026-07-28'\n"
+            "related: []\n"
+            "---\n"
+            "Body.\n"
+        )
+        path = tmp_path / "2026-07-28-editor-demo-plan.md"
+        path.write_text(document, encoding="utf-8")
+        content = path.read_text(encoding="utf-8")
+
+        meta, _body = parse_frontmatter(content)
+        assert meta["tags"] == ["#plan", "#editor-demo"]
+        assert meta["related"] == []
+
+        vault_meta, _vault_body = parse_vault_metadata(content)
+        assert vault_meta.tags == ["#plan", "#editor-demo"]
+        assert vault_meta.related == []

--- a/src/vaultspec_core/vaultcore/tests/test_hydration.py
+++ b/src/vaultspec_core/vaultcore/tests/test_hydration.py
@@ -7,7 +7,12 @@ import pytest
 from vaultspec_core.core.exceptions import ResourceExistsError
 from vaultspec_core.vaultcore import hydrate_template
 from vaultspec_core.vaultcore.body_schema import CURRENT_BODY_SCHEMA
-from vaultspec_core.vaultcore.hydration import create_vault_doc, get_template_path
+from vaultspec_core.vaultcore.hydration import (
+    DocumentIdentity,
+    TemplateFields,
+    create_vault_doc,
+    get_template_path,
+)
 from vaultspec_core.vaultcore.models import DocType
 
 pytestmark = [pytest.mark.unit]
@@ -94,10 +99,8 @@ class TestTemplatePathLegacyFallback:
 
         path = create_vault_doc(
             tmp_path,
-            DocType.REFERENCE,
-            "stale-feat",
-            "2026-06-10",
-            title="legacy fallback",
+            DocumentIdentity(DocType.REFERENCE, "stale-feat", "2026-06-10"),
+            TemplateFields(title="legacy fallback"),
             content_root=content_root,
         )
         assert path.exists()
@@ -114,10 +117,8 @@ class TestTemplatePathLegacyFallback:
         with pytest.raises(FileNotFoundError) as excinfo:
             create_vault_doc(
                 tmp_path,
-                DocType.REFERENCE,
-                "no-template-feat",
-                "2026-06-10",
-                title="missing",
+                DocumentIdentity(DocType.REFERENCE, "no-template-feat", "2026-06-10"),
+                TemplateFields(title="missing"),
                 content_root=content_root,
             )
         assert "vaultspec-core install --upgrade" in str(excinfo.value)
@@ -132,7 +133,9 @@ date: {yyyy-mm-dd}
 
 # {title}
 """
-    result = hydrate_template(template, "my-feature", "2026-03-01", title="My Title")
+    result = hydrate_template(
+        template, "my-feature", "2026-03-01", TemplateFields(title="My Title")
+    )
 
     assert 'tags: ["#adr", "#my-feature"]' in result
     assert "date: 2026-03-01" in result
@@ -142,7 +145,9 @@ date: {yyyy-mm-dd}
 def test_hydrate_template_placeholders():
     """Verify supported placeholders and the topic alias are hydrated."""
     template = "{feature} {yyyy-mm-dd} {title} {topic}"
-    result = hydrate_template(template, "feat", "2026-02-01", title="Plan Title")
+    result = hydrate_template(
+        template, "feat", "2026-02-01", TemplateFields(title="Plan Title")
+    )
     assert result == "feat 2026-02-01 Plan Title Plan Title"
 
 
@@ -180,21 +185,21 @@ def test_hydrate_template_skips_placeholders_inside_html_comments(caplog):
 def test_hydrate_template_substitutes_tier_when_passed():
     """Verify the {tier} placeholder is hydrated when tier is supplied."""
     template = "tier: {tier}"
-    result = hydrate_template(template, "feat", "2026-05-18", tier="L3")
+    result = hydrate_template(template, "feat", "2026-05-18", TemplateFields(tier="L3"))
     assert result == "tier: L3"
 
 
 def test_hydrate_template_substitutes_quoted_tier_placeholder():
     """The quoted template placeholder hydrates to an unquoted scalar."""
     template = "tier: '{tier}'"
-    result = hydrate_template(template, "feat", "2026-06-10", tier="L3")
+    result = hydrate_template(template, "feat", "2026-06-10", TemplateFields(tier="L3"))
     assert result == "tier: L3"
 
 
 def test_hydrate_template_substitutes_mdformat_normalized_tier():
     """Verify mdformat-normalized plan templates still hydrate tier."""
     template = "tier: {tier: null}"
-    result = hydrate_template(template, "feat", "2026-05-18", tier="L3")
+    result = hydrate_template(template, "feat", "2026-05-18", TemplateFields(tier="L3"))
     assert result == "tier: L3"
 
 
@@ -231,11 +236,8 @@ def test_create_vault_doc_plan_substitutes_tier(tmp_path):
 
     path = create_vault_doc(
         tmp_path,
-        DocType.PLAN,
-        "tier-test",
-        "2026-05-18",
-        title="Tier test",
-        tier="L3",
+        DocumentIdentity(DocType.PLAN, "tier-test", "2026-05-18"),
+        TemplateFields(title="Tier test", tier="L3"),
     )
     assert path.exists()
     content = path.read_text(encoding="utf-8")
@@ -257,10 +259,8 @@ def test_create_vault_doc_stamps_current_body_schema(tmp_path):
 
     path = create_vault_doc(
         tmp_path,
-        DocType.ADR,
-        "schema-stamp",
-        "2026-07-27",
-        title="Schema stamp",
+        DocumentIdentity(DocType.ADR, "schema-stamp", "2026-07-27"),
+        TemplateFields(title="Schema stamp"),
     )
     metadata, _body = parse_vault_metadata(path.read_text(encoding="utf-8"))
 
@@ -288,10 +288,8 @@ def test_create_vault_doc_replaces_stale_template_schema_stamp(tmp_path):
 
     path = create_vault_doc(
         tmp_path,
-        DocType.ADR,
-        "schema-stamp",
-        "2026-07-27",
-        title="Schema stamp",
+        DocumentIdentity(DocType.ADR, "schema-stamp", "2026-07-27"),
+        TemplateFields(title="Schema stamp"),
     )
     metadata, _body = parse_vault_metadata(path.read_text(encoding="utf-8"))
 
@@ -363,11 +361,8 @@ def test_create_vault_doc_plan_default_tier_l1(tmp_path):
 
     path = create_vault_doc(
         tmp_path,
-        DocType.PLAN,
-        "tier-default",
-        "2026-05-18",
-        title="Default tier",
-        tier="L1",
+        DocumentIdentity(DocType.PLAN, "tier-default", "2026-05-18"),
+        TemplateFields(title="Default tier", tier="L1"),
     )
     assert path.exists()
     content = path.read_text(encoding="utf-8")
@@ -406,10 +401,8 @@ class TestCreateVaultDocStemCollision:
         with pytest.raises(ResourceExistsError, match="already exists"):
             create_vault_doc(
                 vault_project,
-                DocType.ADR,
-                "my-feat",
-                "2026-03-17",
-                title="Duplicate",
+                DocumentIdentity(DocType.ADR, "my-feat", "2026-03-17"),
+                TemplateFields(title="Duplicate"),
             )
 
     def test_cross_type_stem_collision_rejected(self, vault_project):
@@ -433,20 +426,16 @@ class TestCreateVaultDocStemCollision:
         with pytest.raises(ResourceExistsError, match=r"stem.*already exists"):
             create_vault_doc(
                 vault_project,
-                DocType.ADR,
-                "collide",
-                "2026-03-20",
-                title="Collision",
+                DocumentIdentity(DocType.ADR, "collide", "2026-03-20"),
+                TemplateFields(title="Collision"),
             )
 
     def test_unique_stem_succeeds(self, vault_project):
         """A truly unique stem creates the file without error."""
         path = create_vault_doc(
             vault_project,
-            DocType.ADR,
-            "unique-feat",
-            "2026-03-20",
-            title="Unique",
+            DocumentIdentity(DocType.ADR, "unique-feat", "2026-03-20"),
+            TemplateFields(title="Unique"),
         )
         assert path.exists()
         assert path.stem == "2026-03-20-unique-feat-adr"
@@ -473,10 +462,7 @@ class TestCreateVaultDocTopicInfix:
     def test_infixed_filename_for_admitting_types(self, vault_project, doc_type):
         path = create_vault_doc(
             vault_project,
-            doc_type,
-            "my-feat",
-            "2026-07-16",
-            topic="engine-wire",
+            DocumentIdentity(doc_type, "my-feat", "2026-07-16", topic="engine-wire"),
         )
         assert path.name == f"2026-07-16-my-feat-engine-wire-{doc_type.value}.md"
         assert path.exists()
@@ -484,10 +470,9 @@ class TestCreateVaultDocTopicInfix:
     def test_topic_hydrates_heading_when_title_absent(self, vault_project):
         path = create_vault_doc(
             vault_project,
-            DocType.REFERENCE,
-            "my-feat",
-            "2026-07-16",
-            topic="engine-wire",
+            DocumentIdentity(
+                DocType.REFERENCE, "my-feat", "2026-07-16", topic="engine-wire"
+            ),
         )
         text = path.read_text(encoding="utf-8")
         assert "{topic}" not in text
@@ -497,11 +482,10 @@ class TestCreateVaultDocTopicInfix:
     def test_explicit_title_wins_over_topic_in_heading(self, vault_project):
         path = create_vault_doc(
             vault_project,
-            DocType.REFERENCE,
-            "my-feat",
-            "2026-07-16",
-            title="wire shapes deep dive",
-            topic="engine-wire",
+            DocumentIdentity(
+                DocType.REFERENCE, "my-feat", "2026-07-16", topic="engine-wire"
+            ),
+            TemplateFields(title="wire shapes deep dive"),
         )
         text = path.read_text(encoding="utf-8")
         assert "wire shapes deep dive" in text
@@ -511,9 +495,7 @@ class TestCreateVaultDocTopicInfix:
     def test_omitted_topic_keeps_plain_filename(self, vault_project):
         path = create_vault_doc(
             vault_project,
-            DocType.REFERENCE,
-            "my-feat",
-            "2026-07-16",
+            DocumentIdentity(DocType.REFERENCE, "my-feat", "2026-07-16"),
         )
         assert path.name == "2026-07-16-my-feat-reference.md"
 
@@ -522,60 +504,51 @@ class TestCreateVaultDocTopicInfix:
         with pytest.raises(ValueError, match="topic infix is not supported"):
             create_vault_doc(
                 vault_project,
-                doc_type,
-                "my-feat",
-                "2026-07-16",
-                topic="second",
+                DocumentIdentity(doc_type, "my-feat", "2026-07-16", topic="second"),
             )
 
     def test_two_topics_coexist_and_duplicate_collides(self, vault_project):
         first = create_vault_doc(
             vault_project,
-            DocType.REFERENCE,
-            "my-feat",
-            "2026-07-16",
-            topic="engine-wire",
+            DocumentIdentity(
+                DocType.REFERENCE, "my-feat", "2026-07-16", topic="engine-wire"
+            ),
         )
         second = create_vault_doc(
             vault_project,
-            DocType.REFERENCE,
-            "my-feat",
-            "2026-07-16",
-            topic="deletion-manifest",
+            DocumentIdentity(
+                DocType.REFERENCE, "my-feat", "2026-07-16", topic="deletion-manifest"
+            ),
         )
         assert first.exists() and second.exists()
         assert first.name != second.name
         with pytest.raises(ResourceExistsError, match="already exists"):
             create_vault_doc(
                 vault_project,
-                DocType.REFERENCE,
-                "my-feat",
-                "2026-07-16",
-                topic="engine-wire",
+                DocumentIdentity(
+                    DocType.REFERENCE, "my-feat", "2026-07-16", topic="engine-wire"
+                ),
             )
 
     def test_two_adr_topics_coexist_and_duplicate_collides(self, vault_project):
         first = create_vault_doc(
             vault_project,
-            DocType.ADR,
-            "my-feat",
-            "2026-07-16",
-            topic="circuit-accounting",
+            DocumentIdentity(
+                DocType.ADR, "my-feat", "2026-07-16", topic="circuit-accounting"
+            ),
         )
         second = create_vault_doc(
             vault_project,
-            DocType.ADR,
-            "my-feat",
-            "2026-07-16",
-            topic="sibling-adoption",
+            DocumentIdentity(
+                DocType.ADR, "my-feat", "2026-07-16", topic="sibling-adoption"
+            ),
         )
         assert first.name == "2026-07-16-my-feat-circuit-accounting-adr.md"
         assert second.name == "2026-07-16-my-feat-sibling-adoption-adr.md"
         with pytest.raises(ResourceExistsError, match="already exists"):
             create_vault_doc(
                 vault_project,
-                DocType.ADR,
-                "my-feat",
-                "2026-07-16",
-                topic="circuit-accounting",
+                DocumentIdentity(
+                    DocType.ADR, "my-feat", "2026-07-16", topic="circuit-accounting"
+                ),
             )

--- a/src/vaultspec_core/vaultcore/tests/test_modified_stamp.py
+++ b/src/vaultspec_core/vaultcore/tests/test_modified_stamp.py
@@ -26,7 +26,14 @@ from vaultspec_core.vaultcore import (
     parse_lenient_date,
     parse_vault_metadata,
 )
-from vaultspec_core.vaultcore.hydration import create_vault_doc, hydrate_template
+from vaultspec_core.vaultcore.hydration import (
+    DocumentIdentity,
+    ExecBinding,
+    ParentPlan,
+    TemplateFields,
+    create_vault_doc,
+    hydrate_template,
+)
 from vaultspec_core.vaultcore.models import refresh_modified_stamp
 
 if TYPE_CHECKING:
@@ -292,12 +299,12 @@ class TestScaffoldStamp:
         content_root = self._content_root(tmp_path)
         path = create_vault_doc(
             tmp_path,
-            doc_type,
-            "stamp-feat",
-            "2026-06-12",
-            title="stamp probe",
+            DocumentIdentity(doc_type, "stamp-feat", "2026-06-12"),
+            TemplateFields(
+                title="stamp probe",
+                tier="L1" if doc_type is DocType.PLAN else None,
+            ),
             content_root=content_root,
-            tier="L1" if doc_type is DocType.PLAN else None,
         )
         metadata, _ = parse_vault_metadata(path.read_text(encoding="utf-8"))
         assert metadata.date == "2026-06-12"
@@ -308,13 +315,13 @@ class TestScaffoldStamp:
         content_root = self._content_root(tmp_path)
         path = create_vault_doc(
             tmp_path,
-            DocType.EXEC,
-            "stamp-feat",
-            "2026-06-12",
+            DocumentIdentity(DocType.EXEC, "stamp-feat", "2026-06-12"),
+            exec_binding=ExecBinding(
+                plan=ParentPlan(stem="2026-06-12-stamp-feat-plan"),
+                step_id="S01",
+                step_display_path="W01.P01.S01",
+            ),
             content_root=content_root,
-            step_id="S01",
-            step_display_path="W01.P01.S01",
-            plan_stem="2026-06-12-stamp-feat-plan",
         )
         metadata, _ = parse_vault_metadata(path.read_text(encoding="utf-8"))
         assert metadata.modified == "2026-06-12"
@@ -324,10 +331,8 @@ class TestScaffoldStamp:
         content_root = self._content_root(tmp_path)
         path = create_vault_doc(
             tmp_path,
-            DocType.RESEARCH,
-            "stamp-feat",
-            "2026-06-12",
-            title="placement probe",
+            DocumentIdentity(DocType.RESEARCH, "stamp-feat", "2026-06-12"),
+            TemplateFields(title="placement probe"),
             content_root=content_root,
         )
         content = path.read_text(encoding="utf-8")
@@ -348,7 +353,9 @@ class TestScaffoldStamp:
             "---\n"
             "# {feature} research: {topic}\n"
         )
-        hydrated = hydrate_template(template, "stamp-feat", "2026-06-12", "probe")
+        hydrated = hydrate_template(
+            template, "stamp-feat", "2026-06-12", TemplateFields(title="probe")
+        )
         assert hydrated.count("modified:") == 1
         metadata, _ = parse_vault_metadata(hydrated)
         assert metadata.modified == "2026-06-12"

--- a/src/vaultspec_core/vaultcore/tests/test_resolve.py
+++ b/src/vaultspec_core/vaultcore/tests/test_resolve.py
@@ -9,7 +9,12 @@ import pytest
 if TYPE_CHECKING:
     from pathlib import Path
 
-from vaultspec_core.vaultcore.hydration import create_vault_doc, hydrate_template
+from vaultspec_core.vaultcore.hydration import (
+    DocumentIdentity,
+    TemplateFields,
+    create_vault_doc,
+    hydrate_template,
+)
 from vaultspec_core.vaultcore.models import DocType
 from vaultspec_core.vaultcore.resolve import (
     RelatedResolutionError,
@@ -228,7 +233,7 @@ class TestHydrateWithRelatedAndTags:
             template,
             "feat",
             "2026-03-01",
-            related=["[[2026-03-01-feat-research]]"],
+            TemplateFields(related=["[[2026-03-01-feat-research]]"]),
         )
         assert "[[2026-03-01-feat-research]]" in result
         assert "{yyyy-mm-dd-*}" not in result
@@ -239,7 +244,9 @@ class TestHydrateWithRelatedAndTags:
             "date: '2026-03-01'\n"
             'related:\n  - "[[{yyyy-mm-dd-*}]]"\n---\n# Title\n'
         )
-        result = hydrate_template(template, "feat", "2026-03-01", related=[])
+        result = hydrate_template(
+            template, "feat", "2026-03-01", TemplateFields(related=[])
+        )
         assert "related: []" in result
         assert "{yyyy-mm-dd-*}" not in result
 
@@ -253,7 +260,7 @@ class TestHydrateWithRelatedAndTags:
             template,
             "feat",
             "2026-03-01",
-            related=["[[doc-a]]", "[[doc-b]]", "[[doc-c]]"],
+            TemplateFields(related=["[[doc-a]]", "[[doc-b]]", "[[doc-c]]"]),
         )
         assert "[[doc-a]]" in result
         assert "[[doc-b]]" in result
@@ -268,7 +275,7 @@ class TestHydrateWithRelatedAndTags:
             template,
             "feat",
             "2026-03-01",
-            extra_tags=["#scope-backend", "#priority-high"],
+            TemplateFields(extra_tags=["#scope-backend", "#priority-high"]),
         )
         assert "#scope-backend" in result
         assert "#priority-high" in result
@@ -323,11 +330,10 @@ class TestCreateVaultDocWithRelated:
     def test_create_with_resolved_related(self, vault_env: Path) -> None:
         path = create_vault_doc(
             vault_env,
-            DocType.ADR,
-            "test-feat",
-            "2026-03-15",
-            title="Decision",
-            related=["[[2026-03-01-test-feat-research]]"],
+            DocumentIdentity(DocType.ADR, "test-feat", "2026-03-15"),
+            TemplateFields(
+                title="Decision", related=["[[2026-03-01-test-feat-research]]"]
+            ),
         )
         content = path.read_text(encoding="utf-8")
         assert "[[2026-03-01-test-feat-research]]" in content
@@ -336,11 +342,8 @@ class TestCreateVaultDocWithRelated:
     def test_create_with_extra_tags(self, vault_env: Path) -> None:
         path = create_vault_doc(
             vault_env,
-            DocType.ADR,
-            "tag-feat",
-            "2026-03-15",
-            title="Tags Test",
-            extra_tags=["#scope-api"],
+            DocumentIdentity(DocType.ADR, "tag-feat", "2026-03-15"),
+            TemplateFields(title="Tags Test", extra_tags=["#scope-api"]),
         )
         content = path.read_text(encoding="utf-8")
         assert "#scope-api" in content
@@ -350,10 +353,8 @@ class TestCreateVaultDocWithRelated:
     def test_create_without_related_defaults_to_empty(self, vault_env: Path) -> None:
         path = create_vault_doc(
             vault_env,
-            DocType.ADR,
-            "no-rel-feat",
-            "2026-03-15",
-            title="No Related",
+            DocumentIdentity(DocType.ADR, "no-rel-feat", "2026-03-15"),
+            TemplateFields(title="No Related"),
         )
         content = path.read_text(encoding="utf-8")
         # Placeholder must be replaced - created docs must pass validation

--- a/tests/test_automation_contracts.py
+++ b/tests/test_automation_contracts.py
@@ -21,59 +21,72 @@ def _recipe_exists(justfile_text: str, name: str) -> bool:
     return re.search(pattern, justfile_text) is not None
 
 
-def test_justfile_contains_required_recipes() -> None:
+def test_justfile_exposes_every_verb_at_the_root() -> None:
+    """Every entry point is a root verb; there is no nested dispatch namespace.
+
+    The harness was previously reached through `just dev <verb>` with a
+    parallel `just prod` mirror of the shipped CLI.  Both are gone: the
+    justfile is a development-only file, so a `dev` namespace inside it named
+    nothing, and mirroring a finished product's CLI only adds a layer that
+    drifts.  This pins the collapse so neither reappears.
+    """
     justfile = _read("justfile")
-    required = {
-        "prod",
-        "dev",
-        "ci",
-        "_dev-deps",
-        "_dev-lint",
-        "_dev-fix",
-        "_dev-audit",
-        "_dev-test",
-        "_dev-build",
-        "_dev-precommit",
-    }
-    missing = [name for name in sorted(required) if not _recipe_exists(justfile, name)]
+    missing = [
+        name
+        for name in sorted(
+            {
+                "deps",
+                "lint",
+                "fix",
+                "audit",
+                "test",
+                "build",
+                "precommit",
+                "vault",
+                "framework",
+                "assets",
+                "health",
+                "ci",
+            }
+        )
+        if not _recipe_exists(justfile, name)
+    ]
     assert not missing, f"Missing required just recipes: {missing}"
 
+    assert not _recipe_exists(justfile, "prod"), (
+        "`just prod` mirrored the shipped vaultspec-core CLI and was removed; "
+        "invoke the product directly with `uv run --no-sync vaultspec-core`."
+    )
+    assert not re.search(r"(?m)^_dev-", justfile), (
+        "The `_dev-*` internal recipe namespace was collapsed to root verbs."
+    )
 
-def test_justfile_exposes_approved_targets() -> None:
+
+def test_justfile_delegates_every_verb_to_the_dev_package() -> None:
+    """No recipe may carry shell logic; `dev/toolchain.py` is the only source.
+
+    The justfile previously branched on `os()` and embedded PowerShell
+    `switch` bodies, which meant every target existed twice and could drift
+    between platforms.  Each recipe is now a single delegation, so the
+    declarative toolchain is the one place a target is defined.
+    """
     justfile = _read("justfile")
-    # Top-level namespace recipes
-    assert "prod *args='':" in justfile
-    assert "dev target='--help' *args='':" in justfile
-    assert "ci *args='':" in justfile
-    # Internal dev recipes with default targets
-    assert "_dev-deps target='--help':" in justfile
-    assert "_dev-lint target='--help':" in justfile
-    assert "_dev-fix target='--help':" in justfile
-    assert "_dev-audit target='--help':" in justfile
-    assert "_dev-test target='--help':" in justfile
-    assert "_dev-build target='--help':" in justfile
-    assert "_dev-precommit target='--help':" in justfile
-    # Dev dispatch covers all verbs
-    for verb in (
-        "deps",
-        "lint",
-        "fix",
-        "audit",
-        "test",
-        "build",
-        "precommit",
-    ):
-        assert verb in justfile
-    # Lint sub-targets
-    for target in ("python", "type", "links", "toml", "markdown", "workflow"):
-        assert target in justfile
-    # Build/test sub-targets
-    for target in ("python", "all"):
-        assert target in justfile
+    for verb in ("deps", "lint", "fix", "audit", "test", "build", "health"):
+        assert re.search(
+            rf"(?m)^{verb} target='[a-z-]+':\n\s+\{{\{{dev\}}\}} {verb} ", justfile
+        ), f"Recipe `{verb}` must delegate to the dev package in one line"
+    for shell_ism in ('if os() == "windows"', "switch (", "Get-Command", "elseif"):
+        assert shell_ism not in justfile, (
+            f"Shell branching {shell_ism!r} belongs in dev/toolchain.py, "
+            "not the justfile"
+        )
 
 
 def test_dependency_audit_uses_uv_native_scanner() -> None:
-    justfile = _read("justfile")
+    # The invocation moved out of the justfile into the declarative toolchain
+    # when every recipe collapsed to a single delegation; the contract is
+    # unchanged, so it is asserted against its new home.
+    toolchain = _read("dev/toolchain.py")
     audit_script = _read("scripts/dependency_audit.py")
     # The supply-chain gate's justfile recipe delegates to the cross-platform
     # audit wrapper, which runs uv's native auditor against the frozen
@@ -81,7 +94,7 @@ def test_dependency_audit_uses_uv_native_scanner() -> None:
     # dependency groups, so no group-selection flag is pinned: --all-groups
     # was accepted by uv 0.10.x but rejected by 0.11.x, and breaking CI on a
     # uv minor bump is exactly the brittleness this audit is meant to prevent.
-    assert "scripts/dependency_audit.py" in justfile
+    assert "scripts/dependency_audit.py" in toolchain
     assert "uv audit" in audit_script
     assert "--preview-features" in audit_script
     assert "--frozen" in audit_script
@@ -92,7 +105,7 @@ def test_dependency_audit_uses_uv_native_scanner() -> None:
     # may appear in the recipe or the wrapper. When uv's preview decoder
     # aborts on a malformed OSV record, the wrapper independently repeats the
     # bulk OSV query rather than falling back to a second tool.
-    for surface in (justfile, audit_script):
+    for surface in (toolchain, audit_script):
         assert "pip-audit" not in surface
         assert "pip-tools" not in surface
 
@@ -197,40 +210,95 @@ def test_pre_commit_runs_vault_annotation_sanitizer() -> None:
     assert "vault sanitize annotations" in raw
 
 
-def test_lint_all_runs_every_validation_surface() -> None:
-    justfile = _read("justfile")
-    assert "just _dev-lint-python" in justfile
-    assert "just _dev-lint-type" in justfile
-    assert "just _dev-lint-links" in justfile
-    assert "just _dev-lint-toml" in justfile
-    assert "just _dev-lint-markdown" in justfile
-    assert "just _dev-lint-workflow" in justfile
-    assert "uv run ruff format --check src tests" in justfile
+def _toolchain_targets(verb_name: str) -> set[str]:
+    """Return the target names the dev toolchain declares for one verb."""
+    from dev import toolchain
+
+    verb = toolchain.find_verb(verb_name)
+    assert verb is not None, f"dev/toolchain.py declares no `{verb_name}` verb"
+    return {target.name for target in verb.targets}
 
 
-def test_test_all_runs_python() -> None:
-    justfile = _read("justfile")
-    assert "just _dev-test-python" in justfile
-    assert "just _dev-build-python" in justfile
+def test_lint_covers_every_validation_surface() -> None:
+    """The gating dimensions must all be reachable by name."""
+    required = {
+        "python",
+        "type",
+        "toml",
+        "links",
+        "markdown",
+        "workflow",
+        "complexity",
+        "nesting",
+        "size",
+        "type-strict",
+        "all",
+    }
+    missing = sorted(required - _toolchain_targets("lint"))
+    assert not missing, f"lint verb is missing targets: {missing}"
 
 
-def test_fix_surface_covers_all_autofixable_targets() -> None:
-    justfile = _read("justfile")
-    assert "_dev-fix target='--help':" in justfile
-    assert "uv run ruff format src tests" in justfile
-    assert "uv run ruff check --fix src tests" in justfile
-    assert "taplo fmt" in justfile
-    assert "pymarkdown" in justfile
-    assert ".pymarkdown.json" in justfile
-    assert "vault check all --fix" in justfile
-    assert "vault sanitize annotations" in justfile
+def test_audit_covers_every_advisory_dimension() -> None:
+    """Advisory dimensions are named individually so each can graduate to lint."""
+    required = {"deps", "security", "dead-code", "dependencies", "complexity", "all"}
+    missing = sorted(required - _toolchain_targets("audit"))
+    assert not missing, f"audit verb is missing targets: {missing}"
 
 
-def test_markdown_lint_uses_pymarkdown() -> None:
-    justfile = _read("justfile")
-    assert "pymarkdown" in justfile
-    assert "--config .pymarkdown.json" in justfile
-    assert "README.md" in justfile
+def test_only_the_dependency_audit_gates() -> None:
+    """`deps` is a verdict and gates; every other audit dimension is a lead.
+
+    A check whose documented contract and actual exit code disagree is worse
+    than no check, so the advisory flag is asserted rather than assumed.
+    """
+    from dev import toolchain
+
+    audit = toolchain.find_verb("audit")
+    assert audit is not None
+    by_name = {target.name: target for target in audit.targets}
+    assert not by_name["deps"].advisory, "the dependency audit must gate"
+    for name in ("security", "dead-code", "dependencies", "complexity"):
+        assert by_name[name].advisory, f"audit target `{name}` must be advisory"
+
+
+def test_health_report_is_measurement_only() -> None:
+    """Every health target exits 0; it ranks offenders rather than gating."""
+    from dev import toolchain
+
+    health = toolchain.find_verb("health")
+    assert health is not None
+    assert {"report", "fast", "census"} <= {t.name for t in health.targets}
+    for target in health.targets:
+        assert target.advisory, (
+            f"health target `{target.name}` must be advisory - the report is the "
+            "measurement instrument, and the gates live in pyproject.toml"
+        )
+
+
+def test_fix_surface_covers_every_autofixable_target() -> None:
+    required = {"python", "toml", "markdown", "vault", "all"}
+    missing = sorted(required - _toolchain_targets("fix"))
+    assert not missing, f"fix verb is missing targets: {missing}"
+
+
+def test_bandit_excludes_every_nested_test_tree() -> None:
+    """The security scan must not measure test code at any nesting depth.
+
+    A path-shaped exclusion (`<pkg>/tests`) only covers the top-level test
+    package and silently admitted `<pkg>/hooks/tests/` and its siblings, which
+    is where the scan's only MEDIUM findings came from. The glob covers every
+    depth.
+    """
+    from dev import toolchain
+
+    audit = toolchain.find_verb("audit")
+    assert audit is not None
+    security = next(t for t in audit.targets if t.name == "security")
+    argv = security.steps[0].argv
+    assert "-x" in argv, "the bandit scan must carry an exclusion"
+    assert argv[argv.index("-x") + 1] == "*/tests/*", (
+        "the bandit exclusion must be a glob covering nested test trees"
+    )
 
 
 def test_ci_workflow_calls_just_for_quality_gates() -> None:
@@ -248,24 +316,21 @@ def test_ci_workflow_calls_just_for_quality_gates() -> None:
 
     expected_runs = {
         "lint-and-type": {
-            "just dev deps sync",
-            "just dev lint python",
-            "just dev lint type",
-            "just dev lint toml",
-            "just dev lint links",
-            "just dev lint markdown",
+            "just deps sync",
+            "just lint python",
+            "just lint type",
+            "just lint toml",
+            "just lint links",
+            "just lint markdown",
         },
-        "tests": {"just dev deps sync", "just dev test python"},
-        "windows-vault-repair": {
-            "just dev deps sync",
-            (
-                "uv run pytest src/vaultspec_core/tests/cli/test_vault_repair.py "
-                "src/vaultspec_core/vaultcore/checks/tests/"
-                "test_structure_case_rename.py -q"
-            ),
+        "tests": {"just deps sync", "just test unit"},
+        "windows-vault-repair": {"just deps sync", "just test vault-repair"},
+        "vault-audit": {
+            "just deps sync",
+            "just framework install",
+            "just vault check",
         },
-        "vault-audit": {"just dev deps sync", "just prod vault check all"},
-        "dependency-audit": {"just dev deps sync", "just dev audit deps"},
+        "dependency-audit": {"just deps sync", "just audit deps"},
     }
 
     for job_name, expected in expected_runs.items():
@@ -293,14 +358,57 @@ def test_ci_workflow_installs_native_lint_tools() -> None:
     assert "actions/setup-node@v4" not in used_actions
 
 
-def test_prod_delegates_to_cli() -> None:
-    justfile = _read("justfile")
-    # prod recipe passes all args through to uv run vaultspec-core
-    assert "prod *args='':" in justfile
-    assert '"uv run vaultspec-core " + args' in justfile
-    # install/uninstall available via prod namespace (documented in comments)
-    assert "just prod install" in justfile
-    assert "uv run vaultspec-core" in justfile
+def test_quality_gate_thresholds_are_declared_not_reimplemented() -> None:
+    """Every ratcheted threshold lives in pyproject.toml, not in the harness.
+
+    The harness composes the gates by invoking their tools; the moment it
+    carries a threshold of its own, the reported number and the enforced
+    number can drift apart. This pins each baseline-calibrated dimension to
+    its declaration site.
+    """
+    pyproject = _read("pyproject.toml")
+    for table in (
+        "[tool.complexipy]",
+        "[tool.pylint.format]",
+        "[tool.pylint.design]",
+        "[tool.ruff.lint.mccabe]",
+        "[tool.ruff.lint.pylint]",
+        "[tool.vulture]",
+        "[tool.bandit]",
+        "[tool.deptry]",
+        "[tool.basedpyright]",
+    ):
+        assert table in pyproject, f"missing gate declaration {table}"
+
+    toolchain = _read("dev/toolchain.py")
+    for threshold_flag in (
+        "--max-complexity-allowed",
+        "--max-module-lines",
+        "--max-attributes",
+        "--min-confidence",
+    ):
+        assert threshold_flag not in toolchain, (
+            f"{threshold_flag} must be declared in pyproject.toml, not passed "
+            "on the command line where it can drift from the gate"
+        )
+
+
+def test_test_tree_exclusion_patterns_match_windows_paths() -> None:
+    """Ignore patterns must be TOML literal strings, not basic strings.
+
+    As a basic string, `".*[\\\\/]tests[\\\\/].*"` decodes to the regex
+    `.*[\\/]tests[\\/].*`, whose character class contains only a forward slash
+    - the backslash reads as an escape of `/` rather than a class member. The
+    pattern then never matches a Windows path and the test tree silently
+    enters the gate it was meant to leave. Both sibling repositories carry
+    this defect; the literal-string form is the fix.
+    """
+    pyproject = _read("pyproject.toml")
+    assert "ignore-paths = ['.*[\\\\/]tests[\\\\/].*']" in pyproject
+    assert "extend_exclude = ['.*[\\\\/]tests[\\\\/].*']" in pyproject
+    assert '".*[\\\\/]tests[\\\\/].*"' not in pyproject, (
+        "a basic-string ignore pattern never matches a Windows path"
+    )
 
 
 def test_provider_capability_enum_covers_all_tools(tmp_path: Path) -> None:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -384,7 +384,11 @@ def test_resolver_skips_repair_when_not_managed() -> None:
 def test_vault_add_force_overwrites_existing() -> None:
     """vault add --force must overwrite an existing document."""
     from vaultspec_core.core.exceptions import ResourceExistsError
-    from vaultspec_core.vaultcore.hydration import create_vault_doc
+    from vaultspec_core.vaultcore.hydration import (
+        DocumentIdentity,
+        WritePolicy,
+        create_vault_doc,
+    )
     from vaultspec_core.vaultcore.models import DocType
 
     tmp_path = PROJECT_ROOT / ".pytest-tmp" / f"vault-add-force-{uuid4().hex}"
@@ -400,15 +404,14 @@ def test_vault_add_force_overwrites_existing() -> None:
             force=False,
         )
 
-        path1 = create_vault_doc(tmp_path, DocType.ADR, "test-feat", "2026-04-11")
+        identity = DocumentIdentity(DocType.ADR, "test-feat", "2026-04-11")
+        path1 = create_vault_doc(tmp_path, identity)
         assert path1.exists()
 
         with pytest.raises(ResourceExistsError, match="already exists"):
-            create_vault_doc(tmp_path, DocType.ADR, "test-feat", "2026-04-11")
+            create_vault_doc(tmp_path, identity)
 
-        path2 = create_vault_doc(
-            tmp_path, DocType.ADR, "test-feat", "2026-04-11", force=True
-        )
+        path2 = create_vault_doc(tmp_path, identity, write=WritePolicy(force=True))
         assert path2 == path1
         assert path2.exists()
     finally:
@@ -419,7 +422,11 @@ def test_vault_add_force_overwrites_existing() -> None:
 @pytest.mark.unit
 def test_vault_add_dry_run_no_write() -> None:
     """vault add --dry-run must return path without creating file."""
-    from vaultspec_core.vaultcore.hydration import create_vault_doc
+    from vaultspec_core.vaultcore.hydration import (
+        DocumentIdentity,
+        WritePolicy,
+        create_vault_doc,
+    )
     from vaultspec_core.vaultcore.models import DocType
 
     tmp_path = PROJECT_ROOT / ".pytest-tmp" / f"vault-add-dry-{uuid4().hex}"
@@ -437,10 +444,8 @@ def test_vault_add_dry_run_no_write() -> None:
 
         path = create_vault_doc(
             tmp_path,
-            DocType.RESEARCH,
-            "dry-test",
-            "2026-04-11",
-            dry_run=True,
+            DocumentIdentity(DocType.RESEARCH, "dry-test", "2026-04-11"),
+            write=WritePolicy(dry_run=True),
         )
         assert not path.exists()
         assert path.name == "2026-04-11-dry-test-research.md"
@@ -534,7 +539,7 @@ def test_vault_add_creates_distinct_same_day_topic_infixed_adrs() -> None:
 def test_resource_exists_error_includes_hint() -> None:
     """ResourceExistsError from create_vault_doc must include a hint."""
     from vaultspec_core.core.exceptions import ResourceExistsError
-    from vaultspec_core.vaultcore.hydration import create_vault_doc
+    from vaultspec_core.vaultcore.hydration import DocumentIdentity, create_vault_doc
     from vaultspec_core.vaultcore.models import DocType
 
     tmp_path = PROJECT_ROOT / ".pytest-tmp" / f"hint-test-{uuid4().hex}"
@@ -550,10 +555,11 @@ def test_resource_exists_error_includes_hint() -> None:
             force=False,
         )
 
-        create_vault_doc(tmp_path, DocType.ADR, "hint-feat", "2026-04-11")
+        identity = DocumentIdentity(DocType.ADR, "hint-feat", "2026-04-11")
+        create_vault_doc(tmp_path, identity)
 
         with pytest.raises(ResourceExistsError) as exc_info:
-            create_vault_doc(tmp_path, DocType.ADR, "hint-feat", "2026-04-11")
+            create_vault_doc(tmp_path, identity)
         assert exc_info.value.hint
         assert "--force" in exc_info.value.hint
     finally:

--- a/tests/unit/mcp_server/test_create_tool.py
+++ b/tests/unit/mcp_server/test_create_tool.py
@@ -116,6 +116,55 @@ async def test_create_rejects_index_type_per_item(vault_root):
         assert "auto-generated" in payload["items"][0]["error"]["message"]
 
 
+async def test_create_rejects_unknown_document_type_per_item(vault_root):
+    """A type outside the taxonomy fails its item with the offending value."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        payload = await _create(
+            client,
+            [{"feature": "type-reject", "type": "brief"}],
+        )
+        assert payload["status"] == "failed"
+        item = payload["items"][0]
+        assert item["target"] == "brief:type-reject"
+        assert item["error"]["message"] == "Invalid document type: brief"
+
+
+async def test_create_rejects_invalid_plan_tier(vault_root):
+    """A tier outside ``L1``-``L4`` fails the item and writes nothing."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        payload = await _create(
+            client,
+            [{"feature": "tier-reject", "type": "plan", "tier": "L5"}],
+        )
+        assert payload["status"] == "failed"
+        assert payload["items"][0]["error"]["message"] == (
+            "Invalid tier 'L5'. Allowed values: L1, L2, L3, L4."
+        )
+        assert not any((vault_root / ".vault" / "plan").glob("*-tier-reject-plan.md"))
+
+
+async def test_create_reports_unresolvable_related_with_failures(vault_root):
+    """An unresolvable ``related`` entry fails the item and lists each failure."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        payload = await _create(
+            client,
+            [
+                {
+                    "feature": "related-reject",
+                    "type": "research",
+                    "related": ["[[no-such-document]]"],
+                }
+            ],
+        )
+        assert payload["status"] == "failed"
+        error = payload["items"][0]["error"]
+        assert error["message"].startswith("Cannot resolve related document(s): ")
+        assert error["failures"] == ["[[no-such-document]]"]
+
+
 async def test_create_empty_batch_raises_protocol_error(vault_root):
     """An empty batch is a malformed whole-call input surfaced as ``isError``."""
     mcp = create_server()

--- a/tests/unit/mcp_server/test_plan_tools.py
+++ b/tests/unit/mcp_server/test_plan_tools.py
@@ -134,6 +134,56 @@ async def test_plan_edit_failed_op_does_not_abort_batch(vault_root):
         assert result["items"][1]["error"] is not None
 
 
+async def test_plan_edit_unknown_operation_fails_the_item(vault_root):
+    """An unrecognised verb fails its item and echoes the verb it was given."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        await _create_plan(client, "unknownverb")
+        result = await _plan_edit(
+            client,
+            "unknownverb",
+            [{"operation": "retire", "step_id": "S01"}],
+        )
+        assert result["status"] == "failed"
+        item = result["items"][0]
+        assert item["operation"] == "retire"
+        assert item["error"]["message"] == "Unknown plan_edit operation: 'retire'"
+        assert result["total_steps"] == 0
+
+
+async def test_plan_edit_missing_required_fields_fail_per_operation(vault_root):
+    """Each verb reports its own missing-precondition message."""
+    mcp = create_server()
+    async with create_connected_server_and_client_session(mcp) as client:
+        await _create_plan(client, "preconditions")
+        result = await _plan_edit(
+            client,
+            "preconditions",
+            [
+                {"operation": "add", "action": "No scope"},
+                {"operation": "insert", "scope": "src/x.py"},
+                {"operation": "edit", "action": "No step id"},
+                {"operation": "remove"},
+            ],
+        )
+        assert result["status"] == "failed"
+        messages = [item["error"]["message"] for item in result["items"]]
+        assert messages == [
+            "'add' requires 'action' and 'scope'",
+            "'insert' requires 'action' and 'scope'",
+            "'edit' requires 'step_id'",
+            "'remove' requires 'step_id'",
+        ]
+        assert [item["operation"] for item in result["items"]] == [
+            "add",
+            "insert",
+            "edit",
+            "remove",
+        ]
+        plan = parse_plan(_plan_path(vault_root, "preconditions").read_text("utf-8"))
+        assert plan.steps == []
+
+
 async def test_plan_edit_empty_batch_is_protocol_error(vault_root):
     """An empty operation list is a whole-call protocol error."""
     mcp = create_server()

--- a/tools/health_report.py
+++ b/tools/health_report.py
@@ -1,0 +1,379 @@
+"""Aggregate code-health report for ``src/vaultspec_core``.
+
+Prints one readable report covering every health dimension, grouping the worst
+offenders per dimension. ALWAYS exits 0 - this is the measurement instrument
+for the remediation campaign, not a gate. Gates live in:
+
+- ``[tool.complexipy]``          (cognitive complexity, baseline-calibrated)
+- ``[tool.pylint]``              (module length + class shape, baseline-calibrated)
+- ``[tool.ruff.lint.pylint]``    (function-size limits, baseline-calibrated)
+- ``[tool.ruff.lint.mccabe]``    (cyclomatic complexity, baseline-calibrated)
+- ``ty`` / ``basedpyright``      (type checking)
+
+Every gate is configured declaratively in ``pyproject.toml`` and invoked
+directly by a ``just lint`` recipe. This module is the one place that composes
+them, and it exists to rank offenders across dimensions - not to re-implement
+any threshold, which would let the report and the gate disagree.
+
+Dimensions reported here:
+
+1. Cyclomatic complexity   (radon ``cc`` - worst blocks)
+2. Cognitive complexity    (complexipy - worst functions)
+3. Function-size limits    (ruff PLR091x/PLR1702 vs upstream DEFAULTS)
+4. Module length           (physical LOC - longest modules)
+5. Maintainability index   (radon ``mi`` - lowest-ranked modules)
+6. Strict type checking    (basedpyright strict)
+
+radon is used through its Python API (``radon.complexity`` / ``radon.metrics``)
+rather than its CLI: the CLI feeds every ``[tool.*]`` table of pyproject.toml
+into a ``%``-interpolating configparser and crashes on the pytest log formats.
+The API path has no config discovery.
+
+Usage:
+    uv run --no-sync python tools/health_report.py [--top N] [--fast] [--census]
+
+``--fast`` skips the basedpyright section (it is the slowest by far).
+``--census`` prints the threshold distributions used to calibrate each
+baseline ratchet in ``pyproject.toml`` instead of the offender tables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+from complexipy import file_complexity
+from radon.complexity import cc_rank, cc_visit
+from radon.metrics import mi_rank, mi_visit
+from rich.console import Console
+from rich.table import Table
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PACKAGE_DIR = REPO_ROOT / "src" / "vaultspec_core"
+
+COGNITIVE_REPORT_FLOOR = 10  # report functions above this; the gate is at 20
+
+console = Console()
+
+
+def _python_files(production_only: bool = False) -> list[Path]:
+    return [
+        path
+        for path in sorted(PACKAGE_DIR.rglob("*.py"))
+        if "__pycache__" not in path.parts
+        and not (production_only and "tests" in path.parts)
+    ]
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _section(title: str, mode: str) -> None:
+    console.rule(f"[bold]{title}[/bold]  [dim]({mode})[/dim]")
+
+
+def _distribution(values: list[int], thresholds: list[int]) -> list[tuple[int, int]]:
+    """Count how many measured items sit above each candidate threshold."""
+    return [(t, sum(1 for value in values if value > t)) for t in thresholds]
+
+
+def report_cyclomatic(top: int) -> None:
+    _section(
+        "Cyclomatic complexity (radon cc)",
+        "gated by ruff C90 via [tool.ruff.lint.mccabe] and by xenon ranks",
+    )
+    blocks: list[tuple[int, str, str]] = []
+    for path in _python_files():
+        source = path.read_text(encoding="utf-8")
+        for block in cc_visit(source):
+            blocks.append((block.complexity, block.name, _rel(path)))
+    blocks.sort(reverse=True)
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("CC", justify="right")
+    table.add_column("Grade")
+    table.add_column("Block")
+    table.add_column("Module")
+    for complexity, name, module in blocks[:top]:
+        table.add_row(str(complexity), cc_rank(complexity), name, module)
+    console.print(table)
+
+
+def report_cognitive(top: int) -> None:
+    """Rank the worst cognitive-complexity functions across the whole tree.
+
+    The gate in ``[tool.complexipy]`` measures production only; this reports the
+    test tree alongside it, because the two populations differ enough that
+    collapsing them hides which one a hotspot belongs to.
+    """
+    _section(
+        "Cognitive complexity (complexipy)",
+        f"production gated via [tool.complexipy]; reporting > "
+        f"{COGNITIVE_REPORT_FLOOR} across the whole tree",
+    )
+    findings: list[tuple[int, str, str]] = []
+    for path in _python_files():
+        scope = "test" if "tests" in path.parts else "prod"
+        for function in file_complexity(str(path)).functions:
+            if function.complexity > COGNITIVE_REPORT_FLOOR:
+                findings.append(
+                    (
+                        function.complexity,
+                        scope,
+                        f"{_rel(path)}:{function.line_start} {function.name}",
+                    )
+                )
+    findings.sort(reverse=True)
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Cognitive", justify="right")
+    table.add_column("Scope")
+    table.add_column("Module:line Function")
+    for value, scope, location in findings[:top]:
+        table.add_row(str(value), scope, location)
+    console.print(table)
+
+
+def _function_limit_findings() -> list[tuple[int, str, str, str]]:
+    """Run ruff's size rules at UPSTREAM defaults and return every finding."""
+    defaults = {
+        "lint.pylint.max-args": 5,
+        "lint.pylint.max-returns": 6,
+        "lint.pylint.max-branches": 12,
+        "lint.pylint.max-statements": 50,
+        "lint.pylint.max-nested-blocks": 5,
+        "lint.mccabe.max-complexity": 10,
+    }
+    cmd = [
+        sys.executable,
+        "-m",
+        "ruff",
+        "check",
+        "src",
+        "--select",
+        "PLR0911,PLR0912,PLR0913,PLR0915,PLR1702,C901",
+        "--preview",
+        "--output-format",
+        "json",
+        "--exit-zero",
+    ]
+    for key, value in defaults.items():
+        cmd.extend(["--config", f"{key}={value}"])
+    result = subprocess.run(cmd, cwd=REPO_ROOT, capture_output=True, text=True)
+    diagnostics = json.loads(result.stdout or "[]")
+
+    value_pattern = re.compile(r"\((\d+) > \d+\)")
+    findings: list[tuple[int, str, str, str]] = []
+    for item in diagnostics:
+        match = value_pattern.search(item["message"])
+        value = int(match.group(1)) if match else 0
+        module = Path(item["filename"]).resolve()
+        location = f"{_rel(module)}:{item['location']['row']}"
+        findings.append((value, item["code"], item["message"], location))
+    findings.sort(reverse=True)
+    return findings
+
+
+def report_function_limits(top: int) -> None:
+    _section(
+        "Function-size limits (ruff PLR091x / C901 vs upstream defaults)",
+        "gated at baseline via [tool.ruff.lint.pylint] and [tool.ruff.lint.mccabe]",
+    )
+    findings = _function_limit_findings()
+    counts: Counter[str] = Counter(code for _, code, _, _ in findings)
+
+    summary = ", ".join(f"{code}={count}" for code, count in sorted(counts.items()))
+    console.print(f"violations vs upstream defaults: {summary or 'none'}")
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Value", justify="right")
+    table.add_column("Rule")
+    table.add_column("Message")
+    table.add_column("Module:line")
+    for value, code, message, location in findings[:top]:
+        table.add_row(str(value), code, message, location)
+    console.print(table)
+
+
+def report_module_length(top: int) -> None:
+    _section(
+        "Module length (physical LOC)",
+        "gated by pylint C0302 via [tool.pylint.format] (production only)",
+    )
+    lengths: list[tuple[int, str]] = []
+    for path in _python_files():
+        with path.open("rb") as handle:
+            lengths.append((sum(1 for _ in handle), _rel(path)))
+    lengths.sort(reverse=True)
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Lines", justify="right")
+    table.add_column("Module")
+    for line_count, module in lengths[:top]:
+        table.add_row(str(line_count), module)
+    console.print(table)
+
+
+def report_maintainability(top: int) -> None:
+    _section(
+        "Maintainability index (radon mi)",
+        "report-only (informational ranking, lower is worse)",
+    )
+    scores: list[tuple[float, str]] = []
+    for path in _python_files():
+        source = path.read_text(encoding="utf-8")
+        scores.append((mi_visit(source, multi=True), _rel(path)))
+    scores.sort()
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("MI", justify="right")
+    table.add_column("Rank")
+    table.add_column("Module")
+    for score, module in scores[:top]:
+        table.add_row(f"{score:.2f}", mi_rank(score), module)
+    console.print(table)
+
+
+def report_strict_types(top: int) -> None:
+    _section(
+        "Strict type checking (basedpyright strict)",
+        "advisory until the burndown reaches zero; ty remains the fast gate",
+    )
+    executable = shutil.which("basedpyright")
+    if executable is None:
+        console.print(
+            "[yellow]basedpyright not found on PATH - run "
+            "`uv sync --locked --group dev`[/yellow]"
+        )
+        return
+    result = subprocess.run(
+        [executable, "--outputjson"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        console.print("[red]basedpyright produced no parseable output[/red]")
+        console.print(result.stderr[:2000])
+        return
+
+    summary = payload.get("summary", {})
+    console.print(
+        f"files analyzed: {summary.get('filesAnalyzed', '?')}  "
+        f"errors: {summary.get('errorCount', '?')}  "
+        f"warnings: {summary.get('warningCount', '?')}"
+    )
+    per_file: Counter[str] = Counter()
+    per_rule: Counter[str] = Counter()
+    for diagnostic in payload.get("generalDiagnostics", []):
+        if diagnostic.get("severity") == "error":
+            per_file[diagnostic.get("file", "?")] += 1
+            per_rule[diagnostic.get("rule", "(no rule)")] += 1
+
+    rules = Table(show_header=True, header_style="bold")
+    rules.add_column("Errors", justify="right")
+    rules.add_column("Rule")
+    for rule, count in per_rule.most_common(top):
+        rules.add_row(str(count), rule)
+    console.print(rules)
+
+    table = Table(show_header=True, header_style="bold")
+    table.add_column("Errors", justify="right")
+    table.add_column("Module")
+    for file_name, count in per_file.most_common(top):
+        module = Path(file_name)
+        label = _rel(module) if module.is_absolute() else file_name
+        table.add_row(str(count), label)
+    console.print(table)
+
+
+def report_census() -> None:
+    """Print the distributions each baseline ratchet in pyproject.toml is set from.
+
+    Every gate here is calibrated at the current worst offender so it is green
+    on landing and can only be lowered. This is the measurement that justifies
+    each number, and the census comment beside it.
+    """
+    console.rule("[bold]Baseline census[/bold]  [dim](production only)[/dim]")
+
+    cognitive: list[int] = []
+    for path in _python_files(production_only=True):
+        cognitive.extend(f.complexity for f in file_complexity(str(path)).functions)
+    console.print(f"\n[bold]Cognitive complexity[/bold] (worst {max(cognitive)})")
+    for threshold, count in _distribution(cognitive, [30, 25, 20, 18, 16, 15]):
+        console.print(f"  over {threshold:>4}: {count:>4} functions")
+
+    cyclomatic: list[int] = []
+    for path in _python_files(production_only=True):
+        source = path.read_text(encoding="utf-8")
+        cyclomatic.extend(block.complexity for block in cc_visit(source))
+    console.print(f"\n[bold]Cyclomatic complexity[/bold] (worst {max(cyclomatic)})")
+    for threshold, count in _distribution(cyclomatic, [25, 20, 15, 12, 10]):
+        console.print(f"  over {threshold:>4}: {count:>4} blocks")
+
+    lengths = [
+        sum(1 for _ in path.open("rb")) for path in _python_files(production_only=True)
+    ]
+    console.print(
+        f"\n[bold]Module length[/bold] "
+        f"({len(lengths)} production modules, longest {max(lengths)})"
+    )
+    for threshold, count in _distribution(lengths, [2000, 1500, 1200, 1000, 500]):
+        console.print(f"  over {threshold:>4}: {count:>4} modules")
+
+    console.print("\n[bold]Function-size limits[/bold] (worst value per ruff rule)")
+    worst: dict[str, int] = {}
+    for value, code, _, _ in _function_limit_findings():
+        worst[code] = max(worst.get(code, 0), value)
+    for code, value in sorted(worst.items()):
+        console.print(f"  {code}: worst {value}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=10,
+        help="worst offenders to list per dimension (default 10)",
+    )
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help="skip the basedpyright section (slowest dimension)",
+    )
+    parser.add_argument(
+        "--census",
+        action="store_true",
+        help="print baseline-calibration distributions instead of offender tables",
+    )
+    args = parser.parse_args()
+
+    if args.census:
+        report_census()
+        return 0
+
+    console.print(
+        "[bold]vaultspec-core code-health report[/bold] "
+        "[dim](measurement only - always exits 0)[/dim]"
+    )
+    report_cyclomatic(args.top)
+    report_cognitive(args.top)
+    report_function_limits(args.top)
+    report_module_length(args.top)
+    report_maintainability(args.top)
+    if not args.fast:
+        report_strict_types(args.top)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -69,12 +69,48 @@ wheels = [
 ]
 
 [[package]]
+name = "astroid"
+version = "4.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/63/0adf26577da5eff6eb7a177876c1cfa213856be9926a000f65c4add9692b/astroid-4.0.4.tar.gz", hash = "sha256:986fed8bcf79fb82c78b18a53352a0b287a73817d6dbcfba3162da36667c49a0", size = 406358, upload-time = "2026-02-07T23:35:07.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/cf/1c5f42b110e57bc5502eb80dbc3b03d256926062519224835ef08134f1f9/astroid-4.0.4-py3-none-any.whl", hash = "sha256:52f39653876c7dec3e3afd4c2696920e05c83832b9737afc21928f2d2eb7a753", size = 276445, upload-time = "2026-02-07T23:35:05.344Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
+name = "basedpyright"
+version = "1.39.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodejs-wheel-binaries" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/4b/c1f4e211e50389304d6af32b9280e026a7133e3ad59bbdf8f7a3250f8bee/basedpyright-1.39.9.tar.gz", hash = "sha256:32cbea5fc8273e89df3db20daea56cb7286e419ccdfdc479c64759d2dc071901", size = 24412216, upload-time = "2026-06-27T02:19:49.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/d4/e1fa108710d0498a18c77b1e13897f31eab47c69aa8cfe2d2a4df746541e/basedpyright-1.39.9-py3-none-any.whl", hash = "sha256:6b0837b9eba972c71895167ab9b127e6afdbc17abc92312e3f8d15ca82a5611c", size = 13374276, upload-time = "2026-06-27T02:19:54.431Z" },
 ]
 
 [[package]]
@@ -160,6 +196,54 @@ wheels = [
 ]
 
 [[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
@@ -191,6 +275,54 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/0d/a0b2fd781050d29c9df64ac6df30b5f18b775724b79779f56fc5a8298fe9/Columnar-1.4.1.tar.gz", hash = "sha256:c3cb57273333b2ff9cfaafc86f09307419330c97faa88dcfe23df05e6fbb9c72", size = 11386, upload-time = "2021-12-27T21:58:56.123Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/00/a17a5657bf090b9dffdb310ac273c553a38f9252f60224da9fe62d9b60e9/Columnar-1.4.1-py3-none-any.whl", hash = "sha256:8efb692a7e6ca07dcc8f4ea889960421331a5dffa8e5af81f0a67ad8ea1fc798", size = 11845, upload-time = "2021-12-27T21:58:54.388Z" },
+]
+
+[[package]]
+name = "complexipy"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tomli" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/82/6a5c35b7c31ef56ed3d5fc94cd84d066ac1affb2484fc94afa0dbb15c127/complexipy-6.2.0.tar.gz", hash = "sha256:c90db418f1a3e885ebe75537e5930e2ad98543e3302b55f59684db343d30de2b", size = 355624, upload-time = "2026-07-23T03:44:13.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/75/27c11d3921bbd575b9e398fcec895444b7dcacc28500c54e642a56198a28/complexipy-6.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f926157cdeada0bb3e8729429bea928ca210b2cf6249ac70a2fb09548a606f50", size = 2318369, upload-time = "2026-07-23T03:42:37.268Z" },
+    { url = "https://files.pythonhosted.org/packages/77/80/ad38a2afa6a7f1878935493b725b7f33db94b748458224948b21a807f9d6/complexipy-6.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:18ec1d43b40fa5c32288b137c7516814afb73843dce7019ba6280d5f6666240f", size = 2260208, upload-time = "2026-07-23T03:42:38.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a4/b97e3cd5f338bcc77f0fcd8914bd2fa1deb14aeb62027e2f14d92109f9d1/complexipy-6.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaa51743c27f6a7ff00f6cf19be871903bd101318b0eb1aa9ba958e6c1922898", size = 2462929, upload-time = "2026-07-23T03:42:39.757Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/0d/178f6a0e2dca3c2acdb0a4108c5942fd9ee6c5e76379a5aa9ddfc4564cb4/complexipy-6.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9d6a561815bff1cad0c43649ec1b6d501b8c0a0ebc4c84ab34fabcd5b35b78ad", size = 2394705, upload-time = "2026-07-23T03:42:41.112Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e4/00921335f5f43fe5160b4b31763df55b53daa7dcd00fe11787975f9c941e/complexipy-6.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cec2b4dc54e6b8ecc993a6e66652816ba93c3bc99729b28ed5d3410e39e713b8", size = 2611667, upload-time = "2026-07-23T03:42:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/3c/e0d65a1e20da7c7fdb6da365119bc7de32e3cad946d97aea96e87291ac69/complexipy-6.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5bd3ccc2fda92ebfd82ffa53498df1783d809a0c6ad56941eed42fcf312d0acc", size = 2848850, upload-time = "2026-07-23T03:42:43.748Z" },
+    { url = "https://files.pythonhosted.org/packages/87/cf/1d939868ae311c004ebeaf19403e03375f38edcf1037822216592bcc17e6/complexipy-6.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1dfc7145be69fad1a828b4d92391a4e70299d8cdc0d74541a9b0d02daf05c67b", size = 2524160, upload-time = "2026-07-23T03:42:45.008Z" },
+    { url = "https://files.pythonhosted.org/packages/72/69/964a50dd8de47eedea4a05405fe2a2d7037fcc59702a5488c36234d39fe7/complexipy-6.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b3077f387b7c225d1a5416e42dd005a9bd61031494608b768fe9fe62f67e662", size = 2487218, upload-time = "2026-07-23T03:42:46.216Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/ed/a6304b3519bbdefc3fe3b68926be11e14708f4724be6668e9c81f5e56058/complexipy-6.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2d426720668664fb79f04c271da5fa2c0293ffb1e19ed4db0a8de134ad16d550", size = 2641994, upload-time = "2026-07-23T03:42:47.54Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/9805118d69a7ab3dc5bce00ab6d1c1207f4619777b50981a0179979ecf39/complexipy-6.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54c00af2b42d14ba0e94c812b33c018c386013128de584f8cbc3124567d28c7e", size = 2737925, upload-time = "2026-07-23T03:42:49.301Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/749ec64ef80b3863efb6b8cef03071a0054c1041e1082059c7d0d4f23d54/complexipy-6.2.0-cp313-cp313-win32.whl", hash = "sha256:338359fb31b928f1a49063106b2cecd8e6f827897cf348efadc6fbd12719b961", size = 2036290, upload-time = "2026-07-23T03:42:50.645Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7d/31122b321a5647512af1d748e689556112d3b381da78ed7f1d982a5884ea/complexipy-6.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:624762987e37db3da602996f9190a33cf995f1768a6652d6d21f6170767750ad", size = 2187968, upload-time = "2026-07-23T03:42:51.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/fb/9d0f90e32d1a2462ed4f4012ea922a759e708cd8816506486e4347249957/complexipy-6.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:498018df8448124247880fb7d824130401a8ac18a8b17aca7ebd54b91c5502bf", size = 2319799, upload-time = "2026-07-23T03:42:53.242Z" },
+    { url = "https://files.pythonhosted.org/packages/af/60/4f0b620afb20ed0a78356325d7dc5835b8c3610847d7adda3237e80cffb3/complexipy-6.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8077354d21cd7256347af67e33d0d0c2965a2512a9e174dfa01d6935a6a2c8ef", size = 2261117, upload-time = "2026-07-23T03:42:54.618Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ca/1843e382dc4b4f612ada7b8a3ebf2bd4e4584f3acf99fce243ed735dc883/complexipy-6.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f954e8d62891b85c0f279c335dda7df24638fa83efe3c1d5f4752100c61b4494", size = 2463571, upload-time = "2026-07-23T03:42:55.895Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/53/24cf69643ab14d7070ce243f504c63624dec13c916bb8bae99ccaf2a3fde/complexipy-6.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0341b7d7ebc67a5e7b500007df2195f4f92d4e24e21a85fd954ff77f4dc6af18", size = 2394587, upload-time = "2026-07-23T03:42:57.158Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f1/c70bc68ad4bd57af77991dd3d85f27bfaf27e5263e3afea7862d0d63e561/complexipy-6.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e9c615f1910c7436e9dfc7680e79399a89bded1c554b9c0a37b94db1e6def55", size = 2612999, upload-time = "2026-07-23T03:42:58.531Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/eb/db02f3f6cd1c3d047aac8b10b1ff95c98af4f538e07c1d32c9ff9cf757dc/complexipy-6.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7285614c6be583ea702d22a19c09ec235b81bd11d9e754c9a940493e008a7e10", size = 2850798, upload-time = "2026-07-23T03:42:59.959Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/41/d3f1eef665f9833adaee9aff1232bcba43451244fbf1ab4a180365236aff/complexipy-6.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:708c80d46ac70dbfa17bf82742d89852aeb679b0d7c05379314930327841ce3f", size = 2525119, upload-time = "2026-07-23T03:43:01.331Z" },
+    { url = "https://files.pythonhosted.org/packages/98/6a/bed199004647f134deafeff21afefde4e180694a58d11dd14e7287b28985/complexipy-6.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12064f3e210243c532a3734fc87c149dbb4806ac171ce42843ee816d25387def", size = 2487604, upload-time = "2026-07-23T03:43:02.689Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b8/0a2b482ba94f744a54a09e54a77563c1bc22847664d7af5349d4f4940199/complexipy-6.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d78cbea32ad23dcc6ab2d5589712e9a9493f1295d13ae3bb96268f8427cea6ed", size = 2642190, upload-time = "2026-07-23T03:43:04.321Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/1ec6e25c7b0a5706c20c6a06d92fdbe768d103c80ccd37a8755b85c41525/complexipy-6.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:579450cf61ff04e59149e1901cb27de3d80cd4815a227ad24c2e92ebdf4b449c", size = 2738474, upload-time = "2026-07-23T03:43:05.749Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/d1/80f4cc44d489db0c256f05fa1bb468c80d5db0e7309bba6260218f59e167/complexipy-6.2.0-cp314-cp314-win32.whl", hash = "sha256:3a22f5f2a6843a8d9652076368b457102a0c9e95b63769b5a50ef3686427fd96", size = 2036901, upload-time = "2026-07-23T03:43:07.289Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f0/16db165c81e6b2246e9a765bbb4ce4a1929a9ca151aee0637cf78092f8b9/complexipy-6.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:89fabd582ed95cb0bae44f065b40a6afbc045d8717acbaf693ba3eafa50baaa8", size = 2190135, upload-time = "2026-07-23T03:43:08.691Z" },
+    { url = "https://files.pythonhosted.org/packages/20/22/1d27d7d75d32c49d0bcabe2e118ef7f1491b9bdfe02c7043b62a574f9409/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51a318d2bb83a766c5b7a1adc9d123df9fd822cee8df648c925b698506469e58", size = 2462244, upload-time = "2026-07-23T03:43:10.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6c/680f1dc9a671f4c3aa50c4922f0cfa5605a34bbbb5861725101580d8b45a/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50555b34bc069c8e06832b42755a93939215e21734891bad910ef0b6eb1e18fa", size = 2399189, upload-time = "2026-07-23T03:43:11.824Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c0/5ed9f7815c5abb4c91b2d0d78df7996c182ab61ac233f40fc92a907e23de/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1348392bf58532653bf3583f18fb655b058e680432c23264a6ffc8f27451cc01", size = 2615954, upload-time = "2026-07-23T03:43:13.417Z" },
+    { url = "https://files.pythonhosted.org/packages/58/56/fb835163c4af2119539875b3d9c7ce09fd1c02cb952968fd9b71b54e2916/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de886742128d50e8100a8cee3b4596be2ec4b55cdedfce4ac8f9f45fbe8fbd85", size = 2850104, upload-time = "2026-07-23T03:43:15.148Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/5a/3b50eb8c2d6b6016379825cf330fd7ba45a5859500000bb50586e1e008e0/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f50e3496d9dcc547d9c5d515bf297c87c9c57afe33cbb6df341e614fa57b1738", size = 2524210, upload-time = "2026-07-23T03:43:16.562Z" },
+    { url = "https://files.pythonhosted.org/packages/51/0e/c7f061240d82abed2d34a6e5fd4165fd97f6c7d0c90dadeff1fc4a93366b/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28914d763c03d3a662ac2d666bc4151852788e6e767f52dd07c94e8332a4b265", size = 2487720, upload-time = "2026-07-23T03:43:17.882Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0a/ed66cc8d14d8cd0d76154f30e36b05a9bb058b462541056666f5f1bd7880/complexipy-6.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:63eed569ba56d2e90a167a38f241fa06de99ee9f96ec950c55a2aa22694e4ce0", size = 2641145, upload-time = "2026-07-23T03:43:19.273Z" },
+    { url = "https://files.pythonhosted.org/packages/81/2e/eb2a778b9ce6bfae57f41eb8f042df3167174d2627bf1eec37b6bf64eb44/complexipy-6.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cbbefd1fc3e72da8016647176de792a579a276b1308f0822b5b1585f16eaf5a2", size = 2737833, upload-time = "2026-07-23T03:43:20.692Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3d/1dc7456c01d46ffb5a18e4cdbcba9c3e81ba209f5587ea2280e1e5b49d26/complexipy-6.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa80249ef9b552da259f2cc2b16482f547f05f76a4f377dcff3f568ea7fcaed0", size = 2614198, upload-time = "2026-07-23T03:43:22.271Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/39/2d4be85a221c167a36960175ea006ad310680c35cbe005cd5ba4c5322a92/complexipy-6.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:42442a233ecaec535e6543869867184ac0cd6dead64f57ce581e650d4d5dfbfb", size = 2487356, upload-time = "2026-07-23T03:43:23.613Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/5f/fd5a17602585ff8625072ab356b36ee6de42cf82a865cd919dbf68a87241/complexipy-6.2.0-cp315-cp315t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:04f4c4e08d2d4650828b33b88ebe7521e71fcc2d1a7883808e92404c414676e1", size = 2616158, upload-time = "2026-07-23T03:43:25.003Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/df/af4eebce70ed8f91a94f84cf65c7aac2720c808eacc9772b8f53df0cb23a/complexipy-6.2.0-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:037fe51f18b3aad5b09ac74880735d3dc21dd54b62fcb02a8d5f1acbd76da8f5", size = 2488018, upload-time = "2026-07-23T03:43:26.33Z" },
 ]
 
 [[package]]
@@ -314,6 +446,47 @@ nvrtc = [
 ]
 nvtx = [
     { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+
+[[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -519,6 +692,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isort"
+version = "8.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -564,6 +746,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "mando"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/24/cd70d5ae6d35962be752feccb7dca80b5e0c2d450e995b16abd6275f3296/mando-0.7.1.tar.gz", hash = "sha256:18baa999b4b613faefb00eac4efadcf14f510b59b924b66e08289aa1de8c3500", size = 37868, upload-time = "2022-02-24T08:12:27.316Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/f0/834e479e47e499b6478e807fb57b31cc2db696c4db30557bb6f5aea4a90b/mando-0.7.1-py2.py3-none-any.whl", hash = "sha256:26ef1d70928b6057ee3ca12583d73c63e05c49de8972d620c278a7b206581a8a", size = 28149, upload-time = "2022-02-24T08:12:25.24Z" },
 ]
 
 [[package]]
@@ -628,6 +822,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325", size = 9658, upload-time = "2022-01-24T01:14:51.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e", size = 7350, upload-time = "2022-01-24T01:14:49.62Z" },
 ]
 
 [[package]]
@@ -755,6 +958,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/22/2a5beb4e21417c73233d9f65cf6f3e96e891b80d2f550a8f630ebc6b88c6/nodejs_wheel_binaries-24.16.0.tar.gz", hash = "sha256:c973cb69dc5fd16e6f6dc6e579e2c3d5534e2a1f57619dddf5ba070efa7dde37", size = 8056, upload-time = "2026-05-30T16:52:09.807Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/d1/68b43b53cd0fa83ae6fd406705023ca988d9e0ca41c724d82e66fbeb2ef6/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:d9f8f677dcf30e37ac244f07869726abe043f01eb0f45722b1df31cc2af7093c", size = 55666374, upload-time = "2026-05-30T16:51:39.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/b2/40a989159599080da485de966c4c2d207e852ac7aa7864702626d96c8bf5/nodejs_wheel_binaries-24.16.0-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:3d0370fe7120ce9697a4f60d40480d2bd8808d9f30131458d5afc0040d4e5a51", size = 55838487, upload-time = "2026-05-30T16:51:43.383Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/a7/cd42174fb5ff6faff7fa8d326a18914d8f232098ab5de055b57c16fa13ca/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:85dc92bbb79c851569c5925dcc2a4c915a034efab375f99e4e7e6bbe9cca8342", size = 60179540, upload-time = "2026-05-30T16:51:47.036Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/c8a1f9ae140aa28df8744d984d01d4b3af7cdd6555af12127f40ceb45a7d/nodejs_wheel_binaries-24.16.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2f3036292811514ba847b3708492644764f88a833ac425c5f55007014308ddfd", size = 60716262, upload-time = "2026-05-30T16:51:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c9/7c35b3737f59e36d0249c265397b7bff570519b95301d6e16ea361e904ad/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:db8a8a76ebd2b28ecbfc9ad464baa3707241b9e050a30e2efdf6f60c0f886502", size = 62230592, upload-time = "2026-05-30T16:51:55Z" },
+    { url = "https://files.pythonhosted.org/packages/04/96/d931255cf9d11a84d6b54d882dba7434646467d568ccf070ea3418638df3/nodejs_wheel_binaries-24.16.0-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f1a3d8f7b4491cbbd023ba3fc4e901fcca2d9fb80d57f24ba3890de8b1dbac03", size = 62841759, upload-time = "2026-05-30T16:51:59.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/7b/8b7a3f41bc255411be30b6d7d288aab8ffd9ea2055db8555ced3548007b9/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_amd64.whl", hash = "sha256:bb136be9944f0662dcf1120f45193a6b75b13fac378971a95cc42c9f879a81aa", size = 42027734, upload-time = "2026-05-30T16:52:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/17/66/1ed71f1f529b8ca727d42c7ceb9db0bef145ce4a13dfc86fb50aa44f3be6/nodejs_wheel_binaries-24.16.0-py2.py3-none-win_arm64.whl", hash = "sha256:8308940b5edd0a50dc5267ea36ba21c9f668e83fe0d9f293937174d3a7e31c36", size = 39714528, upload-time = "2026-05-30T16:52:06.421Z" },
 ]
 
 [[package]]
@@ -999,6 +1218,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/41/ca/f587424a41e860e97ef6a1e75fd9d33594370130fca3ed343dcf671a0e21/phart-2.0.6.tar.gz", hash = "sha256:3d262d879425c6f4a6acc21e848012e0fbf7d3bc7a5e5b8c83424c4aad536671", size = 645804, upload-time = "2026-06-03T01:22:00.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/57/c64cfa798a4af43003c702c08eeedd94aad6c675ecd29ee5523e7fbaa06b/phart-2.0.6-py3-none-any.whl", hash = "sha256:c2ac6da5d60408cf29630f88b18bdc1e56d8862390dd27936ce920d24e4dc0b2", size = 110906, upload-time = "2026-06-03T01:21:58.999Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
 ]
 
 [[package]]
@@ -1307,6 +1535,24 @@ crypto = [
 ]
 
 [[package]]
+name = "pylint"
+version = "4.0.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "astroid" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "dill" },
+    { name = "isort" },
+    { name = "mccabe" },
+    { name = "platformdirs" },
+    { name = "tomlkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/1d/3bb57f303701549550d74bf7ced2b07412be97125c167a0c9d216aa9f762/pylint-4.0.6.tar.gz", hash = "sha256:52f19191bee08bf103f9705ad1a0ece4aa5a0a4ef2bdcbd969375a1e6f6579d5", size = 1585588, upload-time = "2026-06-14T14:43:26.772Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/da/acb2e7d4dbd2dfb792d38c0d850481f29ad7049b356d23f56c687d35203b/pylint-4.0.6-py3-none-any.whl", hash = "sha256:d11a0e1fdb7b1cd46ec5d6fc78fee8b95f28695b2d6140e5809925f61e32ea54", size = 538389, upload-time = "2026-06-14T14:43:24.873Z" },
+]
+
+[[package]]
 name = "pymarkdownlnt"
 version = "0.9.39"
 source = { registry = "https://pypi.org/simple" }
@@ -1384,6 +1630,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]
@@ -1475,6 +1734,19 @@ wheels = [
 ]
 
 [[package]]
+name = "radon"
+version = "6.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "mando" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/6d/98e61600febf6bd929cf04154537c39dc577ce414bafbfc24a286c4fa76d/radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5", size = 1874992, upload-time = "2023-03-26T06:24:38.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/f7/d00d9b4a0313a6be3a3e0818e6375e15da6d7076f4ae47d1324e7ca986a1/radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859", size = 52784, upload-time = "2023-03-26T06:24:33.949Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1557,6 +1829,33 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/d7/01d31d5bdb09bc026fab77f59a371fdf8f9b292e4810546c56182ca70498/regex-2026.7.19-cp314-cp314t-win32.whl", hash = "sha256:2c4e61e2e1be56f63ec3cc618aa9e0de81ef6f43d177205451840022e24f5b78", size = 274526, upload-time = "2026-07-19T00:19:42.398Z" },
     { url = "https://files.pythonhosted.org/packages/52/0e/cea4ce73bc0a8247a0748228ae6669984c7e1f8134b6fa66e59c0572e0ea/regex-2026.7.19-cp314-cp314t-win_amd64.whl", hash = "sha256:c639ea314df70a7b2811e8020448c75af8c9445f5a60f8a4ced81c306a9380c2", size = 283763, upload-time = "2026-07-19T00:19:44.644Z" },
     { url = "https://files.pythonhosted.org/packages/6f/b6/26e41975febae63b7a6e3e02f32cff6cff2e4f10d19c929082f56aebf7c6/regex-2026.7.19-cp314-cp314t-win_arm64.whl", hash = "sha256:9a15e785f244f3e07847b984ce8773fc3da10a9f3c131cc49a4c5b4d672b4547", size = 283451, upload-time = "2026-07-19T00:19:46.639Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/1a/5f3c22d38bf1d87d1f4a961489d9eba35c4370a21395562d94410cdd0e73/requirements_parser-0.13.1.tar.gz", hash = "sha256:78811383b2089b6c5197a1431bc2c12ff950245edca39a23eea3460782038dd3", size = 22783, upload-time = "2026-06-18T07:52:25.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f9/15b44d5e4401b0013bbcefe3c09d7bfddcce28cc3d41b1d3077bcedf5b1f/requirements_parser-0.13.1-py3-none-any.whl", hash = "sha256:6e385663eb32589d16e5b22bb6e5251a57908e73803ffff438b53cd6ea2056e0", size = 14926, upload-time = "2026-06-18T07:52:24.171Z" },
 ]
 
 [[package]]
@@ -1851,6 +2150,15 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
 name = "sly"
 version = "0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1882,6 +2190,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/dd/04d56c2a5232358df41f3d0f0e31833d378b6c8ed7803a6b1b7867b0eba6/stevedore-5.9.0.tar.gz", hash = "sha256:abbd0af7a38a8bbb1d6adea2e35b17609cf004eaac323e88a8d8963640dd2b3c", size = 514850, upload-time = "2026-07-02T11:38:08.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/8d/008761f6e1000600e5303db30d05724bdcf3d2d186cbb59fac79b52e39ed/stevedore-5.9.0-py3-none-any.whl", hash = "sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7", size = 54463, upload-time = "2026-07-02T11:38:07.43Z" },
 ]
 
 [[package]]
@@ -2256,23 +2573,32 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
+    { name = "basedpyright" },
+    { name = "complexipy" },
+    { name = "deptry" },
     { name = "identify" },
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
     { name = "mdformat-gfm" },
     { name = "mdformat-gfm-alerts" },
     { name = "prek" },
+    { name = "pylint" },
     { name = "pymarkdownlnt" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-durations" },
     { name = "pytest-reportlog" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+    { name = "radon" },
     { name = "ruff" },
     { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
     { name = "torch", version = "2.13.0+cu130", source = { registry = "https://download.pytorch.org/whl/cu130" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "ty" },
     { name = "vaultspec-rag", extra = ["mcp"] },
+    { name = "vulture" },
+    { name = "xenon" },
 ]
 
 [package.metadata]
@@ -2308,23 +2634,32 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.9.4" },
+    { name = "basedpyright", specifier = ">=1.39" },
+    { name = "complexipy", specifier = ">=6.2" },
+    { name = "deptry", specifier = ">=0.25.1" },
     { name = "identify", specifier = ">=2.0.0" },
     { name = "mdformat", specifier = ">=1.0.0" },
     { name = "mdformat-frontmatter", specifier = ">=2.0.10" },
     { name = "mdformat-gfm", specifier = ">=1.0.0" },
     { name = "mdformat-gfm-alerts", specifier = ">=1.0.0" },
     { name = "prek", specifier = ">=0.3.2" },
+    { name = "pylint", specifier = ">=4.0" },
     { name = "pymarkdownlnt", specifier = ">=0.9.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-durations", specifier = ">=1.0.0" },
     { name = "pytest-reportlog", specifier = ">=0.4.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
+    { name = "radon", specifier = ">=6.0.1" },
     { name = "ruff", specifier = ">=0.15.2" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32'", specifier = ">=2.4" },
     { name = "torch", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = ">=2.4", index = "https://download.pytorch.org/whl/cu130" },
     { name = "ty", specifier = ">=0.0.15" },
     { name = "vaultspec-rag", extras = ["mcp"], specifier = ">=0.3.8" },
+    { name = "vulture", specifier = ">=2.16" },
+    { name = "xenon", specifier = ">=0.9.3" },
 ]
 
 [[package]]
@@ -2359,6 +2694,15 @@ wheels = [
 [package.optional-dependencies]
 mcp = [
     { name = "mcp" },
+]
+
+[[package]]
+name = "vulture"
+version = "2.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]
@@ -2440,4 +2784,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]
+
+[[package]]
+name = "xenon"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "radon" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/7c/2b341eaeec69d514b635ea18481885a956d196a74322a4b0942ef0c31691/xenon-0.9.3.tar.gz", hash = "sha256:4a7538d8ba08aa5d79055fb3e0b2393c0bd6d7d16a4ab0fcdef02ef1f10a43fa", size = 9883, upload-time = "2024-10-21T10:27:53.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/5d/29ff8665b129cafd147d90b86e92babee32e116e3c84447107da3e77f8fb/xenon-0.9.3-py2.py3-none-any.whl", hash = "sha256:6e2c2c251cc5e9d01fe984e623499b13b2140fcbf74d6c03a613fa43a9347097", size = 8966, upload-time = "2024-10-21T10:27:51.121Z" },
 ]


### PR DESCRIPTION
Mirrors the rag/aeat quality-gate pattern into vaultspec-core and rebuilds the
`justfile` on a platform-agnostic backend.

## Harness shape

- `prod` mirror removed. `vaultspec-core` and `vaultspec-rag` are finished
  products with their own CLIs and MCP servers; wrapping either only adds a
  layer that can drift. What the harness does expose is what the repository
  does to *itself* - its own `.vault/` corpus and `.vaultspec/` harness - as the
  `vault` and `framework` verbs.
- `dev` parent removed, children collapsed to top-level verbs: `just lint type`,
  `just test broad`, `just fix markdown`.
- `set quiet := true`; every recipe carries a doc comment, so `just --list`
  renders a complete annotated index and `just <verb> help` prints per-target
  descriptions.

## Platform agnostic by construction

Every recipe body is a single command - no shell branching, no pipes, no
conditionals, no `sh`-versus-PowerShell dialect, and no shell script backing the
file. Dispatch, step chaining, tool-or-Docker fallback, and advisory-versus-
gating exit codes all live in the new `dev/` package, which imports only the
standard library. `dev/toolchain.py` is the single declarative source of truth.

## Newly exposed dev tooling

`assets` (README renderers), `analytics` (the `statistic` module), `binaries`
(PyApp, aligned to the release workflow's `--no-project`), `framework`, `vault`,
`health`, and the `repo` / `benchmark` / `harness` test lanes. Ruff now also
covers `scripts/` and `statistic/`, which were silently unlinted.

## Guards

`dev/tests/test_registry.py` fails when the justfile and the registry drift
apart, when an aggregate references a missing target, and when a test lane is
reachable from neither `test all` nor a CI step - the defect that had left the
repository-root `tests/` tree unrun.

## CI

Repointed to the new recipe names; the raw `pytest` steps now call
`just test broad` / `just test vault-repair`, so CI and local runs issue
identical commands.