### PR TITLE
fix(vault): preserve body hash integrity across rewrites

### DIFF
--- a/.vault/audit/2026-08-13-body-hash-integrity-audit.md
+++ b/.vault/audit/2026-08-13-body-hash-integrity-audit.md
@@ -8,6 +8,7 @@ body_schema: 'body-v1'
 body_hash: 'sha256:e7566feb4a3892ba61e4e450e614ffbfa7f8c6e2da9c0856ad22c7e6f5e51bf2'
 related: []
 ---
+
 # `body-hash-integrity` audit: `Body hash integrity review`
 
 ## Scope

--- a/.vault/audit/2026-08-13-body-hash-integrity-audit.md
+++ b/.vault/audit/2026-08-13-body-hash-integrity-audit.md
@@ -1,0 +1,55 @@
+---
+tags:
+  - '#audit'
+  - '#body-hash-integrity'
+date: '2026-08-13'
+modified: '2026-08-13'
+body_schema: 'body-v1'
+body_hash: 'sha256:e7566feb4a3892ba61e4e450e614ffbfa7f8c6e2da9c0856ad22c7e6f5e51bf2'
+related: []
+---
+# `body-hash-integrity` audit: `Body hash integrity review`
+
+## Scope
+
+Review issues 299 and 306 against the canonical plan frontmatter rewrite and generated feature-index ownership boundaries. The review covers CLI, MCP, repair, rename, concurrency, reporting, strict typing, and real-behavior tests.
+
+## Findings
+
+### generated-frontmatter-drift | high | No-op detection preserved corrupted metadata
+
+The initial shortcut compared only the body digest and stored `body_hash`, allowing drift in generator-owned fields to survive. Remediation now requires the complete canonical document, except intentionally preserved timestamps, to match before reporting unchanged.
+
+### creation-date-reset | high | Genuine updates overwrote the creation date
+
+The original generator emitted today into both `date` and `modified`. Remediation preserves a valid existing creation date and advances only `modified` when canonical generated content changes.
+
+### misleading-index-outcomes | medium | No-op indexes were reported as generated
+
+The path-only result prevented CLI and repair callers from distinguishing a write from a no-op. Remediation introduces a typed changed result and projects it through text, JSON, repair planning, cache invalidation, MCP, and rename callers.
+
+### stale-snapshot-overwrite | medium | Concurrent writers could use stale membership
+
+Callers previously collected graph nodes before entering the index write boundary. Remediation serializes each index and refreshes production graph membership under that lock; explicit nodes remain available only for isolated callers and tests.
+
+### swallowed-index-read-error | low | Read failures authorized replacement
+
+The original shortcut swallowed every read `OSError`. Remediation propagates existing-target read failures and leaves the uncertain filesystem object unchanged.
+
+### malformed-frontmatter-crash | medium | Non-mapping YAML could abort regeneration
+
+The generic YAML parser can produce a list or scalar. Remediation treats non-mapping frontmatter as noncanonical and rewrites it instead of calling mapping methods on it.
+
+### duplicate-hash-acceptance | medium | Duplicate hash keys could satisfy a shortcut
+
+Last-key-wins YAML parsing could hide a forged duplicate. Remediation uses complete canonical-text equality for no-op eligibility, so duplicate generator-owned keys force a rewrite to one canonical field.
+
+### owning-path-coverage | medium | Issue 299 lacked CLI and MCP proof
+
+Serializer-only coverage did not prove the reported mutation routes. Remediation adds real CLI and MCP mutations covering nulls, lists, nested mappings and date-like values, with exactly one truthful `body_hash` after persistence.
+
+## Recommendations
+
+- Keep feature-index rendering, membership refresh, locking, timestamp preservation and changed-state reporting in the canonical index module.
+- Keep CLI, MCP, repair and rename surfaces as projections of the typed generation result.
+- Retain end-to-end CLI and MCP preservation tests alongside serializer-level property coverage.

--- a/src/vaultspec_core/cli/vault_feature_cmd.py
+++ b/src/vaultspec_core/cli/vault_feature_cmd.py
@@ -28,7 +28,6 @@ if TYPE_CHECKING:
 
     import typer as _typer
 
-    from vaultspec_core.graph import VaultGraph
     from vaultspec_core.vaultcore.query import (
         FeatureArchiveResult,
         FeatureDetail,
@@ -158,26 +157,21 @@ def _emit_feature_index_json(status: str, generated_paths: list[Path]) -> None:
 
 
 def _generate_feature_indexes(
-    graph: VaultGraph,
     root_dir: Path,
     features: list[str],
     json_output: bool,
 ) -> list[Path]:
     """Regenerate the index document for each feature, returning written paths."""
     from vaultspec_core.console import get_console
-    from vaultspec_core.vaultcore.index import generate_feature_index
+    from vaultspec_core.vaultcore.index import generate_feature_index_result
 
     generated_paths: list[Path] = []
     for feat in features:
-        nodes = graph.get_feature_nodes(feat)
-        if not nodes:
+        result = generate_feature_index_result(root_dir, feat)
+        if result.changed:
+            generated_paths.append(result.path)
             if not json_output:
-                get_console().print(f"[dim]No documents found for #{feat}.[/dim]")
-            continue
-        path = generate_feature_index(root_dir, feat, nodes=nodes)
-        generated_paths.append(path)
-        if not json_output:
-            get_console().print(f"[green]Index:[/green] {path}")
+                get_console().print(f"[green]Index:[/green] {result.path}")
     return generated_paths
 
 
@@ -203,7 +197,7 @@ def _run_feature_index(
         get_console().print("[dim]No features found in vault.[/dim]")
         return
 
-    generated_paths = _generate_feature_indexes(graph, root_dir, features, json_output)
+    generated_paths = _generate_feature_indexes(root_dir, features, json_output)
 
     if generated_paths:
         from vaultspec_core.cli._cache_hook import invalidate_graph_cache

--- a/src/vaultspec_core/core/__init__.py
+++ b/src/vaultspec_core/core/__init__.py
@@ -38,6 +38,7 @@ from .exceptions import VaultSpecError as VaultSpecError
 from .exceptions import WorkspaceNotInitializedError as WorkspaceNotInitializedError
 from .helpers import atomic_write as atomic_write
 from .helpers import build_file as build_file
+from .helpers import dump_yaml as dump_yaml
 from .helpers import ensure_dir as ensure_dir
 from .home import CoreHomeLayout as CoreHomeLayout
 from .home import ProcessRegistryDiagnosis as ProcessRegistryDiagnosis

--- a/src/vaultspec_core/core/helpers.py
+++ b/src/vaultspec_core/core/helpers.py
@@ -175,7 +175,7 @@ def _ensure_literal_representer() -> None:
     degraded environment.  See GitHub issue #85.
 
     Uses double-checked locking so that two threads calling
-    :func:`_yaml_dump` concurrently for the first time both observe a
+    :func:`dump_yaml` concurrently for the first time both observe a
     registered representer without either of them entering the critical
     section twice.  ``yaml.add_representer`` mutates a class-level
     ``Dumper.yaml_representers`` dict, and although the GIL serialises
@@ -192,7 +192,7 @@ def _ensure_literal_representer() -> None:
         _literal_representer_registered = True
 
 
-def _yaml_dump(data: dict[str, Any]) -> str:
+def dump_yaml(data: dict[str, Any]) -> str:
     """Serialize a dict to YAML, using literal block style for multi-line values.
 
     Args:
@@ -224,7 +224,7 @@ def build_file(frontmatter: dict[str, Any], body: str) -> str:
     Returns:
         A string of the form ``---\\n<yaml>\\n---\\n\\n<body>``.
     """
-    fm_str = _yaml_dump(frontmatter)
+    fm_str = dump_yaml(frontmatter)
     return f"---\n{fm_str}\n---\n\n{body}"
 
 

--- a/src/vaultspec_core/core/tests/test_helpers_yaml.py
+++ b/src/vaultspec_core/core/tests/test_helpers_yaml.py
@@ -5,14 +5,14 @@ made the entire framework un-importable when PyYAML's surface was even
 partially broken (e.g. a corrupt install missing ``yaml/__init__.py``).
 The fix moves the registration into a lazy
 :func:`~vaultspec_core.core.helpers._ensure_literal_representer` that runs
-on first ``_yaml_dump`` call.
+on first ``dump_yaml`` call.
 
 These tests pin that contract:
 
 - importing ``vaultspec_core.core`` does **not** mutate PyYAML's global
   representer registry until a serialization actually happens;
 - the lazy registration is idempotent and survives module reload;
-- ``_yaml_dump`` (and ``build_file``) still produce literal block scalars
+- ``dump_yaml`` (and ``build_file``) still produce literal block scalars
   for multi-line strings, matching the pre-fix output;
 - importing the package on a degraded PyYAML (``add_representer`` missing)
   succeeds; only the *first* dump raises.
@@ -89,7 +89,7 @@ class TestNoImportTimeSideEffect:
 
 
 class TestLazyRegistrationOnDump:
-    """``_yaml_dump`` registers the representer on first call and reuses it."""
+    """``dump_yaml`` registers the representer on first call and reuses it."""
 
     def test_dump_registers_then_marks_flag_true(self) -> None:
         helpers = _reload_helpers()
@@ -98,7 +98,7 @@ class TestLazyRegistrationOnDump:
             "module-level reload must leave the lazy flag unset"
         )
 
-        out = helpers._yaml_dump({"key": "single line"})
+        out = helpers.dump_yaml({"key": "single line"})
 
         assert helpers._literal_representer_registered is True
         assert "key:" in out
@@ -113,7 +113,7 @@ class TestLazyRegistrationOnDump:
     def test_multiline_string_uses_literal_block_scalar(self) -> None:
         helpers = _reload_helpers()
 
-        rendered = helpers._yaml_dump(
+        rendered = helpers.dump_yaml(
             {
                 "name": "single",
                 "body": "line one\nline two\nline three",
@@ -151,7 +151,7 @@ class TestDegradedPyYAML:
         """Simulate the issue #85 scenario: ``yaml.add_representer`` is gone.
 
         Reloading the helpers module under that condition must succeed; only
-        the *first* attempt to call ``_yaml_dump`` should raise, and it must
+        the *first* attempt to call ``dump_yaml`` should raise, and it must
         raise a clear ``AttributeError`` rather than crash at import.
         """
         script = textwrap.dedent(
@@ -167,11 +167,11 @@ class TestDegradedPyYAML:
             assert helpers._literal_representer_registered is False
 
             try:
-                helpers._yaml_dump({"k": "multi\\nline"})
+                helpers.dump_yaml({"k": "multi\\nline"})
             except AttributeError:
                 print("ok")
             else:
-                raise AssertionError("_yaml_dump did not surface AttributeError")
+                raise AssertionError("dump_yaml did not surface AttributeError")
             """
         )
         result = subprocess.run(
@@ -223,7 +223,7 @@ class TestDegradedPyYAML:
 
 
 class TestConcurrentRegistration:
-    """Two threads first-calling _yaml_dump must not race the registration.
+    """Two threads first-calling dump_yaml must not race the registration.
 
     ``yaml.add_representer`` mutates a class-level dict on PyYAML's
     Dumper.  In CPython that single statement is GIL-serialised, but the
@@ -257,7 +257,7 @@ class TestConcurrentRegistration:
             def worker() -> None:
                 try:
                     barrier.wait(timeout=5)
-                    helpers._yaml_dump({"k": "multi\nline"})
+                    helpers.dump_yaml({"k": "multi\nline"})
                 except BaseException as exc:
                     errors.append(exc)
 
@@ -287,7 +287,7 @@ class TestConcurrentRegistration:
         def worker() -> None:
             try:
                 barrier.wait(timeout=5)
-                results.append(helpers._yaml_dump({"body": "a\nb"}))
+                results.append(helpers.dump_yaml({"body": "a\nb"}))
             except BaseException as exc:
                 errors.append(exc)
 

--- a/src/vaultspec_core/mcp_server/tests/test_plan_tools.py
+++ b/src/vaultspec_core/mcp_server/tests/test_plan_tools.py
@@ -122,6 +122,42 @@ async def test_plan_edit_add_insert_edit_remove_preserves_ids(vault_root: Path) 
         assert s02.action == "Second action v2"
 
 
+async def test_plan_edit_preserves_future_frontmatter_and_reattests_body(
+    vault_root: Path,
+) -> None:
+    """The MCP write path carries future YAML through a truthful re-attestation."""
+    from vaultspec_core.vaultcore import parse_frontmatter
+    from vaultspec_core.vaultcore.body_hash import document_body_digest
+
+    mcp = create_server()
+    async with Client(mcp) as client:
+        await _create_plan(client, "futuremcp")
+        path = _plan_path(vault_root, "futuremcp")
+        source = path.read_text(encoding="utf-8").replace(
+            "tier: L1\n",
+            "tier: L1\n"
+            "future_null: null\n"
+            "future_values: [one, 2, true]\n"
+            "future_map: {mode: strict, retries: 3}\n",
+        )
+        path.write_text(source, encoding="utf-8")
+
+        result = await _plan_edit(
+            client,
+            "futuremcp",
+            [{"operation": "add", "action": "Future safe", "scope": "src/f.py"}],
+        )
+
+        assert result["status"] == "ok"
+        persisted = path.read_text(encoding="utf-8")
+        metadata, _ = parse_frontmatter(persisted)
+        assert metadata["future_null"] is None
+        assert metadata["future_values"] == ["one", 2, True]
+        assert metadata["future_map"] == {"mode": "strict", "retries": 3}
+        assert persisted.count("body_hash:") == 1
+        assert metadata["body_hash"] == document_body_digest(persisted)
+
+
 async def test_plan_edit_failed_op_does_not_abort_batch(vault_root: Path) -> None:
     """A bad op fails per-item while a good op in the same batch still applies."""
     mcp = create_server()

--- a/src/vaultspec_core/mcp_server/tools/documents.py
+++ b/src/vaultspec_core/mcp_server/tools/documents.py
@@ -689,14 +689,10 @@ def _regenerate_indexes(root_dir: Path, features: set[str]) -> None:
         root_dir: The project root.
         features: The normalized feature names to regenerate indexes for.
     """
-    from ...graph import VaultGraph
-    from ...vaultcore.index import generate_feature_index
+    from ...vaultcore.index import generate_feature_index_result
 
-    graph = VaultGraph(root_dir)
     for feature in sorted(features):
-        nodes = graph.get_feature_nodes(feature)
-        if nodes:
-            generate_feature_index(root_dir, feature, nodes=nodes)
+        generate_feature_index_result(root_dir, feature)
 
 
 # ---------------------------------------------------------------------------

--- a/src/vaultspec_core/plan/frontmatter.py
+++ b/src/vaultspec_core/plan/frontmatter.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from vaultspec_core.vaultcore.models import normalize_date
 from vaultspec_core.vaultcore.parser import parse_frontmatter
@@ -71,6 +71,9 @@ class PlanFrontmatter:
             source document and defaulted to ``L2``; the writer agent or
             ``vaultspec-core vault plan check --fix`` should add the field on
             first edit.
+        extra: Frontmatter fields not owned by the plan model. These values
+            are carried through a parse/serialise round trip so a writer does
+            not erase metadata introduced by a newer VaultSpec version.
     """
 
     tier: Tier
@@ -78,6 +81,7 @@ class PlanFrontmatter:
     tags: list[str] = field(default_factory=list)
     date: str = ""
     legacy_tier_default: bool = False
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 def parse_plan_frontmatter(source: str | Path) -> PlanFrontmatter:
@@ -115,6 +119,11 @@ def parse_plan_frontmatter(source: str | Path) -> PlanFrontmatter:
         tags=tags,
         date=date,
         legacy_tier_default=legacy_default,
+        extra={
+            key: value
+            for key, value in raw.items()
+            if key not in {"tier", "related", "tags", "date"}
+        },
     )
 
 

--- a/src/vaultspec_core/plan/serialiser.py
+++ b/src/vaultspec_core/plan/serialiser.py
@@ -176,6 +176,8 @@ def _emit_block(parts: list[str], content: str | None) -> None:
 
 
 def _render_frontmatter(plan: Plan) -> str:
+    from vaultspec_core.core.helpers import dump_yaml
+
     fm = plan.frontmatter
     lines = ["---", "tags:"]
     for tag in fm.tags:
@@ -186,6 +188,8 @@ def _render_frontmatter(plan: Plan) -> str:
         lines.append("related:")
         for entry in fm.related:
             lines.append(f"  - '{entry}'")
+    if fm.extra:
+        lines.extend(dump_yaml(fm.extra).splitlines())
     lines.append("---")
     return "\n".join(lines)
 

--- a/src/vaultspec_core/tests/cli/test_vault_cli.py
+++ b/src/vaultspec_core/tests/cli/test_vault_cli.py
@@ -429,6 +429,28 @@ class TestVaultJsonOutput:
         assert result.output.lstrip().startswith("{")
         assert payload == {"generated": []}
 
+    def test_feature_index_json_reports_existing_current_index_unchanged(
+        self, factory: WorkspaceFactory
+    ) -> None:
+        """A semantic no-op reports no generated paths and no update."""
+        factory.install("core")
+        created = factory.run(
+            "vault", "add", "research", "--feature", "stable-index", "--no-hints"
+        )
+        assert created.exit_code == 0, created.output
+        first = factory.run(
+            "vault", "feature", "index", "--feature", "stable-index", "--json"
+        )
+        assert first.exit_code == 0, first.output
+
+        second = factory.run(
+            "vault", "feature", "index", "--feature", "stable-index", "--json"
+        )
+
+        envelope = json.loads(second.output)
+        assert envelope["status"] == "unchanged"
+        assert envelope["data"] == {"generated": []}
+
 
 class TestVaultGraphScopingFlags:
     """vault graph --node/--depth ego scoping and --derived/--no-derived."""

--- a/src/vaultspec_core/tests/plan/test_e2e.py
+++ b/src/vaultspec_core/tests/plan/test_e2e.py
@@ -42,6 +42,44 @@ def test_status_command_reports_clean_plan(tmp_path: Path, runner: CliRunner) ->
     assert "Steps" in result.stdout
 
 
+def test_cli_mutation_preserves_future_frontmatter_and_reattests_body(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    """A real plan verb preserves unowned YAML and writes one truthful hash."""
+    from vaultspec_core.vaultcore import parse_frontmatter
+    from vaultspec_core.vaultcore.body_hash import document_body_digest
+
+    source = (
+        make_clean_plan("L1", rng=random.Random(99), steps=1)
+        .render()
+        .replace(
+            "tier: L1\n",
+            "tier: L1\n"
+            "body_hash: 'sha256:stale'\n"
+            "future_null: null\n"
+            "future_date: 2026-08-13\n"
+            "future_values: [one, 2, true]\n"
+            "future_map: {mode: strict, retries: 3}\n",
+        )
+    )
+    plan_path = tmp_path / "future-plan.md"
+    plan_path.write_text(source, encoding="utf-8")
+
+    result = runner.invoke(
+        app, ["vault", "plan", "step", "check", str(plan_path), "S01"]
+    )
+
+    assert result.exit_code == 0, result.stdout
+    persisted = plan_path.read_text(encoding="utf-8")
+    metadata, _ = parse_frontmatter(persisted)
+    assert metadata["future_null"] is None
+    assert str(metadata["future_date"]) == "2026-08-13"
+    assert metadata["future_values"] == ["one", 2, True]
+    assert metadata["future_map"] == {"mode": "strict", "retries": 3}
+    assert persisted.count("body_hash:") == 1
+    assert metadata["body_hash"] == document_body_digest(persisted)
+
+
 def test_status_json_output_is_valid_json(tmp_path: Path, runner: CliRunner) -> None:
     """``vault plan status --json`` emits a parseable payload."""
     import json

--- a/src/vaultspec_core/tests/plan/test_serialiser.py
+++ b/src/vaultspec_core/tests/plan/test_serialiser.py
@@ -119,6 +119,28 @@ def test_serialised_related_uses_single_quoted_wikilinks(tier: str) -> None:
     assert "  - '[[2026-05-05-test-feature-adr]]'" in rendered
 
 
+def test_round_trip_preserves_unowned_frontmatter_fields() -> None:
+    """A plan writer carries metadata introduced by another version."""
+    spec = make_clean_plan("L2", rng=random.Random(7), phases=1, steps=1).render()
+    source = spec.replace(
+        "tier: L2\n",
+        "tier: L2\n"
+        "body_hash: 'sha256:future-attestation'\n"
+        "future_contract:\n"
+        "  enabled: true\n"
+        "  modes:\n"
+        "    - strict\n",
+    )
+
+    rendered = serialise_plan(parse_plan(source))
+    reparsed = parse_plan(rendered)
+
+    assert reparsed.frontmatter.extra == {
+        "body_hash": "sha256:future-attestation",
+        "future_contract": {"enabled": True, "modes": ["strict"]},
+    }
+
+
 # ---- Stability under randomised parameters ----------------------------------
 
 

--- a/src/vaultspec_core/vaultcore/index.py
+++ b/src/vaultspec_core/vaultcore/index.py
@@ -114,7 +114,8 @@ def generate_feature_index(
     )
 
     from ..core.helpers import atomic_write
-    from .body_hash import set_body_hash
+    from .body_hash import document_body_digest, set_body_hash
+    from .parser import parse_frontmatter
 
     # Attest the rendered body like every other stamping path. The generator
     # rebuilds the whole document from scratch, so the fingerprint is a pure
@@ -124,9 +125,16 @@ def generate_feature_index(
 
     index_dir.mkdir(parents=True, exist_ok=True)
     try:
-        if index_path.exists() and index_path.read_text(encoding="utf-8") == content:
-            logger.info("Feature index already current: %s", index_path)
-            return index_path
+        if index_path.exists():
+            existing = index_path.read_text(encoding="utf-8")
+            expected_digest = document_body_digest(content)
+            existing_frontmatter, _ = parse_frontmatter(existing)
+            if (
+                document_body_digest(existing) == expected_digest
+                and existing_frontmatter.get("body_hash") == expected_digest
+            ):
+                logger.info("Feature index body already current: %s", index_path)
+                return index_path
     except OSError:
         pass
     atomic_write(index_path, content)

--- a/src/vaultspec_core/vaultcore/index.py
+++ b/src/vaultspec_core/vaultcore/index.py
@@ -9,7 +9,9 @@ tag and links to them via ``related:`` frontmatter.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, cast
 
 from .models import vault_today
 
@@ -20,16 +22,88 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["generate_feature_index"]
+__all__ = [
+    "FeatureIndexResult",
+    "feature_index_lock_target",
+    "generate_feature_index",
+    "generate_feature_index_result",
+]
 
 
-def generate_feature_index(
+@dataclass(frozen=True)
+class FeatureIndexResult:
+    """Outcome of one canonical feature-index regeneration."""
+
+    path: Path
+    changed: bool
+
+
+def feature_index_lock_target(docs_dir: Path, feature: str) -> Path:
+    """Return the ignored per-feature sentinel used by index writers."""
+    return docs_dir / "data" / "index" / feature
+
+
+def _render_index(
+    feature: str,
+    nodes: list[DocNode],
+    *,
+    created: str,
+    modified: str,
+) -> str:
+    """Render one canonical generated feature index."""
+    from .body_hash import set_body_hash
+    from .body_schema import CURRENT_BODY_SCHEMA
+
+    related_links = sorted(
+        f"[[{node.name}]]"
+        for node in nodes
+        if node.path and not node.name.endswith(".index")
+    )
+    by_type: dict[str, list[DocNode]] = {}
+    for node in nodes:
+        if node.path and not node.name.endswith(".index"):
+            key = node.doc_type.value if node.doc_type else "unknown"
+            by_type.setdefault(key, []).append(node)
+
+    body_lines: list[str] = []
+    for type_name in sorted(by_type):
+        body_lines.extend((f"### {type_name}", ""))
+        for node in sorted(by_type[type_name], key=lambda n: (n.date or "", n.name)):
+            body_lines.append(f"- `{node.name}` - {node.title or node.name}")
+        body_lines.append("")
+    document_list = "\n".join(body_lines).rstrip()
+    related_block = (
+        "related:\n" + "\n".join(f"  - '{link}'" for link in related_links)
+        if related_links
+        else "related: []"
+    )
+    content = (
+        "---\n"
+        "generated: true\n"
+        "tags:\n"
+        "  - '#index'\n"
+        f"  - '#{feature}'\n"
+        f"date: '{created}'\n"
+        f"modified: '{modified}'\n"
+        f"body_schema: '{CURRENT_BODY_SCHEMA}'\n"
+        f"{related_block}\n"
+        "---\n\n"
+        f"# `{feature}` feature index\n\n"
+        f"Auto-generated index of all documents tagged with `#{feature}`.\n\n"
+        "## Documents\n\n"
+        f"{document_list}\n"
+    )
+    return set_body_hash(content)
+
+
+def generate_feature_index_result(
     root_dir: Path,
     feature: str,
     *,
-    nodes: list[DocNode],
+    nodes: list[DocNode] | None = None,
     date_str: str | None = None,
-) -> Path:
+    dry_run: bool = False,
+) -> FeatureIndexResult:
     """Create or update a feature index file for *feature*.
 
     The index file lives at ``<docs_dir>/<index_dir>/<feature>.index.md``
@@ -37,7 +111,8 @@ def generate_feature_index(
     with the feature, plus a body listing documents grouped by type. The
     rendered frontmatter carries the standard two-tag shape
     (``#index`` directory tag plus ``#<feature>`` feature tag), the
-    ``generated: true`` marker, a ``modified:`` stamp equal to ``date:``,
+    ``generated: true`` marker, a stable creation ``date:``, a ``modified:``
+    stamp refreshed only when canonical generated content changes,
     and a ``body_hash:`` fingerprint of the rendered body, so the index
     reconciles cleanly against the modified-stamp checker like every other
     CLI-created document.
@@ -45,98 +120,71 @@ def generate_feature_index(
     Args:
         root_dir: Project root directory.
         feature: Feature name (without ``#`` prefix).
-        nodes: Pre-fetched list of :class:`~vaultspec_core.graph.api.DocNode`
-            for this feature (from :meth:`VaultGraph.get_feature_nodes`).
+        nodes: Explicit nodes for isolated callers and tests. Production callers
+            omit this so membership is refreshed under the index lock.
         date_str: Override date for the index. Defaults to today.
+        dry_run: Compute whether the canonical index would change without writing.
 
     Returns:
-        Path to the created or updated index file.
+        Typed path and physical-change outcome.
     """
     from ..config import get_config
-    from .body_schema import CURRENT_BODY_SCHEMA
+    from ..core.helpers import advisory_lock, atomic_write
+    from .models import normalize_date
+    from .parser import parse_frontmatter
 
     cfg = get_config()
     docs_dir = root_dir / cfg.docs_dir
     index_dir = docs_dir / cfg.index_dir
     index_path = index_dir / f"{feature}.index.md"
-    date = date_str or vault_today().isoformat()
+    today = date_str or vault_today().isoformat()
+    lock_target = feature_index_lock_target(docs_dir, feature)
+    if not dry_run:
+        lock_target.parent.mkdir(parents=True, exist_ok=True)
+    lock = nullcontext() if dry_run else advisory_lock(lock_target)
+    with lock:
+        if not dry_run:
+            index_dir.mkdir(parents=True, exist_ok=True)
+        if nodes is None:
+            from ..graph import VaultGraph
 
-    # Build related links from all feature nodes (excluding self)
-    related_links: list[str] = []
-    for node in nodes:
-        if node.path and not node.name.endswith(".index"):
-            related_links.append(f"[[{node.name}]]")
+            nodes = VaultGraph(root_dir, use_cache=False).get_feature_nodes(feature)
+        if not nodes:
+            logger.info("No documents found for feature index: %s", feature)
+            return FeatureIndexResult(index_path, changed=False)
 
-    # Build body document list grouped by type
-    by_type: dict[str, list[DocNode]] = {}
-    for node in nodes:
-        if node.path and not node.name.endswith(".index"):
-            dt_key = node.doc_type.value if node.doc_type else "unknown"
-            by_type.setdefault(dt_key, []).append(node)
-
-    body_lines: list[str] = []
-    for type_name in sorted(by_type):
-        body_lines.append(f"### {type_name}")
-        body_lines.append("")
-        for node in sorted(by_type[type_name], key=lambda n: (n.date or "", n.name)):
-            title = node.title or node.name
-            body_lines.append(f"- `{node.name}` - {title}")
-        body_lines.append("")
-
-    document_list = "\n".join(body_lines).rstrip()
-
-    # Build related YAML block
-    if related_links:
-        related_yaml = "\n".join(f"  - '{link}'" for link in sorted(related_links))
-        related_block = f"related:\n{related_yaml}"
-    else:
-        related_block = "related: []"
-
-    content = (
-        f"---\n"
-        f"generated: true\n"
-        f"tags:\n"
-        f"  - '#index'\n"
-        f"  - '#{feature}'\n"
-        f"date: '{date}'\n"
-        f"modified: '{date}'\n"
-        f"body_schema: '{CURRENT_BODY_SCHEMA}'\n"
-        f"{related_block}\n"
-        f"---\n"
-        f"\n"
-        f"# `{feature}` feature index\n"
-        f"\n"
-        f"Auto-generated index of all documents tagged with `#{feature}`.\n"
-        f"\n"
-        f"## Documents\n"
-        f"\n"
-        f"{document_list}\n"
-    )
-
-    from ..core.helpers import atomic_write
-    from .body_hash import document_body_digest, set_body_hash
-    from .parser import parse_frontmatter
-
-    # Attest the rendered body like every other stamping path. The generator
-    # rebuilds the whole document from scratch, so the fingerprint is a pure
-    # function of the content just assembled and the byte-equality
-    # short-circuit below stays exact.
-    content = set_body_hash(content)
-
-    index_dir.mkdir(parents=True, exist_ok=True)
-    try:
+        existing: str | None = None
+        created = today
+        modified = today
         if index_path.exists():
             existing = index_path.read_text(encoding="utf-8")
-            expected_digest = document_body_digest(content)
-            existing_frontmatter, _ = parse_frontmatter(existing)
-            if (
-                document_body_digest(existing) == expected_digest
-                and existing_frontmatter.get("body_hash") == expected_digest
-            ):
-                logger.info("Feature index body already current: %s", index_path)
-                return index_path
-    except OSError:
-        pass
-    atomic_write(index_path, content)
-    logger.info("Generated feature index: %s", index_path)
-    return index_path
+            parsed, _ = parse_frontmatter(existing)
+            raw = cast("object", parsed)
+            if isinstance(raw, dict):
+                metadata = cast("dict[str, Any]", raw)
+                created = normalize_date(metadata.get("date")) or today
+                modified = normalize_date(metadata.get("modified")) or created
+
+        unchanged = _render_index(feature, nodes, created=created, modified=modified)
+        if existing == unchanged:
+            logger.info("Feature index body already current: %s", index_path)
+            return FeatureIndexResult(index_path, changed=False)
+
+        content = _render_index(feature, nodes, created=created, modified=today)
+        if not dry_run:
+            atomic_write(index_path, content)
+            logger.info("Generated feature index: %s", index_path)
+        return FeatureIndexResult(index_path, changed=True)
+
+
+def generate_feature_index(
+    root_dir: Path,
+    feature: str,
+    *,
+    nodes: list[DocNode] | None = None,
+    date_str: str | None = None,
+) -> Path:
+    """Compatibility entry point returning the generated index path."""
+    return generate_feature_index_result(
+        root_dir, feature, nodes=nodes, date_str=date_str
+    ).path

--- a/src/vaultspec_core/vaultcore/query_rename_apply.py
+++ b/src/vaultspec_core/vaultcore/query_rename_apply.py
@@ -96,8 +96,7 @@ def _regenerate_feature_index(
         Path to the regenerated index file.
     """
     from ..config import get_config
-    from ..graph import VaultGraph
-    from .index import generate_feature_index
+    from .index import generate_feature_index_result
 
     cfg = get_config()
     docs_dir = root_dir / cfg.docs_dir
@@ -108,9 +107,8 @@ def _regenerate_feature_index(
     assert_within_docs(docs_dir, index_path)
     existed = index_path.exists()
 
-    graph = VaultGraph(root_dir, use_cache=False)
-    nodes = graph.get_feature_nodes(new)
-    path = generate_feature_index(root_dir, new, nodes=nodes)
+    result = generate_feature_index_result(root_dir, new)
+    path = result.path
     if not index_dir_existed and path.parent.is_dir():
         tx.record_created_dir(path.parent)
     if not existed:

--- a/src/vaultspec_core/vaultcore/repair.py
+++ b/src/vaultspec_core/vaultcore/repair.py
@@ -580,31 +580,32 @@ def _group_root_causes(results: Iterable[CheckResult]) -> list[dict[str, Any]]:
 
 def _refresh_indexes(root_dir: Path, feature: str | None) -> list[Path]:
     from ..graph import VaultGraph
-    from .index import generate_feature_index
+    from .index import generate_feature_index_result
 
     graph = VaultGraph(root_dir)
     features = [feature] if feature else graph.get_features()
     generated: list[Path] = []
     for feat in features:
-        nodes = graph.get_feature_nodes(feat)
-        if not nodes:
-            continue
-        generated.append(generate_feature_index(root_dir, feat, nodes=nodes))
+        result = generate_feature_index_result(root_dir, feat)
+        if result.changed:
+            generated.append(result.path)
     return generated
 
 
 def _index_paths(root_dir: Path, feature: str | None) -> list[Path]:
-    from ..config import get_config
     from ..graph import VaultGraph
+    from .index import generate_feature_index_result
 
-    cfg = get_config()
-    index_dir = root_dir / cfg.docs_dir / cfg.index_dir
     graph = VaultGraph(root_dir)
-    if feature:
-        features = [feature] if graph.get_feature_nodes(feature) else []
-    else:
-        features = graph.get_features()
-    return [index_dir / f"{feat}.index.md" for feat in features if feat]
+    features = [feature] if feature else graph.get_features()
+    return [
+        result.path
+        for feat in features
+        if feat
+        and (
+            result := generate_feature_index_result(root_dir, feat, dry_run=True)
+        ).changed
+    ]
 
 
 def _skipped_index_phase(reason: str) -> dict[str, Any]:

--- a/src/vaultspec_core/vaultcore/tests/test_index.py
+++ b/src/vaultspec_core/vaultcore/tests/test_index.py
@@ -124,6 +124,35 @@ class TestGenerateFeatureIndex:
         assert p1 == p2
         assert c1 == c2
 
+    def test_unchanged_body_preserves_creation_and_modified_dates(
+        self, tmp_path: Path
+    ) -> None:
+        """A date rollover does not dirty an index whose body is unchanged."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+        path = generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-23")
+        before = path.read_bytes()
+
+        generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-24")
+
+        assert path.read_bytes() == before
+        assert b"date: '2026-03-23'" in before
+        assert b"modified: '2026-03-23'" in before
+
+    def test_unchanged_body_repairs_a_stale_attestation(self, tmp_path: Path) -> None:
+        """A no-op is allowed only when the existing body hash is truthful."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+        path = generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-23")
+        stale = path.read_text(encoding="utf-8").replace(
+            "body_hash: 'sha256:", "body_hash: 'sha256:stale-"
+        )
+        path.write_text(stale, encoding="utf-8")
+
+        generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-24")
+
+        repaired = path.read_text(encoding="utf-8")
+        assert "sha256:stale-" not in repaired
+        assert "date: '2026-03-24'" in repaired
+
     def test_update_reflects_new_docs(self, tmp_path: Path) -> None:
         v1 = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
         _gen(tmp_path, "f", v1)

--- a/src/vaultspec_core/vaultcore/tests/test_index.py
+++ b/src/vaultspec_core/vaultcore/tests/test_index.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING
 
 import pytest
 
 from ...config import reset_config
 from ...graph.api import DocNode
-from ..index import generate_feature_index
+from ..index import feature_index_lock_target, generate_feature_index_result
 from ..models import DocType
 
 if TYPE_CHECKING:
@@ -45,7 +46,9 @@ def _node(
 
 
 def _gen(tmp_path: Path, feat: str, nodes: list[DocNode]) -> Path:
-    return generate_feature_index(tmp_path, feat, nodes=nodes, date_str="2026-03-23")
+    return generate_feature_index_result(
+        tmp_path, feat, nodes=nodes, date_str="2026-03-23"
+    ).path
 
 
 class TestGenerateFeatureIndex:
@@ -129,11 +132,16 @@ class TestGenerateFeatureIndex:
     ) -> None:
         """A date rollover does not dirty an index whose body is unchanged."""
         nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
-        path = generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-23")
+        path = generate_feature_index_result(
+            tmp_path, "f", nodes=nodes, date_str="2026-03-23"
+        ).path
         before = path.read_bytes()
 
-        generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-24")
+        result = generate_feature_index_result(
+            tmp_path, "f", nodes=nodes, date_str="2026-03-24"
+        )
 
+        assert result.changed is False
         assert path.read_bytes() == before
         assert b"date: '2026-03-23'" in before
         assert b"modified: '2026-03-23'" in before
@@ -141,17 +149,185 @@ class TestGenerateFeatureIndex:
     def test_unchanged_body_repairs_a_stale_attestation(self, tmp_path: Path) -> None:
         """A no-op is allowed only when the existing body hash is truthful."""
         nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
-        path = generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-23")
+        path = generate_feature_index_result(
+            tmp_path, "f", nodes=nodes, date_str="2026-03-23"
+        ).path
         stale = path.read_text(encoding="utf-8").replace(
             "body_hash: 'sha256:", "body_hash: 'sha256:stale-"
         )
         path.write_text(stale, encoding="utf-8")
 
-        generate_feature_index(tmp_path, "f", nodes=nodes, date_str="2026-03-24")
+        generate_feature_index_result(tmp_path, "f", nodes=nodes, date_str="2026-03-24")
 
         repaired = path.read_text(encoding="utf-8")
         assert "sha256:stale-" not in repaired
-        assert "date: '2026-03-24'" in repaired
+        assert "date: '2026-03-23'" in repaired
+        assert "modified: '2026-03-24'" in repaired
+
+    def test_read_error_propagates_without_replacement(self, tmp_path: Path) -> None:
+        """An unreadable existing target is not treated as a missing index."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+        target = tmp_path / ".vault" / "index" / "f.index.md"
+        target.mkdir(parents=True)
+
+        with pytest.raises(OSError):
+            generate_feature_index_result(
+                tmp_path, "f", nodes=nodes, date_str="2026-03-24"
+            )
+
+        assert target.is_dir()
+
+    def test_changed_body_preserves_creation_date_and_refreshes_modified(
+        self, tmp_path: Path
+    ) -> None:
+        """Membership changes advance modified without rewriting creation date."""
+        first = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+        path = generate_feature_index_result(
+            tmp_path, "f", nodes=first, date_str="2026-03-23"
+        ).path
+        second = [*first, _node(tmp_path, "b", "adr", "f", "2026-03-02", "B")]
+
+        result = generate_feature_index_result(
+            tmp_path, "f", nodes=second, date_str="2026-03-24"
+        )
+
+        content = path.read_text(encoding="utf-8")
+        assert result.changed is True
+        assert "date: '2026-03-23'" in content
+        assert "modified: '2026-03-24'" in content
+        assert "[[b]]" in content
+
+    @pytest.mark.parametrize(
+        "mutation",
+        [
+            ("generated: true", "generated: false"),
+            ("  - '#index'", "  - '#audit'"),
+            ("related:\n  - '[[a]]'", "related: []"),
+            ("body_hash:", "body_hash: 'sha256:forged'\nbody_hash:"),
+        ],
+    )
+    def test_metadata_drift_forces_canonical_rewrite(
+        self, tmp_path: Path, mutation: tuple[str, str]
+    ) -> None:
+        """A truthful body hash never blesses noncanonical generated metadata."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+        path = _gen(tmp_path, "f", nodes)
+        before, after = mutation
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(before, after), encoding="utf-8"
+        )
+
+        result = generate_feature_index_result(
+            tmp_path, "f", nodes=nodes, date_str="2026-03-24"
+        )
+
+        content = path.read_text(encoding="utf-8")
+        assert result.changed is True
+        assert "generated: true" in content
+        assert "  - '#index'" in content
+        assert "related:\n  - '[[a]]'" in content
+        assert content.count("body_hash:") == 1
+
+    @pytest.mark.parametrize("frontmatter", ["- one\n- two", "hello"])
+    def test_non_mapping_frontmatter_is_repaired(
+        self, tmp_path: Path, frontmatter: str
+    ) -> None:
+        """Valid YAML scalars and lists do not crash index regeneration."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+        path = _gen(tmp_path, "f", nodes)
+        _, body = path.read_text(encoding="utf-8").split("---\n", 2)[1:]
+        path.write_text(f"---\n{frontmatter}\n---\n{body}", encoding="utf-8")
+
+        result = generate_feature_index_result(
+            tmp_path, "f", nodes=nodes, date_str="2026-03-24"
+        )
+
+        assert result.changed is True
+        assert "generated: true" in path.read_text(encoding="utf-8")
+
+    def test_dry_run_reports_change_without_writing(self, tmp_path: Path) -> None:
+        """Dry-run computes the physical outcome and leaves bytes untouched."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+        path = _gen(tmp_path, "f", nodes)
+        before = path.read_bytes()
+        changed = [*nodes, _node(tmp_path, "b", "adr", "f", "2026-03-02", "B")]
+
+        result = generate_feature_index_result(
+            tmp_path, "f", nodes=changed, date_str="2026-03-24", dry_run=True
+        )
+
+        assert result.changed is True
+        assert path.read_bytes() == before
+
+    def test_fresh_dry_run_creates_no_files_or_directories(
+        self, tmp_path: Path
+    ) -> None:
+        """Previewing an absent index is filesystem-pure."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+
+        result = generate_feature_index_result(
+            tmp_path, "f", nodes=nodes, date_str="2026-03-24", dry_run=True
+        )
+
+        assert result.changed is True
+        assert not (tmp_path / ".vault").exists()
+
+    def test_generation_uses_only_gitignored_lock_storage(self, tmp_path: Path) -> None:
+        """Generation never leaves a sibling lock beside the tracked index."""
+        nodes = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]
+
+        path = _gen(tmp_path, "f", nodes)
+
+        assert not path.with_suffix(path.suffix + ".lock").exists()
+        assert (tmp_path / ".vault" / "data" / "index" / "f.lock").exists()
+
+    def test_membership_is_refreshed_after_acquiring_the_index_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """A waiting writer sees documents created before its lock is granted."""
+        from vaultspec_core.core.helpers import advisory_lock
+
+        def write_doc(name: str) -> None:
+            path = tmp_path / ".vault" / "research" / f"{name}.md"
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                "---\n"
+                "tags:\n"
+                "  - '#research'\n"
+                "  - '#f'\n"
+                "date: '2026-03-23'\n"
+                "related: []\n"
+                "---\n\n"
+                f"# {name}\n",
+                encoding="utf-8",
+            )
+
+        write_doc("a")
+        target = generate_feature_index_result(
+            tmp_path, "f", date_str="2026-03-23"
+        ).path
+        errors: list[BaseException] = []
+
+        def regenerate() -> None:
+            try:
+                generate_feature_index_result(tmp_path, "f", date_str="2026-03-24")
+            except BaseException as exc:
+                errors.append(exc)
+
+        lock_target = feature_index_lock_target(tmp_path / ".vault", "f")
+        with advisory_lock(lock_target):
+            worker = threading.Thread(target=regenerate)
+            worker.start()
+            worker.join(timeout=0.1)
+            assert worker.is_alive(), "writer did not block on the production lock"
+            write_doc("b")
+        worker.join(timeout=10)
+
+        assert not worker.is_alive()
+        assert errors == []
+        content = target.read_text(encoding="utf-8")
+        assert "[[a]]" in content
+        assert "[[b]]" in content
 
     def test_update_reflects_new_docs(self, tmp_path: Path) -> None:
         v1 = [_node(tmp_path, "a", "research", "f", "2026-03-01", "A")]


### PR DESCRIPTION
## Summary

- preserve arbitrary unowned plan frontmatter across CLI and MCP mutations while maintaining one truthful canonical `body_hash`
- expose and reuse the canonical YAML serializer for plan frontmatter rewrites
- make generated feature indexes canonical, idempotent, and concurrency-safe: preserve creation dates, refresh modified dates only on real changes, repair malformed metadata, and refresh membership under an ignored per-feature lock
- report only physical index changes in CLI, JSON, repair, and dry-run flows without creating dry-run artifacts
- preserve the public `generate_feature_index(...) -> Path` API while exposing a typed internal change result

Closes #299
Closes #306

## Validation

- affected-path runtime suite after rebasing onto current `main`: 645 passed
- `just lint type`: passed repository-wide
- `uv run --no-sync basedpyright`: 0 errors, 0 warnings, 0 notes
- `just lint markdown`: passed repository-wide
- scoped Ruff check and repository-wide Ruff format check: passed
- `git diff --check`: passed
- `vault check all --feature body-hash-integrity`: all enforced checks clean (only expected audit lifecycle warnings)
- independent final reviews: approved with no findings
- GitHub CI: all checks passed, including broad Ubuntu and Windows suites