### PR TITLE
fix(sync): honour pre-commit hook removal instead of resurrecting it

### DIFF
--- a/src/vaultspec_core/cli/root_install.py
+++ b/src/vaultspec_core/cli/root_install.py
@@ -47,7 +47,10 @@ def cmd_install(
         list[str] | None,
         typer.Option(
             "--skip",
-            help="Skip a component (core or provider name). Repeatable.",
+            help=(
+                "Skip a component: core, a provider name, mcp, or "
+                "precommit. Repeatable."
+            ),
         ),
     ] = None,
     mode: Annotated[
@@ -74,7 +77,8 @@ def cmd_install(
 
     Scaffolds the workspace structure and syncs all managed resources.
     Use --upgrade to update builtin rules without re-scaffolding.
-    Use --skip to exclude components on retry (e.g. --skip core --skip claude).
+    Use --skip to exclude components on retry (e.g. --skip core --skip claude);
+    valid targets are core, provider names, mcp, and precommit.
     For MCP-capable providers, installation reconciles canonical MCP definitions
     into project-scope provider-native configuration. It does not start MCP
     servers or grant provider trust.
@@ -133,6 +137,7 @@ def cmd_install(
         dry_run=dry_run,
         scope="framework",
         render=not json_output,
+        skip=set(skip),
     )
 
     try:
@@ -331,6 +336,7 @@ def cmd_uninstall(
         dry_run=dry_run,
         scope="framework",
         render=not json_output,
+        skip=set(skip),
     )
 
     try:

--- a/src/vaultspec_core/cli/root_preflight.py
+++ b/src/vaultspec_core/cli/root_preflight.py
@@ -30,6 +30,7 @@ def _run_preflight(
     dry_run: bool = False,
     scope: str = "framework",
     render: bool = True,
+    skip: set[str] | None = None,
 ) -> None:
     """Run diagnosis and resolution pre-flight.
 
@@ -37,6 +38,10 @@ def _run_preflight(
     repair, scaffold, adopt) and displays their outcomes. Non-preflight
     steps are shown as informational. Blocks on conflicts unless
     *dry_run* is ``True``.
+
+    *skip* carries the invoking command's ``--skip`` set into resolution,
+    so preflight never repairs a component the main command was told to
+    leave alone (#284).
 
     Raises :class:`typer.Exit` with code 1 if conflicts are present and
     *dry_run* is ``False``, or if any preflight execution step fails.
@@ -58,7 +63,7 @@ def _run_preflight(
     # raw traceback escape preflight. render is the human-console flag, so its
     # inverse selects the machine-readable json error envelope.
     try:
-        plan = resolve(diag, action, provider, force=force, dry_run=dry_run)
+        plan = resolve(diag, action, provider, force=force, dry_run=dry_run, skip=skip)
     except (VaultSpecError, OSError) as exc:
         _handle_error(exc, json_output=not render)
         return  # unreachable: _handle_error raises typer.Exit

--- a/src/vaultspec_core/cli/root_sync.py
+++ b/src/vaultspec_core/cli/root_sync.py
@@ -243,7 +243,10 @@ def cmd_sync(
         list[str] | None,
         typer.Option(
             "--skip",
-            help="Skip a component (core or provider name). Repeatable.",
+            help=(
+                "Skip a component: core, a provider name, mcp, or "
+                "precommit. Repeatable."
+            ),
         ),
     ] = None,
     json_output: Annotated[bool, typer.Option("--json", help="Output as JSON")] = False,
@@ -260,7 +263,8 @@ def cmd_sync(
 
     Defaults to syncing all providers. Pass a provider name to sync only
     that provider (e.g. 'vaultspec-core sync claude').
-    Use --skip to exclude providers (e.g. --skip claude --skip codex).
+    Use --skip to exclude components (e.g. --skip claude --skip precommit);
+    valid targets are core, provider names, mcp, and precommit.
     """
     skip = list(skip or [])
     apply_target(target, split_source=True, json_output=json_output)
@@ -282,6 +286,7 @@ def cmd_sync(
         dry_run=dry_run,
         scope="sync",
         render=not json_output,
+        skip=set(skip),
     )
 
     from vaultspec_core.core.commands import sync_provider

--- a/src/vaultspec_core/core/resolver.py
+++ b/src/vaultspec_core/core/resolver.py
@@ -53,6 +53,7 @@ def resolve(
     force: bool = False,
     dry_run: bool = False,
     target: Path | None = None,
+    skip: set[str] | None = None,
 ) -> ResolutionPlan:
     """Build a resolution plan from diagnosed workspace state.
 
@@ -71,12 +72,17 @@ def resolve(
         target: Workspace root directory. Used to read manifest flags.
             Falls back to :func:`~vaultspec_core.core.types.get_context`
             if not provided.
+        skip: Component names the invoking command was asked to skip
+            (``--skip``). A skipped component contributes no resolution
+            steps, so preflight cannot repair what the main command was
+            told to leave alone (#284).
 
     Returns:
         A :class:`ResolutionPlan` with steps, warnings, and conflicts.
     """
     _ = dry_run  # reserved for executor phase
     action = CliAction(action)
+    skip = skip or set()
     plan = ResolutionPlan()
 
     if action == CliAction.DOCTOR:
@@ -137,14 +143,15 @@ def resolve(
                 "Could not resolve render mode for precommit advisory", exc_info=True
             )
 
-    _resolve_precommit(
-        plan,
-        diagnosis.precommit,
-        prov_action,
-        force=force,
-        precommit_managed=pc_managed,
-        expected_entry_prefix=expected_entry_prefix,
-    )
+    if "precommit" not in skip:
+        _resolve_precommit(
+            plan,
+            diagnosis.precommit,
+            prov_action,
+            force=force,
+            precommit_managed=pc_managed,
+            expected_entry_prefix=expected_entry_prefix,
+        )
     _resolve_mode_mismatch(plan, diagnosis.mode_mismatch)
 
     # Per-provider rules

--- a/src/vaultspec_core/core/resolver_repo.py
+++ b/src/vaultspec_core/core/resolver_repo.py
@@ -152,10 +152,13 @@ def _resolve_gitattributes(
 
 #: Repair reason per pre-commit signal, for the signals install and sync can
 #: repair in place. ``{entry_prefix}`` is filled with the mode-appropriate
-#: canonical hook entry prefix. NO_FILE is absent: scaffolding an entirely
-#: missing config is a sync-only repair with its own reason.
+#: canonical hook entry prefix. NO_FILE and NO_HOOKS are absent: total
+#: absence - no config at all, or a config the operator stripped of every
+#: vaultspec hook - is a decision, not drift (#284). Repairing it here would
+#: run in preflight, before the sync body's reconcile pass can observe the
+#: removal and stand management down; install and upgrade re-enroll
+#: explicitly through the provisioning scaffold instead.
 _PRECOMMIT_REPAIR_REASONS: dict[PrecommitSignal, str] = {
-    PrecommitSignal.NO_HOOKS: "No vaultspec-core hooks found in pre-commit config",
     PrecommitSignal.INCOMPLETE: "Missing canonical hooks in pre-commit config",
     PrecommitSignal.NON_CANONICAL: (
         "Hook entries use non-canonical pattern; should use '{entry_prefix}'"
@@ -192,15 +195,12 @@ def _resolve_precommit(
     if signal in _PRECOMMIT_INERT_SIGNALS:
         return
 
-    if signal == PrecommitSignal.NO_FILE:
-        if action == CliAction.SYNC:
-            plan.steps.append(
-                ResolutionStep(
-                    action=ResolutionAction.REPAIR_PRECOMMIT,
-                    target=".pre-commit-config.yaml",
-                    reason="Pre-commit config missing but management is enabled",
-                )
-            )
+    if signal in (PrecommitSignal.NO_FILE, PrecommitSignal.NO_HOOKS):
+        # Absence is honoured as an operator decision, never repaired as
+        # drift (#284): the sync body's reconcile pass observes the removal
+        # and durably stands management down, which a preflight re-scaffold
+        # here would forever preempt. Install/upgrade re-enroll through the
+        # provisioning scaffold, not through a resolution step.
         return
 
     reason = _PRECOMMIT_REPAIR_REASONS.get(signal)

--- a/src/vaultspec_core/tests/cli/test_precommit_standdown.py
+++ b/src/vaultspec_core/tests/cli/test_precommit_standdown.py
@@ -1,0 +1,135 @@
+"""Regression tests for GH issue #284: sync honours pre-commit hook removal.
+
+Deleting ``.pre-commit-config.yaml``, or stripping every vaultspec hook from
+it, is an operator decision. ``sync`` must not resurrect the hooks through
+its preflight; instead the sync body's reconcile pass observes the removal
+and durably stands management down (``precommit_managed`` flips to
+``False``), after which subsequent syncs leave the file alone. ``--skip
+precommit`` must reach preflight as well, so a skipped component can never
+be re-scaffolded before the main command runs.
+
+All tests drive the real install/sync engine (and the real CLI for the
+preflight path) against a ``WorkspaceFactory`` install; no mocks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from vaultspec_core.cli import app
+from vaultspec_core.config import reset_config
+from vaultspec_core.core.manifest import read_manifest_data
+from vaultspec_core.tests.cli.workspace_factory import WorkspaceFactory
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+pytestmark = [pytest.mark.integration]
+
+_CONFIG_NAME = ".pre-commit-config.yaml"
+
+_FOREIGN_ONLY_CONFIG = """\
+repos:
+- repo: local
+  hooks:
+  - id: my-project-lint
+    name: My project lint
+    entry: my-lint
+    language: system
+"""
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Iterator[None]:
+    reset_config()
+    yield
+    reset_config()
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner(env={"NO_COLOR": "1"})
+
+
+class TestSyncStandsDownOnRemoval:
+    """The reconcile pass must honour hook removal instead of repairing it."""
+
+    def test_sync_honours_deleted_config(self, tmp_path: Path) -> None:
+        factory = WorkspaceFactory(tmp_path).install("claude")
+        config = tmp_path / _CONFIG_NAME
+        assert config.exists()
+        assert read_manifest_data(tmp_path).precommit_managed is True
+
+        config.unlink()
+        factory.sync()
+
+        assert not config.exists(), "sync resurrected a deleted pre-commit config"
+        assert read_manifest_data(tmp_path).precommit_managed is False
+
+    def test_standdown_is_durable_across_syncs(self, tmp_path: Path) -> None:
+        factory = WorkspaceFactory(tmp_path).install("claude")
+        (tmp_path / _CONFIG_NAME).unlink()
+        factory.sync()
+        factory.sync()
+
+        assert not (tmp_path / _CONFIG_NAME).exists()
+        assert read_manifest_data(tmp_path).precommit_managed is False
+
+    def test_sync_stands_down_when_hooks_stripped(self, tmp_path: Path) -> None:
+        factory = WorkspaceFactory(tmp_path).install("claude")
+        config = tmp_path / _CONFIG_NAME
+        config.write_text(_FOREIGN_ONLY_CONFIG, encoding="utf-8")
+
+        factory.sync()
+
+        assert config.read_text(encoding="utf-8") == _FOREIGN_ONLY_CONFIG, (
+            "sync re-added vaultspec hooks the operator stripped"
+        )
+        assert read_manifest_data(tmp_path).precommit_managed is False
+
+    def test_skip_precommit_leaves_component_untouched(self, tmp_path: Path) -> None:
+        factory = WorkspaceFactory(tmp_path).install("claude")
+        (tmp_path / _CONFIG_NAME).unlink()
+
+        factory.sync(skip={"precommit"})
+
+        assert not (tmp_path / _CONFIG_NAME).exists()
+        # Skip means "leave alone entirely": the reconcile pass never ran,
+        # so the management flag is not flipped either.
+        assert read_manifest_data(tmp_path).precommit_managed is True
+
+
+class TestCliSyncPreflightHonoursRemoval:
+    """The #284 repro path: the ``sync`` CLI runs preflight before the body."""
+
+    def test_cli_sync_does_not_resurrect_deleted_config(
+        self, tmp_path: Path, runner: CliRunner
+    ) -> None:
+        WorkspaceFactory(tmp_path).install("claude")
+        (tmp_path / _CONFIG_NAME).unlink()
+
+        result = runner.invoke(app, ["sync", "--target", str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert not (tmp_path / _CONFIG_NAME).exists(), (
+            "CLI sync preflight resurrected a deleted pre-commit config"
+        )
+        assert read_manifest_data(tmp_path).precommit_managed is False
+
+    def test_cli_sync_skip_precommit_does_not_rescaffold(
+        self, tmp_path: Path, runner: CliRunner
+    ) -> None:
+        WorkspaceFactory(tmp_path).install("claude")
+        (tmp_path / _CONFIG_NAME).unlink()
+
+        result = runner.invoke(
+            app, ["sync", "--target", str(tmp_path), "--skip", "precommit"]
+        )
+
+        assert result.exit_code == 0, result.output
+        assert not (tmp_path / _CONFIG_NAME).exists()
+        assert read_manifest_data(tmp_path).precommit_managed is True

--- a/src/vaultspec_core/tests/cli/test_resolver.py
+++ b/src/vaultspec_core/tests/cli/test_resolver.py
@@ -477,32 +477,30 @@ class TestPrecommitRules:
 
         assert plan.steps == []
 
-    def test_missing_config_is_scaffolded_on_sync_only(self) -> None:
-        sync_plan = ResolutionPlan()
-        _resolve_precommit(
-            sync_plan, PrecommitSignal.NO_FILE, CliAction.SYNC, force=False
-        )
-        assert [(s.action, s.target, s.reason) for s in sync_plan.steps] == [
-            (
-                ResolutionAction.REPAIR_PRECOMMIT,
-                ".pre-commit-config.yaml",
-                "Pre-commit config missing but management is enabled",
-            )
-        ]
+    @pytest.mark.parametrize(
+        "signal", [PrecommitSignal.NO_FILE, PrecommitSignal.NO_HOOKS]
+    )
+    @pytest.mark.parametrize(
+        "action", [CliAction.INSTALL, CliAction.SYNC, CliAction.UNINSTALL]
+    )
+    def test_absence_is_honoured_not_repaired(
+        self, signal: PrecommitSignal, action: CliAction
+    ) -> None:
+        """Total hook absence is an operator decision, never drift (#284).
 
-        install_plan = ResolutionPlan()
-        _resolve_precommit(
-            install_plan, PrecommitSignal.NO_FILE, CliAction.INSTALL, force=False
-        )
-        assert install_plan.steps == []
+        A resolution step here would execute in preflight, before the sync
+        body's reconcile pass can observe the removal and stand management
+        down - the exact resurrection loop issue #284 reports.
+        """
+        plan = ResolutionPlan()
+
+        _resolve_precommit(plan, signal, action, force=False)
+
+        assert plan.steps == []
 
     @pytest.mark.parametrize(
         ("signal", "reason"),
         [
-            (
-                PrecommitSignal.NO_HOOKS,
-                "No vaultspec-core hooks found in pre-commit config",
-            ),
             (
                 PrecommitSignal.INCOMPLETE,
                 "Missing canonical hooks in pre-commit config",


### PR DESCRIPTION
## What

`vaultspec-core sync` regenerated `.pre-commit-config.yaml` on every run with no working opt-out (#284). The designed stand-down existed - `_reconcile_precommit_management` flips `precommit_managed=false` when the operator removes the hooks - but it was unreachable: the resolver emitted `REPAIR_PRECOMMIT` for `NO_FILE` under SYNC, and preflight executed it before the sync body ever ran, resurrecting the file first. `sync --skip precommit` resurrected it too, because the `--skip` set never reached preflight.

## Why it dangled

Both halves landed the same day (2026-04-11): the opt-out mechanism in `fc6b3855`, then review-response commit `d3cb7d1c` added the preflight resurrection branch - and the stand-down had zero test coverage, so nothing caught that preflight ordering made it dead code.

## Changes

- **resolver** (`resolver_repo.py`): `NO_FILE` and `NO_HOOKS` are inert for every action - total absence is an operator decision, not drift. `INCOMPLETE`/`NON_CANONICAL` (partial presence = continuing enrollment) still repair on install/sync.
- **preflight** (`resolver.py`, `root_preflight.py`): the invoking command's `--skip` set threads into resolution; a skipped component contributes no resolution steps.
- **CLI help** (`root_install.py`, `root_sync.py`): `precommit` and `mcp` documented as valid `--skip` targets on install, sync, and uninstall (both were already accepted by `validate_skip`, silently).
- **tests**: new `test_precommit_standdown.py` covers the stand-down end-to-end - engine reconcile and CLI preflight paths, deletion and hook-stripping variants, and skip semantics (skip = leave alone entirely, flag untouched). `test_resolver.py` rewritten where it encoded the resurrection.

## Behaviour after this change

- Delete the config (or strip the vaultspec hooks) -> next `sync` observes it, durably stands management down, never recreates the file.
- `install` / `install --upgrade` remain explicit re-enrollment points (provisioning scaffold unchanged); `--skip precommit` there is the durable opt-out, now documented.
- Not in scope (follow-on, ADR-shaped): a committed team-wide `workspace.json` hooks declaration so the opt-out survives fresh clones.

## Verification

Full unit gate: 2018 passed. Targeted integration suites (flow-bugs, signals, collectors, convergence-advisories, ambiguous-states, install-conditions, lock-sentinel, sync-backfill): 292 passed. ruff + ty clean.

Closes #284