### PR TITLE
feat(precommit): let a workspace decline managed pre-commit scaffolding

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -345,6 +345,10 @@ full options.
 
 #### Precommit
 
+- `vaultspec-core spec precommit disable` - Decline vaultspec-managed
+  .pre-commit-config.yaml scaffolding.
+- `vaultspec-core spec precommit enable` - Restore vaultspec-managed
+  .pre-commit-config.yaml scaffolding.
 - `vaultspec-core spec precommit migrate` - Transplant the canonical vaultspec hooks
   into prek.toml.
 
@@ -2351,8 +2355,23 @@ vaultspec-core spec precommit [OPTIONS] COMMAND [ARGS]...
 
 #### Subcommands
 
+- `disable` (`--json`) - Decline vaultspec-managed `.pre-commit-config.yaml`
+  scaffolding.
+- `enable` (`--json`) - Restore vaultspec-managed `.pre-commit-config.yaml` scaffolding.
 - `migrate` (`--remove-yaml`, `--dry-run`, `--json`) - Transplant the canonical
   vaultspec hooks into `prek.toml`.
+
+By default every `install` and `sync` scaffolds `.pre-commit-config.yaml` and reconciles
+the canonical hooks into it. `disable` records `hooks.pre_commit = false` in the
+committed `.vaultspec/workspace.json`, which declines that permanently: no later run
+regenerates the file, and the vaultspec-managed `.gitignore` block starts ignoring
+`/.pre-commit-config.yaml` so a resurrected copy cannot be committed by accident. Use it
+in projects that run their gates explicitly and forbid a commit hook - a tree-wide hook
+that rewrites the working tree to the staged state is unsafe when several workers share
+one checkout. Neither verb touches an existing `.pre-commit-config.yaml`; declining is a
+policy statement, and deleting the file is yours to do. `enable` clears the declaration
+again, and is a no-op in a workspace that never declared one. Both are idempotent and
+exit zero when the requested state already holds.
 
 When `prek.toml` owns the hook boundary, sync no longer scaffolds
 `.pre-commit-config.yaml` and prek silently ignores it. `migrate` renders the canonical
@@ -2363,12 +2382,25 @@ present in `prek.toml`.
 
 #### Options
 
-- `--remove-yaml` (default off) - Also delete the superseded `.pre-commit-config.yaml`
-  once the canonical hooks are verifiably present in `prek.toml`.
-- `--dry-run` (default off) - Preview without writing.
+- `--remove-yaml` (default off, `migrate` only) - Also delete the superseded
+  `.pre-commit-config.yaml` once the canonical hooks are verifiably present in
+  `prek.toml`.
+- `--dry-run` (default off, `migrate` only) - Preview without writing.
 - `--json` (default off) - Emit the result as JSON.
 
 #### Examples
+
+- **Stop vaultspec from ever writing the hook config again**:
+
+  ```bash
+  vaultspec-core spec precommit disable
+  ```
+
+- **Restore managed scaffolding**:
+
+  ```bash
+  vaultspec-core spec precommit enable
+  ```
 
 - **Preview the transplant without writing**:
 

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -165,6 +165,14 @@ project running vaultspec-core beside a companion package can declare each in it
 mode; `vaultspec-core install --upgrade` records a mode for a workspace provisioned
 before modes existed by inferring it from the existing hook and dependency shape.
 
+**Or decline the hooks entirely.** Not every project wants a commit hook: a tree-wide
+hook that rewrites the working tree to the staged state is unsafe when several workers
+share one checkout, and some teams run their gates explicitly instead.
+`vaultspec-core spec precommit disable` records that in the same committed
+`workspace.json`, so no later `install` or `sync` regenerates `.pre-commit-config.yaml`
+and the managed `.gitignore` block starts ignoring it.
+`vaultspec-core spec precommit enable` reverses the decision.
+
 **Maintain.** `vaultspec-core vault check all --fix` validates and repairs the vault,
 and `vaultspec-core vault graph --feature search-api` visualizes a feature. The CLI
 maintains each document's `modified:` and `date:` stamps; never hand-edit them.

--- a/src/vaultspec_core/builtins/reference/cli.md
+++ b/src/vaultspec_core/builtins/reference/cli.md
@@ -280,6 +280,10 @@ hand-edit between the markers.
 
 #### Precommit
 
+- `vaultspec-core spec precommit disable` - Decline vaultspec-managed
+  .pre-commit-config.yaml scaffolding.
+- `vaultspec-core spec precommit enable` - Restore vaultspec-managed
+  .pre-commit-config.yaml scaffolding.
 - `vaultspec-core spec precommit migrate` - Transplant the canonical vaultspec hooks
   into prek.toml.
 
@@ -755,10 +759,14 @@ the shared `--body`, `--from-file`, `--force`, and `--dry-run` flags; `edit` tak
 
 ### vaultspec-core spec precommit
 
-Manage the project's pre-commit integration. `vaultspec-core spec precommit migrate`
-converts a legacy `.pre-commit-config.yaml` to `prek.toml`, and takes `--remove-yaml` to
-delete the superseded YAML once the canonical hooks are verifiably present in
-`prek.toml`, plus `--dry-run` and `--json`.
+Manage the project's pre-commit integration. `vaultspec-core spec precommit disable`
+records `hooks.pre_commit = false` in the committed `.vaultspec/workspace.json`, so no
+later `install` or `sync` scaffolds `.pre-commit-config.yaml` and the managed
+`.gitignore` block starts ignoring it; `enable` clears that declaration. Both are
+idempotent, take `--json`, and leave any existing `.pre-commit-config.yaml` on disk.
+`vaultspec-core spec precommit migrate` converts a legacy `.pre-commit-config.yaml` to
+`prek.toml`, and takes `--remove-yaml` to delete the superseded YAML once the canonical
+hooks are verifiably present in `prek.toml`, plus `--dry-run` and `--json`.
 
 ### vaultspec-core spec reference
 

--- a/src/vaultspec_core/cli/spec_cmd_hooks.py
+++ b/src/vaultspec_core/cli/spec_cmd_hooks.py
@@ -415,9 +415,97 @@ def cmd_hooks_run(
 # =============================================================================
 
 precommit_app = make_app(
-    help="Manage the pre-commit hook boundary for prek-owned workspaces.",
+    help="Manage whether and where vaultspec's pre-commit hooks are scaffolded.",
     no_args_is_help=True,
 )
+
+
+def _set_precommit_policy(
+    *, enabled: bool, json_output: bool, target: Path | None
+) -> None:
+    """Persist the workspace's pre-commit policy and report the outcome.
+
+    The one implementation behind ``enable`` and ``disable``, which differ only
+    by the boolean they persist and the sentence they print. Both are idempotent
+    and report an already-satisfied request as success, so a sync script can set
+    the policy unconditionally.
+    """
+    apply_target(target)
+    from vaultspec_core.core.exceptions import VaultSpecError
+    from vaultspec_core.core.types import get_context
+    from vaultspec_core.core.workspace_mode import (
+        HooksDeclaration,
+        read_hooks_declaration,
+        write_hooks_declaration,
+    )
+
+    root = get_context().target_dir
+    try:
+        already = read_hooks_declaration(root).pre_commit == enabled
+        if not already:
+            write_hooks_declaration(root, HooksDeclaration(pre_commit=enabled))
+    except (VaultSpecError, OSError) as exc:
+        _handle_error(exc, json_output=json_output)
+        return
+
+    status = "unchanged" if already else "updated"
+    if json_output:
+        emit_json(
+            "spec.precommit.enable" if enabled else "spec.precommit.disable",
+            status,
+            {"pre_commit": enabled, "workspace": str(root)},
+        )
+        raise typer.Exit(0)
+
+    from vaultspec_core.console import get_console
+
+    console = get_console()
+    if enabled:
+        console.print(
+            f"[green]{status}[/green]: vaultspec-core scaffolds "
+            ".pre-commit-config.yaml in this workspace."
+        )
+    else:
+        console.print(
+            f"[green]{status}[/green]: vaultspec-core will not scaffold "
+            ".pre-commit-config.yaml in this workspace."
+        )
+        console.print(
+            "  [dim]Any existing .pre-commit-config.yaml is left in place; "
+            "delete it yourself if you no longer want it.[/dim]"
+        )
+    raise typer.Exit(0)
+
+
+@precommit_app.command("disable")
+def cmd_precommit_disable(
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Decline vaultspec-managed .pre-commit-config.yaml scaffolding.
+
+    Records hooks.pre_commit = false in the committed
+    .vaultspec/workspace.json, so no later install or sync regenerates the
+    file, and the vaultspec-managed .gitignore block starts ignoring it so a
+    resurrected copy cannot be committed by accident. For projects that run
+    their gates explicitly and forbid a commit hook. Any existing
+    .pre-commit-config.yaml is left on disk untouched.
+    """
+    _set_precommit_policy(enabled=False, json_output=json_output, target=target)
+
+
+@precommit_app.command("enable")
+def cmd_precommit_enable(
+    json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
+    target: TargetOption = None,
+) -> None:
+    """Restore vaultspec-managed .pre-commit-config.yaml scaffolding.
+
+    Clears a previously recorded opt-out so the next install or sync scaffolds
+    the canonical hooks again. This is the default for a workspace that has
+    never declared a preference, so running it there is a no-op.
+    """
+    _set_precommit_policy(enabled=True, json_output=json_output, target=target)
 
 
 @precommit_app.command("migrate")

--- a/src/vaultspec_core/core/gitignore.py
+++ b/src/vaultspec_core/core/gitignore.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from .enums import ManagedState, Tool
 from .helpers import advisory_lock, atomic_write_bytes
+from .workspace_mode import read_hooks_declaration
 
 logger = logging.getLogger(__name__)
 
@@ -181,6 +182,12 @@ def get_recommended_entries(target: Path) -> list[str]:
     advisory-lock sentinels, the install manifest, and the vault's local
     caches. Authored content is never added here.
 
+    The one entry that is not a runtime by-product is
+    ``/.pre-commit-config.yaml``, and it appears only when the workspace has
+    declared it does not want that file. A config the workspace declined is not
+    policy a teammate should inherit, so the sharing rule that keeps it out of
+    the block does not apply to it.
+
     Args:
         target: Workspace root directory.
     """
@@ -217,6 +224,19 @@ def get_recommended_entries(target: Path) -> list[str]:
         if framework_installed:
             for lock_path in managed_lock_paths(target):
                 entries.add(f"/{lock_path}")
+
+        # ``.pre-commit-config.yaml`` is team-shared while a workspace wants
+        # hooks, so it is deliberately absent from the block above even though
+        # its ``.lock`` sentinel is listed: the sentinel is per-machine runtime
+        # state and the config it locks is authoritative policy a teammate
+        # should inherit.  That reverses the moment the workspace declares it
+        # does not want the file.  A declined config is not policy anyone should
+        # inherit, and until it is ignored a sweep-style ``git add -A`` recommits
+        # the hooks the declaration just refused - which is how the file kept
+        # coming back before the opt-out existed.  Anchored with a leading slash
+        # so it matches only at the workspace root.
+        if framework_installed and not read_hooks_declaration(target).pre_commit:
+            entries.add("/.pre-commit-config.yaml")
 
     except Exception:
         # Fallback for very early bootstrap or corruption

--- a/src/vaultspec_core/core/precommit.py
+++ b/src/vaultspec_core/core/precommit.py
@@ -19,6 +19,11 @@ from ruamel.yaml import YAML, YAMLError
 from .enums import InstallMode, PrecommitHook, render_mode
 from .helpers import advisory_lock, atomic_write
 from .prek_boundary import PrekBoundaryState, collect_prek_boundary
+from .workspace_mode import (
+    CORE_DISTRIBUTION_NAME,
+    read_hooks_declaration,
+    resolve_render_mode,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -428,18 +433,36 @@ def scaffold_precommit(
     caller passes its resolved mode explicitly, because the declaration is
     written only after scaffolding.
 
-    Skips scaffolding entirely when ``prek.toml`` is present at *target*
-    (assessed through
+    Skips scaffolding entirely in two cases.
+
+    The first is a committed opt-out: a workspace whose declaration sets
+    ``hooks.pre_commit`` to ``false`` has decided it runs its gates explicitly
+    and forbids a commit hook, so no install or sync writes the file. The
+    declaration is read on every call rather than resolved once at provision
+    time, so the choice survives every later run instead of being re-decided by
+    whichever verb happens to reach here.
+
+    The second is ``prek.toml`` being present at *target* (assessed through
     :func:`~vaultspec_core.core.prek_boundary.collect_prek_boundary`):
     prek reads ``prek.toml`` exclusively and silently ignores a co-present
     ``.pre-commit-config.yaml``, so writing the YAML would leave hooks prek
     never runs. The operator transplants hooks into ``prek.toml`` with
     ``spec precommit migrate``; the log messages distinguish a healthy
     transplant (hooks already in ``prek.toml``) from stranded hooks.
-    """
-    if mode is None:
-        from .workspace_mode import CORE_DISTRIBUTION_NAME, resolve_render_mode
 
+    Neither skip deletes an existing ``.pre-commit-config.yaml``. Declining
+    future scaffolding is a policy statement; removing a file the operator may
+    still have reasons to keep is a destructive act they ask for explicitly.
+    """
+    if not read_hooks_declaration(target).pre_commit:
+        logger.info(
+            "The workspace declaration at %s sets hooks.pre_commit to false; "
+            "skipping .pre-commit-config.yaml scaffolding.",
+            target,
+        )
+        return []
+
+    if mode is None:
         mode = resolve_render_mode(target, package=CORE_DISTRIBUTION_NAME)
     canonical_hooks = canonical_precommit_hooks_for_mode(mode)
 

--- a/src/vaultspec_core/core/resolver.py
+++ b/src/vaultspec_core/core/resolver.py
@@ -126,6 +126,16 @@ def resolve(
             pc_managed = _mdata.precommit_managed
         except Exception:
             pc_managed = True
+        # A committed opt-out outranks the per-machine manifest flag. Without
+        # this the doctor would keep planning a repair the scaffold declines to
+        # perform, leaving a workspace that made a deliberate choice
+        # permanently reporting a defect it must never fix.
+        try:
+            from .workspace_mode import read_hooks_declaration
+
+            pc_managed = pc_managed and read_hooks_declaration(target).pre_commit
+        except Exception:
+            logger.debug("Could not read the hook declaration", exc_info=True)
 
     # The canonical entry prefix the non-canonical precommit advisory names is
     # mode-dependent: a tool-mode workspace should be told to use the uvx form,

--- a/src/vaultspec_core/core/workspace_mode.py
+++ b/src/vaultspec_core/core/workspace_mode.py
@@ -1,4 +1,4 @@
-"""Read and write the committed workspace mode declaration.
+"""Read and write the committed workspace declaration.
 
 Vaultspec-core is development-harness tooling, not a runtime dependency of the
 projects it governs, so the choice between tool mode and dependency mode is a
@@ -7,6 +7,14 @@ decision the whole team must share. This module owns the committed
 from the gitignored per-machine ``providers.json`` manifest: the declaration is
 the source of truth every contributor and a fresh clone read, while the
 manifest only echoes the locally resolved value for bookkeeping.
+
+The same file also carries the workspace's git-hook policy. Scaffolding a
+``.pre-commit-config.yaml`` installs a gate that rewrites the working tree to
+the staged state, which is unsafe in a checkout several workers share, so a
+project that runs its gates explicitly must be able to decline it once and have
+that survive every later sync. :class:`HooksDeclaration` is that declaration;
+it is workspace-scoped rather than per-package because a workspace has exactly
+one hook configuration no matter how many packages are provisioned into it.
 
 Reads are lenient about a missing file (there is simply no persisted choice
 yet) and strict about a present but broken one: corrupt JSON or an
@@ -37,10 +45,15 @@ __all__ = ["canonical_distribution_name"]
 
 WORKSPACE_FILENAME = "workspace.json"
 
-#: Current declaration schema version. Schema 2.0 is the per-package ``packages``
-#: map that lets one committed ``workspace.json`` carry a mode (and optional
-#: version floor) for each provisioned distribution independently.
-WORKSPACE_SCHEMA_VERSION = "2.0"
+#: Current declaration schema version. Schema 2.0 introduced the per-package
+#: ``packages`` map that lets one committed ``workspace.json`` carry a mode (and
+#: optional version floor) for each provisioned distribution independently.
+#: Schema 2.1 adds the optional top-level ``hooks`` object; the bump is a minor
+#: one because the addition is purely additive - a 2.1 file parses identically
+#: under the 2.0 reader, which ignores top-level keys it does not know. The
+#: version is informational: no reader gates on it, and the key is written only
+#: when it departs from the default, so an unchanged workspace never gains it.
+WORKSPACE_SCHEMA_VERSION = "2.1"
 
 #: The legacy single-key schema (``install_mode`` plus an optional
 #: ``minimum_vaultspec_version`` at the top level) that ``install-mode`` shipped.
@@ -223,6 +236,27 @@ class PackageDeclaration:
 
 
 @dataclass
+class HooksDeclaration:
+    """The workspace's committed policy on vaultspec-managed git hooks.
+
+    Workspace-scoped rather than per-package: a checkout has exactly one hook
+    configuration, whatever mix of packages is provisioned into it.
+
+    Attributes:
+        pre_commit: Whether vaultspec-core may scaffold and reconcile its
+            managed hooks in ``.pre-commit-config.yaml``. Defaults to ``True``,
+            which is also what an absent declaration means, so an existing
+            workspace that has never expressed a preference keeps scaffolding
+            exactly as before. Setting it to ``False`` declines the file
+            permanently: every later ``install`` and ``sync`` leaves it alone,
+            and the managed ``.gitignore`` block starts ignoring it so a
+            resurrected copy can never be committed by accident.
+    """
+
+    pre_commit: bool = True
+
+
+@dataclass
 class WorkspaceDeclaration:
     """The committed shared declaration of a workspace's provisioning mode.
 
@@ -285,34 +319,24 @@ def _parse_package_entry(path: Path, name: object, entry: Any) -> PackageDeclara
     return PackageDeclaration(install_mode=mode, minimum_version=minimum)
 
 
-def _read_packages_map(target: Path) -> dict[str, PackageDeclaration] | None:
-    """Read every package entry from the committed ``workspace.json``.
+def _read_raw(target: Path) -> dict[str, Any] | None:
+    """Read and shape-validate the committed ``workspace.json`` document.
 
-    The single parse point behind the whole read surface. A missing file is
-    lenient (returns ``None``); a present but broken file is strict (raises).
-    Two on-disk shapes are recognized: the schema 2.0 ``packages`` map is parsed
-    entry by entry, and the legacy schema 1.0 single-key shape
-    (``install_mode`` plus optional ``minimum_vaultspec_version`` at the top
-    level) is folded into a one-entry map keyed to :data:`_DISTRIBUTION_NAME`,
-    renaming the top-level ``minimum_vaultspec_version`` floor to the
-    package-relative ``minimum_version``. The fold happens purely in memory; the
-    next write persists the file in schema 2.0 shape.
-
-    Package keys are canonicalized per PEP 503 so callers can look an entry up by
-    any spelling of a distribution name.
+    The single JSON parse point behind every reader in this module, so the
+    packages map and the hooks declaration cannot disagree about what counts as
+    a missing file versus a broken one. A missing file is lenient (returns
+    ``None``); a present but unreadable, unparseable, or non-object file is
+    strict and raises.
 
     Args:
         target: Workspace root directory.
 
     Returns:
-        A mapping of canonicalized distribution name to
-        :class:`PackageDeclaration`, or ``None`` when the file is absent.
+        The parsed top-level object, or ``None`` when the file is absent.
 
     Raises:
         VaultSpecError: If the file exists but contains invalid JSON, is
-            unreadable, is not an object, or names an ``install_mode`` outside
-            the canonical :class:`~vaultspec_core.core.enums.InstallMode`
-            vocabulary.
+            unreadable, or is not a JSON object.
     """
     path = _workspace_path(target)
     if not path.exists():
@@ -330,7 +354,94 @@ def _read_packages_map(target: Path) -> dict[str, PackageDeclaration] | None:
             f"Malformed workspace declaration at {path}: expected a JSON object.",
             hint="Fix the JSON by hand or re-run 'vaultspec-core install --mode'.",
         )
-    raw = cast("dict[str, Any]", raw)
+    return cast("dict[str, Any]", raw)
+
+
+def read_hooks_declaration(target: Path) -> HooksDeclaration:
+    """Read the workspace's committed git-hook policy.
+
+    Absence is not a decision to be repaired: a workspace with no declaration
+    file, no ``hooks`` object, or no ``pre_commit`` key has simply never
+    expressed a preference, and every such case returns the permissive default
+    so scaffolding behaves exactly as it did before the key existed. Only an
+    explicit ``false`` declines.
+
+    A present but broken ``hooks`` object is strict and raises, matching the
+    fail-loud contract the rest of the read surface honors: silently ignoring a
+    malformed opt-out would reinstall the very file the operator declined.
+
+    Args:
+        target: Workspace root directory.
+
+    Returns:
+        The declared :class:`HooksDeclaration`, or the default when undeclared.
+
+    Raises:
+        VaultSpecError: If the file exists but is malformed, or its ``hooks``
+            value is not an object, or ``hooks.pre_commit`` is not a boolean.
+    """
+    raw = _read_raw(target)
+    if raw is None:
+        return HooksDeclaration()
+    hooks = raw.get("hooks")
+    if hooks is None:
+        return HooksDeclaration()
+    path = _workspace_path(target)
+    if not isinstance(hooks, dict):
+        raise VaultSpecError(
+            f"Malformed 'hooks' object in workspace declaration at {path}: "
+            "expected a JSON object.",
+            hint="Fix the JSON by hand or re-run "
+            "'vaultspec-core spec precommit enable'.",
+        )
+    # A bare ``isinstance(x, dict)`` narrows an ``object`` from JSON only to
+    # ``dict[Unknown, Unknown]``, so re-type it the way the package-entry
+    # reader above does before reading a key off it.
+    hooks = cast("dict[str, Any]", hooks)
+    pre_commit = hooks.get("pre_commit", True)
+    if not isinstance(pre_commit, bool):
+        raise VaultSpecError(
+            f"Invalid hooks.pre_commit in workspace declaration at {path}: "
+            f"{pre_commit!r}.",
+            hint="Set hooks.pre_commit to true or false, or re-run "
+            "'vaultspec-core spec precommit enable'.",
+        )
+    return HooksDeclaration(pre_commit=pre_commit)
+
+
+def _read_packages_map(target: Path) -> dict[str, PackageDeclaration] | None:
+    """Read every package entry from the committed ``workspace.json``.
+
+    The single parse point behind the whole read surface. A missing file is
+    lenient (returns ``None``); a present but broken file is strict (raises).
+    Two on-disk shapes are recognized: the schema 2.0 ``packages`` map is parsed
+    entry by entry, and the legacy schema 1.0 single-key shape
+    (``install_mode`` plus optional ``minimum_vaultspec_version`` at the top
+    level) is folded into a one-entry map keyed to :data:`_DISTRIBUTION_NAME`,
+    renaming the top-level ``minimum_vaultspec_version`` floor to the
+    package-relative ``minimum_version``. The fold happens purely in memory; the
+    next write persists the file in the current schema shape.
+
+    Package keys are canonicalized per PEP 503 so callers can look an entry up by
+    any spelling of a distribution name.
+
+    Args:
+        target: Workspace root directory.
+
+    Returns:
+        A mapping of canonicalized distribution name to
+        :class:`PackageDeclaration`, or ``None`` when the file is absent.
+
+    Raises:
+        VaultSpecError: If the file exists but contains invalid JSON, is
+            unreadable, is not an object, or names an ``install_mode`` outside
+            the canonical :class:`~vaultspec_core.core.enums.InstallMode`
+            vocabulary.
+    """
+    raw = _read_raw(target)
+    if raw is None:
+        return None
+    path = _workspace_path(target)
 
     packages_raw = raw.get("packages")
     if packages_raw is not None:
@@ -463,16 +574,29 @@ def read_workspace_declaration(target: Path) -> WorkspaceDeclaration | None:
     )
 
 
-def _write_packages_map(target: Path, packages: dict[str, PackageDeclaration]) -> None:
-    """Serialize *packages* to ``.vaultspec/workspace.json`` in schema 2.0 shape.
+def _write_document(
+    target: Path, packages: dict[str, PackageDeclaration], hooks: HooksDeclaration
+) -> None:
+    """Serialize the whole declaration to ``.vaultspec/workspace.json``.
 
-    The single lock-free write primitive. Emits the ``{"schema_version": "2.0",
-    "packages": {...}}`` envelope canonically: ``json.dumps`` with
-    ``sort_keys=True`` orders the package names and every nested key
-    deterministically, two-space indent and a trailing newline keep the
-    committed file diff-clean. Each package entry carries its ``install_mode``
-    and, only when set, its ``minimum_version`` floor, so an unset floor never
-    writes a null. Callers that must not race a concurrent writer wrap this in
+    The single lock-free write primitive, and the only place the on-disk shape
+    is decided. Emits the ``{"schema_version": ..., "packages": {...}}``
+    envelope canonically: ``json.dumps`` with ``sort_keys=True`` orders the
+    package names and every nested key deterministically, two-space indent and a
+    trailing newline keep the committed file diff-clean. Each package entry
+    carries its ``install_mode`` and, only when set, its ``minimum_version``
+    floor, so an unset floor never writes a null.
+
+    The write is whole-document rather than key-wise, so every caller must
+    supply *both* halves of the declaration or silently drop the one it did not
+    name. That is why *hooks* is a required parameter rather than an optional
+    one defaulted to :class:`HooksDeclaration`: a mode write that forgot it
+    would erase a committed hook opt-out and reinstall the file the operator
+    declined, and a default would make that omission invisible. A default-valued
+    *hooks* writes no ``hooks`` key at all, so a workspace that has never
+    declined keeps a byte-identical file.
+
+    Callers that must not race a concurrent writer wrap this in
     :func:`~vaultspec_core.core.helpers.advisory_lock`; this primitive itself
     takes no lock so it can be composed inside a caller's own read-modify-write
     critical section without re-entering a non-reentrant lock.
@@ -480,6 +604,7 @@ def _write_packages_map(target: Path, packages: dict[str, PackageDeclaration]) -
     Args:
         target: Workspace root directory.
         packages: Mapping of distribution name to :class:`PackageDeclaration`.
+        hooks: The workspace's git-hook policy.
     """
     path = _workspace_path(target)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -489,11 +614,30 @@ def _write_packages_map(target: Path, packages: dict[str, PackageDeclaration]) -
         if decl.minimum_version is not None:
             entry["minimum_version"] = decl.minimum_version
         packages_payload[name] = entry
-    payload = {
+    payload: dict[str, Any] = {
         "schema_version": WORKSPACE_SCHEMA_VERSION,
         "packages": packages_payload,
     }
+    if hooks != HooksDeclaration():
+        payload["hooks"] = {"pre_commit": hooks.pre_commit}
     atomic_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def write_hooks_declaration(target: Path, declaration: HooksDeclaration) -> None:
+    """Persist the workspace's git-hook policy to ``.vaultspec/workspace.json``.
+
+    Upserts the ``hooks`` object while leaving every package entry untouched.
+    The whole read-modify-write cycle runs under a single advisory lock so a
+    concurrent mode writer is serialized rather than clobbered, and a legacy
+    single-key file is migrated to the current shape on this write.
+
+    Args:
+        target: Workspace root directory.
+        declaration: The :class:`HooksDeclaration` to persist.
+    """
+    path = _workspace_path(target)
+    with advisory_lock(path):
+        _write_document(target, _read_packages_map(target) or {}, declaration)
 
 
 def write_package_declaration(
@@ -505,9 +649,14 @@ def write_package_declaration(
     only *package*'s entry and leaves every sibling package's entry untouched.
     The whole read-modify-write cycle runs under a single advisory lock, so two
     processes writing different packages' entries are serialized rather than
-    clobbering each other's map, and a legacy single-key file is migrated to
-    schema 2.0 shape on the first write. The entry is keyed by canonicalized
+    clobbering each other's map, and a legacy single-key file is migrated to the
+    current schema shape on the first write. The entry is keyed by canonicalized
     distribution name, matching :func:`read_package_declaration`.
+
+    The committed hook policy is read inside the same lock and written straight
+    back through, because the write primitive emits the whole document: an
+    install or sync that recorded a mode would otherwise erase a hook opt-out
+    and resurrect the file the operator declined.
 
     Args:
         target: Workspace root directory.
@@ -519,7 +668,7 @@ def write_package_declaration(
     with advisory_lock(path):
         packages = _read_packages_map(target) or {}
         packages[key] = declaration
-        _write_packages_map(target, packages)
+        _write_document(target, packages, read_hooks_declaration(target))
 
 
 def write_workspace_declaration(
@@ -532,8 +681,8 @@ def write_workspace_declaration(
     :class:`WorkspaceDeclaration` while leaving every companion package's entry
     untouched. The whole read-modify-write cycle runs under a single advisory
     lock so a concurrent writer of a sibling package's entry is serialized rather
-    than clobbered. The file is always rewritten in schema 2.0 shape, so a legacy
-    single-key file is migrated on the first write. The declaration's own
+    than clobbered. The file is always rewritten in the current schema shape, so a
+    legacy single-key file is migrated on the first write. The declaration's own
     ``schema_version`` field is ignored on write; the on-disk version is always
     :data:`WORKSPACE_SCHEMA_VERSION`.
 

--- a/src/vaultspec_core/tests/cli/test_precommit_opt_out.py
+++ b/src/vaultspec_core/tests/cli/test_precommit_opt_out.py
@@ -1,0 +1,271 @@
+"""The committed opt-out from managed ``.pre-commit-config.yaml`` scaffolding.
+
+A project that runs its gates explicitly must be able to decline the hook
+config once and have that survive every later run. Before the opt-out existed
+the file came back on every ``install`` and ``sync``, from four separate call
+sites, and was not covered by the managed ``.gitignore`` block even though its
+``.lock`` sentinel was - so a sweep-style ``git add -A`` recommitted the hooks.
+
+These tests drive the real filesystem, the real ``install_run``, and the real
+CLI; no mocks, patches, or stubs. They pin:
+
+* the scaffold declines when the declaration says so, and still emits when it
+  is absent or permissive;
+* the decline reaches the doctor's repair executor, and the resolver stops
+  planning a repair, so a declined workspace does not report a defect forever
+  behind a fix that is now a permanent no-op;
+* the managed ``.gitignore`` block lists the config only once declined;
+* the CLI verbs write the declaration and are idempotent.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from vaultspec_core.core.commands import scaffold_precommit
+from vaultspec_core.core.gitignore import get_recommended_entries
+from vaultspec_core.core.workspace_mode import (
+    HooksDeclaration,
+    read_hooks_declaration,
+    write_hooks_declaration,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from typer.testing import CliRunner
+
+    from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+pytestmark = [pytest.mark.integration]
+
+_CONFIG = ".pre-commit-config.yaml"
+
+
+def _decline(root: Path) -> None:
+    write_hooks_declaration(root, HooksDeclaration(pre_commit=False))
+
+
+def _bare_workspace(root: Path) -> Path:
+    """Give *root* the ``.vaultspec/`` directory ``--target`` validation needs."""
+    (root / ".vaultspec").mkdir(parents=True, exist_ok=True)
+    return root
+
+
+class TestScaffoldHonoursTheDeclaration:
+    def test_declined_workspace_is_not_scaffolded(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        _decline(tmp_path)
+
+        caplog.set_level("INFO", logger="vaultspec_core.core.precommit")
+        result = scaffold_precommit(tmp_path)
+
+        assert result == []
+        assert not (tmp_path / _CONFIG).exists()
+        assert any(
+            "sets hooks.pre_commit to false" in rec.message for rec in caplog.records
+        )
+
+    def test_undeclared_workspace_is_scaffolded(self, tmp_path: Path) -> None:
+        """The permissive default: absence is not a decision."""
+        result = scaffold_precommit(tmp_path)
+
+        assert result == [(_CONFIG, "precommit")]
+        assert (tmp_path / _CONFIG).exists()
+
+    def test_explicitly_enabled_workspace_is_scaffolded(self, tmp_path: Path) -> None:
+        write_hooks_declaration(tmp_path, HooksDeclaration(pre_commit=True))
+
+        assert scaffold_precommit(tmp_path) == [(_CONFIG, "precommit")]
+        assert (tmp_path / _CONFIG).exists()
+
+    def test_dry_run_reports_nothing_when_declined(self, tmp_path: Path) -> None:
+        """The install manifest preview must not advertise a file it won't write."""
+        _decline(tmp_path)
+
+        assert scaffold_precommit(tmp_path, dry_run=True) == []
+
+    def test_existing_config_is_left_alone(self, tmp_path: Path) -> None:
+        """Declining future scaffolding never deletes what is already there."""
+        config = tmp_path / _CONFIG
+        config.write_text("repos: []\n", encoding="utf-8")
+        _decline(tmp_path)
+
+        assert scaffold_precommit(tmp_path) == []
+        assert config.read_text(encoding="utf-8") == "repos: []\n"
+
+    def test_doctor_repair_executor_honours_the_decline(self, tmp_path: Path) -> None:
+        """The repair path is a distinct call site and must not resurrect it."""
+        from vaultspec_core.core.diagnosis.signals import ResolutionAction
+        from vaultspec_core.core.executor import _execute_repair_precommit
+        from vaultspec_core.core.resolver_types import ResolutionStep
+
+        _decline(tmp_path)
+        _execute_repair_precommit(
+            tmp_path,
+            ResolutionStep(
+                action=ResolutionAction.REPAIR_PRECOMMIT,
+                target=str(tmp_path),
+                reason="test",
+            ),
+        )
+
+        assert not (tmp_path / _CONFIG).exists()
+
+    def test_resolver_plans_no_precommit_repair(
+        self, factory: WorkspaceFactory
+    ) -> None:
+        """The doctor must not keep proposing a repair the scaffold declines.
+
+        Otherwise a workspace that made a deliberate choice reports a defect
+        forever and the offered fix is a permanent no-op.
+        """
+        from vaultspec_core.core.diagnosis import diagnose
+        from vaultspec_core.core.diagnosis.signals import ResolutionAction
+        from vaultspec_core.core.enums import CliAction
+        from vaultspec_core.core.resolver import resolve
+
+        factory.install()
+        _decline(factory.root)
+        (factory.root / _CONFIG).unlink()
+
+        plan = resolve(diagnose(factory.root), CliAction.SYNC, target=factory.root)
+
+        assert not any(
+            step.action is ResolutionAction.REPAIR_PRECOMMIT for step in plan.steps
+        )
+
+
+class TestOptOutSurvivesInstall:
+    def test_upgrade_does_not_resurrect_the_declined_config(
+        self, factory: WorkspaceFactory
+    ) -> None:
+        """The reported defect: delete the file, run again, it comes back."""
+        factory.install()
+        assert (factory.root / _CONFIG).exists()
+
+        _decline(factory.root)
+        (factory.root / _CONFIG).unlink()
+
+        factory.install(upgrade=True)
+
+        assert not (factory.root / _CONFIG).exists()
+        assert read_hooks_declaration(factory.root).pre_commit is False
+
+    def test_install_over_a_committed_declaration_writes_nothing(
+        self, factory: WorkspaceFactory
+    ) -> None:
+        """A teammate cloning a repo whose declaration already declines.
+
+        The committed ``.vaultspec/`` arrives with the checkout, so the first
+        local install adopts it rather than scaffolding from nothing - and must
+        respect the declaration it just inherited.
+        """
+        from vaultspec_core.core.commands import install_run
+
+        factory.create_gitignore()
+        _decline(factory.root)
+
+        install_run(path=factory.root, provider="all", adopt=True)
+
+        assert not (factory.root / _CONFIG).exists()
+
+
+class TestManagedGitignoreEntry:
+    def test_declined_config_is_ignored(self, factory: WorkspaceFactory) -> None:
+        factory.install()
+        _decline(factory.root)
+
+        assert f"/{_CONFIG}" in get_recommended_entries(factory.root)
+
+    def test_wanted_config_is_not_ignored(self, factory: WorkspaceFactory) -> None:
+        """A wanted config stays team-shared, matching the sharing policy."""
+        factory.install()
+
+        entries = get_recommended_entries(factory.root)
+        assert f"/{_CONFIG}" not in entries
+        # The adjacent per-machine sentinel is ignored either way; the
+        # asymmetry between the two is deliberate, not an oversight.
+        assert f"/{_CONFIG}.lock" in entries
+
+    def test_entry_reaches_the_written_block(self, factory: WorkspaceFactory) -> None:
+        from vaultspec_core.core.enums import ManagedState
+        from vaultspec_core.core.gitignore import ensure_gitignore_block
+
+        factory.install()
+        _decline(factory.root)
+        ensure_gitignore_block(
+            factory.root,
+            get_recommended_entries(factory.root),
+            state=ManagedState.PRESENT,
+        )
+
+        text = (factory.root / ".gitignore").read_text(encoding="utf-8")
+        assert f"/{_CONFIG}\n" in text
+
+
+class TestCliVerbs:
+    def test_disable_writes_the_declaration(
+        self, runner: CliRunner, factory: WorkspaceFactory
+    ) -> None:
+        from vaultspec_core.tests.cli.conftest import run_vaultspec
+
+        result = run_vaultspec(
+            runner, "spec", "precommit", "disable", target=_bare_workspace(factory.root)
+        )
+
+        assert result.exit_code == 0, result.output
+        assert read_hooks_declaration(factory.root).pre_commit is False
+
+    def test_enable_clears_the_declaration(
+        self, runner: CliRunner, factory: WorkspaceFactory
+    ) -> None:
+        from vaultspec_core.tests.cli.conftest import run_vaultspec
+
+        _decline(factory.root)
+        result = run_vaultspec(
+            runner, "spec", "precommit", "enable", target=factory.root
+        )
+
+        assert result.exit_code == 0, result.output
+        assert read_hooks_declaration(factory.root).pre_commit is True
+
+    def test_disable_is_idempotent(
+        self, runner: CliRunner, factory: WorkspaceFactory
+    ) -> None:
+        """An already-satisfied request is success, reported as unchanged."""
+        import json
+
+        from vaultspec_core.tests.cli.conftest import run_vaultspec
+
+        _decline(factory.root)
+        result = run_vaultspec(
+            runner, "spec", "precommit", "disable", "--json", target=factory.root
+        )
+
+        assert result.exit_code == 0, result.output
+        assert json.loads(result.output)["status"] == "unchanged"
+
+    def test_disable_reports_updated_on_first_call(
+        self, runner: CliRunner, factory: WorkspaceFactory
+    ) -> None:
+        import json
+
+        from vaultspec_core.tests.cli.conftest import run_vaultspec
+
+        result = run_vaultspec(
+            runner,
+            "spec",
+            "precommit",
+            "disable",
+            "--json",
+            target=_bare_workspace(factory.root),
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "updated"
+        assert payload["data"]["pre_commit"] is False

--- a/src/vaultspec_core/tests/cli/test_workspace_mode.py
+++ b/src/vaultspec_core/tests/cli/test_workspace_mode.py
@@ -13,6 +13,7 @@ from vaultspec_core.core.workspace_mode import (
     DEPENDENCY_LEAK_ADVISORY,
     WORKSPACE_SCHEMA_VERSION,
     DependencyEvidence,
+    HooksDeclaration,
     ModeProvenance,
     PackageDeclaration,
     ResolvedMode,
@@ -20,10 +21,12 @@ from vaultspec_core.core.workspace_mode import (
     dependency_leak_advisory,
     detect_package_evidence,
     newly_establishes_dependency,
+    read_hooks_declaration,
     read_package_declaration,
     read_workspace_declaration,
     resolve_install_mode,
     resolve_install_mode_with_provenance,
+    write_hooks_declaration,
     write_package_declaration,
     write_workspace_declaration,
 )
@@ -499,6 +502,96 @@ class TestV2CorruptEntries:
 
         with pytest.raises(VaultSpecError, match="Malformed 'packages' map"):
             read_workspace_declaration(factory.root)
+
+
+class TestHooksDeclaration:
+    """The committed git-hook policy: absent means permissive, false declines."""
+
+    def test_absent_file_is_permissive(self, factory: WorkspaceFactory) -> None:
+        assert read_hooks_declaration(factory.root).pre_commit is True
+
+    def test_declaration_without_hooks_key_is_permissive(
+        self, factory: WorkspaceFactory
+    ) -> None:
+        write_workspace_declaration(
+            factory.root, WorkspaceDeclaration(install_mode=InstallMode.TOOL)
+        )
+
+        assert read_hooks_declaration(factory.root).pre_commit is True
+
+    def test_default_policy_writes_no_hooks_key(
+        self, factory: WorkspaceFactory
+    ) -> None:
+        """An untouched workspace never gains the key, so no file churns."""
+        write_workspace_declaration(
+            factory.root, WorkspaceDeclaration(install_mode=InstallMode.TOOL)
+        )
+
+        raw = json.loads(_declaration_path(factory.root).read_text(encoding="utf-8"))
+        assert "hooks" not in raw
+
+    def test_opt_out_round_trips(self, factory: WorkspaceFactory) -> None:
+        write_hooks_declaration(factory.root, HooksDeclaration(pre_commit=False))
+
+        raw = json.loads(_declaration_path(factory.root).read_text(encoding="utf-8"))
+        assert raw["hooks"] == {"pre_commit": False}
+        assert read_hooks_declaration(factory.root).pre_commit is False
+
+    def test_opt_out_survives_a_mode_write(self, factory: WorkspaceFactory) -> None:
+        """The declaration must outlive every later install or sync.
+
+        The write primitive emits the whole document, so a mode write that
+        failed to carry the hook policy through would silently clear the
+        opt-out - the exact regression this asserts against.
+        """
+        write_hooks_declaration(factory.root, HooksDeclaration(pre_commit=False))
+
+        write_workspace_declaration(
+            factory.root, WorkspaceDeclaration(install_mode=InstallMode.DEPENDENCY)
+        )
+
+        assert read_hooks_declaration(factory.root).pre_commit is False
+        mode = read_workspace_declaration(factory.root)
+        assert mode is not None
+        assert mode.install_mode is InstallMode.DEPENDENCY
+
+    def test_hook_write_preserves_package_entries(
+        self, factory: WorkspaceFactory
+    ) -> None:
+        write_package_declaration(
+            factory.root,
+            "vaultspec-rag",
+            PackageDeclaration(install_mode=InstallMode.TOOL),
+        )
+
+        write_hooks_declaration(factory.root, HooksDeclaration(pre_commit=False))
+
+        assert read_package_declaration(factory.root, "vaultspec-rag") is not None
+
+    def test_non_object_hooks_raises(self, factory: WorkspaceFactory) -> None:
+        _write_raw(
+            factory.root,
+            json.dumps({"schema_version": "2.1", "packages": {}, "hooks": False}),
+        )
+
+        with pytest.raises(VaultSpecError, match="Malformed 'hooks' object"):
+            read_hooks_declaration(factory.root)
+
+    def test_non_boolean_pre_commit_raises(self, factory: WorkspaceFactory) -> None:
+        """A malformed opt-out must fail loud, never fall back to emitting."""
+        _write_raw(
+            factory.root,
+            json.dumps(
+                {
+                    "schema_version": "2.1",
+                    "packages": {},
+                    "hooks": {"pre_commit": "false"},
+                }
+            ),
+        )
+
+        with pytest.raises(VaultSpecError, match=r"Invalid hooks\.pre_commit"):
+            read_hooks_declaration(factory.root)
 
 
 def _pyproject(root: Path, body: str) -> Path:


### PR DESCRIPTION
Follow-on to #286, which fixed the mechanical half of #284 (sync no longer resurrects removed hooks). This adds the half that PR left open: a **committed, team-wide** opt-out.

Rebased onto `main` after #286 landed; the resolver/preflight commit this branch originally carried is now redundant and has been dropped. What remains is one commit.

## Why the merged fix is not enough

`precommit_managed` lives in `.vaultspec/providers.json`, which the managed `.gitignore` block ignores, and both install paths recompute it from disk via `_detect_precommit_managed`. It records "hooks currently present", not "operator wants hooks", and a fresh clone falls back to `True`. #286 turned "resurrects on every sync" into "resurrects on every install" - `install --force` bootstrap still re-scaffolds today.

## The change

`workspace.json` carries `hooks.pre_commit`. Setting it false stands the scaffold down on every later run and stops the resolver planning a repair that would be a permanent no-op. `spec precommit disable` / `enable` write it; both are idempotent, and neither touches a file already on disk, because declining future scaffolding is a policy statement while deleting the file is the operator's to do.

Absence stays permissive: a workspace that never expressed a preference reads exactly as before, and its declaration file stays byte-identical, since the key is written only when it departs from the default. The write primitive now emits the whole document and takes the hook policy as a required argument, so a mode write cannot silently drop an opt-out.

The managed `.gitignore` block gains `/.pre-commit-config.yaml` **only once declined**. A wanted config is team-shared policy a teammate should inherit; a declined one is not policy at all. That distinction is what keeps this inside the `cli-spec-gitignore` boundary rather than contradicting it, and it is why the config and its `.lock` sentinel are treated differently.

## Verification

- `spec precommit disable` then `sync`: config left in place as documented, declaration persisted, and `/.pre-commit-config.yaml` ignored **only after** the opt-out - confirmed not ignored beforehand.
- Composes with #286: `_resolve_precommit` is gated on `"precommit" not in skip` at the call site, and the declaration read narrows `pc_managed` on top of the manifest flag.
- 166 tests green across `test_precommit_opt_out.py`, `test_workspace_mode.py`, `test_precommit_standdown.py`, `test_resolver.py`.
- Unit gate: 2016 passed. Ruff clean.

Note: the `Tests` (release-acceptance) check is red on `main` independently of this branch - 3 failures needing the real `claude` CLI on the runner, plus the stdio watchdog PID test. Same pre-existing redness #286 was admin-merged over; it needs its own fix.
