### PR TITLE
feat(mcp): add read-only launch mode

### DIFF
--- a/.vault/adr/2026-08-01-mcp-read-only-adr.md
+++ b/.vault/adr/2026-08-01-mcp-read-only-adr.md
@@ -1,0 +1,51 @@
+---
+tags:
+  - '#adr'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_schema: 'body-v1'
+body_hash: 'sha256:f5a250e46d94c03f90ec08e0fb2aaf8a2daec0ed488dfccfe0b2c18bbc38a8a1'
+related:
+  - "[[2026-08-01-mcp-read-only-research]]"
+  - "[[2026-07-09-mcp-tool-schema-adr]]"
+---
+# `mcp-read-only` adr: `read-only MCP launch mode` | (**status:** `accepted`)
+
+## Problem Statement
+
+Orchestrated agents need the vault orientation surface without receiving any mutation capability. The accepted `mcp-tool-schema` design intentionally exposes both first-class write tools and the broadly capable `invoke` gateway; an explicit launch-time boundary is therefore required. The security and consumer requirement is grounded by `2026-08-01-mcp-read-only-research`.
+
+## Considerations
+
+- `2026-08-01-mcp-read-only-research` establishes that hiding a tool after it reaches the client does not satisfy the capability boundary.
+- `2026-07-09-mcp-tool-schema-adr` assigns read-only semantics to orientation tools but deliberately retains mutation tools and `invoke` in the normal catalog.
+- The consumer contract requires the default server surface to remain unchanged and the restricted surface to remain asserted at runtime.
+
+## Considered options
+
+**Client-side denylist.** Rejected: the server still advertises prohibited schemas and a client configuration error can re-expose them.
+
+**Consumer-owned wrapper server.** Rejected: it forks the catalog and makes a consumer owner of this server's security policy.
+
+**Server-owned `--read-only` registration mode.** Chosen: the server registers only a positively allowlisted orientation surface, so prohibited tools are absent from `tools/list` by construction.
+
+## Constraints
+
+- The normal launch must retain its complete existing catalog and behavior.
+- Restricted mode may register only `status`, `find`, `discover`, and a validation-only `check` interface.
+- Restricted `check` must neither advertise nor accept repair through `fix`.
+- The mode is a stable runtime contract; no consumer version pin is required or substituted for surface assertion.
+- Existing MCP bootstrap, transport, and registry ownership remain unchanged.
+
+## Implementation
+
+The launch parser accepts `--read-only` and passes its value to server construction. Tool registration selects a positive restricted registration set when enabled and preserves the normal set otherwise. The restricted `check` registration exposes validation only, while normal mode retains the existing repair-capable signature. Real MCP-session tests inspect advertised tool names and schemas in both modes, ensuring default parity and preventing new write tools from entering the restricted catalog accidentally.
+
+## Rationale
+
+A server-side positive allowlist is the only option that makes an unavailable capability unrepresentable to the client. It retains catalog ownership in this project, aligns with the existing tiered-tool decision, and gives consumers a small, stable surface that can be verified at connection time. `2026-08-01-mcp-read-only-research` establishes the security criterion; `2026-07-09-mcp-tool-schema-adr` supplies the current catalog classification.
+
+## Consequences
+
+Consumers can compose vault orientation with agent workflows without granting mutation authority. New tools are excluded from restricted mode until deliberately classified, which favors safety but creates an intentional maintenance obligation. `check --fix` remains available only to normal launches; callers needing repair must deliberately select that broader capability.

--- a/.vault/adr/2026-08-01-mcp-read-only-adr.md
+++ b/.vault/adr/2026-08-01-mcp-read-only-adr.md
@@ -10,6 +10,7 @@ related:
   - "[[2026-08-01-mcp-read-only-research]]"
   - "[[2026-07-09-mcp-tool-schema-adr]]"
 ---
+
 # `mcp-read-only` adr: `read-only MCP launch mode` | (**status:** `accepted`)
 
 ## Problem Statement

--- a/.vault/audit/2026-08-01-mcp-read-only-audit.md
+++ b/.vault/audit/2026-08-01-mcp-read-only-audit.md
@@ -1,0 +1,37 @@
+---
+tags:
+  - '#audit'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_schema: 'body-v1'
+body_hash: 'sha256:c5ef76e30166d38477bd03fc5295cbfdb77a0be58f0b7f89b374408580305ca3'
+related:
+  - '[[2026-08-01-mcp-read-only-research]]'
+  - '[[2026-08-01-mcp-read-only-adr]]'
+  - '[[2026-08-01-mcp-read-only-plan]]'
+---
+# `mcp-read-only` audit: `read-only MCP launch mode`
+
+## Scope
+
+Reviewed issue #300 against the accepted research, ADR, and L1 plan: launch parsing, server registration, `check` schemas and behavior, normal-mode compatibility, and the in-memory and stdio MCP tests. The final focused MCP suite passed: 8 tests.
+
+## Findings
+
+### forbidden-fix-argument | medium | Restricted `check` silently accepts `fix`
+
+A real `create_server(read_only=True)` session initially accepted `check` with `{"fix": true}` as a successful call. The handler ran with `fix=False`, so it did not repair, but the restricted interface neither rejected the prohibited argument nor proved that clients could not rely on it. This violated the ADR constraint that restricted `check` must neither advertise nor accept `fix`.
+
+### normal-repair-regression-guard | low | Default repair compatibility lacked behavioral coverage
+
+The normal catalog initially retained `check` with `fix`, but its tests asserted only tool names, annotations, and a no-argument validation call. They did not execute `check` with `{"fix": true}`.
+
+## Recommendations
+
+- Keep explicit wire-level rejection for prohibited read-only `check` arguments as the SDK evolves.
+- Retain normal-mode `fix` coverage whenever the check tool is changed.
+
+## Resolution
+
+The medium finding is resolved by a read-only MCP extension guard that returns an error result when a `check` request includes `fix`. In-memory and real stdio sessions now prove the schema omits `fix` and a supplied `fix` is rejected. The default-surface test now proves that `fix` remains advertised and a real normal-mode `check` call accepts `fix=True` and reports that repair mode was applied.

--- a/.vault/audit/2026-08-01-mcp-read-only-audit.md
+++ b/.vault/audit/2026-08-01-mcp-read-only-audit.md
@@ -11,6 +11,7 @@ related:
   - '[[2026-08-01-mcp-read-only-adr]]'
   - '[[2026-08-01-mcp-read-only-plan]]'
 ---
+
 # `mcp-read-only` audit: `read-only MCP launch mode`
 
 ## Scope

--- a/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S01.md
+++ b/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S01.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_schema: 'body-v1'
+body_hash: 'sha256:4829946e273e8e6ffc9dbc80f794e7cd56f4f7b2af783bba93df6e385a81d6b5'
+step_id: 'S01'
+related:
+  - "[[2026-08-01-mcp-read-only-plan]]"
+---
+# `S01` execution record
+
+## Description
+
+- Add the `--read-only` Typer launch option.
+- Thread the mode through server construction and the stdio serving entry point.
+- Keep the default launch mode and instructions unchanged.
+
+## Outcome
+
+`vaultspec-mcp --read-only` constructs the restricted server mode; an ordinary launch retains the complete nine-tool surface.
+
+## Notes
+
+No service lifecycle change was made.

--- a/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S01.md
+++ b/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S01.md
@@ -10,6 +10,7 @@ step_id: 'S01'
 related:
   - "[[2026-08-01-mcp-read-only-plan]]"
 ---
+
 # `S01` execution record
 
 ## Description

--- a/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S02.md
+++ b/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S02.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_schema: 'body-v1'
+body_hash: 'sha256:3bff92e0f76ffe3d8eb10c559706824bb2669aede20b85cc1883e3a0c3f75a8f'
+step_id: 'S02'
+related:
+  - "[[2026-08-01-mcp-read-only-plan]]"
+---
+# `S02` execution record
+
+## Description
+
+- Keep only `status`, `find`, `check`, and `discover` registered in read-only mode.
+- Omit document mutation, plan, and gateway invocation tools.
+- Register a separate `check` signature without the repair parameter.
+
+## Outcome
+
+The restricted server has a positive allowlist and cannot expose the `fix` input or an invocation path.
+
+## Notes
+
+Default registration remains complete.

--- a/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S02.md
+++ b/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S02.md
@@ -10,6 +10,7 @@ step_id: 'S02'
 related:
   - "[[2026-08-01-mcp-read-only-plan]]"
 ---
+
 # `S02` execution record
 
 ## Description

--- a/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S03.md
+++ b/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S03.md
@@ -10,6 +10,7 @@ step_id: 'S03'
 related:
   - "[[2026-08-01-mcp-read-only-plan]]"
 ---
+
 # `S03` execution record
 
 ## Description

--- a/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S03.md
+++ b/.vault/exec/2026-08-01-mcp-read-only/2026-08-01-mcp-read-only-S03.md
@@ -1,0 +1,27 @@
+---
+tags:
+  - '#exec'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_schema: 'body-v1'
+body_hash: 'sha256:af513e6d2e21479ad37c5ff37e7622d35476c8cb4f987224eb40ffc337a01d13'
+step_id: 'S03'
+related:
+  - "[[2026-08-01-mcp-read-only-plan]]"
+---
+# `S03` execution record
+
+## Description
+
+- Add exact-surface and annotation assertions for read-only server construction.
+- Add a real stdio subprocess test for the `--read-only` launch flag.
+- Exercise the read-only `check` handler and assert its result reports no repair.
+
+## Outcome
+
+The contract is verified in process and through the public stdio launch path.
+
+## Notes
+
+The focused test run retains one existing asyncio-marker warning on an unrelated synchronous test.

--- a/.vault/index/mcp-read-only.index.md
+++ b/.vault/index/mcp-read-only.index.md
@@ -1,0 +1,27 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_schema: 'body-v1'
+body_hash: 'sha256:c4bec9c229604e9256b93c935e4dc9513ad2ddb1ea86cb6da6bc13435e95c87f'
+related:
+  - '[[2026-08-01-mcp-read-only-adr]]'
+  - '[[2026-08-01-mcp-read-only-research]]'
+---
+
+# `mcp-read-only` feature index
+
+Auto-generated index of all documents tagged with `#mcp-read-only`.
+
+## Documents
+
+### adr
+
+- `2026-08-01-mcp-read-only-adr` - `mcp-read-only` adr: `read-only MCP launch mode` | (**status:** `accepted`)
+
+### research
+
+- `2026-08-01-mcp-read-only-research` - `mcp-read-only` research: capability-scoped MCP launch

--- a/.vault/index/mcp-read-only.index.md
+++ b/.vault/index/mcp-read-only.index.md
@@ -6,9 +6,14 @@ tags:
 date: '2026-08-01'
 modified: '2026-08-01'
 body_schema: 'body-v1'
-body_hash: 'sha256:c4bec9c229604e9256b93c935e4dc9513ad2ddb1ea86cb6da6bc13435e95c87f'
+body_hash: 'sha256:2074c8c238b2d6da935b1bba5856c44f68884835ae8f89325897c9ca6f420252'
 related:
+  - '[[2026-08-01-mcp-read-only-S01]]'
+  - '[[2026-08-01-mcp-read-only-S02]]'
+  - '[[2026-08-01-mcp-read-only-S03]]'
   - '[[2026-08-01-mcp-read-only-adr]]'
+  - '[[2026-08-01-mcp-read-only-audit]]'
+  - '[[2026-08-01-mcp-read-only-plan]]'
   - '[[2026-08-01-mcp-read-only-research]]'
 ---
 
@@ -21,6 +26,20 @@ Auto-generated index of all documents tagged with `#mcp-read-only`.
 ### adr
 
 - `2026-08-01-mcp-read-only-adr` - `mcp-read-only` adr: `read-only MCP launch mode` | (**status:** `accepted`)
+
+### audit
+
+- `2026-08-01-mcp-read-only-audit` - `mcp-read-only` audit: `read-only MCP launch mode`
+
+### exec
+
+- `2026-08-01-mcp-read-only-S01` - `S01` execution record
+- `2026-08-01-mcp-read-only-S02` - `S02` execution record
+- `2026-08-01-mcp-read-only-S03` - `S03` execution record
+
+### plan
+
+- `2026-08-01-mcp-read-only-plan` - `mcp-read-only` plan
 
 ### research
 

--- a/.vault/plan/2026-08-01-mcp-read-only-plan.md
+++ b/.vault/plan/2026-08-01-mcp-read-only-plan.md
@@ -1,0 +1,191 @@
+---
+tags:
+  - '#plan'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_hash: 'sha256:60329a3b38647b22f52352af3acbc060dd619edc4d3f358f7e43b8d2d1c8ea7e'
+tier: L1
+related:
+  - '[[2026-08-01-mcp-read-only-adr]]'
+---
+
+<!-- LINK RULES:
+     - [[wiki-links]] are ONLY for .vault/ documents in the
+       related: field above.
+     - The related: field carries the AUTHORISING documents
+       (ADR, research, reference, prior plan) for every Step in
+       this plan. Steps inherit this chain; per-row reference
+       footers do not exist.
+     - NEVER use [[wiki-links]] or markdown links in the
+       document body. -->
+
+<!-- FRONTMATTER RULES:
+     tags: one directory tag (hardcoded #plan) and one feature tag.
+     Replace mcp-read-only with a kebab-case feature tag, e.g. #foo-bar.
+     Additional tags may be appended below the required pair.
+
+     modified: CLI-maintained last-modified stamp; set at scaffold time,
+     refreshed by mutating CLI verbs and vault check fix; never hand-edit.
+
+     tier is mandatory for new plans. Allowed: L1, L2, L3, L4.
+     L1 = Steps only. L2 = Phases above Steps. L3 = Waves above
+     Phases above Steps. L4 = Epic above Waves above Phases above
+     Steps; PM association required. Pre-existing plans without this
+     field default to L2.
+
+     Related: use wiki-links as '[[yyyy-mm-dd-foo-bar]]'. The related field
+     carries the AUTHORIZING documents (ADR, research, reference, prior
+     plan) for every Step in this plan; Steps inherit this chain;
+     per-row reference footers do not exist.
+
+     DO NOT add fields beyond those scaffolded; metadata lives
+     only in the frontmatter. -->
+
+
+<!-- HIERARCHY AND TIERS:
+     Epic > Wave > Phase > Step. Step is the canonical leaf-row
+     noun. Execution Record artifact: <Step Record>.
+     Tier is declared in frontmatter as tier: L1/L2/L3/L4
+     (mandatory for new plans; pre-existing plans without the
+     field default to L2 and the writer adds the field on first
+     edit). The tier selects containers:
+       L1 = Steps only.
+       L2 = Phases above Steps.
+       L3 = Waves above Phases above Steps.
+       L4 = Epic above Waves above Phases above Steps; MUST declare
+            a project-management association in the Epic intent
+            block prose.
+     Selection is by complexity criteria, not container counting.
+     Writer never invents containers to qualify a tier. -->
+
+<!-- IDENTIFIERS AND ROW CONTRACT:
+     S##, P##, W## are flat, per-document, append-only, immutable.
+     Promotion adds containers without renumbering. Gaps are not
+     reused.
+     Display paths are computed from current grouping:
+       Step path:    L1 S##   L2 P##.S##   L3/L4 W##.P##.S##
+       Phase heading:        L2 P##       L3/L4 W##.P##
+       Wave heading:                      L3/L4 W##
+     Row format:
+       - [ ] `<display-path>` - imperative-verb action; `path/to/file`.
+     Two-state checkboxes only ([ ] open, [x] closed). No per-row
+     reference footers; wiki-links and markdown links are forbidden
+     in plan body. Authorizing documents go in the plan's `related:`
+     frontmatter once.
+     ASCII spaced hyphens everywhere; em-dash (U+2014) and en-dash
+     (U+2013) are forbidden. Step rows within a Phase are
+     contiguous. -->
+
+<!-- NO COMPRESSION:
+     N self-similar actions = N rows. Never collapse into "for each
+     X, do Y" / "across all callers, do Z" / "in every module,
+     replace W". The rule applies at every tier including L1. -->
+
+<!-- VAULTSPEC-CORE VAULT PLAN CLI:
+     The `vaultspec-core vault plan` CLI is the canonical surface for
+     structural manipulation of this plan document. Writers and
+     executors MUST use `vaultspec-core vault plan step add/insert/move/
+     remove/check/uncheck/toggle/edit`,
+     `vaultspec-core vault plan phase add/move/remove/edit`,
+     `vaultspec-core vault plan wave add/move/remove/edit`,
+     `vaultspec-core vault plan epic intent`, and
+     `vaultspec-core vault plan tier promote/demote` for every
+     identifier-affecting change rather than hand-editing the row
+     grammar. Hand edits are tolerated by the parser but flagged by
+     `vaultspec-core vault plan check`; canonical-identifier preservation is
+     guaranteed only when the CLI performs the mutation. Run
+     `vaultspec-core vault plan --help` for the full subcommand
+     surface. -->
+
+# `mcp-read-only` plan
+
+<!-- One-line headline summary plan. -->
+
+## Description
+
+<!-- Briefly describe the proposed work. Reference `{adr}`s,
+`{research}`, `{reference}`. Supporting documentation must be read prior to
+writing the plan document. A plan may execute one ADR or a cluster; when
+several feed it, state here which Wave or Phase each ADR governs. -->
+
+## Steps
+
+- [x] `S01` - Add the read-only launch option and server mode selection; `src/vaultspec_core/mcp_server/app.py`.
+- [x] `S02` - Restrict server registration to the read-only allowlist; `src/vaultspec_core/mcp_server/tools/`.
+- [x] `S03` - Prove the advertised read-only MCP surface; `src/vaultspec_core/mcp_server/tests/test_tool_surface.py`.
+
+<!-- The plan's tier (declared in frontmatter as `tier: L1`, `L2`, `L3`, or
+`L4`) determines the structure under this section:
+
+- `L1`: a flat list of Step rows (no Phase, Wave, or Epic).
+- `L2`: one or more `### Phase` blocks each containing Step rows.
+- `L3`: one or more `## Wave` blocks each containing Phase blocks.
+- `L4`: a `## Epic intent` block, followed by Wave blocks. -->
+
+<!-- Replace this scaffold with the tier-appropriate structure for your plan.
+Format examples for each block type are embedded below as commented
+templates. -->
+
+<!-- IMPORTANT: This document must be updated between execution runs to
+     track progress. -->
+
+<!-- PHASE BLOCK FORMAT (L2, L3, L4):
+     ### Phase `P02` - rewrite the writer-agent contract
+
+     One sentence stating what this Phase delivers.
+
+     - [ ] `P02.S01` - imperative-verb action; `path/to/file`.
+     - [ ] `P02.S02` - imperative-verb action; `path/to/file`.
+
+     At L3/L4 the Phase heading uses the ancestor-aware path
+     (### Phase `W01.P02` - ...). The intent sentence is mandatory. -->
+
+<!-- WAVE BLOCK FORMAT (L3, L4):
+     ## Wave `W01` - language-only convention rollout
+
+     One paragraph stating what this Wave delivers, which downstream
+     Wave depends on it, and which authorizing documents back it.
+
+     ### Phase `W01.P01` - ...
+     ### Phase `W01.P02` - ...
+
+     The Wave intent paragraph is mandatory. -->
+
+<!-- EPIC INTENT BLOCK FORMAT (L4 only):
+     ## Epic intent
+
+     One paragraph stating the strategic goal, the external project-
+     management association (milestone name, project board identifier,
+     roadmap entry), the timeline horizon, and the teams or agents
+     involved.
+
+     ## Wave `W01` - ...
+     ## Wave `W02` - ...
+
+     The ## Epic intent block is mandatory at L4 and absent at L1, L2,
+     L3. The plan title (the level-one # heading at the top of the
+     document) is the Epic title; no separate Epic heading is emitted. -->
+
+## Parallelization
+
+<!-- State which Steps, Phases, or Waves can be executed in parallel and
+which carry hard ordering. At `L1` and `L2`, parallelism is decided
+per-Step or per-Phase. At `L3` and `L4`, Waves are sequenced by
+default (one Wave must land before the next can begin); Phases
+within a single Wave may be parallelized when they share no hard
+interdependency. -->
+
+## Verification
+
+<!-- State the mission success criteria for this plan. Each criterion
+should be a verifiable check (test passes, surface conforms,
+reviewer signs off) rather than a free-form assertion.
+
+The plan is complete when every Step in the plan is closed
+(`- [x]`). At `L4`, the Epic-completion check additionally requires
+the declared project-management association to report the Epic
+complete.
+
+For tier-specific verification cadence, see the authorizing
+documents linked in the `related:` frontmatter. -->

--- a/.vault/plan/2026-08-01-mcp-read-only-plan.md
+++ b/.vault/plan/2026-08-01-mcp-read-only-plan.md
@@ -42,7 +42,6 @@ related:
      DO NOT add fields beyond those scaffolded; metadata lives
      only in the frontmatter. -->
 
-
 <!-- HIERARCHY AND TIERS:
      Epic > Wave > Phase > Step. Step is the canonical leaf-row
      noun. Execution Record artifact: <Step Record>.

--- a/.vault/research/2026-08-01-mcp-read-only-research.md
+++ b/.vault/research/2026-08-01-mcp-read-only-research.md
@@ -1,0 +1,40 @@
+---
+tags:
+  - '#research'
+  - '#mcp-read-only'
+date: '2026-08-01'
+modified: '2026-08-01'
+body_schema: 'body-v1'
+body_hash: 'sha256:4a708c953d339b627a5d3d229390791d265e7685af294785aba0ab1f775bfa1d'
+related:
+  - "[[2026-07-09-mcp-tool-schema-adr]]"
+  - "[[2026-07-09-mcp-tool-schema-reference]]"
+---
+# `mcp-read-only` research: capability-scoped MCP launch
+
+Issue #300 asks whether `vaultspec-mcp` can provide vault grounding to orchestrated agents without exposing a mutation capability. The evidence supports a server-owned launch mode that omits mutation tools from `tools/list`; the remaining design question for an ADR is the exact treatment of `check`, whose normal `fix` option writes to the vault.
+
+## Findings
+
+### The advertised tool catalog is the relevant security boundary
+
+Issue #300 records an observed containment failure in which a write-capable server, reachable through user-global configuration, scaffolded real vault documents despite a filesystem deny. A client-side permission filter therefore does not meet the stated requirement: models must not receive the schema of capabilities they are prohibited from using. The existing accepted MCP-schema decision defines both first-class mutation tools and a broadly capable `invoke` gateway, so tool annotations alone cannot remove those capabilities from discovery. The ADR must decide a launch-time registration boundary rather than a client-side denylist. https://github.com/nevenincs/vaultspec-core/issues/300 `.vault/adr/2026-07-09-mcp-tool-schema-adr.md`
+
+### The read-only catalog is deliberately small and should be allowlisted
+
+The issue names `status`, `find`, and `discover` as orientation-only operations, and proposes validation through `check`; it expressly excludes `create`, `edit`, `plan_progress`, `plan_edit`, and `invoke`. The accepted schema ADR independently marks `status`, `find`, and `discover` read-only and idempotent, while `invoke` is destructive because it reaches the long-tail command catalog. A positive allowlist means a future mutating tool remains absent until it is deliberately classified, rather than becoming visible by default. `.vault/adr/2026-07-09-mcp-tool-schema-adr.md` https://github.com/nevenincs/vaultspec-core/issues/300
+
+### `check` needs a read-only signature, not only a safe default
+
+The accepted schema ADR describes `check` as read-only only when `fix` is false; `fix` makes it mutating. A server that advertises the usual `check(fix: bool)` handler under `--read-only` would still offer a write path and its schema to the client. The read-only mode therefore needs a check registration that neither advertises nor accepts `fix`, while the normal launch retains the complete handler unchanged. This is the one interface refinement the ADR must make explicit. `.vault/adr/2026-07-09-mcp-tool-schema-adr.md` https://github.com/nevenincs/vaultspec-core/issues/300
+
+### The default server interface is a compatibility requirement
+
+The issue requires the flag to be a stable consumer contract and requires default launch behavior to remain unchanged. The existing static-launch decision retains `app.py` bootstrap and the console script as the MCP entry point, so the new option should be parsed at that existing boundary and passed into tool registration. Tests must inspect a real server's advertised list for both modes, asserting exact read-only membership and default equivalence; unit tests of a hand-maintained name list alone would not prove the wire-visible contract. `.vault/reference/2026-07-09-mcp-tool-schema-reference.md` `.vault/adr/2026-07-17-mcp-static-launch-adr.md` https://github.com/nevenincs/vaultspec-core/issues/300
+
+## Sources
+
+- https://github.com/nevenincs/vaultspec-core/issues/300
+- `.vault/adr/2026-07-09-mcp-tool-schema-adr.md`
+- `.vault/reference/2026-07-09-mcp-tool-schema-reference.md`
+- `.vault/adr/2026-07-17-mcp-static-launch-adr.md`

--- a/.vault/research/2026-08-01-mcp-read-only-research.md
+++ b/.vault/research/2026-08-01-mcp-read-only-research.md
@@ -10,6 +10,7 @@ related:
   - "[[2026-07-09-mcp-tool-schema-adr]]"
   - "[[2026-07-09-mcp-tool-schema-reference]]"
 ---
+
 # `mcp-read-only` research: capability-scoped MCP launch
 
 Issue #300 asks whether `vaultspec-mcp` can provide vault grounding to orchestrated agents without exposing a mutation capability. The evidence supports a server-owned launch mode that omits mutation tools from `tools/list`; the remaining design question for an ADR is the exact treatment of `check`, whose normal `fix` option writes to the vault.

--- a/src/vaultspec_core/mcp_server/app.py
+++ b/src/vaultspec_core/mcp_server/app.py
@@ -10,14 +10,18 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Annotated, Any, override
 
 import typer
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
+    from mcp.server.context import CallNext, HandlerResult, ServerRequestContext
+
+from mcp.server.extension import Extension
 from mcp.server.mcpserver import MCPServer
+from mcp.types import CallToolRequestParams, CallToolResult, TextContent
 
 from vaultspec_core import __version__
 from vaultspec_core.cli._app import make_app
@@ -32,8 +36,33 @@ from .tools import (
 logger = logging.getLogger(__name__)
 
 
-def _build_instructions() -> str:
-    """Compose the server ``instructions`` string naming the nine-tool surface.
+class _ReadOnlyCheckGuard(Extension):
+    """Reject repair arguments that the SDK would otherwise ignore."""
+
+    identifier = "io.vaultspec/read-only-check"
+
+    @override
+    async def intercept_tool_call(
+        self,
+        params: CallToolRequestParams,
+        ctx: ServerRequestContext[Any, Any],
+        call_next: CallNext,
+    ) -> HandlerResult:
+        if params.name == "check" and "fix" in (params.arguments or {}):
+            return CallToolResult(
+                content=[
+                    TextContent(
+                        type="text",
+                        text="read-only check does not accept the 'fix' argument",
+                    )
+                ],
+                is_error=True,
+            )
+        return await call_next(ctx)
+
+
+def _build_instructions(*, read_only: bool) -> str:
+    """Compose the server ``instructions`` string for the selected surface.
 
     Names each first-class tool so a host that surfaces server instructions can
     orient an agent without a round-trip, and carries the tool-schema version
@@ -44,6 +73,16 @@ def _build_instructions() -> str:
     Returns:
         The assembled instructions string.
     """
+    if read_only:
+        return (
+            "Vaultspec-core MCP server in read-only mode (tool-schema version "
+            f"{__version__}). It exposes only 'status' (project orientation and "
+            "grounding traces), 'find' (document and feature discovery with blob "
+            "hashes and resource links), 'check' (vault health validation without "
+            "repair), and 'discover' (read-only search of the verb catalog). "
+            "Mutation tools and the invocation gateway are deliberately absent."
+        )
+
     return (
         "Vaultspec-core MCP server (tool-schema version "
         f"{__version__}). Nine tools cover the vaultspec workflow. Hot path: "
@@ -74,7 +113,7 @@ async def _lifespan(_app: MCPServer[None]) -> AsyncGenerator[None]:
     yield None
 
 
-def create_server() -> MCPServer[None]:
+def create_server(*, read_only: bool = False) -> MCPServer[None]:
     """Create and configure the MCPServer instance.
 
     Instantiates :class:`~mcp.server.mcpserver.MCPServer` and registers the
@@ -83,29 +122,34 @@ def create_server() -> MCPServer[None]:
     :class:`contextvars.Context` so that per-request mutations do not leak
     between concurrent requests.
 
+    Args:
+        read_only: Whether to expose only the non-mutating tool surface.
+
     Returns:
         Configured :class:`~mcp.server.mcpserver.MCPServer` ready to serve.
     """
     mcp = MCPServer(
         name="vaultspec-mcp",
-        instructions=_build_instructions(),
+        instructions=_build_instructions(read_only=read_only),
         lifespan=_lifespan,
+        extensions=[_ReadOnlyCheckGuard()] if read_only else None,
     )
 
-    # Register the full nine-tool surface: find/create/edit (documents),
-    # status/check (orientation), plan_progress/plan_edit (plan), and the
-    # discover/invoke gateway. Every handler runs in a copied context for
-    # concurrent-request isolation.
-    register_document_tools(mcp)
-    register_orientation_tools(mcp)
-    register_plan_tools(mcp)
-    register_gateway_tools(mcp)
+    # The restricted mode is a positive allowlist: only non-mutating handlers
+    # are registered, so no write-capable tool reaches the advertised catalog.
+    register_document_tools(mcp, include_mutations=not read_only)
+    register_orientation_tools(mcp, include_fix=not read_only)
+    if not read_only:
+        register_plan_tools(mcp)
+    register_gateway_tools(mcp, include_invoke=not read_only)
 
     return mcp
 
 
 def _serve(
-    ctx_obj: dict[str, Any] | None = None, parent_pid: int | None = None
+    ctx_obj: dict[str, Any] | None = None,
+    parent_pid: int | None = None,
+    read_only: bool = False,
 ) -> None:
     """Resolve runtime context, initialise paths, and start the MCP stdio server.
 
@@ -116,8 +160,9 @@ def _serve(
     Args:
         ctx_obj: Optional Typer context object injected by the root CLI app.
             Must contain ``"layout"`` and ``"target"`` keys when present.
-        parent_pid: Optional explicit client PID the lifetime watchdog
-            watches ahead of discovery.
+        parent_pid: Optional explicit client PID the lifetime watchdog watches
+            ahead of discovery.
+        read_only: Whether to expose only the non-mutating tool surface.
 
     Raises:
         typer.Exit: If ``root_dir`` cannot be resolved in standalone mode.
@@ -146,7 +191,7 @@ def _serve(
 
     logger.info("Starting vaultspec-mcp server root=%s", root_dir)
 
-    mcp = create_server()
+    mcp = create_server(read_only=read_only)
 
     # Backstop for the stdio lifetime contract: stdin EOF can be defeated by
     # inherited pipe handles, so anchor shutdown to the client process itself
@@ -178,6 +223,13 @@ def main(
             ),
         ),
     ] = None,
+    read_only: Annotated[
+        bool,
+        typer.Option(
+            "--read-only",
+            help="Expose only non-mutating MCP tools.",
+        ),
+    ] = False,
 ) -> None:
     """Typer callback entrypoint for vaultspec-mcp.
 
@@ -186,8 +238,9 @@ def main(
             the root CLI app (contains ``"layout"`` and ``"target"`` keys).
         parent_pid: Optional explicit client PID forwarded to the lifetime
             watchdog.
+        read_only: Whether to expose only the non-mutating tool surface.
     """
-    _serve(ctx.obj, parent_pid=parent_pid)
+    _serve(ctx.obj, parent_pid=parent_pid, read_only=read_only)
 
 
 def run() -> None:

--- a/src/vaultspec_core/mcp_server/tests/test_stdio_e2e.py
+++ b/src/vaultspec_core/mcp_server/tests/test_stdio_e2e.py
@@ -51,6 +51,8 @@ _EXPECTED_TOOLS = frozenset(
     }
 )
 
+_READ_ONLY_TOOLS = frozenset({"status", "find", "check", "discover"})
+
 #: Overall client-session ceiling. Deliberately below the 60s ``invoke``
 #: subprocess timeout so a stdin-inheritance regression trips this bound and
 #: fails fast rather than hanging CI to the per-call ceiling.
@@ -141,6 +143,34 @@ async def _drive_session(project: Path) -> None:
         assert "denylist" in denied_text or "out of scope" in denied_text
 
 
+async def _drive_read_only_session(project: Path) -> None:
+    """Launch the real read-only server and prove its wire-visible surface."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "vaultspec_core.mcp_server.app", "--read-only"],
+        cwd=str(project),
+        env={**os.environ, "VAULTSPEC_TARGET_DIR": str(project)},
+    )
+
+    async with (
+        stdio_client(params) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        listed = await session.list_tools()
+        by_name = {tool.name: tool for tool in listed.tools}
+        assert set(by_name) == _READ_ONLY_TOOLS, by_name
+        assert "fix" not in by_name["check"].input_schema.get("properties", {})
+
+        checked = _unwrap(await session.call_tool("check", {}))
+        assert isinstance(checked, dict)
+        check_dict = cast("dict[str, Any]", checked)
+        assert check_dict["fixed"] is False
+
+        rejected_repair = await session.call_tool("check", {"fix": True})
+        assert rejected_repair.is_error
+
+
 @pytest.mark.integration
 def test_mcp_stdio_end_to_end_invoke_does_not_inherit_transport_stdin() -> None:
     """The server serves a full session over real stdio without stdin hangs.
@@ -162,6 +192,25 @@ def test_mcp_stdio_end_to_end_invoke_does_not_inherit_transport_stdin() -> None:
 
         async def _runner() -> None:
             await asyncio.wait_for(_drive_session(project), timeout=_SESSION_TIMEOUT)
+
+        asyncio.run(_runner())
+    finally:
+        reset_config()
+        shutil.rmtree(project, ignore_errors=True)
+
+
+@pytest.mark.integration
+def test_mcp_stdio_read_only_launch_omits_mutation_tools() -> None:
+    """The real ``--read-only`` launch exposes only non-mutating tools."""
+    reset_config()
+    project = Path(tempfile.mkdtemp(prefix="vsc-mcp-read-only-")).resolve()
+    try:
+        WorkspaceFactory(project).install()
+
+        async def _runner() -> None:
+            await asyncio.wait_for(
+                _drive_read_only_session(project), timeout=_SESSION_TIMEOUT
+            )
 
         asyncio.run(_runner())
     finally:

--- a/src/vaultspec_core/mcp_server/tests/test_tool_surface.py
+++ b/src/vaultspec_core/mcp_server/tests/test_tool_surface.py
@@ -42,6 +42,8 @@ _EXPECTED_TOOLS = frozenset(
     }
 )
 
+_READ_ONLY_TOOLS = frozenset({"status", "find", "check", "discover"})
+
 #: The ADR Q6 annotation matrix: each tool mapped to the hints it must declare.
 #: Read-only tools (status/find/discover) leave ``destructive_hint`` unset
 #: (``None``), matching how their :class:`ToolAnnotations` are constructed.
@@ -95,6 +97,25 @@ _ANNOTATIONS = {
     },
 }
 
+_READ_ONLY_ANNOTATIONS = {
+    "status": {
+        "read_only_hint": True,
+        "idempotent_hint": True,
+        "open_world_hint": False,
+    },
+    "find": {"read_only_hint": True, "idempotent_hint": True, "open_world_hint": False},
+    "check": {
+        "read_only_hint": True,
+        "idempotent_hint": True,
+        "open_world_hint": False,
+    },
+    "discover": {
+        "read_only_hint": True,
+        "idempotent_hint": True,
+        "open_world_hint": False,
+    },
+}
+
 
 async def test_surface_registers_exactly_nine_tools_with_schemas(
     vault_root: Path,
@@ -114,6 +135,37 @@ async def test_surface_registers_exactly_nine_tools_with_schemas(
         for hint, value in expected.items():
             actual = getattr(annotations, hint)
             assert actual == value, f"{name}.{hint} == {actual!r}, expected {value!r}"
+
+    assert "fix" in by_name["check"].input_schema.get("properties", {})
+
+
+async def test_read_only_surface_omits_mutation_tools_and_repair(
+    vault_root: Path,
+) -> None:
+    """Read-only mode advertises only validation and orientation operations."""
+    mcp = create_server(read_only=True)
+    tools = await mcp.list_tools()
+    names = {tool.name for tool in tools}
+    assert names == _READ_ONLY_TOOLS, names
+
+    by_name = {tool.name: tool for tool in tools}
+    for name, expected in _READ_ONLY_ANNOTATIONS.items():
+        tool = by_name[name]
+        assert tool.output_schema is not None, f"{name} declares no outputSchema"
+        annotations = tool.annotations
+        assert annotations is not None, f"{name} declares no annotations"
+        for hint, value in expected.items():
+            actual = getattr(annotations, hint)
+            assert actual == value, f"{name}.{hint} == {actual!r}, expected {value!r}"
+
+    check_schema = by_name["check"].input_schema
+    assert "fix" not in check_schema.get("properties", {})
+
+    async with Client(mcp) as client:
+        checked = data_of(await client.call_tool("check", {}))
+        rejected_repair = await client.call_tool("check", {"fix": True})
+    assert checked["fixed"] is False
+    assert rejected_repair.is_error
 
 
 async def test_surface_instructions_name_the_tools_and_version(
@@ -219,9 +271,10 @@ async def test_surface_representative_call_per_tool(vault_root: Path) -> None:
         assert trace["kind"] == "trace"
 
         # check: run the health suite over the vault.
-        checked = data_of(await client.call_tool("check", {}))
+        checked = data_of(await client.call_tool("check", {"fix": True}))
         assert checked["status"] in {"ok", "failed"}
         assert "checks" in checked
+        assert checked["fixed"] is True
 
         # discover: rank the long-tail catalog for a known verb.
         discovered = data_of(

--- a/src/vaultspec_core/mcp_server/tools/documents.py
+++ b/src/vaultspec_core/mcp_server/tools/documents.py
@@ -836,7 +836,9 @@ def _find_documents(
     return rows
 
 
-def register_document_tools(mcp: MCPServer[None]) -> None:
+def register_document_tools(
+    mcp: MCPServer[None], *, include_mutations: bool = True
+) -> None:
     """Register the ``find``, ``create``, and ``edit`` document tools on *mcp*.
 
     ``find`` is read-only and idempotent; ``create`` is non-read-only,
@@ -849,6 +851,7 @@ def register_document_tools(mcp: MCPServer[None]) -> None:
 
     Args:
         mcp: The :class:`~mcp.server.mcpserver.MCPServer` instance to decorate.
+        include_mutations: Whether to register ``create`` and ``edit``.
     """
 
     @mcp.tool(
@@ -913,14 +916,6 @@ def register_document_tools(mcp: MCPServer[None]) -> None:
         logger.debug("Found %d documents.", len(rows))
         return rows
 
-    @mcp.tool(
-        annotations=ToolAnnotations(
-            read_only_hint=False,
-            destructive_hint=False,
-            idempotent_hint=False,
-            open_world_hint=False,
-        ),
-    )
     @_isolated_context
     async def create(
         ctx: Context[Any, Any], documents: list[DocumentSpec]
@@ -964,14 +959,6 @@ def register_document_tools(mcp: MCPServer[None]) -> None:
         logger.debug("create: %d feature index(es) regenerated", len(affected))
         return build_batch(items)
 
-    @mcp.tool(
-        annotations=ToolAnnotations(
-            read_only_hint=False,
-            destructive_hint=True,
-            idempotent_hint=False,
-            open_world_hint=False,
-        ),
-    )
     @_isolated_context
     async def edit(
         ctx: Context[Any, Any], operations: list[EditOperation]
@@ -1001,5 +988,23 @@ def register_document_tools(mcp: MCPServer[None]) -> None:
 
         items = [_edit_one(root_dir, idx, op) for idx, op in enumerate(operations)]
         return build_batch(items)
+
+    if include_mutations:
+        mcp.tool(
+            annotations=ToolAnnotations(
+                read_only_hint=False,
+                destructive_hint=False,
+                idempotent_hint=False,
+                open_world_hint=False,
+            ),
+        )(create)
+        mcp.tool(
+            annotations=ToolAnnotations(
+                read_only_hint=False,
+                destructive_hint=True,
+                idempotent_hint=False,
+                open_world_hint=False,
+            ),
+        )(edit)
 
     _ = (find, create, edit)  # bound by the decorator; silence unused warnings

--- a/src/vaultspec_core/mcp_server/tools/gateway.py
+++ b/src/vaultspec_core/mcp_server/tools/gateway.py
@@ -361,7 +361,9 @@ def _parse_verb(verb: str) -> tuple[str, ...]:
 # ---------------------------------------------------------------------------
 
 
-def register_gateway_tools(mcp: MCPServer[None]) -> None:
+def register_gateway_tools(
+    mcp: MCPServer[None], *, include_invoke: bool = True
+) -> None:
     """Register the ``discover`` and ``invoke`` gateway tools on *mcp*.
 
     ``discover`` is read-only and idempotent: a search never mutates the vault.
@@ -372,6 +374,7 @@ def register_gateway_tools(mcp: MCPServer[None]) -> None:
 
     Args:
         mcp: The :class:`~mcp.server.mcpserver.MCPServer` instance to decorate.
+        include_invoke: Whether to register the mutation-capable ``invoke`` tool.
     """
 
     @mcp.tool(
@@ -433,14 +436,6 @@ def register_gateway_tools(mcp: MCPServer[None]) -> None:
         ]
         return DiscoverResult(query=query, count=len(verbs), verbs=verbs)
 
-    @mcp.tool(
-        annotations=ToolAnnotations(
-            read_only_hint=False,
-            destructive_hint=True,
-            idempotent_hint=False,
-            open_world_hint=False,
-        ),
-    )
     @_isolated_context
     async def invoke(
         ctx: Context[Any, Any],
@@ -542,7 +537,17 @@ def register_gateway_tools(mcp: MCPServer[None]) -> None:
 
         return _fold_completed(entry.verb, entry.supports_json, completed, command)
 
-    _ = (discover, invoke)  # bound by the decorator; silence unused warnings
+    if include_invoke:
+        mcp.tool(
+            annotations=ToolAnnotations(
+                read_only_hint=False,
+                destructive_hint=True,
+                idempotent_hint=False,
+                open_world_hint=False,
+            ),
+        )(invoke)
+
+    _ = (discover, invoke)  # bound by the decorators; silence unused warnings
 
 
 def _fold_completed(

--- a/src/vaultspec_core/mcp_server/tools/orientation.py
+++ b/src/vaultspec_core/mcp_server/tools/orientation.py
@@ -378,7 +378,26 @@ def _checks_to_result(results: list[CheckResult], *, fix: bool) -> CheckResultMo
 # ---------------------------------------------------------------------------
 
 
-def register_orientation_tools(mcp: MCPServer[None]) -> None:
+def _run_check(feature: str | None, *, fix: bool) -> CheckResultModel:
+    """Run vault checks and adapt their results to the MCP response model."""
+    from ...vaultcore.checks import run_all_checks
+
+    logger.info("check: feature=%r fix=%s", feature, fix)
+    root_dir = _get_ctx().target_dir
+    results = run_all_checks(root_dir, feature=feature, fix=fix)
+    report = _checks_to_result(results, fix=fix)
+    logger.debug(
+        "check: %d error(s), %d warning(s), %d fixed",
+        report.total_errors,
+        report.total_warnings,
+        report.total_fixed,
+    )
+    return report
+
+
+def register_orientation_tools(
+    mcp: MCPServer[None], *, include_fix: bool = True
+) -> None:
     """Register the ``status`` and ``check`` orientation tools on *mcp*.
 
     ``status`` is read-only and idempotent. ``check`` is annotated
@@ -389,6 +408,7 @@ def register_orientation_tools(mcp: MCPServer[None]) -> None:
 
     Args:
         mcp: The :class:`~mcp.server.mcpserver.MCPServer` instance to decorate.
+        include_fix: Whether to register the repair-capable ``check`` signature.
     """
 
     @mcp.tool(
@@ -441,52 +461,47 @@ def register_orientation_tools(mcp: MCPServer[None]) -> None:
             raise ValueError(str(exc)) from exc
         return _trace_to_result(trace)
 
-    @mcp.tool(
-        annotations=ToolAnnotations(
-            read_only_hint=False,
-            destructive_hint=False,
-            idempotent_hint=True,
-            open_world_hint=False,
-        ),
-    )
-    @_isolated_context
-    async def check(
-        ctx: Context[Any, Any],
-        feature: str | None = None,
-        fix: bool = False,
-    ) -> CheckResultModel:
-        """Run the vault health-check suite, optionally repairing.
+    if include_fix:
 
-        Runs every checker over the vault (optionally restricted to one
-        feature) and returns the structured findings. With ``fix``, the
-        supporting checkers auto-correct what they safely can and report the
-        corrected count; a repair never overwrites authored prose, so
-        re-running converges (idempotent).
-
-        Args:
-            ctx: The MCP request context (unused; logging routes through the
-                module logger instead of the deprecated client-facing channel).
-            feature: Restrict per-document checks to this feature tag
-                (without ``#``), or ``None`` for the whole vault.
-            fix: When ``True``, apply the safe auto-corrections.
-
-        Returns:
-            The :class:`CheckResultModel` with per-checker summaries and the
-            flattened error- and warning-severity findings.
-        """
-        _ = ctx
-        from ...vaultcore.checks import run_all_checks
-
-        logger.info("check: feature=%r fix=%s", feature, fix)
-        root_dir = _get_ctx().target_dir
-        results = run_all_checks(root_dir, feature=feature, fix=fix)
-        report = _checks_to_result(results, fix=fix)
-        logger.debug(
-            "check: %d error(s), %d warning(s), %d fixed",
-            report.total_errors,
-            report.total_warnings,
-            report.total_fixed,
+        @mcp.tool(
+            name="check",
+            annotations=ToolAnnotations(
+                read_only_hint=False,
+                destructive_hint=False,
+                idempotent_hint=True,
+                open_world_hint=False,
+            ),
         )
-        return report
+        @_isolated_context
+        async def check_with_fix(
+            ctx: Context[Any, Any],
+            feature: str | None = None,
+            fix: bool = False,
+        ) -> CheckResultModel:
+            """Run the vault health-check suite, optionally repairing."""
+            _ = ctx
+            return _run_check(feature, fix=fix)
 
-    _ = (status, check)  # bound by the decorator; silence unused warnings
+        registered_check = check_with_fix
+
+    else:
+
+        @mcp.tool(
+            name="check",
+            annotations=ToolAnnotations(
+                read_only_hint=True,
+                idempotent_hint=True,
+                open_world_hint=False,
+            ),
+        )
+        @_isolated_context
+        async def check_read_only(
+            ctx: Context[Any, Any], feature: str | None = None
+        ) -> CheckResultModel:
+            """Run the vault health-check suite without repair."""
+            _ = ctx
+            return _run_check(feature, fix=False)
+
+        registered_check = check_read_only
+
+    _ = (status, registered_check)  # bound by the decorators; silence unused warnings


### PR DESCRIPTION
Closes #300\n\n## Summary\n- add aultspec-mcp --read-only with a server-side allowlist: status, ind, check, and discover\n- omit all write tools and the invocation gateway; read-only check has no ix schema and rejects a supplied ix argument on the wire\n- retain and test the default nine-tool surface and repair-capable check\n\n## Verification\n- uff check on changed MCP source and tests\n- asedpyright on changed MCP source\n- pytest src/vaultspec_core/mcp_server/tests/test_tool_surface.py src/vaultspec_core/mcp_server/tests/test_stdio_e2e.py -q (8 passed; one existing asyncio-marker warning)\n- aultspec-core vault check all (no errors; pre-existing/template warnings remain)