### PR TITLE
fix(plan): prevent destructive structural rewrites

### DIFF
--- a/.vault/audit/2026-08-13-plan-mutation-loss-guard-audit.md
+++ b/.vault/audit/2026-08-13-plan-mutation-loss-guard-audit.md
@@ -1,0 +1,26 @@
+---
+tags:
+  - '#audit'
+  - '#plan-mutation-loss-guard'
+date: '2026-08-13'
+modified: '2026-08-13'
+body_schema: 'body-v1'
+body_hash: 'sha256:85465885012a5daeb936d50b4a19585a4343ea0688bd35fd19e56393b9812b65'
+related:
+  - "[[2026-06-05-plan-serializer-fixes-adr]]"
+---
+# `plan-mutation-loss-guard` audit: `Issue 305 implementation review`
+
+## Scope
+
+Reviewed the shared plan write guard, the Phase renumber call site, and real CLI regression coverage for issue 305. The review checked fail-closed handling of malformed hierarchy, active-item multiplicity, legitimate retirement, duplicate repair, and renumber operations, MCP inheritance of the shared guard, actionable errors, and source-file immutability after refusal.
+
+## Findings
+
+### duplicate-identifier-multiplicity | high | Resolved before delivery
+
+The first implementation compared active identifiers as sets, allowing one occurrence of a duplicated identifier to disappear without detection. The guard now counts occurrences and reports the exact lost identifier and count. A regression removes one of two live `S01` rows and proves an undeclared loss is refused without changing the file, while the established display-path-targeted duplicate removal remains available as an explicit repair.
+
+## Recommendations
+
+No open implementation findings remain. Keep the `PLAN010` and `PLAN070` source-structure refusal and multiplicity-aware active-item invariant in the shared write guard so CLI and MCP mutations retain the same protection. Preserve real-behavior regression coverage for malformed headings, independent active-item loss, duplicate occurrence loss and repair, and legitimate Phase renumbering.

--- a/.vault/index/plan-mutation-loss-guard.index.md
+++ b/.vault/index/plan-mutation-loss-guard.index.md
@@ -1,0 +1,22 @@
+---
+generated: true
+tags:
+  - '#index'
+  - '#plan-mutation-loss-guard'
+date: '2026-08-13'
+modified: '2026-08-13'
+body_schema: 'body-v1'
+body_hash: 'sha256:cf5eba335f2f3349c4e2af785cd9293c4a13acf3d1a50c44ebf7658b517e853d'
+related:
+  - '[[2026-08-13-plan-mutation-loss-guard-audit]]'
+---
+
+# `plan-mutation-loss-guard` feature index
+
+Auto-generated index of all documents tagged with `#plan-mutation-loss-guard`.
+
+## Documents
+
+### audit
+
+- `2026-08-13-plan-mutation-loss-guard-audit` - `plan-mutation-loss-guard` audit: `Issue 305 implementation review`

--- a/src/vaultspec_core/cli/plan_cmd_phase.py
+++ b/src/vaultspec_core/cli/plan_cmd_phase.py
@@ -236,6 +236,7 @@ def cmd_phase_renumber(
         dry_run=dry_run,
         canonicalise=canonicalise,
         success_msg=f"Renumbered Phase `{phase_id}` to `{phase.canonical_id}`.",
+        expected_retired={phase_id},
         json_output=json_output,
         command="vault.plan.phase.renumber",
     )

--- a/src/vaultspec_core/plan/write_guard.py
+++ b/src/vaultspec_core/plan/write_guard.py
@@ -1,6 +1,6 @@
 """Integrity guards for serialised plan writes, shared by every write path.
 
-Three defensive checks protect a plan document across the moment its mutated,
+Five defensive checks protect a plan document across the moment its mutated,
 re-serialised text replaces the on-disk bytes, and they must run on *every*
 write path so no surface can corrupt a plan the others protect. Two run
 *before* the write:
@@ -15,6 +15,13 @@ write path so no surface can corrupt a plan the others protect. Two run
   multiplies a plan several times over, so serialised output larger than
   ``max(floor, factor * len(source))`` signals a serialiser fault and the write
   is refused rather than corrupting the file or exhausting the disk.
+- **Source-structure guard** (issue #305): a plan with error-level structural
+  findings is not safe input to a whole-document rewrite. The mutation is
+  refused with the checker's existing diagnosis and repair hint.
+- **Active-identifier preservation guard** (issue #305): every Wave, Phase,
+  and Step visible before a mutation must remain visible afterwards unless the
+  command explicitly retires it. This catches destructive round trips even
+  when no individual checker recognises the malformed input that caused them.
 
 One runs *after* the write:
 
@@ -35,6 +42,7 @@ the check to drift.
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import TYPE_CHECKING
 
 from vaultspec_core.plan.commands._errors import PlanCommandError
@@ -87,6 +95,40 @@ def _retired_ids(plan: Plan) -> set[str]:
     return plan.retired_step_ids | plan.retired_phase_ids | plan.retired_wave_ids
 
 
+def _active_ids(plan: Plan) -> Counter[str]:
+    """Return multiplicity-aware active container and Step identifiers."""
+    return Counter(
+        [wave.canonical_id for wave in plan.waves]
+        + [phase.canonical_id for phase in plan.phases]
+        + [step.canonical_id for step in plan.steps]
+    )
+
+
+def _guard_source_structure(plan: Plan, source_text: str) -> None:
+    """Refuse a whole-document rewrite of structurally invalid source."""
+    from vaultspec_core.plan.checks import Severity, collect_all
+
+    destructive_structure_codes = {"PLAN010", "PLAN070"}
+    errors = [
+        finding
+        for finding in collect_all(plan, source_text)
+        if finding.severity is Severity.ERROR
+        and finding.code in destructive_structure_codes
+    ]
+    if not errors:
+        return
+
+    details = "; ".join(
+        f"{finding.code} line {finding.line_number}: {finding.message} "
+        f"Fix: {finding.fix_hint}"
+        for finding in errors
+    )
+    raise PlanWriteGuardError(
+        "mutation aborted: the source plan has structural errors and is not "
+        f"safe to rewrite. {details}"
+    )
+
+
 def guard_plan_write(
     original_text: str,
     new_text: str,
@@ -96,8 +138,9 @@ def guard_plan_write(
 ) -> None:
     """Run both plan-write integrity guards over a pending serialisation.
 
-    Parses the pre- and post-mutation text once, then enforces the
-    unexpected-retirement and growth-ceiling guards in that order. A parse
+    Parses the pre- and post-mutation text once, then enforces the source
+    structure, unexpected-retirement, active-identifier preservation, and
+    growth-ceiling guards in that order. A parse
     failure on either text is itself a refusal, since an unparseable result is
     never a safe thing to persist.
 
@@ -121,6 +164,8 @@ def guard_plan_write(
         msg = f"Plan validation failed during parsing: {exc}"
         raise PlanWriteGuardError(msg) from exc
 
+    _guard_source_structure(old_plan, original_text)
+
     newly_retired = _retired_ids(new_plan) - _retired_ids(old_plan)
     expected: set[str] = expected_retired if expected_retired is not None else set()
     unexpected = newly_retired - expected
@@ -129,6 +174,21 @@ def guard_plan_write(
         msg = (
             f"mutation aborted: unexpected retirement of active plan items: "
             f"{joined}. This indicates a serialization conflict."
+        )
+        raise PlanWriteGuardError(msg)
+
+    lost_active = _active_ids(old_plan) - _active_ids(new_plan)
+    for identifier in expected:
+        del lost_active[identifier]
+    if lost_active:
+        joined = ", ".join(
+            f"{identifier} ({count} occurrence(s))"
+            for identifier, count in sorted(lost_active.items())
+        )
+        msg = (
+            "mutation aborted: serialised output drops active plan items: "
+            f"{joined}. No write was performed; repair the source structure "
+            "and retry."
         )
         raise PlanWriteGuardError(msg)
 

--- a/src/vaultspec_core/tests/plan/test_e2e.py
+++ b/src/vaultspec_core/tests/plan/test_e2e.py
@@ -575,6 +575,179 @@ related: []
     assert "S01" in str(exc_info.value)
 
 
+def test_wave_add_refuses_mislevelled_wave_without_touching_source(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    """Issue #305: PLAN070 input must never reach a destructive rewrite."""
+    original_text = """---
+tags:
+  - '#plan'
+  - '#test'
+date: '2026-08-13'
+tier: L3
+related: []
+---
+
+# `test` plan
+
+### Wave `W01` - misplaced wave
+
+Wave intent.
+
+### Phase `W01.P01` - retained phase
+
+Phase intent.
+
+- [ ] `W01.P01.S01` - preserve this step; `src/a.py`.
+"""
+    plan_path = tmp_path / "test-plan.md"
+    plan_path.write_text(original_text, encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "vault",
+            "plan",
+            "wave",
+            "add",
+            str(plan_path),
+            "--title",
+            "new wave",
+            "--intent",
+            "New wave intent.",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "PLAN070" in result.output
+    assert "heading level 3" in result.output
+    assert "Added Wave" not in result.output
+    assert plan_path.read_text(encoding="utf-8") == original_text
+
+
+def test_write_guard_refuses_unexpected_active_identifier_loss(tmp_path: Path) -> None:
+    """Issue #305: the round-trip invariant is independent of PLAN070."""
+    from vaultspec_core.cli.plan_cmd import save_plan_or_dry_run
+    from vaultspec_core.plan.commands._errors import PlanCommandError
+    from vaultspec_core.plan.parser import parse_plan
+
+    original_text = """---
+tags:
+  - '#plan'
+  - '#test'
+date: '2026-08-13'
+tier: L3
+related: []
+---
+
+# `test` plan
+
+## Wave `W01` - existing wave
+
+Wave intent.
+
+### Phase `W01.P01` - existing phase
+
+Phase intent.
+
+- [ ] `W01.P01.S01` - preserve this step; `src/a.py`.
+"""
+    plan_path = tmp_path / "test-plan.md"
+    plan_path.write_text(original_text, encoding="utf-8")
+    plan = parse_plan(original_text)
+    plan.waves = []
+
+    with pytest.raises(PlanCommandError, match="drops active plan items"):
+        save_plan_or_dry_run(
+            path=plan_path,
+            plan=plan,
+            original_text=original_text,
+            dry_run=False,
+            canonicalise=False,
+            success_msg="Mutated plan",
+            expected_retired=set(),
+        )
+
+    assert plan_path.read_text(encoding="utf-8") == original_text
+
+
+def test_write_guard_refuses_loss_of_one_duplicate_identifier(tmp_path: Path) -> None:
+    """Issue #305: active-item preservation counts duplicate occurrences."""
+    from vaultspec_core.cli.plan_cmd import save_plan_or_dry_run
+    from vaultspec_core.plan.commands._errors import PlanCommandError
+    from vaultspec_core.plan.parser import parse_plan
+
+    original_text = """---
+tags:
+  - '#plan'
+  - '#test'
+date: '2026-08-13'
+tier: L1
+related: []
+---
+
+# `test` plan
+
+- [ ] `S01` - preserve first occurrence; `src/a.py`.
+- [ ] `S01` - preserve second occurrence; `src/b.py`.
+"""
+    plan_path = tmp_path / "test-plan.md"
+    plan_path.write_text(original_text, encoding="utf-8")
+    plan = parse_plan(original_text)
+    plan.steps.pop()
+
+    with pytest.raises(
+        PlanCommandError, match=r"S01 \(1 occurrence\(s\)\)"
+    ):
+        save_plan_or_dry_run(
+            path=plan_path,
+            plan=plan,
+            original_text=original_text,
+            dry_run=False,
+            canonicalise=False,
+            success_msg="Mutated plan",
+            expected_retired=set(),
+        )
+
+    assert plan_path.read_text(encoding="utf-8") == original_text
+
+
+def test_phase_renumber_declares_the_replaced_identifier(
+    tmp_path: Path, runner: CliRunner
+) -> None:
+    """The loss guard permits the renumber verb's explicit retirement."""
+    original_text = """---
+tags:
+  - '#plan'
+  - '#test'
+date: '2026-08-13'
+tier: L2
+related: []
+---
+
+# `test` plan
+
+### Phase `P01` - existing phase
+
+Phase intent.
+
+- [ ] `P01.S01` - preserve this step; `src/a.py`.
+"""
+    plan_path = tmp_path / "test-plan.md"
+    plan_path.write_text(original_text, encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["vault", "plan", "phase", "renumber", str(plan_path), "P01", "--to", "P02"],
+    )
+
+    assert result.exit_code == 0, result.output
+    content = plan_path.read_text(encoding="utf-8")
+    assert "### Phase `P02`" in content
+    assert "- [ ] `P02.S01`" in content
+    assert "<!-- RETIRED: P01 -->" in content
+
+
 def test_resolve_vault_root_from_plan_path_under_docs_dir(tmp_path: Path) -> None:
     """``resolve_vault_root`` derives the root from a plan under ``.vault/plan/``.
 

--- a/src/vaultspec_core/tests/plan/test_e2e.py
+++ b/src/vaultspec_core/tests/plan/test_e2e.py
@@ -696,9 +696,7 @@ related: []
     plan = parse_plan(original_text)
     plan.steps.pop()
 
-    with pytest.raises(
-        PlanCommandError, match=r"S01 \(1 occurrence\(s\)\)"
-    ):
+    with pytest.raises(PlanCommandError, match=r"S01 \(1 occurrence\(s\)\)"):
         save_plan_or_dry_run(
             path=plan_path,
             plan=plan,

--- a/src/vaultspec_core/tests/plan/test_preservation.py
+++ b/src/vaultspec_core/tests/plan/test_preservation.py
@@ -371,6 +371,14 @@ Preamble L4
 
 Old epic intent paragraph.
 
+## Wave `W01` - delivery
+
+Wave intent.
+
+### Phase `W01.P01` - implementation
+
+Phase intent.
+
 - [ ] `W01.P01.S01` - action; `src/a.py`.
 
 Closing text


### PR DESCRIPTION
## Summary

- refuse structural plan mutations when PLAN010 or PLAN070 shows the parsed model is unsafe
- enforce multiplicity-aware preservation of active Wave, Phase, and Step identifiers in the shared CLI/MCP write guard
- preserve legitimate removals, demotions, duplicate repair, and Phase renumbering
- add real CLI and direct guard regressions proving refused writes leave source bytes unchanged

Closes #305

## Validation

- `uv run --no-sync pytest src/vaultspec_core/tests/plan -q` - 525 passed
- focused issue and duplicate-repair scenarios - 6 passed
- `uv run --no-sync ruff check ...` - passed
- `uv run --no-sync basedpyright src/vaultspec_core/plan/write_guard.py src/vaultspec_core/cli/plan_cmd_phase.py` - passed
- `uv run --no-sync vaultspec-core vault check all` - clean with 8 unrelated pre-existing warnings
- `just ci` - blocked by 21 pre-existing NetworkX generic typing diagnostics outside this diff
