### PR TITLE
fix(tests): green the release-acceptance gate on runners without the CLIs

### DIFF
--- a/tests/cli/test_mcp_hosts.py
+++ b/tests/cli/test_mcp_hosts.py
@@ -1,4 +1,13 @@
-"""Real Claude Code and Codex CLI acceptance for native MCP enrollment."""
+"""Real Claude Code and Codex CLI acceptance for native MCP enrollment.
+
+Every test here shells out to the genuine ``claude`` binary, so the module
+carries the ``claude`` marker the rest of the suite already uses for that
+requirement. ``EXCLUDED_MARKERS`` deselects it wherever the CLI is not
+provisioned - which is every hosted runner - so these stay release-acceptance
+tests run against a real host rather than a gate that fails on absence.
+Without the marker ``just test repo`` collected them everywhere and
+``_host_executable`` asserted, reporting a missing binary as a code defect.
+"""
 
 from __future__ import annotations
 
@@ -15,7 +24,7 @@ from vaultspec_core.config import reset_config
 from vaultspec_core.core.commands import install_run
 from vaultspec_core.core.mcps import mcp_uninstall
 
-pytestmark = pytest.mark.integration
+pytestmark = [pytest.mark.integration, pytest.mark.claude]
 
 
 def _host_executable(name: str) -> str:

--- a/tests/unit/mcp_server/test_watchdog.py
+++ b/tests/unit/mcp_server/test_watchdog.py
@@ -277,8 +277,15 @@ def test_armed_worker_exits_when_dead_client_pid_signals() -> None:
 
     The test holds the victim's ``Popen`` handle so the kernel keeps the
     process object alive after exit: ``OpenProcess`` then succeeds and the
-    wait fires at once. On POSIX the override path declines and the worker
-    reports it stayed up.
+    wait fires at once.
+
+    POSIX has no equivalent contract. ``client_pid`` is a Windows-only anchor -
+    :func:`arm_client_watchdog` does not consult it on POSIX, where the backstop
+    is a coarse reparent poll against the *real* parent. So arming reports
+    success and the worker stays up, because its parent (this test process) is
+    very much alive. The assertion here used to expect a decline, which the
+    POSIX-backstop work stopped being true without updating the expectation; it
+    then failed on every Linux run.
     """
     victim = subprocess.Popen([sys.executable, "-c", "pass"], stdout=subprocess.DEVNULL)
     victim.wait(timeout=60)
@@ -308,7 +315,9 @@ def test_armed_worker_exits_when_dead_client_pid_signals() -> None:
         assert "still-alive" not in proc.stdout
         assert elapsed < 15, f"worker outlived a dead client by {elapsed:.1f}s"
     else:
-        assert "armed=False" in proc.stdout
+        # The reparent poll arms regardless of the ignored client_pid, and
+        # watches a live parent, so the worker must survive its full sleep.
+        assert "armed=True" in proc.stdout
         assert "still-alive" in proc.stdout
 
 


### PR DESCRIPTION
The required `Tests` job has been red on `main` independently of any PR, so the last two merges (#286, #285) both needed an admin override. Two unrelated causes, neither a product defect.

## 1. Host-acceptance tests ran where the host does not exist

`tests/cli/test_mcp_hosts.py` shells out to the genuine `claude` binary. It carried only the `integration` marker, so `just test repo` collected it on every runner and `_host_executable` asserted when the binary was absent:

```
AssertionError: Release acceptance requires the real claude CLI
assert None is not None
```

That reports unprovisioned tooling as a code failure. The suite already has a `claude` marker for precisely this requirement, and `EXCLUDED_MARKERS` (`not gemini and not claude and not network`) deselects it in the gating lanes - the module just never claimed it, the way the `gemini`-marked tests do.

Marking it keeps these as genuine acceptance tests run against a real host, rather than a gate that fails on absence. They still run anywhere the CLI is provisioned.

## 2. A stale POSIX expectation in the watchdog

`test_armed_worker_exits_when_dead_client_pid_signals` asserted that arming against a dead `client_pid` **declines** on POSIX. That stopped being true when the POSIX reparent-backstop landed: `client_pid` is a Windows-only anchor, `arm_client_watchdog` never consults it on POSIX, and the coarse reparent poll arms unconditionally against the *real* parent. So it returns `True` and the worker stays up.

The expectation was left behind and failed on every Linux run. The CI output confirms the corrected contract directly - it printed exactly `armed=True\nstill-alive\n`, which is what the test now asserts.

The Windows branch, which pins the behaviour the test is actually named for, is untouched.

## Verification

- `pytest tests -m "not gemini and not claude and not network"` (what `just test repo` runs): **383 passed, 3 deselected, exit 0**. Previously 4 failed / 382 passed.
- Watchdog cohort on Windows: **14 passed**.
- Ruff clean, formatting clean.

With this in, `main` should merge on its own checks without `--admin`.
